### PR TITLE
agents: rate model calls with Models.dev

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -969,7 +969,7 @@
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.4", "", { "dependencies": { "@ai-sdk/provider": "4.0.0", "@ai-sdk/provider-utils": "5.0.1", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-xO0e9duft/uZlnDaIeBZmzTMjfdEz1kkDzWnhQNkJZZljsKWVi6IREZW9nAa+Dx6jYJssyxSUggaFYBAV1WZpw=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@4.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@4.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-aWO7iwhFUGf347tCwNGggggfmZigaSu7TF739IZSrWWABUp7zkb4Cr3fMqvBe5EIS7ABJJu3Cadn0g/zs1G0QQ=="],
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.1", "", { "dependencies": { "@ai-sdk/provider": "4.0.0", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-p9Ra+dN4jjHrssXvklNf4nFvWbj1KePMfUOs7nue0NuoIMbYFBULhX4Vu0+6DWLnw3+UsLL9+RCKLtzzU43Qpg=="],
 
@@ -2449,6 +2449,10 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@ai-sdk/gateway/@ai-sdk/provider": ["@ai-sdk/provider@4.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg=="],
+
+    "@ai-sdk/provider-utils/@ai-sdk/provider": ["@ai-sdk/provider@4.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg=="],
+
     "@ai-sdk/provider-utils/@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
 
     "@radix-ui/react-accordion/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
@@ -2658,6 +2662,8 @@
     "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "@vercel/sandbox/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "ai/@ai-sdk/provider": ["@ai-sdk/provider@4.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg=="],
 
     "bcrypt-pbkdf/tweetnacl": ["tweetnacl@0.14.5", "", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "check": "biome check .",
     "check:fix": "biome check --write .",
     "generate:client": "bun --filter @sixb/server generate:openapi && bun --filter @sixb/client generate && bun check:fix",
+    "generate:ai-pricing": "bun scripts/generate-models-dev-pricing.ts",
     "docs:dev": "bun --filter @sixb/docs dev",
     "docs:build": "bun --filter @sixb/docs build",
     "docs:typecheck": "bun --filter @sixb/docs typecheck",

--- a/packages/agent-worker/README.md
+++ b/packages/agent-worker/README.md
@@ -18,8 +18,8 @@ const worker = new AgentWorker(sixb, {
 await worker.start()
 ```
 
-`sixb` must provide `storage.agents`, `storage.aiUsage`, `storage.auth`, `queues.agents`, `agents`,
-`broker`, and `sandboxes`.
+`sixb` must provide `storage.agents`, `storage.aiUsage`, `storage.aiCosts`, `storage.auth`,
+`queues.agents`, `agents`, `broker`, and `sandboxes`.
 
 ## Execution Model
 
@@ -29,9 +29,9 @@ await worker.start()
 - The worker transitions the durable run from `queued` to `running` when it claims the job.
 - The queue lease is the sole authority for liveness and redelivery; the worker renews it during
   turns.
-- Every completed `streamText` and `generateText` provider call is appended to `storage.aiUsage`;
-  API conversation and workflow-agent summaries are derived from that ledger. Run rows do not store
-  a second usage aggregate.
+- Every completed `streamText` and `generateText` provider call is appended to `storage.aiUsage`
+  with an immutable Models.dev valuation in `storage.aiCosts`; API conversation and workflow-agent
+  summaries are derived from that ledger. Run rows do not store a second usage aggregate.
 - Every delivery rotates a durable execution token that fences stale finalization after redelivery.
   Usage remains unfenced because a completed provider call is billable even when execution ownership
   changes afterward. The run also persists the queue-returned lease expiration for gateway
@@ -42,7 +42,8 @@ await worker.start()
 ## Usage accounting
 
 Every completed conversation and workflow-agent provider call observed by the AI SDK lifecycle is
-appended to `storage.aiUsage`, including individual calls in tool loops and calls completed before
+appended to `storage.aiUsage` and rated against the versioned Models.dev snapshot shipped with and
+lazily loaded by the agent worker, including individual calls in tool loops and calls completed before
 later cancellation, tool failure, output validation, or execution ownership loss. Workflow nodes
 use their own durable execution and inherit the parent workflow's admission-time group snapshot.
 Usage writes are intentionally not fenced: a stale worker cannot finalize the execution, but a
@@ -54,7 +55,10 @@ bounded backoff and cannot trigger another provider call. Once an append is defe
 blocks the next model step and the owning Agent run or workflow fails closed while accounting
 recovery continues independently. If the durable handoff also fails, the same stop prevents silent
 usage loss. This local path cannot close a process-crash window before lifecycle delivery;
-provider-side reconciliation is the appropriate later layer for that guarantee.
+provider-side reconciliation is the appropriate later layer for that guarantee. A model middleware
+also retains the provider's response model identity and provider metadata. Sixb rates only exact
+Models.dev matches observed through reviewed AI SDK namespaces; custom providers, aliases, and
+unsupported deployment contexts remain unpriceable rather than being normalized heuristically.
 
 ## Live Stream
 

--- a/packages/agent-worker/src/ai-pricing/accounting.ts
+++ b/packages/agent-worker/src/ai-pricing/accounting.ts
@@ -1,0 +1,55 @@
+import type {
+  AiCostStorage,
+  AiPricingContext,
+  AiUsageStorage,
+  RecordAiModelCallInput,
+  RecordAiModelCallResult,
+  Storage,
+} from "@sixb/core/storage"
+import type { AgentWorkerStorage } from "../types"
+
+interface RecordAiModelCallAccountingInput {
+  readonly storage: AgentWorkerStorage
+  readonly usage: RecordAiModelCallInput
+  readonly pricingContext: AiPricingContext
+  readonly ratedAt: Date
+}
+
+interface AiAccountingCapabilities {
+  readonly aiUsage: AiUsageStorage
+  readonly aiCosts: AiCostStorage
+}
+
+let modelsDevRater: Promise<typeof import("./models-dev")> | undefined
+
+/** Atomically append usage and a valuation from this worker's lazily loaded pricing snapshot. */
+export async function recordAiModelCallAccounting(
+  input: RecordAiModelCallAccountingInput
+): Promise<RecordAiModelCallResult> {
+  const { rateAiModelCall } = await loadModelsDevRater()
+  return input.storage.transaction(async (tx) => {
+    const { aiUsage, aiCosts } = requireAccountingCapabilities(tx)
+    const usage = await aiUsage.recordModelCall(input.usage)
+    const cost = rateAiModelCall({
+      usage: usage.record,
+      pricingContext: input.pricingContext,
+      ratedAt: input.ratedAt,
+    })
+    await aiCosts.recordModelCallCost(cost)
+    return usage
+  })
+}
+
+function loadModelsDevRater(): Promise<typeof import("./models-dev")> {
+  modelsDevRater ??= import("./models-dev")
+  return modelsDevRater
+}
+
+function requireAccountingCapabilities(storage: Storage): AiAccountingCapabilities {
+  if (!storage.aiUsage || !storage.aiCosts) {
+    throw new Error(
+      "[SixbAgentWorker] AI model-call accounting requires storage.aiUsage and storage.aiCosts."
+    )
+  }
+  return { aiUsage: storage.aiUsage, aiCosts: storage.aiCosts }
+}

--- a/packages/agent-worker/src/ai-pricing/models-dev-pricing.json
+++ b/packages/agent-worker/src/ai-pricing/models-dev-pricing.json
@@ -1,0 +1,25855 @@
+{
+  "source": {
+    "id": "models.dev",
+    "version": "sha256:24ecf000f12432c8107463f1e9b99d9e8c27ad7b45ce36808be7fde5554d47ba",
+    "url": "https://models.dev/api.json",
+    "observedAt": "2026-08-25T17:54:39.833Z"
+  },
+  "providers": {
+    "302ai": {
+      "chatgpt-4o-latest": { "input": "5000000000", "output": "15000000000" },
+      "claude-3-5-haiku-20241022": { "input": "800000000", "output": "4000000000" },
+      "claude-3-5-haiku-latest": { "input": "800000000", "output": "4000000000" },
+      "claude-haiku-4-5": { "input": "1000000000", "output": "5000000000" },
+      "claude-haiku-4-5-20251001": { "input": "1000000000", "output": "5000000000" },
+      "claude-opus-4-1-20250805": { "input": "15000000000", "output": "75000000000" },
+      "claude-opus-4-1-20250805-thinking": { "input": "15000000000", "output": "75000000000" },
+      "claude-opus-4-20250514": { "input": "15000000000", "output": "75000000000" },
+      "claude-opus-4-5": { "input": "5000000000", "output": "25000000000" },
+      "claude-opus-4-5-20251101": { "input": "5000000000", "output": "25000000000" },
+      "claude-opus-4-5-20251101-thinking": { "input": "5000000000", "output": "25000000000" },
+      "claude-opus-4-6": { "input": "5000000000", "output": "25000000000" },
+      "claude-opus-4-6-thinking": { "input": "5000000000", "output": "25000000000" },
+      "claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-sonnet-4-20250514": { "input": "3000000000", "output": "15000000000" },
+      "claude-sonnet-4-5": { "input": "3000000000", "output": "15000000000" },
+      "claude-sonnet-4-5-20250929": { "input": "3000000000", "output": "15000000000" },
+      "claude-sonnet-4-5-20250929-thinking": { "input": "3000000000", "output": "15000000000" },
+      "claude-sonnet-4-6": { "input": "3000000000", "output": "15000000000" },
+      "claude-sonnet-4-6-thinking": { "input": "3000000000", "output": "15000000000" },
+      "deepseek-chat": { "input": "290000000", "output": "430000000" },
+      "deepseek-reasoner": { "input": "290000000", "output": "430000000" },
+      "deepseek-v3.2": { "input": "290000000", "output": "430000000" },
+      "deepseek-v3.2-thinking": { "input": "290000000", "output": "430000000" },
+      "doubao-seed-1-6-thinking-250715": { "input": "121000000", "output": "1210000000" },
+      "doubao-seed-1-6-vision-250815": { "input": "114000000", "output": "1143000000" },
+      "doubao-seed-1-8-251215": { "input": "114000000", "output": "286000000" },
+      "doubao-seed-code-preview-251028": { "input": "170000000", "output": "1140000000" },
+      "gemini-2.0-flash-lite": { "input": "75000000", "output": "300000000" },
+      "gemini-2.5-flash": { "input": "300000000", "output": "2500000000" },
+      "gemini-2.5-flash-image": { "input": "300000000", "output": "30000000000" },
+      "gemini-2.5-flash-lite-preview-09-2025": { "input": "100000000", "output": "400000000" },
+      "gemini-2.5-flash-nothink": { "input": "300000000", "output": "2500000000" },
+      "gemini-2.5-flash-preview-09-2025": { "input": "300000000", "output": "2500000000" },
+      "gemini-2.5-pro": { "input": "1250000000", "output": "10000000000" },
+      "gemini-3-flash-preview": { "input": "500000000", "output": "3000000000" },
+      "gemini-3-pro-image-preview": { "input": "2000000000", "output": "120000000000" },
+      "gemini-3-pro-preview": { "input": "2000000000", "output": "12000000000" },
+      "gemini-3.1-flash-image-preview": { "input": "500000000", "output": "60000000000" },
+      "glm-4.5": { "input": "286000000", "output": "1142000000" },
+      "glm-4.5-air": { "input": "114300000", "output": "286000000" },
+      "glm-4.5-airx": { "input": "572000000", "output": "1714000000" },
+      "glm-4.5-x": { "input": "1143000000", "output": "2290000000" },
+      "glm-4.5v": { "input": "290000000", "output": "860000000" },
+      "glm-4.6": { "input": "286000000", "output": "1142000000" },
+      "glm-4.6v": { "input": "145000000", "output": "430000000" },
+      "glm-4.7": { "input": "286000000", "output": "1142000000" },
+      "glm-4.7-flashx": { "input": "71500000", "output": "429000000" },
+      "glm-5": { "input": "600000000", "output": "2600000000" },
+      "glm-5-turbo": { "input": "720000000", "output": "3200000000" },
+      "glm-5.1": { "input": "860000000", "output": "3500000000" },
+      "glm-5v-turbo": { "input": "720000000", "output": "3200000000" },
+      "glm-for-coding": { "input": "86000000", "output": "343000000" },
+      "gpt-4.1": { "input": "2000000000", "output": "8000000000" },
+      "gpt-4.1-mini": { "input": "400000000", "output": "1600000000" },
+      "gpt-4.1-nano": { "input": "100000000", "output": "400000000" },
+      "gpt-4o": { "input": "2500000000", "output": "10000000000" },
+      "gpt-5": { "input": "1250000000", "output": "10000000000" },
+      "gpt-5-mini": { "input": "250000000", "output": "2000000000" },
+      "gpt-5-pro": { "input": "15000000000", "output": "120000000000" },
+      "gpt-5-thinking": { "input": "1250000000", "output": "10000000000" },
+      "gpt-5.1": { "input": "1250000000", "output": "10000000000" },
+      "gpt-5.1-chat-latest": { "input": "1250000000", "output": "10000000000" },
+      "gpt-5.2": { "input": "1750000000", "output": "14000000000" },
+      "gpt-5.2-chat-latest": { "input": "1750000000", "output": "14000000000" },
+      "gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "0",
+        "tiers": [{ "input": "5000000000", "output": "22500000000", "aboveInputTokens": "272000" }]
+      },
+      "gpt-5.4-mini": { "input": "750000000", "output": "4500000000" },
+      "gpt-5.4-mini-2026-03-17": { "input": "750000000", "output": "4500000000" },
+      "gpt-5.4-nano": { "input": "200000000", "output": "1250000000" },
+      "gpt-5.4-nano-2026-03-17": { "input": "200000000", "output": "1250000000" },
+      "gpt-5.4-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "cacheRead": "0",
+        "cacheWrite": "0",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "grok-4-1-fast-non-reasoning": { "input": "200000000", "output": "500000000" },
+      "grok-4-1-fast-reasoning": { "input": "200000000", "output": "500000000" },
+      "grok-4-fast-non-reasoning": { "input": "200000000", "output": "500000000" },
+      "grok-4-fast-reasoning": { "input": "200000000", "output": "500000000" },
+      "grok-4.1": { "input": "2000000000", "output": "10000000000" },
+      "grok-4.20-beta-0309-non-reasoning": { "input": "2000000000", "output": "6000000000" },
+      "grok-4.20-beta-0309-reasoning": { "input": "2000000000", "output": "6000000000" },
+      "grok-4.20-multi-agent-beta-0309": { "input": "2000000000", "output": "6000000000" },
+      "kimi-k2-0905-preview": { "input": "632000000", "output": "2530000000" },
+      "kimi-k2-thinking": { "input": "575000000", "output": "2300000000" },
+      "kimi-k2-thinking-turbo": { "input": "1265000000", "output": "9119000000" },
+      "MiniMax-M1": { "input": "132000000", "output": "1254000000" },
+      "MiniMax-M2": { "input": "330000000", "output": "1320000000" },
+      "MiniMax-M2.1": { "input": "300000000", "output": "1200000000" },
+      "MiniMax-M2.7": { "input": "300000000", "output": "1200000000" },
+      "MiniMax-M2.7-highspeed": { "input": "600000000", "output": "4800000000" },
+      "ministral-14b-2512": { "input": "330000000", "output": "330000000" },
+      "mistral-large-2512": { "input": "1100000000", "output": "3300000000" },
+      "qwen-flash": { "input": "22000000", "output": "220000000" },
+      "qwen-max-latest": { "input": "343000000", "output": "1372000000" },
+      "qwen-plus": { "input": "120000000", "output": "1200000000" },
+      "qwen3-235b-a22b": { "input": "290000000", "output": "2860000000" },
+      "qwen3-235b-a22b-instruct-2507": { "input": "290000000", "output": "1143000000" },
+      "qwen3-30b-a3b": { "input": "110000000", "output": "1080000000" },
+      "qwen3-coder-480b-a35b-instruct": { "input": "860000000", "output": "3430000000" },
+      "qwen3-max-2025-09-23": { "input": "860000000", "output": "3430000000" }
+    },
+    "abacus": {
+      "claude-3-7-sonnet-20250219": { "input": "3000000000", "output": "15000000000" },
+      "claude-fable-5": { "input": "10000000000", "output": "50000000000" },
+      "claude-haiku-4-5-20251001": { "input": "1000000000", "output": "5000000000" },
+      "claude-opus-4-1-20250805": { "input": "15000000000", "output": "75000000000" },
+      "claude-opus-4-20250514": { "input": "15000000000", "output": "75000000000" },
+      "claude-opus-4-5-20251101": { "input": "5000000000", "output": "25000000000" },
+      "claude-opus-4-6": { "input": "5000000000", "output": "25000000000" },
+      "claude-opus-4-7": { "input": "5000000000", "output": "25000000000" },
+      "claude-opus-4-8": { "input": "5000000000", "output": "25000000000" },
+      "claude-opus-5": { "input": "5000000000", "output": "25000000000" },
+      "claude-sonnet-4-20250514": { "input": "3000000000", "output": "15000000000" },
+      "claude-sonnet-4-5-20250929": { "input": "3000000000", "output": "15000000000" },
+      "claude-sonnet-4-6": { "input": "3000000000", "output": "15000000000" },
+      "claude-sonnet-5": { "input": "3000000000", "output": "15000000000" },
+      "deepseek-ai/DeepSeek-R1": { "input": "3000000000", "output": "7000000000" },
+      "deepseek-ai/DeepSeek-V3.1-Terminus": { "input": "270000000", "output": "1000000000" },
+      "deepseek-ai/DeepSeek-V3.2": { "input": "270000000", "output": "400000000" },
+      "deepseek-ai/DeepSeek-V4-Flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "30000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "150000000"
+      },
+      "deepseek/deepseek-v3.1": { "input": "550000000", "output": "1660000000" },
+      "gemini-2.5-flash": { "input": "300000000", "output": "2500000000", "cacheRead": "30000000" },
+      "gemini-2.5-flash-image": { "input": "300000000", "output": "30000000000" },
+      "gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000"
+      },
+      "gemini-3-pro-image": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000"
+      },
+      "gemini-3-pro-image-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000"
+      },
+      "gemini-3.1-flash-image": { "input": "500000000", "output": "3000000000" },
+      "gemini-3.1-flash-image-preview": { "input": "500000000", "output": "3000000000" },
+      "gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000"
+      },
+      "gemini-3.1-flash-lite-preview": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "1000000000"
+      },
+      "gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000"
+      },
+      "gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000"
+      },
+      "gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "gemini-3.6-flash": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000"
+      },
+      "gemini-3.7-flash": { "input": "750000000", "output": "3750000000", "cacheRead": "75000000" },
+      "google/gemma-4-31b-it": { "input": "140000000", "output": "400000000" },
+      "gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "gpt-4.1-mini": { "input": "400000000", "output": "1600000000", "cacheRead": "100000000" },
+      "gpt-4.1-nano": { "input": "100000000", "output": "400000000", "cacheRead": "25000000" },
+      "gpt-4o": { "input": "2500000000", "output": "10000000000", "cacheRead": "1250000000" },
+      "gpt-4o-2024-11-20": { "input": "2500000000", "output": "10000000000" },
+      "gpt-4o-mini": { "input": "150000000", "output": "600000000" },
+      "gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5-codex": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5-mini": { "input": "250000000", "output": "2000000000", "cacheRead": "25000000" },
+      "gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "gpt-5.1": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5.1-chat-latest": { "input": "1250000000", "output": "10000000000" },
+      "gpt-5.1-codex": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5.1-codex-max": { "input": "1250000000", "output": "10000000000" },
+      "gpt-5.2": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.2-chat-latest": { "input": "1750000000", "output": "14000000000" },
+      "gpt-5.2-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.3-chat-latest": { "input": "1750000000", "output": "14000000000" },
+      "gpt-5.3-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "180000000" },
+      "gpt-5.3-codex-xhigh": { "input": "1750000000", "output": "14000000000" },
+      "gpt-5.4": { "input": "2500000000", "output": "15000000000", "cacheRead": "250000000" },
+      "gpt-5.4-mini": { "input": "750000000", "output": "4500000000", "cacheRead": "75000000" },
+      "gpt-5.4-nano": { "input": "200000000", "output": "1250000000", "cacheRead": "20000000" },
+      "gpt-5.5": { "input": "5000000000", "output": "30000000000", "cacheRead": "500000000" },
+      "gpt-5.6-luna": { "input": "1000000000", "output": "6000000000", "cacheRead": "100000000" },
+      "gpt-5.6-sol": { "input": "5000000000", "output": "30000000000", "cacheRead": "500000000" },
+      "gpt-5.6-terra": { "input": "2500000000", "output": "15000000000", "cacheRead": "250000000" },
+      "grok-4-0709": { "input": "3000000000", "output": "15000000000" },
+      "grok-4-1-fast-non-reasoning": { "input": "200000000", "output": "500000000" },
+      "grok-4-fast-non-reasoning": { "input": "200000000", "output": "500000000" },
+      "grok-4.3": { "input": "1250000000", "output": "2500000000", "cacheRead": "200000000" },
+      "grok-4.5": { "input": "2000000000", "output": "6000000000" },
+      "grok-4.6": { "input": "2000000000", "output": "6000000000", "cacheRead": "500000000" },
+      "grok-code-fast-1": { "input": "200000000", "output": "1500000000" },
+      "kimi-k2-turbo-preview": { "input": "150000000", "output": "8000000000" },
+      "kimi-k2.5": { "input": "600000000", "output": "3000000000" },
+      "llama-3.3-70b-versatile": { "input": "590000000", "output": "790000000" },
+      "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+        "input": "140000000",
+        "output": "590000000"
+      },
+      "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo": {
+        "input": "3500000000",
+        "output": "3500000000"
+      },
+      "meta-llama/Meta-Llama-3.1-8B-Instruct": { "input": "20000000", "output": "50000000" },
+      "meta-llama/Meta-Llama-3.3-70B-Instruct": { "input": "590000000", "output": "790000000" },
+      "mimo-v2-pro": { "input": "1000000000", "output": "3000000000", "cacheRead": "200000000" },
+      "MiniMaxAI/MiniMax-M2.7": { "input": "300000000", "output": "1200000000" },
+      "MiniMaxAI/MiniMax-M3": { "input": "300000000", "output": "1200000000" },
+      "moonshotai/Kimi-K2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "moonshotai/Kimi-K2.7-Code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "moonshotai/Kimi-K3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "muse-spark-1.1": { "input": "1250000000", "output": "4250000000", "cacheRead": "150000000" },
+      "muse-spark-1.2": { "input": "1250000000", "output": "4250000000", "cacheRead": "150000000" },
+      "o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "o3-pro": { "input": "20000000000", "output": "40000000000" },
+      "o4-mini": { "input": "1100000000", "output": "4400000000" },
+      "openai/gpt-oss-120b": { "input": "80000000", "output": "440000000" },
+      "qwen-2.5-coder-32b": { "input": "790000000", "output": "790000000" },
+      "Qwen/Qwen2.5-72B-Instruct": { "input": "110000000", "output": "380000000" },
+      "Qwen/Qwen3-235B-A22B-Instruct-2507": { "input": "130000000", "output": "600000000" },
+      "Qwen/Qwen3-32B": { "input": "90000000", "output": "290000000" },
+      "Qwen/Qwen3-Coder-480B-A35B-Instruct": { "input": "290000000", "output": "1200000000" },
+      "Qwen/Qwen3.6-27B": { "input": "320000000", "output": "3200000000" },
+      "Qwen/QwQ-32B": { "input": "400000000", "output": "400000000" },
+      "qwen3-max": { "input": "1200000000", "output": "6000000000" },
+      "qwen3.7-max": { "input": "2500000000", "output": "7500000000" },
+      "qwen3.8-max": { "input": "2000000000", "output": "6000000000" },
+      "route-llm": { "input": "3000000000", "output": "15000000000" },
+      "thinkingmachines/Inkling": {
+        "input": "3740000000",
+        "output": "9360000000",
+        "cacheRead": "748000000"
+      },
+      "zai-org/GLM-4.5": { "input": "600000000", "output": "2200000000" },
+      "zai-org/GLM-4.6": { "input": "600000000", "output": "2200000000" },
+      "zai-org/GLM-4.7": { "input": "600000000", "output": "2200000000" },
+      "zai-org/GLM-5": { "input": "1000000000", "output": "3200000000" },
+      "zai-org/GLM-5.1": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "zai-org/GLM-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" }
+    },
+    "abliteration-ai": {
+      "abliterated-model": {
+        "input": "3000000000",
+        "output": "3000000000",
+        "cacheRead": "300000000"
+      },
+      "abliterated-model-large": {
+        "input": "5000000000",
+        "output": "5000000000",
+        "cacheRead": "500000000"
+      }
+    },
+    "agnes": {
+      "agnes-2.0-flash": { "input": "0", "output": "0" },
+      "agnes-2.5-flash": { "input": "0", "output": "0" },
+      "agnes-2.5-pro-alpha": { "input": "450000000", "output": "900000000", "cacheRead": "3800000" }
+    },
+    "ai-router": {
+      "gpt-5.4": { "input": "2500000000", "output": "15000000000", "cacheRead": "250000000" },
+      "gpt-5.5": { "input": "5000000000", "output": "30000000000", "cacheRead": "500000000" },
+      "gpt-5.6-luna": {
+        "input": "1000000000",
+        "output": "6000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "gpt-5.6-terra": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "3125000000"
+      }
+    },
+    "aiand": {
+      "deepseek-ai/deepseek-v4-flash": { "input": "150000000", "output": "250000000" },
+      "deepseek-ai/deepseek-v4-pro": { "input": "1000000000", "output": "2500000000" },
+      "google/gemma-4-31b-it": { "input": "200000000", "output": "500000000" },
+      "moonshotai/kimi-k2.7-code": { "input": "750000000", "output": "3500000000" },
+      "moonshotai/kimi-k3": {
+        "input": "3000000000",
+        "output": "12500000000",
+        "cacheRead": "500000000"
+      },
+      "motif-technologies/motif-3": { "input": "500000000", "output": "2000000000" },
+      "openai/gpt-oss-120b": { "input": "150000000", "output": "600000000" },
+      "qwen/qwen3.6-27b": { "input": "320000000", "output": "3200000000" },
+      "zai-org/glm-5.2": { "input": "1000000000", "output": "4000000000" }
+    },
+    "aihubmix": {
+      "alicloud-deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "alicloud-deepseek-v4-pro": {
+        "input": "1690000000",
+        "output": "3380000000",
+        "cacheRead": "130000000"
+      },
+      "alicloud-glm-5.1": {
+        "input": "840000000",
+        "output": "3380000000",
+        "cacheRead": "169000000",
+        "cacheWrite": "1056250000"
+      },
+      "claude-fable-5": {
+        "input": "11000000000",
+        "output": "55000000000",
+        "cacheRead": "1100000000",
+        "cacheWrite": "13750000000"
+      },
+      "claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-opus-4-6-think": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-opus-4-7-think": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-8-think": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000",
+        "tiers": [
+          {
+            "input": "6000000000",
+            "output": "22500000000",
+            "cacheRead": "600000000",
+            "cacheWrite": "7500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-sonnet-4-6-think": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000",
+        "tiers": [
+          {
+            "input": "6000000000",
+            "output": "22500000000",
+            "cacheRead": "600000000",
+            "cacheWrite": "7500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "coding-glm-5.1": { "input": "60000000", "output": "220000000", "cacheRead": "13000000" },
+      "coding-glm-5.1-free": { "input": "0", "output": "0" },
+      "coding-minimax-m2.7": { "input": "200000000", "output": "200000000" },
+      "coding-minimax-m2.7-free": { "input": "0", "output": "0" },
+      "coding-minimax-m2.7-highspeed": { "input": "200000000", "output": "200000000" },
+      "coding-xiaomi-mimo-v2.5": {
+        "input": "80000000",
+        "output": "400000000",
+        "cacheRead": "16000000",
+        "tiers": [
+          {
+            "input": "160000000",
+            "output": "800000000",
+            "cacheRead": "32000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "coding-xiaomi-mimo-v2.5-pro": {
+        "input": "200000000",
+        "output": "600000000",
+        "cacheRead": "40000000",
+        "tiers": [
+          {
+            "input": "400000000",
+            "output": "1200000000",
+            "cacheRead": "80000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "deep-deepseek-v4-flash": {
+        "input": "154000000",
+        "output": "308000000",
+        "cacheRead": "30800000"
+      },
+      "deep-deepseek-v4-pro": {
+        "input": "478000000",
+        "output": "956000000",
+        "cacheRead": "4302000"
+      },
+      "doubao-seed-2-0-code-preview": {
+        "input": "480000000",
+        "output": "2410000000",
+        "cacheRead": "96440000",
+        "tiers": [
+          {
+            "input": "720000000",
+            "output": "3620000000",
+            "cacheRead": "144656000",
+            "aboveInputTokens": "32000"
+          },
+          {
+            "input": "1450000000",
+            "output": "7230000000",
+            "cacheRead": "289320000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "doubao-seed-2-0-lite-260428": {
+        "input": "80000000",
+        "output": "510000000",
+        "cacheRead": "16920000",
+        "inputAudio": "1269000000",
+        "tiers": [
+          {
+            "input": "130000000",
+            "output": "760000000",
+            "cacheRead": "25360000",
+            "inputAudio": "1902000000",
+            "aboveInputTokens": "32000"
+          },
+          {
+            "input": "250000000",
+            "output": "1520000000",
+            "cacheRead": "50720000",
+            "inputAudio": "3804000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "doubao-seed-2-0-mini-260428": {
+        "input": "30000000",
+        "output": "280000000",
+        "cacheRead": "5640000",
+        "inputAudio": "423000000",
+        "tiers": [
+          {
+            "input": "60000000",
+            "output": "560000000",
+            "cacheRead": "11280000",
+            "inputAudio": "846000000",
+            "aboveInputTokens": "32000"
+          },
+          {
+            "input": "110000000",
+            "output": "1130000000",
+            "cacheRead": "22560000",
+            "inputAudio": "1692000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "doubao-seed-2-0-pro": {
+        "input": "480000000",
+        "output": "2410000000",
+        "cacheRead": "96440000",
+        "tiers": [
+          {
+            "input": "720000000",
+            "output": "3620000000",
+            "cacheRead": "144656000",
+            "aboveInputTokens": "32000"
+          },
+          {
+            "input": "1450000000",
+            "output": "7230000000",
+            "cacheRead": "289320000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "inputAudio": "1000000000"
+      },
+      "gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "tiers": [
+          {
+            "input": "500000000",
+            "output": "3000000000",
+            "cacheRead": "50000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "1000000000"
+      },
+      "gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.1-pro-preview-customtools": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "1500000000"
+      },
+      "gemini-3.7-flash": { "input": "750000000", "output": "3750000000", "cacheRead": "75000000" },
+      "glm-5.2": { "input": "1126800000", "output": "3943800000", "cacheRead": "281700000" },
+      "glm-5v-turbo": { "input": "704200000", "output": "3098480000", "cacheRead": "169008000" },
+      "gpt-5.1": { "input": "1250000000", "output": "10000000000", "cacheRead": "130000000" },
+      "gpt-5.1-codex": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "gpt-5.2": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.2-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.3-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": { "input": "5000000000", "output": "30000000000", "cacheRead": "500000000" }
+        }
+      },
+      "gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000",
+        "modes": {
+          "fast": { "input": "1500000000", "output": "9000000000", "cacheRead": "150000000" }
+        }
+      },
+      "gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": { "input": "12500000000", "output": "75000000000", "cacheRead": "1250000000" }
+        }
+      },
+      "gpt-5.6-luna": {
+        "input": "1000000000",
+        "output": "6000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "gpt-5.6-terra": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "3125000000"
+      },
+      "grok-4.3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4.5": { "input": "2000000000", "output": "6000000000", "cacheRead": "500000000" },
+      "grok-build-0.1": { "input": "1000000000", "output": "2000000000", "cacheRead": "200000000" },
+      "hy3-preview": { "input": "170000000", "output": "566661000", "cacheRead": "51000000" },
+      "kimi-k2.5": { "input": "600000000", "output": "3000000000", "cacheRead": "100000000" },
+      "kimi-k2.6": { "input": "950000000", "output": "4000000000", "cacheRead": "160000000" },
+      "kimi-k2.7-code": { "input": "950000000", "output": "3999500000", "cacheRead": "160835000" },
+      "kimi-k2.7-code-highspeed": {
+        "input": "1900000000",
+        "output": "7999000000",
+        "cacheRead": "321670000"
+      },
+      "kimi-k3": { "input": "3000000000", "output": "15000000000", "cacheRead": "300000000" },
+      "minimax-m2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "qwen3.6-flash": {
+        "input": "170000000",
+        "output": "1010000000",
+        "cacheRead": "16900000",
+        "cacheWrite": "211250000",
+        "tiers": [
+          {
+            "input": "680000000",
+            "output": "4060000000",
+            "cacheRead": "67600000",
+            "cacheWrite": "845000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3.6-max-preview": {
+        "input": "1270000000",
+        "output": "7610000000",
+        "cacheRead": "126800000",
+        "cacheWrite": "1585000000",
+        "tiers": [
+          {
+            "input": "2110000000",
+            "output": "12670000000",
+            "cacheRead": "211200000",
+            "cacheWrite": "2640000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "qwen3.6-plus": {
+        "input": "280000000",
+        "output": "1690000000",
+        "cacheRead": "28200000",
+        "cacheWrite": "352500000",
+        "tiers": [
+          {
+            "input": "1130000000",
+            "output": "6770000000",
+            "cacheRead": "112800000",
+            "cacheWrite": "1410000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3.7-max": {
+        "input": "1690000000",
+        "output": "5070000000",
+        "cacheRead": "169000000",
+        "cacheWrite": "2112500000"
+      },
+      "qwen3.7-plus": {
+        "input": "282000000",
+        "output": "1128000000",
+        "cacheRead": "56400000",
+        "cacheWrite": "352500000"
+      },
+      "qwen3.8-max": {
+        "input": "1690000000",
+        "output": "5070000000",
+        "cacheRead": "169000000",
+        "cacheWrite": "2112500000"
+      },
+      "xiaomi-mimo-v2.5": {
+        "input": "440000000",
+        "output": "2200000000",
+        "cacheRead": "88000000",
+        "tiers": [
+          {
+            "input": "880000000",
+            "output": "4400000000",
+            "cacheRead": "176000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "xiaomi-mimo-v2.5-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "xiaomi-mimo-v2.5-pro": {
+        "input": "1100000000",
+        "output": "3300000000",
+        "cacheRead": "220000000",
+        "tiers": [
+          {
+            "input": "2200000000",
+            "output": "6600000000",
+            "cacheRead": "440000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "xiaomi-mimo-v2.5-pro-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "zai-glm-5.1": { "input": "845000000", "output": "3380000000", "cacheRead": "183112000" }
+    },
+    "aki-io": {
+      "deepseek-v4-flash-0731-284b": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "100000000"
+      },
+      "gemma4-26b": { "input": "100000000", "output": "500000000" },
+      "gpt-oss-120b": { "input": "150000000", "output": "550000000" },
+      "kimi-k2.7-code-1100b": {
+        "input": "860000000",
+        "output": "3000000000",
+        "cacheRead": "180000000"
+      },
+      "mistral4-119b": { "input": "200000000", "output": "600000000" },
+      "qwen3.6-35b": { "input": "150000000", "output": "500000000" },
+      "qwen3.8-27b": { "input": "300000000", "output": "2200000000", "cacheRead": "100000000" }
+    },
+    "alibaba": {
+      "deepseek-v4-flash-0731": {
+        "input": "200000000",
+        "output": "400000000",
+        "cacheRead": "40000000"
+      },
+      "glm-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "280000000",
+        "cacheWrite": "0"
+      },
+      "qvq-max": { "input": "1200000000", "output": "4800000000" },
+      "qwen-flash": { "input": "50000000", "output": "400000000" },
+      "qwen-max": { "input": "1600000000", "output": "6400000000" },
+      "qwen-mt-plus": { "input": "2460000000", "output": "7370000000" },
+      "qwen-mt-turbo": { "input": "160000000", "output": "490000000" },
+      "qwen-omni-turbo": {
+        "input": "70000000",
+        "output": "270000000",
+        "inputAudio": "4440000000",
+        "outputAudio": "8890000000"
+      },
+      "qwen-omni-turbo-realtime": {
+        "input": "270000000",
+        "output": "1070000000",
+        "inputAudio": "4440000000",
+        "outputAudio": "8890000000"
+      },
+      "qwen-plus": { "input": "400000000", "output": "1200000000", "reasoning": "4000000000" },
+      "qwen-plus-character-ja": { "input": "500000000", "output": "1400000000" },
+      "qwen-turbo": { "input": "50000000", "output": "200000000", "reasoning": "500000000" },
+      "qwen-vl-max": { "input": "800000000", "output": "3200000000" },
+      "qwen-vl-ocr": { "input": "720000000", "output": "720000000" },
+      "qwen-vl-plus": { "input": "210000000", "output": "630000000" },
+      "qwen2-5-14b-instruct": { "input": "350000000", "output": "1400000000" },
+      "qwen2-5-32b-instruct": { "input": "700000000", "output": "2800000000" },
+      "qwen2-5-72b-instruct": { "input": "1400000000", "output": "5600000000" },
+      "qwen2-5-7b-instruct": { "input": "175000000", "output": "700000000" },
+      "qwen2-5-omni-7b": {
+        "input": "100000000",
+        "output": "400000000",
+        "inputAudio": "6760000000"
+      },
+      "qwen2-5-vl-72b-instruct": { "input": "2800000000", "output": "8400000000" },
+      "qwen2-5-vl-7b-instruct": { "input": "350000000", "output": "1050000000" },
+      "qwen3-14b": { "input": "350000000", "output": "1400000000", "reasoning": "4200000000" },
+      "qwen3-235b-a22b": {
+        "input": "700000000",
+        "output": "2800000000",
+        "reasoning": "8400000000"
+      },
+      "qwen3-32b": { "input": "700000000", "output": "2800000000", "reasoning": "8400000000" },
+      "qwen3-8b": { "input": "180000000", "output": "700000000", "reasoning": "2100000000" },
+      "qwen3-asr-flash": { "input": "35000000", "output": "35000000" },
+      "qwen3-coder-30b-a3b-instruct": { "input": "450000000", "output": "2250000000" },
+      "qwen3-coder-480b-a35b-instruct": { "input": "1500000000", "output": "7500000000" },
+      "qwen3-coder-flash": { "input": "300000000", "output": "1500000000" },
+      "qwen3-coder-plus": { "input": "1000000000", "output": "5000000000" },
+      "qwen3-livetranslate-flash-realtime": {
+        "input": "10000000000",
+        "output": "10000000000",
+        "inputAudio": "10000000000",
+        "outputAudio": "38000000000"
+      },
+      "qwen3-max": { "input": "1200000000", "output": "6000000000" },
+      "qwen3-next-80b-a3b-instruct": { "input": "500000000", "output": "2000000000" },
+      "qwen3-next-80b-a3b-thinking": { "input": "500000000", "output": "6000000000" },
+      "qwen3-omni-flash": {
+        "input": "430000000",
+        "output": "1660000000",
+        "inputAudio": "3810000000",
+        "outputAudio": "15110000000"
+      },
+      "qwen3-omni-flash-realtime": {
+        "input": "520000000",
+        "output": "1990000000",
+        "inputAudio": "4570000000",
+        "outputAudio": "18130000000"
+      },
+      "qwen3-vl-235b-a22b": {
+        "input": "700000000",
+        "output": "2800000000",
+        "reasoning": "8400000000"
+      },
+      "qwen3-vl-30b-a3b": {
+        "input": "200000000",
+        "output": "800000000",
+        "reasoning": "2400000000"
+      },
+      "qwen3-vl-plus": { "input": "200000000", "output": "1600000000", "reasoning": "4800000000" },
+      "qwen3.5-122b-a10b": { "input": "400000000", "output": "3200000000" },
+      "qwen3.5-27b": { "input": "300000000", "output": "2400000000" },
+      "qwen3.5-35b-a3b": { "input": "250000000", "output": "2000000000" },
+      "qwen3.5-397b-a17b": { "input": "600000000", "output": "3600000000" },
+      "qwen3.5-plus": { "input": "400000000", "output": "2400000000", "reasoning": "2400000000" },
+      "qwen3.6-27b": { "input": "600000000", "output": "3600000000" },
+      "qwen3.6-35b-a3b": { "input": "248000000", "output": "1485000000" },
+      "qwen3.6-flash": { "input": "187500000", "output": "1125000000", "cacheWrite": "234375000" },
+      "qwen3.6-max-preview": {
+        "input": "1300000000",
+        "output": "7800000000",
+        "cacheRead": "130000000",
+        "cacheWrite": "1625000000"
+      },
+      "qwen3.6-plus": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "200000000",
+            "cacheWrite": "2500000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3.7-max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "3125000000"
+      },
+      "qwen3.7-plus": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "200000000",
+            "cacheWrite": "2500000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3.8-max": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      },
+      "qwq-plus": { "input": "800000000", "output": "2400000000" }
+    },
+    "alibaba-cn": {
+      "deepseek-r1": { "input": "574000000", "output": "2294000000" },
+      "deepseek-r1-0528": { "input": "574000000", "output": "2294000000" },
+      "deepseek-r1-distill-llama-70b": { "input": "287000000", "output": "861000000" },
+      "deepseek-r1-distill-llama-8b": { "input": "0", "output": "0" },
+      "deepseek-r1-distill-qwen-1-5b": { "input": "0", "output": "0" },
+      "deepseek-r1-distill-qwen-14b": { "input": "144000000", "output": "431000000" },
+      "deepseek-r1-distill-qwen-32b": { "input": "287000000", "output": "861000000" },
+      "deepseek-r1-distill-qwen-7b": { "input": "72000000", "output": "144000000" },
+      "deepseek-v3": { "input": "287000000", "output": "1147000000" },
+      "deepseek-v3-1": { "input": "574000000", "output": "1721000000" },
+      "deepseek-v3-2-exp": { "input": "287000000", "output": "431000000" },
+      "deepseek-v4-flash": { "input": "140000000", "output": "280000000", "cacheRead": "2800000" },
+      "deepseek-v4-pro": { "input": "435000000", "output": "870000000", "cacheRead": "3625000" },
+      "glm-5": { "input": "860000000", "output": "3150000000" },
+      "glm-5.1": { "input": "870000000", "output": "3480000000", "cacheRead": "170000000" },
+      "glm-5.2": {
+        "input": "1100000000",
+        "output": "3851000000",
+        "cacheRead": "275000000",
+        "cacheWrite": "0"
+      },
+      "kimi-k2-thinking": { "input": "574000000", "output": "2294000000" },
+      "kimi-k2.5": { "input": "574000000", "output": "2411000000" },
+      "kimi-k2.6": { "input": "929000000", "output": "3858000000" },
+      "kimi/kimi-k2.5": { "input": "600000000", "output": "3000000000", "cacheRead": "100000000" },
+      "MiniMax-M2.5": { "input": "300000000", "output": "1200000000" },
+      "MiniMax/MiniMax-M2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "moonshot-kimi-k2-instruct": { "input": "574000000", "output": "2294000000" },
+      "qvq-max": { "input": "1147000000", "output": "4588000000" },
+      "qwen-deep-research": { "input": "7742000000", "output": "23367000000" },
+      "qwen-doc-turbo": { "input": "87000000", "output": "144000000" },
+      "qwen-flash": { "input": "22000000", "output": "216000000" },
+      "qwen-long": { "input": "72000000", "output": "287000000" },
+      "qwen-math-plus": { "input": "574000000", "output": "1721000000" },
+      "qwen-math-turbo": { "input": "287000000", "output": "861000000" },
+      "qwen-max": { "input": "345000000", "output": "1377000000" },
+      "qwen-mt-plus": { "input": "259000000", "output": "775000000" },
+      "qwen-mt-turbo": { "input": "101000000", "output": "280000000" },
+      "qwen-omni-turbo": {
+        "input": "58000000",
+        "output": "230000000",
+        "inputAudio": "3584000000",
+        "outputAudio": "7168000000"
+      },
+      "qwen-omni-turbo-realtime": {
+        "input": "230000000",
+        "output": "918000000",
+        "inputAudio": "3584000000",
+        "outputAudio": "7168000000"
+      },
+      "qwen-plus": {
+        "input": "115000000",
+        "output": "287000000",
+        "cacheRead": "12000000",
+        "cacheWrite": "144000000",
+        "reasoning": "1147000000"
+      },
+      "qwen-plus-character": { "input": "115000000", "output": "287000000" },
+      "qwen-turbo": { "input": "44000000", "output": "87000000", "reasoning": "431000000" },
+      "qwen-vl-max": { "input": "230000000", "output": "574000000" },
+      "qwen-vl-ocr": { "input": "717000000", "output": "717000000" },
+      "qwen-vl-plus": { "input": "115000000", "output": "287000000" },
+      "qwen2-5-14b-instruct": { "input": "144000000", "output": "431000000" },
+      "qwen2-5-32b-instruct": { "input": "287000000", "output": "861000000" },
+      "qwen2-5-72b-instruct": { "input": "574000000", "output": "1721000000" },
+      "qwen2-5-7b-instruct": { "input": "72000000", "output": "144000000" },
+      "qwen2-5-coder-32b-instruct": { "input": "287000000", "output": "861000000" },
+      "qwen2-5-coder-7b-instruct": { "input": "144000000", "output": "287000000" },
+      "qwen2-5-math-72b-instruct": { "input": "574000000", "output": "1721000000" },
+      "qwen2-5-math-7b-instruct": { "input": "144000000", "output": "287000000" },
+      "qwen2-5-omni-7b": { "input": "87000000", "output": "345000000", "inputAudio": "5448000000" },
+      "qwen2-5-vl-72b-instruct": { "input": "2294000000", "output": "6881000000" },
+      "qwen2-5-vl-7b-instruct": { "input": "287000000", "output": "717000000" },
+      "qwen3-14b": { "input": "144000000", "output": "574000000", "reasoning": "1434000000" },
+      "qwen3-235b-a22b": {
+        "input": "287000000",
+        "output": "1147000000",
+        "reasoning": "2868000000"
+      },
+      "qwen3-32b": { "input": "287000000", "output": "1147000000", "reasoning": "2868000000" },
+      "qwen3-8b": { "input": "72000000", "output": "287000000", "reasoning": "717000000" },
+      "qwen3-asr-flash": { "input": "32000000", "output": "32000000" },
+      "qwen3-coder-30b-a3b-instruct": { "input": "216000000", "output": "861000000" },
+      "qwen3-coder-480b-a35b-instruct": { "input": "861000000", "output": "3441000000" },
+      "qwen3-coder-flash": { "input": "144000000", "output": "574000000" },
+      "qwen3-coder-plus": { "input": "1000000000", "output": "5000000000" },
+      "qwen3-max": { "input": "861000000", "output": "3441000000" },
+      "qwen3-next-80b-a3b-instruct": { "input": "144000000", "output": "574000000" },
+      "qwen3-next-80b-a3b-thinking": { "input": "144000000", "output": "1434000000" },
+      "qwen3-omni-flash": {
+        "input": "58000000",
+        "output": "230000000",
+        "inputAudio": "3584000000",
+        "outputAudio": "7168000000"
+      },
+      "qwen3-omni-flash-realtime": {
+        "input": "230000000",
+        "output": "918000000",
+        "inputAudio": "3584000000",
+        "outputAudio": "7168000000"
+      },
+      "qwen3-vl-235b-a22b": {
+        "input": "286705000",
+        "output": "1146820000",
+        "reasoning": "2867051000"
+      },
+      "qwen3-vl-30b-a3b": {
+        "input": "108000000",
+        "output": "431000000",
+        "reasoning": "1076000000"
+      },
+      "qwen3-vl-plus": { "input": "143353000", "output": "1433525000", "reasoning": "4300576000" },
+      "qwen3.5-397b-a17b": {
+        "input": "430000000",
+        "output": "2580000000",
+        "reasoning": "2580000000"
+      },
+      "qwen3.5-flash": { "input": "172000000", "output": "1720000000", "reasoning": "1720000000" },
+      "qwen3.5-plus": { "input": "573000000", "output": "3440000000", "reasoning": "3440000000" },
+      "qwen3.6-flash": { "input": "187500000", "output": "1125000000", "cacheWrite": "234375000" },
+      "qwen3.6-max-preview": {
+        "input": "1320000000",
+        "output": "7900000000",
+        "cacheRead": "132000000"
+      },
+      "qwen3.6-plus": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "200000000",
+            "cacheWrite": "2500000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3.7-flash": {
+        "input": "29620000",
+        "output": "118500000",
+        "cacheRead": "2962000",
+        "cacheWrite": "37030000",
+        "tiers": [
+          {
+            "input": "88870000",
+            "output": "355490000",
+            "cacheRead": "8887000",
+            "cacheWrite": "111090000",
+            "aboveInputTokens": "32000"
+          },
+          {
+            "input": "177740000",
+            "output": "710980000",
+            "cacheRead": "17774000",
+            "cacheWrite": "222180000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3.7-max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "3125000000"
+      },
+      "qwen3.7-plus": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "200000000",
+            "cacheWrite": "2500000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "qwen3.8-max": {
+        "input": "1777440000",
+        "output": "5332310000",
+        "cacheRead": "222180000",
+        "cacheWrite": "2221790000"
+      },
+      "qwq-32b": { "input": "287000000", "output": "861000000" },
+      "qwq-plus": { "input": "230000000", "output": "574000000" },
+      "siliconflow/deepseek-r1-0528": { "input": "500000000", "output": "2180000000" },
+      "siliconflow/deepseek-v3-0324": { "input": "250000000", "output": "1000000000" },
+      "siliconflow/deepseek-v3.1-terminus": { "input": "270000000", "output": "1000000000" },
+      "siliconflow/deepseek-v3.2": { "input": "270000000", "output": "420000000" },
+      "tongyi-intent-detect-v3": { "input": "58000000", "output": "144000000" }
+    },
+    "alibaba-coding-plan": {
+      "glm-4.7": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "kimi-k2.5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "MiniMax-M2.5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3-coder-next": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3-coder-plus": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3-max-2026-01-23": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.5-plus": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.6-flash": { "input": "187500000", "output": "1125000000", "cacheWrite": "234375000" },
+      "qwen3.6-plus": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.7-max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "3125000000"
+      },
+      "qwen3.7-plus": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" }
+    },
+    "alibaba-coding-plan-cn": {
+      "glm-4.7": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "kimi-k2.5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "MiniMax-M2.5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3-coder-next": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3-coder-plus": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3-max-2026-01-23": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.5-plus": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.6-flash": { "input": "187500000", "output": "1125000000", "cacheWrite": "234375000" },
+      "qwen3.6-plus": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.7-max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "3125000000"
+      },
+      "qwen3.7-plus": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" }
+    },
+    "alibaba-token-plan": {
+      "deepseek-v3.2": { "input": "0", "output": "0" },
+      "deepseek-v4-flash": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "deepseek-v4-flash-0731": {
+        "input": "0",
+        "output": "0",
+        "cacheRead": "0",
+        "cacheWrite": "0"
+      },
+      "deepseek-v4-pro": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "deepseek-v4-pro-0813": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5.1": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5.2": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "happyhorse-1.1-i2v": { "input": "0", "output": "0" },
+      "happyhorse-1.1-r2v": { "input": "0", "output": "0" },
+      "happyhorse-1.1-t2v": { "input": "0", "output": "0" },
+      "kimi-k2.5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "kimi-k2.6": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "kimi-k2.7-code": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "MiniMax-M2.5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen-image-2.0": { "input": "0", "output": "0" },
+      "qwen-image-2.0-pro": { "input": "0", "output": "0" },
+      "qwen3.6-flash": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.6-plus": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.7-max": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.7-plus": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.8-max": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.8-max-preview": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "wan2.7-image": { "input": "0", "output": "0" },
+      "wan2.7-image-pro": { "input": "0", "output": "0" }
+    },
+    "alibaba-token-plan-cn": {
+      "deepseek-v3.2": { "input": "0", "output": "0" },
+      "deepseek-v4-flash": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "deepseek-v4-flash-0731": {
+        "input": "0",
+        "output": "0",
+        "cacheRead": "0",
+        "cacheWrite": "0"
+      },
+      "deepseek-v4-pro": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "deepseek-v4-pro-0813": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5.1": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5.2": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "happyhorse-1.1-i2v": { "input": "0", "output": "0" },
+      "happyhorse-1.1-r2v": { "input": "0", "output": "0" },
+      "happyhorse-1.1-t2v": { "input": "0", "output": "0" },
+      "kimi-k2.5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "kimi-k2.6": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "kimi-k2.7-code": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "MiniMax-M2.5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen-image-2.0": { "input": "0", "output": "0" },
+      "qwen-image-2.0-pro": { "input": "0", "output": "0" },
+      "qwen3.6-flash": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.6-plus": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.7-max": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.7-plus": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.8-max": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "qwen3.8-max-preview": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "wan2.7-image": { "input": "0", "output": "0" },
+      "wan2.7-image-pro": { "input": "0", "output": "0" }
+    },
+    "amazon-bedrock": {
+      "amazon.nova-2-lite-v1:0": { "input": "330000000", "output": "2750000000" },
+      "amazon.nova-lite-v1:0": {
+        "input": "60000000",
+        "output": "240000000",
+        "cacheRead": "15000000"
+      },
+      "amazon.nova-micro-v1:0": {
+        "input": "35000000",
+        "output": "140000000",
+        "cacheRead": "8750000"
+      },
+      "amazon.nova-pro-v1:0": {
+        "input": "800000000",
+        "output": "3200000000",
+        "cacheRead": "200000000"
+      },
+      "anthropic.claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic.claude-opus-4-1-20250805-v1:0": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic.claude-opus-4-5-20251101-v1:0": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic.claude-opus-4-6-v1": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic.claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic.claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic.claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic.claude-sonnet-4-5-20250929-v1:0": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic.claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic.claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "au.anthropic.claude-opus-4-6-v1": {
+        "input": "16500000000",
+        "output": "82500000000",
+        "cacheRead": "1650000000",
+        "cacheWrite": "20625000000"
+      },
+      "au.anthropic.claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "au.anthropic.claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "au.anthropic.claude-sonnet-4-6": {
+        "input": "3300000000",
+        "output": "16500000000",
+        "cacheRead": "330000000",
+        "cacheWrite": "4125000000"
+      },
+      "au.anthropic.claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "deepseek.r1-v1:0": { "input": "1350000000", "output": "5400000000" },
+      "deepseek.v3-v1:0": { "input": "580000000", "output": "1680000000" },
+      "deepseek.v3.2": { "input": "620000000", "output": "1850000000" },
+      "eu.anthropic.claude-fable-5": {
+        "input": "11000000000",
+        "output": "55000000000",
+        "cacheRead": "1100000000",
+        "cacheWrite": "13750000000"
+      },
+      "eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "input": "1100000000",
+        "output": "5500000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "1375000000"
+      },
+      "eu.anthropic.claude-opus-4-5-20251101-v1:0": {
+        "input": "5500000000",
+        "output": "27500000000",
+        "cacheRead": "550000000",
+        "cacheWrite": "6875000000"
+      },
+      "eu.anthropic.claude-opus-4-6-v1": {
+        "input": "5500000000",
+        "output": "27500000000",
+        "cacheRead": "550000000",
+        "cacheWrite": "6875000000"
+      },
+      "eu.anthropic.claude-opus-4-7": {
+        "input": "5500000000",
+        "output": "27500000000",
+        "cacheRead": "550000000",
+        "cacheWrite": "6875000000"
+      },
+      "eu.anthropic.claude-opus-4-8": {
+        "input": "5500000000",
+        "output": "27500000000",
+        "cacheRead": "550000000",
+        "cacheWrite": "6875000000"
+      },
+      "eu.anthropic.claude-opus-5": {
+        "input": "5500000000",
+        "output": "27500000000",
+        "cacheRead": "550000000",
+        "cacheWrite": "6875000000"
+      },
+      "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+        "input": "3300000000",
+        "output": "16500000000",
+        "cacheRead": "330000000",
+        "cacheWrite": "4125000000"
+      },
+      "eu.anthropic.claude-sonnet-4-6": {
+        "input": "3300000000",
+        "output": "16500000000",
+        "cacheRead": "330000000",
+        "cacheWrite": "4125000000"
+      },
+      "eu.anthropic.claude-sonnet-5": {
+        "input": "2200000000",
+        "output": "11000000000",
+        "cacheRead": "220000000",
+        "cacheWrite": "2750000000"
+      },
+      "global.anthropic.claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "global.anthropic.claude-opus-4-5-20251101-v1:0": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "global.anthropic.claude-opus-4-6-v1": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "global.anthropic.claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "global.anthropic.claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "global.anthropic.claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "global.anthropic.claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "global.anthropic.claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "global.openai.gpt-5.6-luna": {
+        "input": "220000000",
+        "output": "1320000000",
+        "cacheRead": "22000000",
+        "cacheWrite": "275000000",
+        "tiers": [
+          {
+            "input": "440000000",
+            "output": "1980000000",
+            "cacheRead": "44000000",
+            "cacheWrite": "550000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "global.openai.gpt-5.6-sol": {
+        "input": "5500000000",
+        "output": "33000000000",
+        "cacheRead": "550000000",
+        "cacheWrite": "6875000000",
+        "tiers": [
+          {
+            "input": "11000000000",
+            "output": "49500000000",
+            "cacheRead": "1100000000",
+            "cacheWrite": "13750000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "global.openai.gpt-5.6-terra": {
+        "input": "2200000000",
+        "output": "13200000000",
+        "cacheRead": "220000000",
+        "cacheWrite": "2750000000",
+        "tiers": [
+          {
+            "input": "4400000000",
+            "output": "19800000000",
+            "cacheRead": "440000000",
+            "cacheWrite": "5500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "google.gemma-3-12b-it": { "input": "50000000", "output": "100000000" },
+      "google.gemma-3-27b-it": { "input": "120000000", "output": "200000000" },
+      "google.gemma-3-4b-it": { "input": "40000000", "output": "80000000" },
+      "jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "jp.anthropic.claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "jp.anthropic.claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "jp.anthropic.claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "jp.anthropic.claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "jp.anthropic.claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "meta.llama3-1-70b-instruct-v1:0": { "input": "720000000", "output": "720000000" },
+      "meta.llama3-1-8b-instruct-v1:0": { "input": "220000000", "output": "220000000" },
+      "meta.llama3-3-70b-instruct-v1:0": { "input": "720000000", "output": "720000000" },
+      "meta.llama4-maverick-17b-instruct-v1:0": { "input": "240000000", "output": "970000000" },
+      "meta.llama4-scout-17b-instruct-v1:0": { "input": "170000000", "output": "660000000" },
+      "minimax.minimax-m2": { "input": "300000000", "output": "1200000000" },
+      "minimax.minimax-m2.1": { "input": "300000000", "output": "1200000000" },
+      "minimax.minimax-m2.5": { "input": "300000000", "output": "1200000000" },
+      "mistral.devstral-2-123b": { "input": "400000000", "output": "2000000000" },
+      "mistral.magistral-small-2509": { "input": "500000000", "output": "1500000000" },
+      "mistral.ministral-3-14b-instruct": { "input": "200000000", "output": "200000000" },
+      "mistral.ministral-3-3b-instruct": { "input": "100000000", "output": "100000000" },
+      "mistral.ministral-3-8b-instruct": { "input": "150000000", "output": "150000000" },
+      "mistral.mistral-large-3-675b-instruct": { "input": "500000000", "output": "1500000000" },
+      "mistral.pixtral-large-2502-v1:0": { "input": "2000000000", "output": "6000000000" },
+      "mistral.voxtral-mini-3b-2507": { "input": "40000000", "output": "40000000" },
+      "mistral.voxtral-small-24b-2507": { "input": "150000000", "output": "350000000" },
+      "moonshot.kimi-k2-thinking": { "input": "600000000", "output": "2500000000" },
+      "moonshotai.kimi-k2.5": { "input": "600000000", "output": "3000000000" },
+      "nvidia.nemotron-nano-12b-v2": { "input": "200000000", "output": "600000000" },
+      "nvidia.nemotron-nano-3-30b": { "input": "60000000", "output": "240000000" },
+      "nvidia.nemotron-nano-9b-v2": { "input": "60000000", "output": "230000000" },
+      "nvidia.nemotron-super-3-120b": { "input": "150000000", "output": "650000000" },
+      "openai.gpt-5.4": {
+        "input": "2750000000",
+        "output": "16500000000",
+        "cacheRead": "275000000"
+      },
+      "openai.gpt-5.5": {
+        "input": "5500000000",
+        "output": "33000000000",
+        "cacheRead": "550000000"
+      },
+      "openai.gpt-5.6-luna": {
+        "input": "220000000",
+        "output": "1320000000",
+        "cacheRead": "22000000",
+        "cacheWrite": "275000000",
+        "tiers": [
+          {
+            "input": "440000000",
+            "output": "1980000000",
+            "cacheRead": "44000000",
+            "cacheWrite": "550000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai.gpt-5.6-sol": {
+        "input": "5500000000",
+        "output": "33000000000",
+        "cacheRead": "550000000",
+        "cacheWrite": "6875000000",
+        "tiers": [
+          {
+            "input": "11000000000",
+            "output": "49500000000",
+            "cacheRead": "1100000000",
+            "cacheWrite": "13750000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai.gpt-5.6-terra": {
+        "input": "2200000000",
+        "output": "13200000000",
+        "cacheRead": "220000000",
+        "cacheWrite": "2750000000",
+        "tiers": [
+          {
+            "input": "4400000000",
+            "output": "19800000000",
+            "cacheRead": "440000000",
+            "cacheWrite": "5500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai.gpt-oss-120b": { "input": "150000000", "output": "600000000" },
+      "openai.gpt-oss-120b-1:0": { "input": "150000000", "output": "600000000" },
+      "openai.gpt-oss-20b": { "input": "70000000", "output": "300000000" },
+      "openai.gpt-oss-20b-1:0": { "input": "70000000", "output": "300000000" },
+      "openai.gpt-oss-safeguard-120b": { "input": "150000000", "output": "600000000" },
+      "openai.gpt-oss-safeguard-20b": { "input": "70000000", "output": "200000000" },
+      "qwen.qwen3-235b-a22b-2507-v1:0": { "input": "220000000", "output": "880000000" },
+      "qwen.qwen3-32b-v1:0": { "input": "150000000", "output": "600000000" },
+      "qwen.qwen3-coder-30b-a3b-v1:0": { "input": "150000000", "output": "600000000" },
+      "qwen.qwen3-coder-480b-a35b-v1:0": { "input": "220000000", "output": "1800000000" },
+      "qwen.qwen3-coder-next": { "input": "220000000", "output": "1800000000" },
+      "qwen.qwen3-next-80b-a3b": { "input": "140000000", "output": "1400000000" },
+      "qwen.qwen3-vl-235b-a22b": { "input": "300000000", "output": "1500000000" },
+      "us.anthropic.claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "us.anthropic.claude-opus-4-1-20250805-v1:0": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "us.anthropic.claude-opus-4-5-20251101-v1:0": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "us.anthropic.claude-opus-4-6-v1": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "us.anthropic.claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "us.anthropic.claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "us.anthropic.claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "us.anthropic.claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "us.anthropic.claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "us.deepseek.r1-v1:0": { "input": "1350000000", "output": "5400000000" },
+      "us.meta.llama4-maverick-17b-instruct-v1:0": { "input": "240000000", "output": "970000000" },
+      "us.meta.llama4-scout-17b-instruct-v1:0": { "input": "170000000", "output": "660000000" },
+      "writer.palmyra-x4-v1:0": { "input": "2500000000", "output": "10000000000" },
+      "writer.palmyra-x5-v1:0": { "input": "600000000", "output": "6000000000" },
+      "xai.grok-4.3": { "input": "1250000000", "output": "2500000000", "cacheRead": "200000000" },
+      "xai.grok-4.6": { "input": "2200000000", "output": "6600000000", "cacheRead": "550000000" },
+      "zai.glm-4.7": { "input": "600000000", "output": "2200000000" },
+      "zai.glm-4.7-flash": { "input": "70000000", "output": "400000000" },
+      "zai.glm-5": { "input": "1000000000", "output": "3200000000" }
+    },
+    "ambient": {
+      "ambient/large": {
+        "input": "600000000",
+        "output": "2000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "0"
+      },
+      "deepseek/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000",
+        "cacheWrite": "0"
+      },
+      "deepseek/deepseek-v4-flash-0731": {
+        "input": "80000000",
+        "output": "180000000",
+        "cacheRead": "16000000",
+        "cacheWrite": "0"
+      },
+      "moonshotai/kimi-k2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "0"
+      },
+      "moonshotai/kimi-k2.7-code": {
+        "input": "690000000",
+        "output": "3490000000",
+        "cacheRead": "140000000",
+        "cacheWrite": "0"
+      },
+      "stepfun/step-3.7-flash": {
+        "input": "190000000",
+        "output": "1140000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "0"
+      },
+      "xiaomi/mimo-v2.5": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "0"
+      },
+      "z-ai/glm-5.2": {
+        "input": "600000000",
+        "output": "2000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "0"
+      },
+      "zai-org/GLM-5.1-FP8": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "0",
+        "cacheWrite": "0"
+      },
+      "zai-org/GLM-5.2-FP8": {
+        "input": "1200000000",
+        "output": "4200000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "0"
+      }
+    },
+    "amd": {
+      "DeepSeek-V4-Flash": { "input": "140000000", "output": "280000000", "cacheRead": "2800000" }
+    },
+    "anthropic": {
+      "claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-haiku-4-5-20251001": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-opus-4-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-5-20251101": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "modes": {
+          "fast": {
+            "input": "10000000000",
+            "output": "50000000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000"
+          }
+        }
+      },
+      "claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "modes": {
+          "fast": {
+            "input": "10000000000",
+            "output": "50000000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000"
+          }
+        }
+      },
+      "claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-4-5-20250929": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      }
+    },
+    "arcee": {
+      "deepseek/deepseek-v4-flash-latest": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "200000000"
+      },
+      "deepseek/deepseek-v4-pro-0813": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "44000000"
+      },
+      "moonshotai/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "thinkingmachines/inkling-small": {
+        "input": "500000000",
+        "output": "1200000000",
+        "cacheRead": "100000000"
+      },
+      "trinity-large-thinking": {
+        "input": "250000000",
+        "output": "800000000",
+        "cacheRead": "60000000"
+      },
+      "zai-org/glm-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" }
+    },
+    "atomic-chat": {
+      "gemma-4-E4B-it-IQ4_XS": { "input": "0", "output": "0" },
+      "gemma-4-E4B-it-MLX-4bit": { "input": "0", "output": "0" },
+      "Meta-Llama-3_1-8B-Instruct-GGUF": { "input": "0", "output": "0" },
+      "Qwen3_5-9B-MLX-4bit": { "input": "0", "output": "0" },
+      "Qwen3_5-9B-Q4_K_M": { "input": "0", "output": "0" }
+    },
+    "auriko": {
+      "claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "modes": {
+          "fast": {
+            "input": "30000000000",
+            "output": "150000000000",
+            "cacheRead": "3000000000",
+            "cacheWrite": "37500000000"
+          }
+        }
+      },
+      "claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "deepseek-v4-flash": { "input": "140000000", "output": "280000000", "cacheRead": "2800000" },
+      "deepseek-v4-pro": { "input": "435000000", "output": "870000000", "cacheRead": "3625000" },
+      "gemini-2.5-flash": { "input": "300000000", "output": "2500000000", "cacheRead": "30000000" },
+      "gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "glm-5.1": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "grok-4.3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "kimi-k2.5": { "input": "500000000", "output": "2800000000" },
+      "kimi-k2.6": { "input": "950000000", "output": "4000000000", "cacheRead": "160000000" },
+      "minimax-m2-7": { "input": "300000000", "output": "1200000000", "cacheWrite": "375000000" },
+      "minimax-m2-7-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheWrite": "375000000"
+      },
+      "qwen-3.6-plus": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "100000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "200000000",
+            "cacheWrite": "2500000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      }
+    },
+    "azure": {
+      "claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-mythos-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "claude-opus-4-1": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "claude-opus-4-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "codestral-2501": { "input": "300000000", "output": "900000000" },
+      "codex-mini": { "input": "1500000000", "output": "6000000000", "cacheRead": "375000000" },
+      "cohere-command-a": { "input": "2500000000", "output": "10000000000" },
+      "cohere-embed-v-4-0": { "input": "120000000", "output": "0" },
+      "cohere-embed-v3-english": { "input": "100000000", "output": "0" },
+      "cohere-embed-v3-multilingual": { "input": "100000000", "output": "0" },
+      "deepseek-r1": { "input": "1350000000", "output": "5400000000" },
+      "deepseek-v3.2": { "input": "580000000", "output": "1680000000" },
+      "deepseek-v3.2-speciale": { "input": "580000000", "output": "1680000000" },
+      "deepseek-v4-flash": { "input": "190000000", "output": "510000000" },
+      "deepseek-v4-pro": { "input": "1740000000", "output": "3480000000" },
+      "gpt-3.5-turbo-0125": { "input": "500000000", "output": "1500000000" },
+      "gpt-3.5-turbo-1106": { "input": "1000000000", "output": "2000000000" },
+      "gpt-3.5-turbo-instruct": { "input": "1500000000", "output": "2000000000" },
+      "gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "gpt-4-turbo-vision": { "input": "10000000000", "output": "30000000000" },
+      "gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "gpt-4.1-mini": { "input": "400000000", "output": "1600000000", "cacheRead": "100000000" },
+      "gpt-4.1-nano": { "input": "100000000", "output": "400000000", "cacheRead": "25000000" },
+      "gpt-4o": { "input": "2500000000", "output": "10000000000", "cacheRead": "1250000000" },
+      "gpt-4o-mini": { "input": "150000000", "output": "600000000", "cacheRead": "75000000" },
+      "gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "130000000" },
+      "gpt-5-codex": { "input": "1250000000", "output": "10000000000", "cacheRead": "130000000" },
+      "gpt-5-mini": { "input": "250000000", "output": "2000000000", "cacheRead": "30000000" },
+      "gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "10000000" },
+      "gpt-5-pro": { "input": "15000000000", "output": "120000000000" },
+      "gpt-5.1": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5.1-codex": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5.1-codex-max": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "gpt-5.2": { "input": "1750000000", "output": "14000000000", "cacheRead": "125000000" },
+      "gpt-5.2-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.3-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.4-mini": { "input": "750000000", "output": "4500000000", "cacheRead": "75000000" },
+      "gpt-5.4-nano": { "input": "200000000", "output": "1250000000", "cacheRead": "20000000" },
+      "gpt-5.4-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000",
+        "tiers": [
+          {
+            "input": "400000000",
+            "output": "1800000000",
+            "cacheRead": "40000000",
+            "cacheWrite": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "5000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-chat-latest": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "gpt-image-1": { "input": "5000000000", "output": "40000000000", "cacheRead": "1250000000" },
+      "gpt-image-1.5": {
+        "input": "5000000000",
+        "output": "32000000000",
+        "cacheRead": "1250000000"
+      },
+      "gpt-image-2": { "input": "5000000000", "output": "30000000000", "cacheRead": "1250000000" },
+      "grok-4-1-fast-non-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "grok-4-1-fast-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "grok-4-20-non-reasoning": { "input": "2000000000", "output": "6000000000" },
+      "grok-4-20-reasoning": { "input": "2000000000", "output": "6000000000" },
+      "kimi-k2.5": { "input": "600000000", "output": "3000000000" },
+      "kimi-k2.6": { "input": "950000000", "output": "4000000000" },
+      "kimi-k2.7-code": { "input": "950000000", "output": "4000000000", "cacheRead": "190000000" },
+      "llama-3.3-70b-instruct": { "input": "710000000", "output": "710000000" },
+      "llama-4-maverick-17b-128e-instruct-fp8": { "input": "250000000", "output": "1000000000" },
+      "llama-4-scout-17b-16e-instruct": { "input": "200000000", "output": "780000000" },
+      "ministral-3b": { "input": "40000000", "output": "40000000" },
+      "mistral-medium-2505": { "input": "400000000", "output": "2000000000" },
+      "mistral-small-2503": { "input": "100000000", "output": "300000000" },
+      "model-router": { "input": "140000000", "output": "0" },
+      "o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "phi-4": { "input": "125000000", "output": "500000000" },
+      "phi-4-mini": { "input": "75000000", "output": "300000000" },
+      "phi-4-mini-reasoning": { "input": "75000000", "output": "300000000" },
+      "phi-4-multimodal": {
+        "input": "80000000",
+        "output": "320000000",
+        "inputAudio": "4000000000"
+      },
+      "phi-4-reasoning": { "input": "125000000", "output": "500000000" },
+      "phi-4-reasoning-plus": { "input": "125000000", "output": "500000000" },
+      "text-embedding-3-large": { "input": "130000000", "output": "0" },
+      "text-embedding-3-small": { "input": "20000000", "output": "0" },
+      "text-embedding-ada-002": { "input": "100000000", "output": "0" }
+    },
+    "azure-cognitive-services": {
+      "claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-mythos-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "claude-opus-4-1": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "claude-opus-4-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "codestral-2501": { "input": "300000000", "output": "900000000" },
+      "codex-mini": { "input": "1500000000", "output": "6000000000", "cacheRead": "375000000" },
+      "cohere-command-a": { "input": "2500000000", "output": "10000000000" },
+      "cohere-embed-v-4-0": { "input": "120000000", "output": "0" },
+      "cohere-embed-v3-english": { "input": "100000000", "output": "0" },
+      "cohere-embed-v3-multilingual": { "input": "100000000", "output": "0" },
+      "deepseek-r1": { "input": "1350000000", "output": "5400000000" },
+      "deepseek-v3.2": { "input": "580000000", "output": "1680000000" },
+      "deepseek-v3.2-speciale": { "input": "580000000", "output": "1680000000" },
+      "gpt-3.5-turbo-0125": { "input": "500000000", "output": "1500000000" },
+      "gpt-3.5-turbo-1106": { "input": "1000000000", "output": "2000000000" },
+      "gpt-3.5-turbo-instruct": { "input": "1500000000", "output": "2000000000" },
+      "gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "gpt-4-turbo-vision": { "input": "10000000000", "output": "30000000000" },
+      "gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "gpt-4.1-mini": { "input": "400000000", "output": "1600000000", "cacheRead": "100000000" },
+      "gpt-4.1-nano": { "input": "100000000", "output": "400000000", "cacheRead": "25000000" },
+      "gpt-4o": { "input": "2500000000", "output": "10000000000", "cacheRead": "1250000000" },
+      "gpt-4o-mini": { "input": "150000000", "output": "600000000", "cacheRead": "75000000" },
+      "gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "130000000" },
+      "gpt-5-codex": { "input": "1250000000", "output": "10000000000", "cacheRead": "130000000" },
+      "gpt-5-mini": { "input": "250000000", "output": "2000000000", "cacheRead": "30000000" },
+      "gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "10000000" },
+      "gpt-5-pro": { "input": "15000000000", "output": "120000000000" },
+      "gpt-5.1": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5.1-codex": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "gpt-5.2": { "input": "1750000000", "output": "14000000000", "cacheRead": "125000000" },
+      "gpt-5.2-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.3-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.4-mini": { "input": "750000000", "output": "4500000000", "cacheRead": "75000000" },
+      "gpt-5.4-nano": { "input": "200000000", "output": "1250000000", "cacheRead": "20000000" },
+      "gpt-5.4-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-luna": {
+        "input": "1000000000",
+        "output": "6000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "9000000000",
+            "cacheRead": "200000000",
+            "cacheWrite": "2500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-terra": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "3125000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "cacheWrite": "6250000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-chat-latest": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "kimi-k2.5": { "input": "600000000", "output": "3000000000" },
+      "kimi-k2.6": { "input": "950000000", "output": "4000000000" },
+      "llama-3.3-70b-instruct": { "input": "710000000", "output": "710000000" },
+      "llama-4-maverick-17b-128e-instruct-fp8": { "input": "250000000", "output": "1000000000" },
+      "llama-4-scout-17b-16e-instruct": { "input": "200000000", "output": "780000000" },
+      "ministral-3b": { "input": "40000000", "output": "40000000" },
+      "mistral-medium-2505": { "input": "400000000", "output": "2000000000" },
+      "mistral-small-2503": { "input": "100000000", "output": "300000000" },
+      "model-router": { "input": "140000000", "output": "0" },
+      "o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "phi-4": { "input": "125000000", "output": "500000000" },
+      "phi-4-mini": { "input": "75000000", "output": "300000000" },
+      "phi-4-mini-reasoning": { "input": "75000000", "output": "300000000" },
+      "phi-4-multimodal": {
+        "input": "80000000",
+        "output": "320000000",
+        "inputAudio": "4000000000"
+      },
+      "phi-4-reasoning": { "input": "125000000", "output": "500000000" },
+      "phi-4-reasoning-plus": { "input": "125000000", "output": "500000000" },
+      "text-embedding-3-large": { "input": "130000000", "output": "0" },
+      "text-embedding-3-small": { "input": "20000000", "output": "0" },
+      "text-embedding-ada-002": { "input": "100000000", "output": "0" }
+    },
+    "bailing": {
+      "Ling-1T": { "input": "570000000", "output": "2290000000" },
+      "Ring-1T": { "input": "570000000", "output": "2290000000" }
+    },
+    "baseten": {
+      "deepseek-ai/DeepSeek-V3.1": { "input": "500000000", "output": "1500000000" },
+      "deepseek-ai/DeepSeek-V4-Flash-0731": {
+        "input": "130000000",
+        "output": "260000000",
+        "cacheRead": "28000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "145000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro-0813": { "input": "1320000000", "output": "3960000000" },
+      "MiniMaxAI/MiniMax-M2.5": { "input": "300000000", "output": "1200000000" },
+      "moonshotai/Kimi-K2.5": {
+        "input": "600000000",
+        "output": "3000000000",
+        "cacheRead": "120000000"
+      },
+      "moonshotai/Kimi-K2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "moonshotai/Kimi-K2.7-Code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "moonshotai/Kimi-K3": { "input": "3000000000", "output": "15000000000" },
+      "nvidia/Nemotron-120B-A12B": {
+        "input": "300000000",
+        "output": "750000000",
+        "cacheRead": "60000000"
+      },
+      "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "120000000"
+      },
+      "openai/gpt-oss-120b": { "input": "100000000", "output": "500000000" },
+      "thinkingmachines/inkling": { "input": "1000000000", "output": "4050000000" },
+      "thinkingmachines/inkling-small": {
+        "input": "500000000",
+        "output": "1200000000",
+        "cacheRead": "100000000"
+      },
+      "zai-org/GLM-4.7": { "input": "600000000", "output": "2200000000", "cacheRead": "120000000" },
+      "zai-org/GLM-5": { "input": "950000000", "output": "3150000000", "cacheRead": "200000000" },
+      "zai-org/GLM-5.1": {
+        "input": "1300000000",
+        "output": "4300000000",
+        "cacheRead": "260000000"
+      },
+      "zai-org/GLM-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "300000000"
+      },
+      "zai-org/GLM-5.2-Fast": {
+        "input": "2100000000",
+        "output": "6600000000",
+        "cacheRead": "210000000"
+      }
+    },
+    "berget": {
+      "google/gemma-4-31B-it": { "input": "275000000", "output": "550000000" },
+      "meta-llama/Llama-3.3-70B-Instruct": { "input": "990000000", "output": "990000000" },
+      "mistralai/Mistral-Medium-3.5-128B": { "input": "1650000000", "output": "5500000000" },
+      "mistralai/Mistral-Small-3.2-24B-Instruct-2506": {
+        "input": "330000000",
+        "output": "330000000"
+      },
+      "moonshotai/Kimi-K2.6": {
+        "input": "830000000",
+        "output": "3850000000",
+        "cacheRead": "160000000"
+      },
+      "moonshotai/Kimi-K3": { "input": "3000000000", "output": "15000000000" },
+      "openai/gpt-oss-120b": { "input": "220000000", "output": "830000000" },
+      "zai-org/GLM-4.7": { "input": "770000000", "output": "2750000000" },
+      "zai-org/GLM-5.2": { "input": "1540000000", "output": "4840000000" }
+    },
+    "cerebras": {
+      "gemma-4-31b": { "input": "990000000", "output": "1490000000" },
+      "gpt-oss-120b": { "input": "350000000", "output": "750000000" }
+    },
+    "chutes": {
+      "deepseek-ai/DeepSeek-V3.2-TEE": {
+        "input": "1000000000",
+        "output": "1000000000",
+        "cacheRead": "100000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Flash-0731-TEE": {
+        "input": "440000000",
+        "output": "1320000000",
+        "cacheRead": "44000000"
+      },
+      "google/gemma-4-31B-turbo-TEE": {
+        "input": "120000000",
+        "output": "370000000",
+        "cacheRead": "12000000"
+      },
+      "moonshotai/Kimi-K2.6-TEE": {
+        "input": "580000000",
+        "output": "3400000000",
+        "cacheRead": "58000000"
+      },
+      "moonshotai/Kimi-K3-TEE": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "Nemotron-3-Nano-Omni-30B-TEE": {
+        "input": "24500000",
+        "output": "97800000",
+        "cacheRead": "2450000"
+      },
+      "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE": {
+        "input": "298900000",
+        "output": "1195700000",
+        "cacheRead": "29890000"
+      },
+      "Qwen/Qwen3-32B-TEE": {
+        "input": "104000000",
+        "output": "416000000",
+        "cacheRead": "10400000"
+      },
+      "Qwen/Qwen3.5-397B-A17B-TEE": {
+        "input": "450000000",
+        "output": "3000000000",
+        "cacheRead": "45000000"
+      },
+      "Qwen/Qwen3.6-27B-TEE": {
+        "input": "300000000",
+        "output": "2000000000",
+        "cacheRead": "30000000"
+      },
+      "Qwen/Qwen3.8-27B-TEE": {
+        "input": "350000000",
+        "output": "2750000000",
+        "cacheRead": "35000000"
+      },
+      "unsloth/Mistral-Nemo-Instruct-2407-TEE": {
+        "input": "24500000",
+        "output": "97800000",
+        "cacheRead": "2450000"
+      },
+      "zai-org/GLM-5.1-TEE": {
+        "input": "980000000",
+        "output": "3080000000",
+        "cacheRead": "98000000"
+      },
+      "zai-org/GLM-5.2-TEE": {
+        "input": "1250000000",
+        "output": "3950000000",
+        "cacheRead": "125000000"
+      }
+    },
+    "clarifai": {
+      "arcee_ai/AFM/models/trinity-mini": { "input": "45000000", "output": "150000000" },
+      "clarifai/main/models/mm-poly-8b": { "input": "658000000", "output": "1110000000" },
+      "deepseek-ai/deepseek-ocr/models/DeepSeek-OCR": {
+        "input": "200000000",
+        "output": "700000000"
+      },
+      "minimaxai/chat-completion/models/MiniMax-M2_5-high-throughput": {
+        "input": "300000000",
+        "output": "1200000000"
+      },
+      "mistralai/completion/models/Ministral-3-14B-Reasoning-2512": {
+        "input": "2500000000",
+        "output": "1700000000"
+      },
+      "mistralai/completion/models/Ministral-3-3B-Reasoning-2512": {
+        "input": "1039000000",
+        "output": "548250000"
+      },
+      "moonshotai/chat-completion/models/Kimi-K2_6": {
+        "input": "950000000",
+        "output": "4000000000"
+      },
+      "openai/chat-completion/models/gpt-oss-120b-high-throughput": {
+        "input": "90000000",
+        "output": "360000000"
+      },
+      "openai/chat-completion/models/gpt-oss-20b": { "input": "45000000", "output": "180000000" },
+      "qwen/qwenCoder/models/Qwen3-Coder-30B-A3B-Instruct": {
+        "input": "114580000",
+        "output": "748120000"
+      },
+      "qwen/qwenLM/models/Qwen3-30B-A3B-Instruct-2507": {
+        "input": "300000000",
+        "output": "500000000"
+      },
+      "qwen/qwenLM/models/Qwen3-30B-A3B-Thinking-2507": {
+        "input": "360000000",
+        "output": "1300000000"
+      }
+    },
+    "claudinio": {
+      "claudinio": { "input": "500000000", "output": "2000000000", "cacheRead": "150000000" },
+      "claudius": { "input": "3000000000", "output": "8000000000", "cacheRead": "900000000" }
+    },
+    "cline-pass": {
+      "cline-pass/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "2800000"
+      },
+      "cline-pass/deepseek-v4-pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "14500000"
+      },
+      "cline-pass/glm-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "cline-pass/glm-5.3": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "cline-pass/kimi-k2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "cline-pass/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "cline-pass/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "cline-pass/mimo-v2.5": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "2800000"
+      },
+      "cline-pass/mimo-v2.5-pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "14500000"
+      },
+      "cline-pass/minimax-m3": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "cline-pass/qwen3.7-max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "3125000000"
+      },
+      "cline-pass/qwen3.7-plus": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "40000000",
+        "cacheWrite": "500000000",
+        "tiers": [
+          {
+            "input": "1200000000",
+            "output": "4800000000",
+            "cacheRead": "120000000",
+            "cacheWrite": "1500000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "cline-pass/qwen3.8-max": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      }
+    },
+    "cloudferro-sherlock": {
+      "meta-llama/Llama-3.3-70B-Instruct": { "input": "2920000000", "output": "2920000000" },
+      "MiniMaxAI/MiniMax-M2.5": { "input": "300000000", "output": "1200000000" },
+      "openai/gpt-oss-120b": { "input": "2920000000", "output": "2920000000" },
+      "speakleash/Bielik-11B-v2.6-Instruct": { "input": "670000000", "output": "670000000" },
+      "speakleash/Bielik-11B-v3.0-Instruct": { "input": "670000000", "output": "670000000" }
+    },
+    "cloudflare-ai-gateway": {
+      "alibaba/qwen3-max": { "input": "1200000000", "output": "6000000000" },
+      "alibaba/qwen3.5-397b-a17b": { "input": "600000000", "output": "3600000000" },
+      "alibaba/qwen3.7-max": {
+        "input": "1250000000",
+        "output": "3750000000",
+        "cacheRead": "250000000"
+      },
+      "alibaba/qwen3.7-plus": {
+        "input": "320000000",
+        "output": "1280000000",
+        "cacheRead": "64000000"
+      },
+      "alibaba/qwen3.8-max": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000"
+      },
+      "anthropic/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-haiku-4.5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic/claude-opus-4.5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-sonnet-4.5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4.6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "145000000"
+      },
+      "moonshotai/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "openai/gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/gpt-4.1-mini": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "100000000"
+      },
+      "openai/gpt-4.1-nano": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-4o": { "input": "1250000000", "output": "5000000000", "cacheRead": "625000000" },
+      "openai/gpt-4o-mini": { "input": "75000000", "output": "300000000", "cacheRead": "37500000" },
+      "openai/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "openai/gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "openai/gpt-5.1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000"
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "openai/gpt-5.4-pro": { "input": "30000000000", "output": "180000000000" },
+      "openai/gpt-5.5": { "input": "5000000000", "output": "30000000000" },
+      "openai/gpt-5.5-pro": { "input": "30000000000", "output": "180000000000" },
+      "openai/gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000"
+      },
+      "openai/gpt-5.6-sol": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "3125000000"
+      },
+      "openai/gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "openai/o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "openai/o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "xai/grok-4.20-0309-non-reasoning": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000"
+      },
+      "xai/grok-4.20-0309-reasoning": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000"
+      },
+      "xai/grok-4.3": { "input": "1250000000", "output": "2500000000", "cacheRead": "200000000" },
+      "xai/grok-4.5": { "input": "2000000000", "output": "6000000000", "cacheRead": "300000000" },
+      "xai/grok-4.6": { "input": "2000000000", "output": "6000000000", "cacheRead": "500000000" }
+    },
+    "cloudflare-workers-ai": {
+      "@cf/aisingapore/gemma-sea-lion-v4-27b-it": { "input": "351000000", "output": "555000000" },
+      "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
+        "input": "497000000",
+        "output": "4881000000"
+      },
+      "@cf/deepseek-ai/deepseek-v4-flash-0731": {
+        "input": "440000000",
+        "output": "1320000000",
+        "cacheRead": "14000000"
+      },
+      "@cf/deepseek-ai/deepseek-v4-pro-0813": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "44000000"
+      },
+      "@cf/google/gemma-4-26b-a4b-it": { "input": "100000000", "output": "300000000" },
+      "@cf/ibm-granite/granite-4.0-h-micro": { "input": "17000000", "output": "112000000" },
+      "@cf/meta/llama-3.1-8b-instruct-fp8": { "input": "152000000", "output": "287000000" },
+      "@cf/meta/llama-3.2-11b-vision-instruct": { "input": "48500000", "output": "676000000" },
+      "@cf/meta/llama-3.2-1b-instruct": { "input": "27000000", "output": "201000000" },
+      "@cf/meta/llama-3.2-3b-instruct": { "input": "50900000", "output": "335000000" },
+      "@cf/meta/llama-3.3-70b-instruct-fp8-fast": { "input": "293000000", "output": "2253000000" },
+      "@cf/meta/llama-4-scout-17b-16e-instruct": { "input": "270000000", "output": "850000000" },
+      "@cf/meta/llama-guard-3-8b": { "input": "484000000", "output": "30000000" },
+      "@cf/mistralai/mistral-small-3.1-24b-instruct": {
+        "input": "351000000",
+        "output": "555000000"
+      },
+      "@cf/moonshotai/kimi-k2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "@cf/moonshotai/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "@cf/nvidia/nemotron-3-120b-a12b": { "input": "500000000", "output": "1500000000" },
+      "@cf/openai/gpt-oss-120b": { "input": "350000000", "output": "750000000" },
+      "@cf/openai/gpt-oss-20b": { "input": "200000000", "output": "300000000" },
+      "@cf/qwen/qwen2.5-coder-32b-instruct": { "input": "660000000", "output": "1000000000" },
+      "@cf/qwen/qwen3-30b-a3b-fp8": { "input": "50900000", "output": "335000000" },
+      "@cf/qwen/qwen3.8-27b": {
+        "input": "450000000",
+        "output": "3200000000",
+        "cacheRead": "50000000"
+      },
+      "@cf/qwen/qwq-32b": { "input": "660000000", "output": "1000000000" },
+      "@cf/zai-org/glm-4.7-flash": { "input": "60500000", "output": "400000000" },
+      "@cf/zai-org/glm-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      }
+    },
+    "cohere": {
+      "command-a-03-2025": { "input": "2500000000", "output": "10000000000" },
+      "command-a-plus-05-2026": { "input": "2500000000", "output": "10000000000" },
+      "command-a-reasoning-08-2025": { "input": "2500000000", "output": "10000000000" },
+      "command-a-translate-08-2025": { "input": "2500000000", "output": "10000000000" },
+      "command-a-vision-07-2025": { "input": "2500000000", "output": "10000000000" },
+      "command-r-08-2024": { "input": "150000000", "output": "600000000" },
+      "command-r-plus-08-2024": { "input": "2500000000", "output": "10000000000" },
+      "command-r7b-12-2024": { "input": "37500000", "output": "150000000" },
+      "command-r7b-arabic-02-2025": { "input": "37500000", "output": "150000000" },
+      "north-mini-code-1-0": { "input": "0", "output": "0" }
+    },
+    "coralbricks": {
+      "glm-5.2-fp4": { "input": "1120000000", "output": "4400000000", "cacheRead": "0" },
+      "gpt-oss-120b": { "input": "120000000", "output": "600000000", "cacheRead": "0" },
+      "kimi-k3": { "input": "3000000000", "output": "15000000000", "cacheRead": "0" }
+    },
+    "cortecs": {
+      "apertus-70b": { "input": "1393000000", "output": "2228000000" },
+      "claude-4-5-sonnet": {
+        "input": "2989000000",
+        "output": "14945000000",
+        "cacheRead": "326000000",
+        "cacheWrite": "4078000000"
+      },
+      "claude-4-6-sonnet": {
+        "input": "3196000000",
+        "output": "15940000000",
+        "cacheRead": "320000000",
+        "cacheWrite": "3999000000"
+      },
+      "claude-haiku-4-5": {
+        "input": "996000000",
+        "output": "4982000000",
+        "cacheRead": "99000000",
+        "cacheWrite": "1186000000"
+      },
+      "claude-opus-5": {
+        "input": "5500000000",
+        "output": "27498000000",
+        "cacheRead": "550000000",
+        "cacheWrite": "6874000000"
+      },
+      "claude-opus4-5": {
+        "input": "5313000000",
+        "output": "26568000000",
+        "cacheRead": "531000000",
+        "cacheWrite": "6645000000"
+      },
+      "claude-opus4-6": {
+        "input": "5313000000",
+        "output": "26561000000",
+        "cacheRead": "531000000",
+        "cacheWrite": "6645000000"
+      },
+      "claude-opus4-7": {
+        "input": "5437000000",
+        "output": "27186000000",
+        "cacheRead": "544000000",
+        "cacheWrite": "6797000000"
+      },
+      "claude-opus4-8": {
+        "input": "5437000000",
+        "output": "27186000000",
+        "cacheRead": "544000000",
+        "cacheWrite": "6797000000"
+      },
+      "claude-sonnet-4": {
+        "input": "2898000000",
+        "output": "14493000000",
+        "cacheRead": "290000000",
+        "cacheWrite": "3624000000"
+      },
+      "claude-sonnet-5": {
+        "input": "2200000000",
+        "output": "11000000000",
+        "cacheRead": "219000000",
+        "cacheWrite": "2749000000"
+      },
+      "codestral-2508": { "input": "334000000", "output": "1003000000", "cacheRead": "33000000" },
+      "cosmos3-super-reasoner": { "input": "99000000", "output": "296000000" },
+      "deepseek-r1-0528": {
+        "input": "652000000",
+        "output": "2570000000",
+        "cacheRead": "163000000"
+      },
+      "deepseek-v3.2": { "input": "296000000", "output": "495000000", "cacheRead": "75000000" },
+      "deepseek-v4-flash-0731": {
+        "input": "130000000",
+        "output": "280000000",
+        "cacheRead": "30000000"
+      },
+      "deepseek-v4-pro": {
+        "input": "1730000000",
+        "output": "3460000000",
+        "cacheRead": "432000000"
+      },
+      "devstral-2512": { "input": "446000000", "output": "2228000000", "cacheRead": "45000000" },
+      "gemini-2.5-flash": {
+        "input": "299000000",
+        "output": "2491000000",
+        "cacheRead": "29000000",
+        "cacheWrite": "97000000"
+      },
+      "gemini-2.5-pro": {
+        "input": "1495000000",
+        "output": "9964000000",
+        "cacheRead": "242000000",
+        "cacheWrite": "434000000"
+      },
+      "gemini-3.1-flash-lite": {
+        "input": "272000000",
+        "output": "1631000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "82000000"
+      },
+      "gemini-3.5-flash": {
+        "input": "1649000000",
+        "output": "9899000000",
+        "cacheRead": "165000000",
+        "cacheWrite": "1000000000"
+      },
+      "gemini-3.5-flash-lite": {
+        "input": "330000000",
+        "output": "2749000000",
+        "cacheRead": "33000000"
+      },
+      "gemini-3.6-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "38000000"
+      },
+      "gemini-3.7-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "38000000"
+      },
+      "gemma-3-27b-it": { "input": "99000000", "output": "299000000" },
+      "gemma-4-26b-a4b-it": { "input": "111000000", "output": "557000000" },
+      "gemma-4-31b-it": { "input": "223000000", "output": "390000000" },
+      "glm-4.7": { "input": "780000000", "output": "2785000000" },
+      "glm-4.7-flash": { "input": "80000000", "output": "478000000" },
+      "glm-5": { "input": "988000000", "output": "3164000000", "cacheRead": "247000000" },
+      "glm-5-turbo": {
+        "input": "1186000000",
+        "output": "3955000000",
+        "cacheRead": "296000000",
+        "cacheWrite": "1544000000"
+      },
+      "glm-5.1": { "input": "1384000000", "output": "4348000000", "cacheRead": "346000000" },
+      "glm-5.2": { "input": "1200000000", "output": "4200000000", "cacheRead": "260000000" },
+      "glm-5v-turbo": {
+        "input": "1186000000",
+        "output": "3955000000",
+        "cacheRead": "296000000",
+        "cacheWrite": "1544000000"
+      },
+      "gpt-4.1": { "input": "2192000000", "output": "8769000000", "cacheRead": "546000000" },
+      "gpt-4.1-mini": { "input": "434000000", "output": "1704000000", "cacheRead": "134000000" },
+      "gpt-4.1-nano": { "input": "111000000", "output": "434000000", "cacheRead": "56000000" },
+      "gpt-4o": { "input": "2659000000", "output": "10635000000", "cacheRead": "1330000000" },
+      "gpt-4o-mini": { "input": "159000000", "output": "638000000", "cacheRead": "81000000" },
+      "gpt-5": { "input": "1375000000", "output": "10960000000", "cacheRead": "156000000" },
+      "gpt-5-mini": { "input": "279000000", "output": "2192000000", "cacheRead": "56000000" },
+      "gpt-5-nano": { "input": "60000000", "output": "439000000", "cacheRead": "19000000" },
+      "gpt-5.1": { "input": "1375000000", "output": "10960000000", "cacheRead": "156000000" },
+      "gpt-5.4": { "input": "2898000000", "output": "15453000000", "cacheRead": "242000000" },
+      "gpt-5.6-luna": {
+        "input": "219000000",
+        "output": "1320000000",
+        "cacheRead": "22000000",
+        "cacheWrite": "275000000"
+      },
+      "gpt-5.6-sol": {
+        "input": "5500000000",
+        "output": "32998000000",
+        "cacheRead": "550000000",
+        "cacheWrite": "6879000000"
+      },
+      "gpt-5.6-terra": {
+        "input": "2200000000",
+        "output": "13199000000",
+        "cacheRead": "219000000",
+        "cacheWrite": "2749000000"
+      },
+      "gpt-oss-120b": { "input": "89000000", "output": "446000000", "cacheRead": "10000000" },
+      "gpt-oss-20b": { "input": "45000000", "output": "167000000" },
+      "gpt-oss-safeguard-120b": { "input": "179000000", "output": "697000000" },
+      "hermes-4-405b": { "input": "996000000", "output": "2989000000" },
+      "hermes-4-70b": { "input": "129000000", "output": "399000000" },
+      "kimi-k2.5": { "input": "495000000", "output": "2768000000", "cacheRead": "124000000" },
+      "kimi-k2.6": { "input": "773000000", "output": "3380000000", "cacheRead": "193000000" },
+      "kimi-k2.7-code": { "input": "750000000", "output": "3500000000", "cacheRead": "201000000" },
+      "kimi-k3": { "input": "3000000000", "output": "14999000000" },
+      "llama-3.1-405b-instruct": { "input": "1950000000", "output": "1950000000" },
+      "llama-3.1-8b-instruct": { "input": "167000000", "output": "167000000" },
+      "llama-3.1-nemotron-ultra-253b-v1": { "input": "598000000", "output": "1794000000" },
+      "llama-3.3-70b-instruct": { "input": "129000000", "output": "399000000" },
+      "minicpm-v-4.5": { "input": "651000000", "output": "1097000000" },
+      "minimax-m2": { "input": "349000000", "output": "1405000000" },
+      "minimax-m2.1": { "input": "359000000", "output": "1435000000" },
+      "minimax-m2.5": { "input": "296000000", "output": "1186000000", "cacheRead": "75000000" },
+      "minimax-m2.7": { "input": "668000000", "output": "2674000000" },
+      "minimax-m3": { "input": "395000000", "output": "1977000000", "cacheRead": "99000000" },
+      "ministral-14b-2512": {
+        "input": "223000000",
+        "output": "223000000",
+        "cacheRead": "22000000"
+      },
+      "ministral-3b-2512": { "input": "111000000", "output": "111000000", "cacheRead": "11000000" },
+      "ministral-8b-2512": { "input": "167000000", "output": "167000000", "cacheRead": "17000000" },
+      "mistral-7b-instruct-v0.2": { "input": "159000000", "output": "219000000" },
+      "mistral-7b-instruct-v0.3": { "input": "111000000", "output": "111000000" },
+      "mistral-large-2402": { "input": "4284000000", "output": "12952000000" },
+      "mistral-large-2512": {
+        "input": "557000000",
+        "output": "1671000000",
+        "cacheRead": "56000000"
+      },
+      "mistral-medium-2508": {
+        "input": "446000000",
+        "output": "2228000000",
+        "cacheRead": "45000000"
+      },
+      "mistral-medium-3.5": { "input": "1671000000", "output": "5570000000" },
+      "mistral-nemo-instruct-2407": {
+        "input": "145000000",
+        "output": "145000000",
+        "cacheRead": "14000000"
+      },
+      "mistral-small-2503": { "input": "111000000", "output": "334000000" },
+      "mistral-small-2603": {
+        "input": "143000000",
+        "output": "568000000",
+        "cacheRead": "14000000"
+      },
+      "mistral-small-3.2-24b-instruct-2506": { "input": "100000000", "output": "312000000" },
+      "mixtral-8x7B-instruct-v0.1": { "input": "488000000", "output": "758000000" },
+      "nemotron-nano-v2-12b": { "input": "240000000", "output": "707000000" },
+      "nova-2-lite": { "input": "373000000", "output": "3144000000" },
+      "nova-lite-v1": { "input": "69000000", "output": "275000000" },
+      "nova-micro-v1": { "input": "40000000", "output": "159000000" },
+      "nova-pro-v1": { "input": "918000000", "output": "3671000000" },
+      "nvidia-nemotron-3-nano-30b-a3b": { "input": "60000000", "output": "240000000" },
+      "nvidia-nemotron-3-nano-omni": { "input": "59000000", "output": "237000000" },
+      "pixtral-12b-2409": { "input": "223000000", "output": "223000000" },
+      "pixtral-large-2502": { "input": "1993000000", "output": "5978000000" },
+      "qwen2.5-vl-72b-instruct": { "input": "250000000", "output": "747000000" },
+      "qwen3-235b-a22b-instruct-2507": {
+        "input": "69000000",
+        "output": "455000000",
+        "cacheRead": "18000000"
+      },
+      "qwen3-30b-a3b-instruct-2507": { "input": "99000000", "output": "299000000" },
+      "qwen3-32b": { "input": "99000000", "output": "299000000" },
+      "qwen3-coder-30b-a3b-instruct": {
+        "input": "67000000",
+        "output": "245000000",
+        "cacheRead": "14000000"
+      },
+      "qwen3-coder-next": { "input": "167000000", "output": "891000000" },
+      "qwen3-next-80b-a3b-thinking": { "input": "149000000", "output": "1195000000" },
+      "qwen3-vl-235b-a22b": {
+        "input": "617000000",
+        "output": "3119000000",
+        "cacheRead": "52000000"
+      },
+      "qwen3.5-122b-a10b": {
+        "input": "495000000",
+        "output": "3460000000",
+        "cacheRead": "124000000"
+      },
+      "qwen3.5-397b-a17b": { "input": "668000000", "output": "4010000000" },
+      "qwen3.5-9b": { "input": "111000000", "output": "167000000" },
+      "qwen3.6-27b": { "input": "446000000", "output": "3008000000" },
+      "qwen3.6-35b-a3b": { "input": "167000000", "output": "557000000" },
+      "qwen3.8-2.4t-a95b": {
+        "input": "2500000000",
+        "output": "6000000000",
+        "cacheRead": "625000000"
+      },
+      "qwen3.8-27b": { "input": "334000000", "output": "2451000000", "cacheRead": "111000000" },
+      "qwen3guard-gen-0.6b": { "input": "0", "output": "0" },
+      "qwen3guard-gen-8b": { "input": "0", "output": "0" },
+      "voxtral-small-2507": { "input": "111000000", "output": "334000000", "cacheRead": "11000000" }
+    },
+    "crof": {
+      "deepseek-v3.2": { "input": "180000000", "output": "350000000", "cacheRead": "40000000" },
+      "deepseek-v4-flash": { "input": "120000000", "output": "210000000", "cacheRead": "3000000" },
+      "deepseek-v4-flash-0731": {
+        "input": "120000000",
+        "output": "210000000",
+        "cacheRead": "3000000"
+      },
+      "deepseek-v4-pro": { "input": "350000000", "output": "800000000", "cacheRead": "3000000" },
+      "deepseek-v4-pro-lightning": {
+        "input": "800000000",
+        "output": "1600000000",
+        "cacheRead": "20000000"
+      },
+      "gemma-4-31b-it": { "input": "100000000", "output": "300000000", "cacheRead": "20000000" },
+      "glm-5.1": {
+        "input": "450000000",
+        "output": "2150000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "0"
+      },
+      "glm-5.2": { "input": "300000000", "output": "1050000000", "cacheRead": "50000000" },
+      "greg-1-mini": { "input": "70000000", "output": "150000000", "cacheRead": "10000000" },
+      "greg-2-super": { "input": "1500000000", "output": "5000000000", "cacheRead": "250000000" },
+      "greg-2-ultra": { "input": "3000000000", "output": "10000000000", "cacheRead": "500000000" },
+      "greg-rp": { "input": "100000000", "output": "300000000", "cacheRead": "20000000" },
+      "kimi-k2.6": { "input": "500000000", "output": "1990000000", "cacheRead": "50000000" },
+      "kimi-k2.7-code": { "input": "550000000", "output": "2250000000", "cacheRead": "50000000" },
+      "kimi-k3": { "input": "2000000000", "output": "8000000000", "cacheRead": "250000000" },
+      "kimi-k3-eco": { "input": "1000000000", "output": "4000000000", "cacheRead": "100000000" },
+      "mimo-v2.5-pro": {
+        "input": "400000000",
+        "output": "800000000",
+        "cacheRead": "3000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3.5-397b-a17b": {
+        "input": "350000000",
+        "output": "1750000000",
+        "cacheRead": "70000000"
+      },
+      "qwen3.5-9b": { "input": "40000000", "output": "150000000", "cacheRead": "8000000" },
+      "qwen3.6-27b": { "input": "200000000", "output": "1500000000", "cacheRead": "40000000" },
+      "qwen3.8-27b": { "input": "250000000", "output": "2100000000", "cacheRead": "60000000" }
+    },
+    "crossmodel": {
+      "anthropic/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic/claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "deepseek/deepseek-v4-flash": {
+        "input": "405000000",
+        "output": "1215000000",
+        "cacheRead": "13500000",
+        "cacheWrite": "405000000"
+      },
+      "deepseek/deepseek-v4-flash-vision-exp": {
+        "input": "405000000",
+        "output": "1215000000",
+        "cacheRead": "13500000",
+        "cacheWrite": "405000000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "1215000000",
+        "output": "3645000000",
+        "cacheRead": "40500000",
+        "cacheWrite": "1215000000"
+      },
+      "gemini/gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "300000000"
+      },
+      "gemini/gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "100000000"
+      },
+      "gemini/gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "cacheWrite": "1250000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "cacheWrite": "2500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "500000000"
+      },
+      "gemini/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2000000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "4000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "1500000000"
+      },
+      "gemini/gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "300000000"
+      },
+      "gemini/gemini-3.6-flash": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "1500000000"
+      },
+      "gemini/gemini-3.7-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "750000000"
+      },
+      "minimax/minimax-m2.7": {
+        "input": "330000000",
+        "output": "1320000000",
+        "cacheRead": "66000000",
+        "cacheWrite": "420000000"
+      },
+      "minimax/minimax-m3": {
+        "input": "330000000",
+        "output": "1320000000",
+        "cacheRead": "66000000",
+        "cacheWrite": "330000000",
+        "tiers": [
+          {
+            "input": "660000000",
+            "output": "2630000000",
+            "cacheRead": "132000000",
+            "cacheWrite": "660000000",
+            "aboveInputTokens": "512000"
+          }
+        ]
+      },
+      "moonshot/kimi-k2.5": {
+        "input": "620000000",
+        "output": "3300000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "620000000"
+      },
+      "moonshot/kimi-k2.6": {
+        "input": "1000000000",
+        "output": "4160000000",
+        "cacheRead": "180000000",
+        "cacheWrite": "1000000000"
+      },
+      "moonshot/kimi-k2.7-code": {
+        "input": "1000000000",
+        "output": "4160000000",
+        "cacheRead": "180000000",
+        "cacheWrite": "1000000000"
+      },
+      "moonshot/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3000000000"
+      },
+      "openai/gpt-4o-mini": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "150000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "cacheWrite": "5000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "750000000"
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "200000000"
+      },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "5000000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "10000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.5-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "openai/gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000",
+        "tiers": [
+          {
+            "input": "400000000",
+            "output": "1800000000",
+            "cacheRead": "40000000",
+            "cacheWrite": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "5000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "qwen/qwen3.6-flash": {
+        "input": "190000000",
+        "output": "1130000000",
+        "cacheRead": "19000000",
+        "cacheWrite": "240000000",
+        "tiers": [
+          {
+            "input": "750000000",
+            "output": "4500000000",
+            "cacheRead": "75000000",
+            "cacheWrite": "940000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen/qwen3.6-plus": {
+        "input": "320000000",
+        "output": "1880000000",
+        "cacheRead": "32000000",
+        "cacheWrite": "400000000",
+        "tiers": [
+          {
+            "input": "1250000000",
+            "output": "7500000000",
+            "cacheRead": "124000000",
+            "cacheWrite": "1570000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen/qwen3.7-flash": {
+        "input": "40000000",
+        "output": "130000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "40000000",
+        "tiers": [
+          {
+            "input": "100000000",
+            "output": "370000000",
+            "cacheRead": "20000000",
+            "cacheWrite": "120000000",
+            "aboveInputTokens": "32000"
+          },
+          {
+            "input": "190000000",
+            "output": "740000000",
+            "cacheRead": "40000000",
+            "cacheWrite": "240000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen/qwen3.7-max": {
+        "input": "1504000000",
+        "output": "4504000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "1880000000"
+      },
+      "qwen/qwen3.7-plus": {
+        "input": "288000000",
+        "output": "1125000000",
+        "cacheRead": "28800000",
+        "cacheWrite": "360000000",
+        "tiers": [
+          {
+            "input": "864000000",
+            "output": "3375000000",
+            "cacheRead": "86400000",
+            "cacheWrite": "1080000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen/qwen3.8-max": {
+        "input": "1880000000",
+        "output": "5630000000",
+        "cacheRead": "230000000",
+        "cacheWrite": "2350000000"
+      },
+      "tencent/hy3": {
+        "input": "160000000",
+        "output": "640000000",
+        "cacheRead": "40000000",
+        "cacheWrite": "160000000"
+      },
+      "x-ai/grok-4.3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "1250000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "2500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "x-ai/grok-4.5": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "2000000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "600000000",
+            "cacheWrite": "4000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "x-ai/grok-4.6": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "2000000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "4000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "x-ai/grok-build-0.1": {
+        "input": "1000000000",
+        "output": "2000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "1000000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "4000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "2000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xiaomi/mimo-v2.5": {
+        "input": "160000000",
+        "output": "320000000",
+        "cacheRead": "4000000",
+        "cacheWrite": "160000000"
+      },
+      "xiaomi/mimo-v2.5-pro": {
+        "input": "470000000",
+        "output": "940000000",
+        "cacheRead": "5000000",
+        "cacheWrite": "470000000"
+      },
+      "z-ai/glm-4.7": {
+        "input": "470000000",
+        "output": "2160000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "470000000",
+        "tiers": [
+          {
+            "input": "620000000",
+            "output": "2470000000",
+            "cacheRead": "130000000",
+            "cacheWrite": "620000000",
+            "aboveInputTokens": "32000"
+          }
+        ]
+      },
+      "z-ai/glm-5": {
+        "input": "600000000",
+        "output": "3000000000",
+        "cacheRead": "160000000",
+        "cacheWrite": "600000000",
+        "tiers": [
+          {
+            "input": "800000000",
+            "output": "3400000000",
+            "cacheRead": "200000000",
+            "cacheWrite": "800000000",
+            "aboveInputTokens": "32000"
+          }
+        ]
+      },
+      "z-ai/glm-5-turbo": {
+        "input": "900000000",
+        "output": "3700000000",
+        "cacheRead": "180000000",
+        "cacheWrite": "900000000",
+        "tiers": [
+          {
+            "input": "1100000000",
+            "output": "4300000000",
+            "cacheRead": "270000000",
+            "cacheWrite": "1100000000",
+            "aboveInputTokens": "32000"
+          }
+        ]
+      },
+      "z-ai/glm-5.1": {
+        "input": "1000000000",
+        "output": "3800000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "1000000000",
+        "tiers": [
+          {
+            "input": "1200000000",
+            "output": "4400000000",
+            "cacheRead": "300000000",
+            "cacheWrite": "1200000000",
+            "aboveInputTokens": "32000"
+          }
+        ]
+      },
+      "z-ai/glm-5.2": {
+        "input": "1200000000",
+        "output": "4400000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "1200000000"
+      },
+      "z-ai/glm-5.3": {
+        "input": "1200000000",
+        "output": "4400000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "1200000000"
+      }
+    },
+    "crusoe": {
+      "deepseek-ai/DeepSeek-V3-0324": {
+        "input": "500000000",
+        "output": "1500000000",
+        "cacheRead": "250000000"
+      },
+      "google/gemma-4-31b-it": {
+        "input": "140000000",
+        "output": "400000000",
+        "cacheRead": "140000000"
+      },
+      "meta-llama/Llama-3.3-70B-Instruct": {
+        "input": "250000000",
+        "output": "750000000",
+        "cacheRead": "130000000"
+      },
+      "moonshotai/Kimi-K2.6": {
+        "input": "700000000",
+        "output": "3500000000",
+        "cacheRead": "350000000"
+      },
+      "nvidia/Nemotron-3-Nano-Omni-Reasoning-30B-A3B": {
+        "input": "300000000",
+        "output": "1830000000",
+        "cacheRead": "300000000",
+        "inputAudio": "500000000"
+      },
+      "openai/gpt-oss-120b": {
+        "input": "50000000",
+        "output": "200000000",
+        "cacheRead": "50000000"
+      },
+      "zai/GLM-5.1": { "input": "1200000000", "output": "4400000000", "cacheRead": "250000000" },
+      "zai/GLM-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" }
+    },
+    "daoxe": {
+      "claude-haiku-4-5-20251001": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "5000000000"
+      },
+      "claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000"
+      },
+      "gpt-5.4": { "input": "2500000000", "output": "15000000000", "cacheRead": "250000000" },
+      "gpt-5.5": { "input": "5000000000", "output": "30000000000", "cacheRead": "500000000" },
+      "grok-4.3": { "input": "1250000000", "output": "2500000000", "cacheRead": "200000000" },
+      "grok-4.5": { "input": "2000000000", "output": "6000000000", "cacheRead": "500000000" },
+      "kimi-k2.5": { "input": "600000000", "output": "3000000000", "cacheRead": "100000000" }
+    },
+    "databricks": {
+      "databricks-claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "databricks-claude-opus-4-1": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "databricks-claude-opus-4-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "databricks-claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "modes": {
+          "fast": {
+            "input": "30000000000",
+            "output": "150000000000",
+            "cacheRead": "3000000000",
+            "cacheWrite": "37500000000"
+          }
+        }
+      },
+      "databricks-claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "modes": {
+          "fast": {
+            "input": "30000000000",
+            "output": "150000000000",
+            "cacheRead": "3000000000",
+            "cacheWrite": "37500000000"
+          }
+        }
+      },
+      "databricks-claude-sonnet-4": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "databricks-claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "databricks-claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "databricks-gemini-2-5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "inputAudio": "1000000000"
+      },
+      "databricks-gemini-2-5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "databricks-gemini-3-1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "inputAudio": "500000000"
+      },
+      "databricks-gemini-3-1-pro": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "databricks-gemini-3-flash": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "inputAudio": "1000000000"
+      },
+      "databricks-gemini-3-pro": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "databricks-glm-5-2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "databricks-gpt-5": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "databricks-gpt-5-1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "databricks-gpt-5-2": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "databricks-gpt-5-4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": { "input": "5000000000", "output": "30000000000", "cacheRead": "500000000" }
+        }
+      },
+      "databricks-gpt-5-4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000",
+        "modes": {
+          "fast": { "input": "1500000000", "output": "9000000000", "cacheRead": "150000000" }
+        }
+      },
+      "databricks-gpt-5-4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "databricks-gpt-5-5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": { "input": "12500000000", "output": "75000000000", "cacheRead": "1250000000" }
+        }
+      },
+      "databricks-gpt-5-6-luna": {
+        "input": "1000000000",
+        "output": "6000000000",
+        "cacheRead": "100000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "9000000000",
+            "cacheRead": "200000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "databricks-gpt-5-6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "databricks-gpt-5-6-terra": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "databricks-gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "databricks-gpt-5-nano": {
+        "input": "50000000",
+        "output": "400000000",
+        "cacheRead": "5000000"
+      },
+      "databricks-gpt-oss-120b": { "input": "72000000", "output": "280000000" },
+      "databricks-gpt-oss-20b": { "input": "50000000", "output": "200000000" },
+      "databricks-kimi-k2-7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      }
+    },
+    "deepinfra": {
+      "ByteDance/Seed-2.0-code": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "100000000",
+        "tiers": [
+          {
+            "input": "1000000000",
+            "output": "6000000000",
+            "cacheRead": "200000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "ByteDance/Seed-2.0-mini": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "20000000",
+        "tiers": [
+          {
+            "input": "200000000",
+            "output": "800000000",
+            "cacheRead": "200000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "ByteDance/Seed-2.0-pro": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "100000000",
+        "tiers": [
+          {
+            "input": "1000000000",
+            "output": "6000000000",
+            "cacheRead": "200000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "deepseek-ai/DeepSeek-R1-0528": {
+        "input": "500000000",
+        "output": "2150000000",
+        "cacheRead": "350000000"
+      },
+      "deepseek-ai/DeepSeek-V3": { "input": "320000000", "output": "890000000" },
+      "deepseek-ai/DeepSeek-V3-0324": {
+        "input": "240000000",
+        "output": "900000000",
+        "cacheRead": "135000000"
+      },
+      "deepseek-ai/DeepSeek-V3.1": {
+        "input": "250000000",
+        "output": "950000000",
+        "cacheRead": "130000000"
+      },
+      "deepseek-ai/DeepSeek-V3.2": {
+        "input": "260000000",
+        "output": "380000000",
+        "cacheRead": "130000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Flash": {
+        "input": "90000000",
+        "output": "180000000",
+        "cacheRead": "18000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Flash-0731": {
+        "input": "80000000",
+        "output": "180000000",
+        "cacheRead": "16000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "input": "1300000000",
+        "output": "2600000000",
+        "cacheRead": "100000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro-0813": {
+        "input": "1300000000",
+        "output": "2600000000",
+        "cacheRead": "100000000"
+      },
+      "google/gemma-4-26B-A4B-it": { "input": "70000000", "output": "340000000" },
+      "google/gemma-4-31B-it": { "input": "130000000", "output": "380000000" },
+      "google/gemma-4-E4B-it": { "input": "20000000", "output": "100000000" },
+      "meta-llama/Llama-3.3-70B-Instruct-Turbo": { "input": "100000000", "output": "320000000" },
+      "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+        "input": "200000000",
+        "output": "800000000"
+      },
+      "meta-llama/Llama-4-Scout-17B-16E-Instruct": { "input": "100000000", "output": "300000000" },
+      "MiniMaxAI/MiniMax-M2.5": {
+        "input": "150000000",
+        "output": "1150000000",
+        "cacheRead": "30000000"
+      },
+      "MiniMaxAI/MiniMax-M2.7": {
+        "input": "250000000",
+        "output": "1000000000",
+        "cacheRead": "50000000"
+      },
+      "MiniMaxAI/MiniMax-M3": {
+        "input": "280000000",
+        "output": "1100000000",
+        "cacheRead": "56000000"
+      },
+      "moonshotai/Kimi-K2.5": {
+        "input": "450000000",
+        "output": "2250000000",
+        "cacheRead": "70000000"
+      },
+      "moonshotai/Kimi-K2.6": {
+        "input": "750000000",
+        "output": "3500000000",
+        "cacheRead": "150000000"
+      },
+      "moonshotai/Kimi-K2.7-Code": {
+        "input": "680000000",
+        "output": "3400000000",
+        "cacheRead": "136000000"
+      },
+      "moonshotai/Kimi-K3": {
+        "input": "2850000000",
+        "output": "14250000000",
+        "cacheRead": "285000000"
+      },
+      "nvidia/Llama-3.3-Nemotron-Super-49B-v1.5": { "input": "400000000", "output": "400000000" },
+      "nvidia/Nemotron-3-Nano-30B-A3B": {
+        "input": "50000000",
+        "output": "200000000",
+        "cacheRead": "25000000"
+      },
+      "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning": {
+        "input": "200000000",
+        "output": "800000000"
+      },
+      "openai/gpt-oss-120b": { "input": "37000000", "output": "170000000" },
+      "openai/gpt-oss-20b": { "input": "30000000", "output": "140000000" },
+      "Qwen/Qwen3-235B-A22B-Instruct-2507": { "input": "90000000", "output": "550000000" },
+      "Qwen/Qwen3-30B-A3B": { "input": "120000000", "output": "500000000" },
+      "Qwen/Qwen3-32B": { "input": "80000000", "output": "280000000" },
+      "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo": {
+        "input": "300000000",
+        "output": "1000000000",
+        "cacheRead": "100000000"
+      },
+      "Qwen/Qwen3-Max": {
+        "input": "1200000000",
+        "output": "6000000000",
+        "cacheRead": "240000000",
+        "tiers": [
+          {
+            "input": "2400000000",
+            "output": "12000000000",
+            "cacheRead": "480000000",
+            "aboveInputTokens": "32000"
+          },
+          {
+            "input": "3000000000",
+            "output": "15000000000",
+            "cacheRead": "600000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "Qwen/Qwen3-Next-80B-A3B-Instruct": { "input": "90000000", "output": "1100000000" },
+      "Qwen/Qwen3-VL-235B-A22B-Instruct": {
+        "input": "200000000",
+        "output": "880000000",
+        "cacheRead": "110000000"
+      },
+      "Qwen/Qwen3.5-122B-A10B": { "input": "290000000", "output": "2400000000" },
+      "Qwen/Qwen3.5-27B": { "input": "260000000", "output": "2600000000" },
+      "Qwen/Qwen3.5-35B-A3B": {
+        "input": "140000000",
+        "output": "1000000000",
+        "cacheRead": "50000000"
+      },
+      "Qwen/Qwen3.5-397B-A17B": {
+        "input": "450000000",
+        "output": "3000000000",
+        "cacheRead": "220000000"
+      },
+      "Qwen/Qwen3.5-9B": { "input": "100000000", "output": "150000000" },
+      "Qwen/Qwen3.6-27B": { "input": "320000000", "output": "3200000000" },
+      "Qwen/Qwen3.6-35B-A3B": { "input": "100000000", "output": "950000000" },
+      "Qwen/Qwen3.7-Max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "15000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "32000"
+          },
+          {
+            "input": "6250000000",
+            "output": "18500000000",
+            "cacheRead": "1250000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "Qwen/Qwen3.8-2.4T-A95B": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000"
+      },
+      "Qwen/Qwen3.8-27B": { "input": "400000000", "output": "3000000000", "cacheRead": "40000000" },
+      "Qwen/Qwen3.8-Max": {
+        "input": "1650000000",
+        "output": "4951000000",
+        "cacheRead": "206000000"
+      },
+      "stepfun-ai/Step-3.7-Flash": {
+        "input": "200000000",
+        "output": "1150000000",
+        "cacheRead": "40000000"
+      },
+      "tencent/Hy3": { "input": "140000000", "output": "580000000", "cacheRead": "35000000" },
+      "thinkingmachines/Inkling": {
+        "input": "950000000",
+        "output": "4050000000",
+        "cacheRead": "160000000"
+      },
+      "thinkingmachines/Inkling-Small": {
+        "input": "450000000",
+        "output": "1200000000",
+        "cacheRead": "100000000"
+      },
+      "XiaomiMiMo/MiMo-V2.5": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "80000000"
+      },
+      "XiaomiMiMo/MiMo-V2.5-Pro": {
+        "input": "1000000000",
+        "output": "3000000000",
+        "cacheRead": "200000000"
+      },
+      "zai-org/GLM-4.6": { "input": "500000000", "output": "2000000000", "cacheRead": "100000000" },
+      "zai-org/GLM-4.7": { "input": "400000000", "output": "1750000000", "cacheRead": "80000000" },
+      "zai-org/GLM-4.7-Flash": {
+        "input": "60000000",
+        "output": "400000000",
+        "cacheRead": "10000000"
+      },
+      "zai-org/GLM-5": { "input": "600000000", "output": "2080000000", "cacheRead": "120000000" },
+      "zai-org/GLM-5.1": {
+        "input": "1050000000",
+        "output": "3500000000",
+        "cacheRead": "205000000"
+      },
+      "zai-org/GLM-5.2": { "input": "750000000", "output": "2400000000", "cacheRead": "140000000" }
+    },
+    "deepseek": {
+      "deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "2800000",
+        "reasoning": "280000000"
+      },
+      "deepseek-v4-flash-vision-exp": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "2800000",
+        "reasoning": "280000000"
+      },
+      "deepseek-v4-pro": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "3625000",
+        "reasoning": "870000000"
+      }
+    },
+    "digitalocean": {
+      "alibaba-qwen3-32b": { "input": "250000000", "output": "550000000" },
+      "all-mini-lm-l6-v2": { "input": "9000000", "output": "0" },
+      "anthropic-claude-3-opus": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic-claude-3.5-haiku": {
+        "input": "800000000",
+        "output": "4000000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "1000000000"
+      },
+      "anthropic-claude-3.5-sonnet": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic-claude-3.7-sonnet": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic-claude-4.1-opus": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic-claude-4.5-haiku": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic-claude-4.5-sonnet": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000",
+        "tiers": [
+          {
+            "input": "6000000000",
+            "output": "22500000000",
+            "cacheRead": "600000000",
+            "cacheWrite": "7500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "anthropic-claude-4.6-sonnet": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000",
+        "tiers": [
+          {
+            "input": "6000000000",
+            "output": "22500000000",
+            "cacheRead": "600000000",
+            "cacheWrite": "7500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "anthropic-claude-5-sonnet": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "anthropic-claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic-claude-haiku-4.5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic-claude-opus-4": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic-claude-opus-4.5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic-claude-opus-4.6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "anthropic-claude-opus-4.7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic-claude-opus-4.8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic-claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic-claude-sonnet-4": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000",
+        "tiers": [
+          {
+            "input": "6000000000",
+            "output": "22500000000",
+            "cacheRead": "300000000",
+            "cacheWrite": "3750000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "arcee-trinity-large-thinking": {
+        "input": "250000000",
+        "output": "900000000",
+        "cacheRead": "60000000"
+      },
+      "bge-m3": { "input": "20000000", "output": "0" },
+      "bge-reranker-v2-m3": { "input": "10000000", "output": "0" },
+      "deepseek-3.2": { "input": "250000000", "output": "800000000", "cacheRead": "75000000" },
+      "deepseek-4-flash": { "input": "67900000", "output": "168000000", "cacheRead": "16800000" },
+      "deepseek-r1-distill-llama-70b": { "input": "990000000", "output": "990000000" },
+      "deepseek-v4-flash-0731": {
+        "input": "80000000",
+        "output": "252000000",
+        "cacheRead": "25200000"
+      },
+      "deepseek-v4-pro": { "input": "870000000", "output": "1740000000", "cacheRead": "174000000" },
+      "deepseek-v4-pro-0813": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "44000000"
+      },
+      "e5-large-v2": { "input": "20000000", "output": "0" },
+      "gemma-4-31B-it": { "input": "180000000", "output": "500000000", "cacheRead": "36000000" },
+      "glm-5": { "input": "1000000000", "output": "3200000000", "cacheRead": "200000000" },
+      "glm-5.1": { "input": "1300000000", "output": "4300000000", "cacheRead": "260000000" },
+      "glm-5.2": { "input": "700000000", "output": "2200000000", "cacheRead": "105000000" },
+      "gte-large-en-v1.5": { "input": "90000000", "output": "0" },
+      "kimi-k2.5": { "input": "500000000", "output": "2700000000", "cacheRead": "203000000" },
+      "kimi-k2.6": { "input": "950000000", "output": "4000000000", "cacheRead": "190000000" },
+      "kimi-k3": { "input": "2850000000", "output": "14250000000", "cacheRead": "285000000" },
+      "llama-4-maverick": { "input": "200000000", "output": "696000000" },
+      "llama3-8b-instruct": { "input": "198000000", "output": "198000000" },
+      "llama3.3-70b-instruct": { "input": "650000000", "output": "650000000" },
+      "mimo-v2.5-pro": { "input": "400000000", "output": "1500000000", "cacheRead": "80000000" },
+      "minimax-m2.5": { "input": "300000000", "output": "1200000000", "cacheRead": "60000000" },
+      "mistral-3-14B": { "input": "200000000", "output": "200000000" },
+      "mistral-nemo-instruct-2407": { "input": "300000000", "output": "300000000" },
+      "multi-qa-mpnet-base-dot-v1": { "input": "9000000", "output": "0" },
+      "nemotron-3-nano-omni": { "input": "500000000", "output": "900000000" },
+      "nemotron-3-ultra-550b": { "input": "900000000", "output": "1700000000" },
+      "nemotron-nano-12b-v2-vl": { "input": "200000000", "output": "600000000" },
+      "nvidia-nemotron-3-super-120b": {
+        "input": "300000000",
+        "output": "650000000",
+        "cacheRead": "60000000"
+      },
+      "openai-gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai-gpt-4o": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai-gpt-4o-mini": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai-gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "openai-gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai-gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "openai-gpt-5.1-codex-max": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai-gpt-5.2": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai-gpt-5.2-pro": { "input": "21000000000", "output": "168000000000" },
+      "openai-gpt-5.3-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai-gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai-gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "openai-gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "openai-gpt-5.4-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "openai-gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai-gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "tiers": [
+          {
+            "input": "400000000",
+            "output": "1800000000",
+            "cacheRead": "40000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai-gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai-gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai-gpt-image-1": {
+        "input": "5000000000",
+        "output": "40000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai-gpt-image-1.5": {
+        "input": "5000000000",
+        "output": "10000000000",
+        "cacheRead": "1000000000"
+      },
+      "openai-gpt-image-2": { "input": "8000000000", "output": "30000000000" },
+      "openai-gpt-oss-120b": {
+        "input": "55000000",
+        "output": "385000000",
+        "cacheRead": "20000000"
+      },
+      "openai-gpt-oss-20b": { "input": "50000000", "output": "450000000" },
+      "openai-o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "openai-o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai-o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "qwen3-coder-flash": {
+        "input": "450000000",
+        "output": "1700000000",
+        "cacheRead": "90000000"
+      },
+      "qwen3-embedding-0.6b": { "input": "40000000", "output": "0" },
+      "qwen3.5-397b-a17b": {
+        "input": "550000000",
+        "output": "3500000000",
+        "cacheRead": "111000000"
+      },
+      "qwen3.8-max": { "input": "2000000000", "output": "6000000000", "cacheRead": "200000000" },
+      "stable-diffusion-3.5-large": { "input": "80000000", "output": "0" },
+      "wan2-2-t2v-a14b": { "input": "600000000", "output": "0" }
+    },
+    "dinference": {
+      "glm-4.7": { "input": "450000000", "output": "1650000000" },
+      "glm-5": { "input": "750000000", "output": "2400000000" },
+      "glm-5.1": { "input": "1250000000", "output": "3890000000" },
+      "glm-5.2": { "input": "1250000000", "output": "3890000000" },
+      "gpt-oss-120b": { "input": "67500000", "output": "270000000" },
+      "minimax-m2.5": { "input": "220000000", "output": "880000000" }
+    },
+    "drun": {
+      "public/deepseek-r1": { "input": "550000000", "output": "2200000000" },
+      "public/deepseek-v3": { "input": "280000000", "output": "1100000000" },
+      "public/minimax-m25": { "input": "290000000", "output": "1160000000" }
+    },
+    "ebcloud": {
+      "DeepSeek-V4-Flash": { "input": "143000000", "output": "285700000" },
+      "DeepSeek-V4-Pro": { "input": "428600000", "output": "857100000" },
+      "GLM-5.1": { "input": "857100000", "output": "3428600000" },
+      "Kimi-K2.6": { "input": "928600000", "output": "3857100000" }
+    },
+    "echo": { "echo": { "input": "10000000000", "output": "50000000000" } },
+    "edenai": {
+      "amazon/moonshot.kimi-k2-thinking": { "input": "600000000", "output": "2500000000" },
+      "amazon/moonshotai.kimi-k2.5": { "input": "600000000", "output": "3000000000" },
+      "amazon/zai.glm-4.7-flash": { "input": "70000000", "output": "400000000" },
+      "amazon/zai.glm-4.7-flash@us": { "input": "70000000", "output": "400000000" },
+      "anthropic/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-fable-latest": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-opus-4-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-5-20251101": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-latest": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "anthropic/claude-sonnet-latest": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "azure/gpt-5.1-codex": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "azure/gpt-5.1-codex-max": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "azure/gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "azure/gpt-5.2-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "cerebras/gpt-oss-120b": {
+        "input": "350000000",
+        "output": "750000000",
+        "cacheRead": "350000000"
+      },
+      "cloudflare/@cf/aisingapore/gemma-sea-lion-v4-27b-it": {
+        "input": "351000000",
+        "output": "555000000"
+      },
+      "cloudflare/@cf/deepseek-ai/deepseek-v4-flash-0731": {
+        "input": "440000000",
+        "output": "1320000000",
+        "cacheRead": "14000000"
+      },
+      "cloudflare/@cf/deepseek-ai/deepseek-v4-pro-0813": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "44000000"
+      },
+      "cloudflare/@cf/meta/llama-guard-3-8b": { "input": "484000000", "output": "30000000" },
+      "cloudflare/@cf/openai/gpt-oss-120b": { "input": "350000000", "output": "750000000" },
+      "cloudflare/@cf/openai/gpt-oss-20b": { "input": "200000000", "output": "300000000" },
+      "cloudflare/@cf/qwen/qwen2.5-coder-32b-instruct": {
+        "input": "660000000",
+        "output": "1000000000"
+      },
+      "cloudflare/@cf/zai-org/glm-4.7-flash": { "input": "60500000", "output": "400000000" },
+      "cohere/command-a-03-2025": { "input": "2500000000", "output": "10000000000" },
+      "cohere/command-r-08-2024": { "input": "150000000", "output": "600000000" },
+      "cohere/command-r-plus-08-2024": { "input": "2500000000", "output": "10000000000" },
+      "cohere/command-r7b-12-2024": { "input": "37500000", "output": "150000000" },
+      "databricks/databricks-gpt-oss-120b": { "input": "150010000", "output": "599970000" },
+      "databricks/databricks-gpt-oss-20b": { "input": "70000000", "output": "300020000" },
+      "deepinfra/ByteDance/Seed-2.0-code": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "100000000"
+      },
+      "deepinfra/ByteDance/Seed-2.0-mini": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "20000000"
+      },
+      "deepinfra/deepseek-ai/DeepSeek-R1": { "input": "700000000", "output": "2400000000" },
+      "deepinfra/deepseek-ai/DeepSeek-V3": { "input": "320000000", "output": "890000000" },
+      "deepinfra/deepseek-ai/DeepSeek-V3-0324": {
+        "input": "240000000",
+        "output": "900000000",
+        "cacheRead": "135000000"
+      },
+      "deepinfra/deepseek-ai/DeepSeek-V4-Flash-0731": {
+        "input": "80000000",
+        "output": "180000000",
+        "cacheRead": "16000000"
+      },
+      "deepinfra/deepseek-ai/DeepSeek-V4-Pro-0813": {
+        "input": "1300000000",
+        "output": "2600000000",
+        "cacheRead": "100000000"
+      },
+      "deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct": {
+        "input": "345000000",
+        "output": "345000000"
+      },
+      "deepinfra/meta-llama/Llama-3.3-70B-Instruct": {
+        "input": "100000000",
+        "output": "320000000"
+      },
+      "deepinfra/meta-llama/Llama-Guard-3-8B": { "input": "55000000", "output": "55000000" },
+      "deepinfra/meta-models/Muse-Glimmer-30B": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "40000000"
+      },
+      "deepinfra/moonshotai/Kimi-K2.5": {
+        "input": "450000000",
+        "output": "2250000000",
+        "cacheRead": "70000000"
+      },
+      "deepinfra/nemotron-3-ultra-550b-a55b": {
+        "input": "500000000",
+        "output": "2200000000",
+        "cacheRead": "100000000"
+      },
+      "deepinfra/nvidia/Llama-3.1-Nemotron-70B-Instruct": {
+        "input": "600000000",
+        "output": "600000000"
+      },
+      "deepinfra/nvidia/Nemotron-3-Nano-30B-A3B": {
+        "input": "50000000",
+        "output": "200000000",
+        "cacheRead": "25000000"
+      },
+      "deepinfra/openai/gpt-oss-120b": { "input": "37000000", "output": "170000000" },
+      "deepinfra/openai/gpt-oss-20b": { "input": "30000000", "output": "140000000" },
+      "deepinfra/stepfun-ai/Step-3.5-Flash": {
+        "input": "90000000",
+        "output": "300000000",
+        "cacheRead": "20000000"
+      },
+      "deepinfra/stepfun-ai/Step-3.7-Flash": {
+        "input": "200000000",
+        "output": "1150000000",
+        "cacheRead": "40000000"
+      },
+      "deepinfra/thinkingmachines/Inkling": {
+        "input": "950000000",
+        "output": "4050000000",
+        "cacheRead": "160000000"
+      },
+      "deepinfra/thinkingmachines/Inkling-Small": {
+        "input": "450000000",
+        "output": "1200000000",
+        "cacheRead": "100000000"
+      },
+      "deepinfra/zai-org/GLM-4.7-Flash": {
+        "input": "60000000",
+        "output": "400000000",
+        "cacheRead": "10000000"
+      },
+      "deepseek/deepseek-chat": {
+        "input": "280000000",
+        "output": "420000000",
+        "cacheRead": "28000000"
+      },
+      "deepseek/deepseek-v4-flash": {
+        "input": "440000000",
+        "output": "1320000000",
+        "cacheRead": "14000000"
+      },
+      "deepseek/deepseek-v4-flash-vision-exp": {
+        "input": "220000000",
+        "output": "660000000",
+        "cacheRead": "7000000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "44000000"
+      },
+      "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731": {
+        "input": "220000000",
+        "output": "660000000",
+        "cacheRead": "7000000"
+      },
+      "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro-0813": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "44000000"
+      },
+      "fireworks_ai/accounts/fireworks/models/gpt-oss-120b": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000"
+      },
+      "fireworks_ai/accounts/fireworks/models/gpt-oss-20b": {
+        "input": "70000000",
+        "output": "300000000",
+        "cacheRead": "35000000"
+      },
+      "fireworks_ai/accounts/fireworks/models/muse-glimmer-30b": {
+        "input": "350000000",
+        "output": "1500000000",
+        "cacheRead": "40000000"
+      },
+      "fireworks_ai/gpt-oss-120b": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "14000000"
+      },
+      "fireworks_ai/gpt-oss-20b": {
+        "input": "70000000",
+        "output": "300000000",
+        "cacheRead": "35000000"
+      },
+      "flexai/deepseek-v4-flash-0731": { "input": "80000000", "output": "180000000" },
+      "flexai/DeepSeek-V4-Flash-0731": { "input": "80000000", "output": "180000000" },
+      "flexai/gpt-oss-120b": { "input": "39000000", "output": "100000000" },
+      "flexai/gpt-oss-20b": { "input": "30000000", "output": "130000000" },
+      "flexai/Muse-Glimmer-30B": { "input": "300000000", "output": "1200000000" },
+      "flexai/Nemotron-3-Super-120B-A12B": { "input": "85000000", "output": "400000000" },
+      "google/gemini-2.5-flash-image": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83333000",
+        "reasoning": "2500000000",
+        "inputAudio": "1000000000"
+      },
+      "google/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "83333000",
+        "reasoning": "3000000000",
+        "inputAudio": "1000000000"
+      },
+      "google/gemini-3-pro-image": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000",
+        "inputAudio": "2000000000"
+      },
+      "google/gemini-3-pro-image-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000",
+        "inputAudio": "2000000000"
+      },
+      "google/gemini-3.1-flash-image": { "input": "500000000", "output": "3000000000" },
+      "google/gemini-3.1-flash-image-preview": { "input": "500000000", "output": "3000000000" },
+      "google/gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "83333000",
+        "reasoning": "1500000000",
+        "inputAudio": "500000000"
+      },
+      "google/gemini-3.1-flash-lite-image": { "input": "250000000", "output": "1500000000" },
+      "google/gemini-3.1-flash-lite-preview": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "83333000",
+        "reasoning": "1500000000",
+        "inputAudio": "500000000"
+      },
+      "google/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000",
+        "inputAudio": "2000000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3.1-pro-preview-customtools": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000",
+        "inputAudio": "2000000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000",
+        "reasoning": "9000000000",
+        "inputAudio": "3000000000"
+      },
+      "google/gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83333000",
+        "reasoning": "2500000000",
+        "inputAudio": "300000000"
+      },
+      "google/gemini-3.6-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "41667000",
+        "reasoning": "3750000000",
+        "inputAudio": "750000000"
+      },
+      "google/gemini-3.7-flash": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000",
+        "reasoning": "7500000000",
+        "inputAudio": "1500000000"
+      },
+      "google/gemini-flash-latest": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000",
+        "reasoning": "7500000000",
+        "inputAudio": "1500000000"
+      },
+      "google/gemini-pro-latest": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000",
+        "inputAudio": "2000000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/lyria-3-clip-preview": { "input": "0", "output": "0" },
+      "groq/openai/gpt-oss-120b": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "groq/openai/gpt-oss-20b": {
+        "input": "75000000",
+        "output": "300000000",
+        "cacheRead": "37500000"
+      },
+      "ionos/meta-llama/Llama-3.3-70B-Instruct": { "input": "758030000", "output": "758030000" },
+      "ionos/openai/gpt-oss-120b": { "input": "174930000", "output": "758030000" },
+      "minimax/MiniMax-M2": { "input": "300000000", "output": "1200000000" },
+      "minimax/MiniMax-M2.1": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "minimax/MiniMax-M2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "minimax/MiniMax-M2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "minimax/MiniMax-M3": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "mistral/codestral-latest": { "input": "300000000", "output": "900000000" },
+      "mistral/devstral-2512": {
+        "input": "440000000",
+        "output": "2200000000",
+        "cacheRead": "44000000"
+      },
+      "mistral/devstral-medium-latest": { "input": "400000000", "output": "2000000000" },
+      "mistral/magistral-medium-latest": { "input": "2000000000", "output": "5000000000" },
+      "mistral/mistral-large-2512": {
+        "input": "500000000",
+        "output": "1500000000",
+        "cacheRead": "50000000"
+      },
+      "mistral/mistral-large-latest": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000"
+      },
+      "mistral/mistral-medium-2505": { "input": "400000000", "output": "2000000000" },
+      "mistral/mistral-medium-2604": { "input": "1500000000", "output": "7500000000" },
+      "mistral/mistral-medium-latest": { "input": "1500000000", "output": "7500000000" },
+      "mistral/mistral-small-2603": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000"
+      },
+      "mistral/mistral-small-latest": { "input": "150000000", "output": "600000000" },
+      "moonshot/kimi-k2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "moonshot/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "moonshot/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "nebius/deepseek-ai/DeepSeek-V4-Flash-0731": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "140000000"
+      },
+      "nebius/meta-llama/Llama-3.3-70B-Instruct": {
+        "input": "130000000",
+        "output": "400000000",
+        "cacheRead": "130000000"
+      },
+      "nebius/nvidia/nemotron-3-super-120b-a12b": {
+        "input": "300000000",
+        "output": "900000000",
+        "cacheRead": "300000000"
+      },
+      "nebius/nvidia/Nemotron-3-Ultra-550b-a55b": {
+        "input": "1000000000",
+        "output": "3000000000",
+        "cacheRead": "1000000000"
+      },
+      "nebius/openai/gpt-oss-120b": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "150000000"
+      },
+      "openai/gpt-3.5-turbo": { "input": "500000000", "output": "1500000000" },
+      "openai/gpt-4": { "input": "30000000000", "output": "60000000000" },
+      "openai/gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "openai/gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/gpt-4.1-mini": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "100000000"
+      },
+      "openai/gpt-4.1-nano": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-4o": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-2024-08-06": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-2024-11-20": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-mini": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "openai/gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "openai/gpt-5-pro": { "input": "15000000000", "output": "120000000000" },
+      "openai/gpt-5.1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.2": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-pro": { "input": "21000000000", "output": "168000000000" },
+      "openai/gpt-5.3-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "openai/gpt-5.4-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "cacheRead": "3000000000",
+        "tiers": [
+          {
+            "input": "60000000000",
+            "output": "270000000000",
+            "cacheRead": "6000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.5-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "cacheRead": "3000000000",
+        "tiers": [
+          {
+            "input": "60000000000",
+            "output": "270000000000",
+            "cacheRead": "6000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000",
+        "tiers": [
+          {
+            "input": "400000000",
+            "output": "1800000000",
+            "cacheRead": "40000000",
+            "cacheWrite": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-sol": {
+        "input": "4000000000",
+        "output": "20000000000",
+        "cacheRead": "400000000",
+        "cacheWrite": "5000000000",
+        "tiers": [
+          {
+            "input": "8000000000",
+            "output": "30000000000",
+            "cacheRead": "800000000",
+            "cacheWrite": "10000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "5000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-latest": {
+        "input": "4000000000",
+        "output": "20000000000",
+        "cacheRead": "400000000",
+        "cacheWrite": "5000000000",
+        "tiers": [
+          {
+            "input": "8000000000",
+            "output": "30000000000",
+            "cacheRead": "800000000",
+            "cacheWrite": "10000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-mini-latest": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-pro-latest": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "cacheRead": "3000000000",
+        "tiers": [
+          {
+            "input": "60000000000",
+            "output": "270000000000",
+            "cacheRead": "6000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "openai/o1-pro": { "input": "150000000000", "output": "600000000000" },
+      "openai/o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "openai/o3-pro": { "input": "20000000000", "output": "80000000000" },
+      "openai/o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "ovhcloud/gpt-oss-120b": { "input": "90000000", "output": "470000000" },
+      "ovhcloud/gpt-oss-20b": { "input": "50000000", "output": "180000000" },
+      "perplexityai/sonar": { "input": "1000000000", "output": "1000000000" },
+      "perplexityai/sonar-deep-research": {
+        "input": "2000000000",
+        "output": "8000000000",
+        "reasoning": "3000000000"
+      },
+      "perplexityai/sonar-pro": { "input": "3000000000", "output": "15000000000" },
+      "perplexityai/sonar-reasoning-pro": { "input": "2000000000", "output": "8000000000" },
+      "qwen/deepseek-v4-flash-0731": { "input": "176000000", "output": "528000000" },
+      "qwen/deepseek-v4-pro-0813": { "input": "580800000", "output": "1742400000" },
+      "qwen/qwen-max": { "input": "1600000000", "output": "6400000000", "cacheRead": "320000000" },
+      "qwen/qwen-vl-max": {
+        "input": "800000000",
+        "output": "3200000000",
+        "cacheRead": "160000000"
+      },
+      "qwen/qwen-vl-plus": { "input": "210000000", "output": "630000000", "cacheRead": "42000000" },
+      "qwen/qwen3-235b-a22b-instruct-2507": { "input": "230000000", "output": "920000000" },
+      "qwen/qwen3-coder-30b-a3b-instruct": { "input": "450000000", "output": "2250000000" },
+      "qwen/qwen3-coder-480b-a35b-instruct": { "input": "1500000000", "output": "7500000000" },
+      "qwen/qwen3-coder-flash": {
+        "input": "300000000",
+        "output": "1500000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "qwen/qwen3-coder-next": { "input": "300000000", "output": "1500000000" },
+      "qwen/qwen3-coder-plus": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "1250000000"
+      },
+      "qwen/qwen3-max": {
+        "input": "1200000000",
+        "output": "6000000000",
+        "cacheRead": "240000000",
+        "cacheWrite": "1500000000"
+      },
+      "qwen/qwen3-next-80b-a3b-instruct": { "input": "150000000", "output": "1200000000" },
+      "qwen/qwen3-next-80b-a3b-thinking": { "input": "150000000", "output": "1200000000" },
+      "qwen/qwen3-vl-235b-a22b-instruct": { "input": "400000000", "output": "1600000000" },
+      "qwen/qwen3-vl-235b-a22b-thinking": { "input": "400000000", "output": "4000000000" },
+      "qwen/qwen3.8-2.4t-a95b": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      },
+      "qwen/qwen3.8-27b": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "625000000"
+      },
+      "qwen/qwen3.8-max": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      },
+      "qwen/qwq-plus": { "input": "800000000", "output": "2400000000" },
+      "scaleway/deepseek-v4-flash-0731": { "input": "466480000", "output": "932960000" },
+      "scaleway/gpt-oss-120b": { "input": "174930000", "output": "699720000" },
+      "scaleway/llama-3.3-70b-instruct": { "input": "1049580000", "output": "1049580000" },
+      "tensorx/deepseek/deepseek-v4-flash-0731": {
+        "input": "250000000",
+        "output": "300000000",
+        "cacheRead": "62500000"
+      },
+      "tensorx/moonshotai/kimi-k2.5": {
+        "input": "500000000",
+        "output": "2800000000",
+        "cacheRead": "125000000"
+      },
+      "together_ai/deepseek-ai/DeepSeek-V4-Flash-0731": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "30000000"
+      },
+      "together_ai/deepseek-ai/DeepSeek-V4-Pro-0813": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "130000000"
+      },
+      "together_ai/meta-models/Muse-Glimmer-30B": {
+        "input": "350000000",
+        "output": "1500000000",
+        "cacheRead": "40000000"
+      },
+      "together_ai/nvidia/nemotron-3-ultra-550b-a55b": {
+        "input": "600000000",
+        "output": "3600000000",
+        "cacheRead": "200000000"
+      },
+      "together_ai/openai/gpt-oss-120b": { "input": "150000000", "output": "600000000" },
+      "together_ai/openai/gpt-oss-20b": { "input": "50000000", "output": "200000000" },
+      "together_ai/thinkingmachines/Inkling": {
+        "input": "1000000000",
+        "output": "4050000000",
+        "cacheRead": "170000000"
+      },
+      "together_ai/thinkingmachines/Inkling-Small": {
+        "input": "500000000",
+        "output": "1200000000",
+        "cacheRead": "100000000"
+      },
+      "vertex/gemini-2.5-flash-image": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83333000",
+        "reasoning": "2500000000",
+        "inputAudio": "1000000000"
+      },
+      "vertex/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "83333000",
+        "reasoning": "3000000000",
+        "inputAudio": "1000000000"
+      },
+      "vertex/gemini-3-pro-image": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000",
+        "inputAudio": "2000000000"
+      },
+      "vertex/gemini-3.1-flash-image": { "input": "500000000", "output": "3000000000" },
+      "vertex/gemini-3.1-flash-lite-image": { "input": "250000000", "output": "1500000000" },
+      "vertex/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000",
+        "inputAudio": "2000000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "vertex/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000",
+        "reasoning": "9000000000",
+        "inputAudio": "3000000000"
+      },
+      "vertex/gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83333000",
+        "reasoning": "2500000000",
+        "inputAudio": "300000000"
+      },
+      "vertex/gemini-3.5-flash-lite@eu": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83333000",
+        "reasoning": "2500000000",
+        "inputAudio": "300000000"
+      },
+      "vertex/gemini-3.5-flash-lite@us": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83333000",
+        "reasoning": "2500000000",
+        "inputAudio": "300000000"
+      },
+      "vertex/gemini-3.5-flash@eu": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000",
+        "reasoning": "9000000000",
+        "inputAudio": "3000000000"
+      },
+      "vertex/gemini-3.5-flash@us": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000",
+        "reasoning": "9000000000",
+        "inputAudio": "3000000000"
+      },
+      "vertex/gemini-3.6-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "41667000",
+        "reasoning": "3750000000",
+        "inputAudio": "750000000"
+      },
+      "vertex/gemini-3.6-flash@eu": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "41667000",
+        "reasoning": "3750000000",
+        "inputAudio": "750000000"
+      },
+      "vertex/gemini-3.6-flash@us": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "41667000",
+        "reasoning": "3750000000",
+        "inputAudio": "750000000"
+      },
+      "vertex/gemini-3.7-flash": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000",
+        "reasoning": "7500000000",
+        "inputAudio": "1500000000"
+      },
+      "vertex/gemini-3.7-flash@eu": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000",
+        "reasoning": "7500000000",
+        "inputAudio": "1500000000"
+      },
+      "vertex/gemini-3.7-flash@us": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000",
+        "reasoning": "7500000000",
+        "inputAudio": "1500000000"
+      },
+      "vertex/gemini-flash-latest": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000",
+        "reasoning": "7500000000",
+        "inputAudio": "1500000000"
+      },
+      "vertex/gemini-pro-latest": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000",
+        "inputAudio": "2000000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-4.20-0309-non-reasoning": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-4.20-0309-reasoning": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-4.3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-4.5": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "300000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "600000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-4.6": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-build-0.1": {
+        "input": "1000000000",
+        "output": "2000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "4000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-latest": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "zai/glm-4.6": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "zai/glm-4.6v": { "input": "300000000", "output": "900000000", "cacheRead": "50000000" },
+      "zai/glm-4.7": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "zai/glm-5": { "input": "1000000000", "output": "3200000000", "cacheRead": "200000000" },
+      "zai/glm-5-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      },
+      "zai/glm-5.1": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "zai/glm-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "zai/glm-5.3": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "zai/glm-5v-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      }
+    },
+    "empiriolabs": {
+      "deepseek-v3-2": { "input": "570000000", "output": "1710000000", "cacheRead": "570000000" },
+      "deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "140000000"
+      },
+      "deepseek-v4-flash-0731": {
+        "input": "424000000",
+        "output": "1272000000",
+        "cacheRead": "424000000"
+      },
+      "deepseek-v4-pro": {
+        "input": "1650000000",
+        "output": "3300000000",
+        "cacheRead": "1650000000"
+      },
+      "deepseek-v4-pro-0813": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "1320000000"
+      },
+      "fugu-ultra-v1-0": {
+        "input": "7500000000",
+        "output": "45000000000",
+        "cacheRead": "1500000000",
+        "tiers": [
+          {
+            "input": "15000000000",
+            "output": "67500000000",
+            "cacheRead": "3000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "fugu-ultra-v1-1": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gemma-4-26b-a4b": { "input": "50000000", "output": "290000000", "cacheRead": "25000000" },
+      "glm-4-5-flash": { "input": "0", "output": "0" },
+      "glm-4-6v-flash": { "input": "0", "output": "0" },
+      "glm-4-7-flash": { "input": "0", "output": "0" },
+      "glm-5-1": {
+        "input": "825000000",
+        "output": "3301000000",
+        "cacheRead": "165000000",
+        "tiers": [
+          {
+            "input": "1100000000",
+            "output": "3851000000",
+            "cacheRead": "220000000",
+            "aboveInputTokens": "32000"
+          }
+        ]
+      },
+      "glm-5-2": { "input": "1400000000", "output": "4400000000", "cacheRead": "1400000000" },
+      "glm-5-3": { "input": "1400000000", "output": "4400000000", "cacheRead": "1400000000" },
+      "kimi-k2-6": { "input": "893900000", "output": "3713100000", "cacheRead": "178800000" },
+      "kimi-k2-7-code": { "input": "950000000", "output": "4000000000", "cacheRead": "950000000" },
+      "kimi-k2-7-code-highspeed": {
+        "input": "1900000000",
+        "output": "8000000000",
+        "cacheRead": "1900000000"
+      },
+      "kimi-k3": { "input": "3000000000", "output": "15000000000", "cacheRead": "3000000000" },
+      "mimo-v2-5": { "input": "700000000", "output": "1400000000", "cacheRead": "14000000" },
+      "mimo-v2-5-pro": { "input": "2175000000", "output": "4350000000", "cacheRead": "18000000" },
+      "minimax-m2-7": { "input": "150000000", "output": "600000000", "cacheRead": "30000000" },
+      "minimax-m2-7-highspeed": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "minimax-m3": {
+        "input": "225000000",
+        "output": "900000000",
+        "cacheRead": "45000000",
+        "tiers": [
+          {
+            "input": "450000000",
+            "output": "1800000000",
+            "cacheRead": "90000000",
+            "aboveInputTokens": "512000"
+          }
+        ]
+      },
+      "mistral-medium-3": { "input": "0", "output": "0" },
+      "mistral-small-4": { "input": "150000000", "output": "600000000", "cacheRead": "150000000" },
+      "muse-glimmer-30b": { "input": "200000000", "output": "800000000", "cacheRead": "50000000" },
+      "muse-spark-1-1": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "1000000000"
+      },
+      "muse-spark-1-2": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "1000000000"
+      },
+      "qwen3-5-122b-a10b": {
+        "input": "115000000",
+        "output": "917000000",
+        "cacheRead": "115000000",
+        "tiers": [
+          {
+            "input": "287000000",
+            "output": "2294000000",
+            "cacheRead": "287000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "qwen3-5-27b": {
+        "input": "86000000",
+        "output": "688000000",
+        "cacheRead": "86000000",
+        "tiers": [
+          {
+            "input": "258000000",
+            "output": "2064000000",
+            "cacheRead": "258000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "qwen3-5-35b-a3b": {
+        "input": "57000000",
+        "output": "459000000",
+        "cacheRead": "57000000",
+        "tiers": [
+          {
+            "input": "229000000",
+            "output": "1835000000",
+            "cacheRead": "229000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "qwen3-5-397b-a17b": {
+        "input": "172000000",
+        "output": "1032000000",
+        "cacheRead": "172000000",
+        "tiers": [
+          {
+            "input": "430000000",
+            "output": "2580000000",
+            "cacheRead": "430000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "qwen3-5-4b": { "input": "40000000", "output": "70000000", "cacheRead": "20000000" },
+      "qwen3-5-9b": { "input": "90000000", "output": "130000000", "cacheRead": "45000000" },
+      "qwen3-5-flash": { "input": "90000000", "output": "368000000", "cacheRead": "90000000" },
+      "qwen3-5-plus": {
+        "input": "360000000",
+        "output": "2210000000",
+        "cacheRead": "360000000",
+        "tiers": [
+          {
+            "input": "1080000000",
+            "output": "6620000000",
+            "cacheRead": "1080000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3-6-27b": { "input": "412564000", "output": "2475384000", "cacheRead": "412564000" },
+      "qwen3-6-35b-a3b": { "input": "70000000", "output": "420000000", "cacheRead": "35000000" },
+      "qwen3-6-flash": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "1000000000",
+            "output": "4000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3-6-max-preview": {
+        "input": "1310000000",
+        "output": "7880000000",
+        "cacheRead": "1310000000",
+        "tiers": [
+          {
+            "input": "1970000000",
+            "output": "11820000000",
+            "cacheRead": "1970000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "qwen3-6-plus": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "2000000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3-7-flash": {
+        "input": "30000000",
+        "output": "130000000",
+        "cacheRead": "6000000",
+        "tiers": [
+          {
+            "input": "100000000",
+            "output": "400000000",
+            "cacheRead": "20000000",
+            "aboveInputTokens": "32000"
+          },
+          {
+            "input": "200000000",
+            "output": "800000000",
+            "cacheRead": "40000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3-7-max": { "input": "2500000000", "output": "7500000000", "cacheRead": "2500000000" },
+      "qwen3-7-plus": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "400000000",
+        "tiers": [
+          {
+            "input": "1200000000",
+            "output": "4800000000",
+            "cacheRead": "1200000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3-8-27b": { "input": "170000000", "output": "500000000", "cacheRead": "80000000" },
+      "qwen3-8-max": { "input": "2000000000", "output": "6000000000", "cacheRead": "2000000000" },
+      "qwen3-max": {
+        "input": "1080000000",
+        "output": "5520000000",
+        "cacheRead": "1080000000",
+        "tiers": [
+          {
+            "input": "2160000000",
+            "output": "11040000000",
+            "cacheRead": "2160000000",
+            "aboveInputTokens": "32000"
+          },
+          {
+            "input": "2700000000",
+            "output": "13800000000",
+            "cacheRead": "2700000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "seed-2-0-code": {
+        "input": "400000000",
+        "output": "2400000000",
+        "cacheRead": "400000000",
+        "tiers": [
+          {
+            "input": "800000000",
+            "output": "4800000000",
+            "cacheRead": "800000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "seed-2-0-lite": {
+        "input": "310000000",
+        "output": "2500000000",
+        "cacheRead": "310000000",
+        "tiers": [
+          {
+            "input": "620000000",
+            "output": "5000000000",
+            "cacheRead": "620000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "seed-2-0-mini": {
+        "input": "120000000",
+        "output": "500000000",
+        "cacheRead": "120000000",
+        "tiers": [
+          {
+            "input": "240000000",
+            "output": "1000000000",
+            "cacheRead": "240000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "seed-2-0-pro": {
+        "input": "630000000",
+        "output": "3790000000",
+        "cacheRead": "630000000",
+        "tiers": [
+          {
+            "input": "1260000000",
+            "output": "7580000000",
+            "cacheRead": "1260000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "seed-2-1-turbo": { "input": "630000000", "output": "3130000000", "cacheRead": "630000000" },
+      "step-3-5-flash": { "input": "100000000", "output": "300000000", "cacheRead": "20000000" },
+      "step-3-5-flash-2603": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "20000000"
+      },
+      "step-3-7-flash": { "input": "200000000", "output": "1150000000", "cacheRead": "40000000" }
+    },
+    "evroc": {
+      "evroc/roc": { "input": "2875000000", "output": "11516000000" },
+      "google/gemma-4-26B-A4B-it": { "input": "144000000", "output": "575000000" },
+      "intfloat/multilingual-e5-large-instruct": { "input": "114000000", "output": "114000000" },
+      "KBLab/kb-whisper-large": {
+        "input": "2300000",
+        "output": "2300000",
+        "outputAudio": "2300000000"
+      },
+      "mistralai/Mistral-Medium-3.5-128B": { "input": "1725000000", "output": "6900000000" },
+      "mistralai/Voxtral-Small-24B-2507": {
+        "input": "2300000",
+        "output": "2300000",
+        "outputAudio": "2300000000"
+      },
+      "moonshotai/Kimi-K2.6": { "input": "1437500000", "output": "5750000000" },
+      "nvidia/Llama-3.3-70B-Instruct-FP8": { "input": "1150000000", "output": "1150000000" },
+      "openai/gpt-oss-120b": { "input": "230000000", "output": "920000000" },
+      "openai/whisper-large-v3": {
+        "input": "2300000",
+        "output": "2300000",
+        "outputAudio": "2300000000"
+      },
+      "openai/whisper-large-v3-turbo": {
+        "input": "2300000",
+        "output": "2300000",
+        "outputAudio": "2300000000"
+      },
+      "Qwen/Qwen3-Embedding-8B": { "input": "115000000", "output": "115000000" },
+      "Qwen/Qwen3-Reranker-4B": { "input": "57500000", "output": "0" },
+      "Qwen/Qwen3.6-35B-A3B": { "input": "345000000", "output": "1380000000" },
+      "Qwen/Qwen3.8-27B": { "input": "870000000", "output": "3500000000" },
+      "zai-org/GLM-5.2": { "input": "1437500000", "output": "5750000000" }
+    },
+    "fastrouter": {
+      "anthropic/claude-opus-4.1": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic/claude-opus-4.8": { "input": "5000000000", "output": "25000000000" },
+      "anthropic/claude-sonnet-4": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4.6": { "input": "3000000000", "output": "15000000000" },
+      "deepseek-ai/deepseek-r1-distill-llama-70b": { "input": "30000000", "output": "140000000" },
+      "deepseek/deepseek-v4-pro": { "input": "1740000000", "output": "3480000000" },
+      "google/gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "37500000"
+      },
+      "google/gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "310000000"
+      },
+      "google/gemini-3-pro-image-preview": { "input": "2000000000", "output": "12000000000" },
+      "google/gemini-3.1-flash-image-preview": { "input": "500000000", "output": "3000000000" },
+      "google/gemini-3.1-pro-preview": { "input": "2000000000", "output": "12000000000" },
+      "google/gemini-3.5-flash": { "input": "1500000000", "output": "9000000000" },
+      "google/gemma-4-31b-it": { "input": "130000000", "output": "380000000" },
+      "minimax/minimax-m2.7": { "input": "300000000", "output": "1200000000" },
+      "minimax/minimax-m2.7-highspeed": { "input": "600000000", "output": "2400000000" },
+      "moonshotai/kimi-k2": { "input": "550000000", "output": "2200000000" },
+      "moonshotai/kimi-k2.6": { "input": "750000000", "output": "3500000000" },
+      "openai/gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "openai/gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "openai/gpt-5.3-codex": { "input": "1750000000", "output": "14000000000" },
+      "openai/gpt-5.4-mini": { "input": "750000000", "output": "4500000000" },
+      "openai/gpt-5.4-nano": { "input": "200000000", "output": "1250000000" },
+      "openai/gpt-5.5": { "input": "5000000000", "output": "30000000000" },
+      "openai/gpt-5.5-pro": { "input": "30000000000", "output": "180000000000" },
+      "openai/gpt-oss-120b": { "input": "150000000", "output": "600000000" },
+      "openai/gpt-oss-20b": { "input": "50000000", "output": "200000000" },
+      "openai/gpt-realtime-1.5": { "input": "4000000000", "output": "16000000000" },
+      "qwen/qwen3-coder": { "input": "300000000", "output": "1200000000" },
+      "sarvam/sarvam-105b": { "input": "40000000", "output": "160000000" },
+      "sarvam/sarvam-30b": { "input": "20000000", "output": "100000000" },
+      "x-ai/grok-4": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "750000000",
+        "cacheWrite": "15000000000"
+      },
+      "x-ai/grok-4.3": { "input": "1250000000", "output": "2500000000" },
+      "x-ai/grok-build-0.1": { "input": "1000000000", "output": "2000000000" },
+      "z-ai/glm-5": { "input": "950000000", "output": "3150000000" },
+      "z-ai/glm-5.1": { "input": "1050000000", "output": "3500000000" }
+    },
+    "fireworks-ai": {
+      "accounts/fireworks/models/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "accounts/fireworks/models/deepseek-v4-flash-0731": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "accounts/fireworks/models/deepseek-v4-pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "145000000"
+      },
+      "accounts/fireworks/models/deepseek-v4-pro-0813": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "44000000"
+      },
+      "accounts/fireworks/models/glm-5p2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "140000000"
+      },
+      "accounts/fireworks/models/gpt-oss-120b": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000"
+      },
+      "accounts/fireworks/models/gpt-oss-20b": {
+        "input": "70000000",
+        "output": "300000000",
+        "cacheRead": "35000000"
+      },
+      "accounts/fireworks/models/inkling": {
+        "input": "1000000000",
+        "output": "4050000000",
+        "cacheRead": "170000000"
+      },
+      "accounts/fireworks/models/kimi-k2p6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "accounts/fireworks/models/kimi-k2p7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "accounts/fireworks/models/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "accounts/fireworks/models/minimax-m2p7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "accounts/fireworks/models/minimax-m3": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "accounts/fireworks/models/muse-glimmer-30b": {
+        "input": "350000000",
+        "output": "1500000000",
+        "cacheRead": "40000000"
+      },
+      "accounts/fireworks/models/nemotron-3-ultra-nvfp4": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "119000000"
+      },
+      "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": {
+        "input": "50000000",
+        "output": "200000000",
+        "cacheRead": "10000000"
+      },
+      "accounts/fireworks/models/qwen3p7-plus": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "80000000"
+      },
+      "accounts/fireworks/models/qwen3p8-max": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000"
+      },
+      "accounts/fireworks/routers/glm-5p2-fast": {
+        "input": "2100000000",
+        "output": "6600000000",
+        "cacheRead": "210000000"
+      },
+      "accounts/fireworks/routers/kimi-k2p6-fast": {
+        "input": "2000000000",
+        "output": "8000000000",
+        "cacheRead": "300000000"
+      },
+      "accounts/fireworks/routers/kimi-k2p6-turbo": {
+        "input": "2000000000",
+        "output": "8000000000",
+        "cacheRead": "300000000"
+      },
+      "accounts/fireworks/routers/kimi-k2p7-code-fast": {
+        "input": "1900000000",
+        "output": "8000000000",
+        "cacheRead": "380000000"
+      },
+      "accounts/fireworks/routers/kimi-k3-fast": {
+        "input": "4500000000",
+        "output": "22500000000",
+        "cacheRead": "450000000"
+      }
+    },
+    "freemodel": {
+      "claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "claude-haiku-4-5-20251001": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "gpt-5.3-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000",
+        "cacheWrite": "1750000000"
+      },
+      "gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      },
+      "gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "750000000"
+      },
+      "gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "5000000000"
+      }
+    },
+    "friendli": {
+      "deepseek-ai/DeepSeek-V3.2": {
+        "input": "500000000",
+        "output": "1500000000",
+        "cacheRead": "250000000"
+      },
+      "google/gemma-4-31B-it": { "input": "140000000", "output": "400000000" },
+      "MiniMaxAI/MiniMax-M2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "zai-org/GLM-5.1": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "zai-org/GLM-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" }
+    },
+    "frogbot": {
+      "claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "deepseek-v4-pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "140000000"
+      },
+      "gemini-2.5-flash": { "input": "300000000", "output": "2500000000", "cacheRead": "75000000" },
+      "gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "310000000"
+      },
+      "gemini-3-1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000"
+      },
+      "gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000"
+      },
+      "gpt-4o": { "input": "2500000000", "output": "10000000000", "cacheRead": "1250000000" },
+      "gpt-5-3-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5-4-mini": { "input": "750000000", "output": "4500000000", "cacheRead": "75000000" },
+      "gpt-5-4-nano": { "input": "200000000", "output": "1250000000", "cacheRead": "20000000" },
+      "gpt-5-5": { "input": "2500000000", "output": "15000000000", "cacheRead": "250000000" },
+      "gpt-oss-120b": { "input": "150000000", "output": "600000000" },
+      "gpt-oss-20b": { "input": "70000000", "output": "200000000" },
+      "grok-4-1-fast-non-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "grok-4-1-fast-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "grok-4-3": { "input": "1250000000", "output": "2500000000", "cacheRead": "200000000" },
+      "grok-code-fast-1": { "input": "200000000", "output": "1500000000", "cacheRead": "20000000" },
+      "kimi-k2-6": { "input": "950000000", "output": "4000000000", "cacheRead": "160000000" },
+      "kimi-k2.5": { "input": "600000000", "output": "3000000000", "cacheRead": "100000000" },
+      "minimax-m2-5": { "input": "300000000", "output": "1200000000", "cacheRead": "30000000" },
+      "minimax-m2-7": { "input": "300000000", "output": "1200000000", "cacheRead": "60000000" },
+      "qwen-3-6-plus": { "input": "500000000", "output": "3000000000", "cacheRead": "100000000" },
+      "zai-glm-5-1": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" }
+    },
+    "github-copilot": {
+      "claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "claude-haiku-4.5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-opus-4.5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4.6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "modes": {
+          "fast": {
+            "input": "30000000000",
+            "output": "150000000000",
+            "cacheRead": "3000000000",
+            "cacheWrite": "37500000000"
+          }
+        }
+      },
+      "claude-opus-4.7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "modes": {
+          "fast": {
+            "input": "30000000000",
+            "output": "150000000000",
+            "cacheRead": "3000000000",
+            "cacheWrite": "37500000000"
+          }
+        }
+      },
+      "claude-opus-4.8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "modes": {
+          "fast": {
+            "input": "10000000000",
+            "output": "50000000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000"
+          }
+        }
+      },
+      "claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-sonnet-4": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-4.5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-4.6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "inputAudio": "1500000000"
+      },
+      "gemini-3.6-flash": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000"
+      },
+      "gemini-3.7-flash": { "input": "750000000", "output": "3750000000", "cacheRead": "75000000" },
+      "gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "gpt-5-mini": { "input": "250000000", "output": "2000000000", "cacheRead": "25000000" },
+      "gpt-5.2": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.2-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.3-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.4-mini": { "input": "750000000", "output": "4500000000", "cacheRead": "75000000" },
+      "gpt-5.4-nano": { "input": "200000000", "output": "1250000000", "cacheRead": "20000000" },
+      "gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "tiers": [
+          {
+            "input": "400000000",
+            "output": "1800000000",
+            "cacheRead": "40000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gpt-5.6-sol": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "3125000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "cacheWrite": "6250000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "grok-4.5": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4.6": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "kimi-k2.7-code": { "input": "950000000", "output": "4000000000", "cacheRead": "190000000" },
+      "kimi-k3": { "input": "3000000000", "output": "15000000000", "cacheRead": "300000000" },
+      "mai-code-1-flash-picker": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "mai-code-1.1-flash": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000"
+      }
+    },
+    "gitlab": {
+      "duo-chat-fable-5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "duo-chat-gpt-5-1": { "input": "0", "output": "0" },
+      "duo-chat-gpt-5-2": { "input": "0", "output": "0" },
+      "duo-chat-gpt-5-2-codex": { "input": "0", "output": "0" },
+      "duo-chat-gpt-5-3-codex": { "input": "0", "output": "0" },
+      "duo-chat-gpt-5-4": { "input": "0", "output": "0" },
+      "duo-chat-gpt-5-4-mini": { "input": "0", "output": "0" },
+      "duo-chat-gpt-5-4-nano": { "input": "0", "output": "0" },
+      "duo-chat-gpt-5-5": { "input": "0", "output": "0" },
+      "duo-chat-gpt-5-6-luna": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "duo-chat-gpt-5-6-sol": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "duo-chat-gpt-5-6-terra": {
+        "input": "0",
+        "output": "0",
+        "cacheRead": "0",
+        "cacheWrite": "0"
+      },
+      "duo-chat-gpt-5-codex": { "input": "0", "output": "0" },
+      "duo-chat-gpt-5-mini": { "input": "0", "output": "0" },
+      "duo-chat-haiku-4-5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "duo-chat-opus-4-5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "duo-chat-opus-4-6": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "duo-chat-opus-4-7": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "duo-chat-opus-4-8": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "duo-chat-opus-5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "duo-chat-sonnet-4-5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "duo-chat-sonnet-4-6": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "duo-chat-sonnet-5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" }
+    },
+    "gmicloud": {
+      "anthropic/claude-opus-4.6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "anthropic/claude-opus-4.7": {
+        "input": "4500000000",
+        "output": "22500000000",
+        "cacheRead": "450000000",
+        "modes": {
+          "fast": {
+            "input": "30000000000",
+            "output": "150000000000",
+            "cacheRead": "3000000000",
+            "cacheWrite": "37500000000"
+          }
+        }
+      },
+      "anthropic/claude-opus-4.8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "anthropic/claude-sonnet-4.6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Flash": {
+        "input": "112000000",
+        "output": "224000000",
+        "cacheRead": "22000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "input": "1392000000",
+        "output": "2784000000",
+        "cacheRead": "116000000"
+      },
+      "moonshotai/Kimi-K2.6": {
+        "input": "855000000",
+        "output": "3600000000",
+        "cacheRead": "144000000"
+      },
+      "moonshotai/kimi-k2.7-code-highspeed": {
+        "input": "1900000000",
+        "output": "8000000000",
+        "cacheRead": "380000000"
+      },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "Qwen/Qwen3.7-Max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "3125000000"
+      },
+      "zai-org/GLM-5-FP8": {
+        "input": "600000000",
+        "output": "1920000000",
+        "cacheRead": "120000000"
+      },
+      "zai-org/GLM-5.1-FP8": {
+        "input": "980000000",
+        "output": "3080000000",
+        "cacheRead": "182000000"
+      },
+      "zai-org/GLM-5.2-FP8": {
+        "input": "979000000",
+        "output": "3080000000",
+        "cacheRead": "182000000"
+      }
+    },
+    "google": {
+      "deep-research-max-preview-04-2026": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "deep-research-preview-04-2026": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-2.5-computer-use-preview-10-2025": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "tiers": [{ "input": "2500000000", "output": "15000000000", "aboveInputTokens": "200000" }]
+      },
+      "gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "inputAudio": "1000000000"
+      },
+      "gemini-2.5-flash-image": {
+        "input": "300000000",
+        "output": "30000000000",
+        "cacheRead": "75000000"
+      },
+      "gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "inputAudio": "300000000"
+      },
+      "gemini-2.5-flash-preview-tts": { "input": "500000000", "output": "10000000000" },
+      "gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-2.5-pro-preview-tts": { "input": "1000000000", "output": "20000000000" },
+      "gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "inputAudio": "1000000000"
+      },
+      "gemini-3-pro-image": { "input": "2000000000", "output": "120000000000" },
+      "gemini-3-pro-image-preview": { "input": "2000000000", "output": "120000000000" },
+      "gemini-3.1-flash-image": { "input": "500000000", "output": "60000000000" },
+      "gemini-3.1-flash-image-preview": { "input": "500000000", "output": "60000000000" },
+      "gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "inputAudio": "500000000"
+      },
+      "gemini-3.1-flash-lite-image": { "input": "250000000", "output": "30000000000" },
+      "gemini-3.1-flash-lite-preview": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "inputAudio": "500000000"
+      },
+      "gemini-3.1-flash-live-preview": {
+        "input": "750000000",
+        "output": "4500000000",
+        "inputAudio": "3000000000",
+        "outputAudio": "12000000000"
+      },
+      "gemini-3.1-flash-tts-preview": { "input": "1000000000", "output": "20000000000" },
+      "gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.1-pro-preview-customtools": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "inputAudio": "1500000000"
+      },
+      "gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "gemini-3.5-live-translate-preview": {
+        "input": "3500000000",
+        "output": "21000000000",
+        "inputAudio": "3500000000",
+        "outputAudio": "21000000000"
+      },
+      "gemini-3.6-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "inputAudio": "750000000"
+      },
+      "gemini-3.7-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "inputAudio": "750000000"
+      },
+      "gemini-embedding-001": { "input": "150000000", "output": "0" },
+      "gemini-embedding-2": { "input": "200000000", "output": "0", "inputAudio": "6500000000" },
+      "gemini-flash-latest": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "inputAudio": "750000000"
+      },
+      "gemini-flash-lite-latest": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "gemini-omni-flash-preview": { "input": "1500000000", "output": "17500000000" },
+      "gemini-robotics-er-1.6-preview": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "inputAudio": "2000000000"
+      },
+      "lyria-3-clip-preview": { "input": "0", "output": "0" },
+      "lyria-3-pro-preview": { "input": "0", "output": "0" }
+    },
+    "google-vertex": {
+      "claude-fable-5@default": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "claude-haiku-4-5@20251001": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-opus-4-1@20250805": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "claude-opus-4-5@20251101": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-6@default": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-opus-4-7@default": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-opus-4-8@default": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-opus-4@20250514": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "claude-opus-5@default": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-sonnet-4-5@20250929": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-4-6@default": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000",
+        "tiers": [
+          {
+            "input": "6000000000",
+            "output": "22500000000",
+            "cacheRead": "600000000",
+            "cacheWrite": "7500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-sonnet-4@20250514": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-5@default": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "deepseek-ai/deepseek-v3.1-maas": {
+        "input": "600000000",
+        "output": "1700000000",
+        "cacheRead": "60000000"
+      },
+      "deepseek-ai/deepseek-v3.2-maas": {
+        "input": "560000000",
+        "output": "1680000000",
+        "cacheRead": "56000000"
+      },
+      "gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "inputAudio": "1000000000"
+      },
+      "gemini-2.5-flash-image": { "input": "300000000", "output": "30000000000" },
+      "gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "inputAudio": "300000000"
+      },
+      "gemini-2.5-flash-tts": { "input": "500000000", "output": "10000000000" },
+      "gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-2.5-pro-tts": { "input": "1000000000", "output": "20000000000" },
+      "gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "inputAudio": "1000000000"
+      },
+      "gemini-3-pro-image": {
+        "input": "2000000000",
+        "output": "120000000000",
+        "cacheRead": "200000000"
+      },
+      "gemini-3.1-flash-image": {
+        "input": "500000000",
+        "output": "60000000000",
+        "cacheRead": "50000000"
+      },
+      "gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "inputAudio": "500000000"
+      },
+      "gemini-3.1-flash-lite-preview": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "inputAudio": "500000000"
+      },
+      "gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.1-pro-preview-customtools": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "inputAudio": "1500000000"
+      },
+      "gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "gemini-3.6-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "inputAudio": "750000000"
+      },
+      "gemini-3.7-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "inputAudio": "750000000"
+      },
+      "gemini-embedding-001": { "input": "150000000", "output": "0" },
+      "gemini-flash-latest": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "inputAudio": "1500000000"
+      },
+      "gemini-flash-lite-latest": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "inputAudio": "500000000"
+      },
+      "meta/llama-3.3-70b-instruct-maas": { "input": "720000000", "output": "720000000" },
+      "meta/llama-4-maverick-17b-128e-instruct-maas": {
+        "input": "350000000",
+        "output": "1150000000"
+      },
+      "moonshotai/kimi-k2-thinking-maas": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "60000000"
+      },
+      "openai/gpt-oss-120b-maas": { "input": "90000000", "output": "360000000" },
+      "openai/gpt-oss-20b-maas": {
+        "input": "70000000",
+        "output": "250000000",
+        "cacheRead": "7000000"
+      },
+      "qwen/qwen3-235b-a22b-instruct-2507-maas": { "input": "220000000", "output": "880000000" },
+      "zai-org/glm-4.7-maas": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "60000000"
+      },
+      "zai-org/glm-5-maas": {
+        "input": "1000000000",
+        "output": "3200000000",
+        "cacheRead": "100000000"
+      }
+    },
+    "google-vertex-anthropic": {
+      "claude-fable-5@default": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "claude-haiku-4-5@20251001": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-opus-4-1@20250805": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "claude-opus-4-5@20251101": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-6@default": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-opus-4-7@default": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-opus-4-8@default": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-opus-4@20250514": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "claude-opus-5@default": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-sonnet-4-5@20250929": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-4-6@default": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000",
+        "tiers": [
+          {
+            "input": "6000000000",
+            "output": "22500000000",
+            "cacheRead": "600000000",
+            "cacheWrite": "7500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-sonnet-4@20250514": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-5@default": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      }
+    },
+    "greenpt": {
+      "deepseek-v4-flash-0731": {
+        "input": "159600000",
+        "output": "399000000",
+        "cacheRead": "45600000"
+      },
+      "devstral-2-123b-instruct-2512": { "input": "570000000", "output": "2736000000" },
+      "gemma-3-27b-it": { "input": "342000000", "output": "684000000" },
+      "gemma4": { "input": "570000000", "output": "1710000000" },
+      "glm-5.1": { "input": "1756000000", "output": "5518000000" },
+      "glm-5.2": { "input": "1254000000", "output": "5016000000", "cacheRead": "313500000" },
+      "glm-5.2-caveman": {
+        "input": "1254000000",
+        "output": "5016000000",
+        "cacheRead": "313500000"
+      },
+      "glm-5.2-caveman-lite": {
+        "input": "1254000000",
+        "output": "5016000000",
+        "cacheRead": "313500000"
+      },
+      "glm-5.2-caveman-ultra": {
+        "input": "1254000000",
+        "output": "5016000000",
+        "cacheRead": "313500000"
+      },
+      "glm-5.2-honey": { "input": "1254000000", "output": "5016000000", "cacheRead": "313500000" },
+      "glm-5.2-honey-lite": {
+        "input": "1254000000",
+        "output": "5016000000",
+        "cacheRead": "313500000"
+      },
+      "glm-5.2-honey-ultra": {
+        "input": "1254000000",
+        "output": "5016000000",
+        "cacheRead": "313500000"
+      },
+      "glm-5.2-ponytail": {
+        "input": "1254000000",
+        "output": "5016000000",
+        "cacheRead": "313500000"
+      },
+      "glm-5.2-ponytail-lite": {
+        "input": "1254000000",
+        "output": "5016000000",
+        "cacheRead": "313500000"
+      },
+      "glm-5.2-ponytail-ultra": {
+        "input": "1254000000",
+        "output": "5016000000",
+        "cacheRead": "313500000"
+      },
+      "gpt-oss-120b": { "input": "228000000", "output": "798000000" },
+      "green-l": { "input": "285000000", "output": "912000000" },
+      "green-l-raw": { "input": "285000000", "output": "912000000" },
+      "green-r": { "input": "399000000", "output": "1083000000" },
+      "green-r-raw": { "input": "399000000", "output": "1083000000" },
+      "green-s": { "input": "4370000", "output": "0" },
+      "green-s-pro": { "input": "4370000", "output": "0" },
+      "holo2-30b-a3b": { "input": "399000000", "output": "969000000" },
+      "kimi-k2.6": { "input": "752400000", "output": "4275000000", "cacheRead": "250800000" },
+      "kimi-k2.6-fast": { "input": "1655000000", "output": "8778000000" },
+      "kimi-k2.7-code": { "input": "900600000", "output": "4389000000", "cacheRead": "188100000" },
+      "kimi-k3": { "input": "3762000000", "output": "18810000000", "cacheRead": "940500000" },
+      "llama-3.3-70b-instruct": { "input": "1254000000", "output": "1254000000" },
+      "minimax-m2.5": { "input": "193800000", "output": "1129000000", "cacheRead": "62700000" },
+      "mistral-medium-3.5-128b": { "input": "2052000000", "output": "10260000000" },
+      "mistral-small-3.2-24b-instruct-2506": { "input": "228000000", "output": "456000000" },
+      "pixtral-12b-2409": { "input": "285000000", "output": "285000000" },
+      "qwen3-235b-a22b-instruct-2507": { "input": "1026000000", "output": "3078000000" },
+      "qwen3-coder-30b-a3b-instruct": { "input": "285000000", "output": "1083000000" },
+      "qwen3.5-397b-a17b": { "input": "798000000", "output": "4959000000" },
+      "qwen3.6-35b-a3b": { "input": "342000000", "output": "2052000000" },
+      "voxtral-small-24b-2507": { "input": "228000000", "output": "513000000" }
+    },
+    "groq": {
+      "allam-2-7b": { "input": "0", "output": "0" },
+      "llama-3.1-8b-instant": { "input": "50000000", "output": "80000000" },
+      "llama-3.3-70b-versatile": { "input": "590000000", "output": "790000000" },
+      "meta-llama/llama-prompt-guard-2-22m": { "input": "30000000", "output": "30000000" },
+      "meta-llama/llama-prompt-guard-2-86m": { "input": "40000000", "output": "40000000" },
+      "openai/gpt-oss-120b": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-oss-20b": { "input": "75000000", "output": "300000000", "cacheRead": "37500000" },
+      "openai/gpt-oss-safeguard-20b": { "input": "75000000", "output": "300000000" },
+      "qwen/qwen3.6-27b": { "input": "600000000", "output": "3000000000", "cacheRead": "300000000" }
+    },
+    "helicone": {
+      "chatgpt-4o-latest": {
+        "input": "5000000000",
+        "output": "20000000000",
+        "cacheRead": "2500000000"
+      },
+      "claude-3-haiku-20240307": {
+        "input": "250000000",
+        "output": "1250000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "300000000"
+      },
+      "claude-3.5-haiku": {
+        "input": "800000000",
+        "output": "4000000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "1000000000"
+      },
+      "claude-3.5-sonnet-v2": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-3.7-sonnet": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-4.5-haiku": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-4.5-opus": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-4.5-sonnet": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-haiku-4-5-20251001": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-opus-4": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "claude-opus-4-1": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "claude-opus-4-1-20250805": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "claude-sonnet-4": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-4-5-20250929": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "deepseek-r1-distill-llama-70b": { "input": "30000000", "output": "130000000" },
+      "deepseek-reasoner": {
+        "input": "560000000",
+        "output": "1680000000",
+        "cacheRead": "70000000"
+      },
+      "deepseek-tng-r1t2-chimera": { "input": "300000000", "output": "1200000000" },
+      "deepseek-v3": { "input": "560000000", "output": "1680000000", "cacheRead": "70000000" },
+      "deepseek-v3.1-terminus": {
+        "input": "270000000",
+        "output": "1000000000",
+        "cacheRead": "216000000"
+      },
+      "deepseek-v3.2": { "input": "270000000", "output": "410000000" },
+      "ernie-4.5-21b-a3b-thinking": { "input": "70000000", "output": "280000000" },
+      "gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "300000000"
+      },
+      "gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "100000000"
+      },
+      "gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "312500000",
+        "cacheWrite": "1250000000"
+      },
+      "gemini-3-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000"
+      },
+      "gemma-3-12b-it": { "input": "50000000", "output": "100000000" },
+      "gemma2-9b-it": { "input": "10000000", "output": "30000000" },
+      "glm-4.6": { "input": "450000000", "output": "1500000000" },
+      "gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "gpt-4.1-mini": { "input": "400000000", "output": "1600000000", "cacheRead": "100000000" },
+      "gpt-4.1-mini-2025-04-14": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "100000000"
+      },
+      "gpt-4.1-nano": { "input": "100000000", "output": "400000000", "cacheRead": "25000000" },
+      "gpt-4o": { "input": "2500000000", "output": "10000000000", "cacheRead": "1250000000" },
+      "gpt-4o-mini": { "input": "150000000", "output": "600000000", "cacheRead": "75000000" },
+      "gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5-chat-latest": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "gpt-5-codex": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5-mini": { "input": "250000000", "output": "2000000000", "cacheRead": "25000000" },
+      "gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "gpt-5-pro": { "input": "15000000000", "output": "120000000000" },
+      "gpt-5.1": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5.1-chat-latest": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "gpt-5.1-codex": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "gpt-oss-120b": { "input": "40000000", "output": "160000000" },
+      "gpt-oss-20b": { "input": "50000000", "output": "200000000" },
+      "grok-3": { "input": "3000000000", "output": "15000000000", "cacheRead": "750000000" },
+      "grok-3-mini": { "input": "300000000", "output": "500000000", "cacheRead": "75000000" },
+      "grok-4": { "input": "3000000000", "output": "15000000000", "cacheRead": "750000000" },
+      "grok-4-1-fast-non-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "grok-4-1-fast-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "grok-4-fast-non-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "grok-4-fast-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "grok-code-fast-1": { "input": "200000000", "output": "1500000000", "cacheRead": "20000000" },
+      "hermes-2-pro-llama-3-8b": { "input": "140000000", "output": "140000000" },
+      "kimi-k2-0711": { "input": "570000000", "output": "2300000000" },
+      "kimi-k2-0905": { "input": "500000000", "output": "2000000000", "cacheRead": "400000000" },
+      "kimi-k2-thinking": { "input": "480000000", "output": "2000000000" },
+      "llama-3.1-8b-instant": { "input": "50000000", "output": "80000000" },
+      "llama-3.1-8b-instruct": { "input": "20000000", "output": "50000000" },
+      "llama-3.1-8b-instruct-turbo": { "input": "20000000", "output": "30000000" },
+      "llama-3.3-70b-instruct": { "input": "130000000", "output": "390000000" },
+      "llama-3.3-70b-versatile": { "input": "590000000", "output": "790000000" },
+      "llama-4-maverick": { "input": "150000000", "output": "600000000" },
+      "llama-4-scout": { "input": "80000000", "output": "300000000" },
+      "llama-guard-4": { "input": "210000000", "output": "210000000" },
+      "llama-prompt-guard-2-22m": { "input": "10000000", "output": "10000000" },
+      "llama-prompt-guard-2-86m": { "input": "10000000", "output": "10000000" },
+      "mistral-large-2411": { "input": "2000000000", "output": "6000000000" },
+      "mistral-nemo": { "input": "20000000000", "output": "40000000000" },
+      "mistral-small": { "input": "75000000", "output": "200000000" },
+      "o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "o1-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "o3-pro": { "input": "20000000000", "output": "80000000000" },
+      "o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "qwen2.5-coder-7b-fast": { "input": "30000000", "output": "90000000" },
+      "qwen3-235b-a22b-thinking": { "input": "300000000", "output": "2900000000" },
+      "qwen3-30b-a3b": { "input": "80000000", "output": "290000000" },
+      "qwen3-32b": { "input": "290000000", "output": "590000000" },
+      "qwen3-coder": { "input": "220000000", "output": "950000000" },
+      "qwen3-coder-30b-a3b-instruct": { "input": "100000000", "output": "300000000" },
+      "qwen3-next-80b-a3b-instruct": { "input": "140000000", "output": "1400000000" },
+      "qwen3-vl-235b-a22b-instruct": { "input": "300000000", "output": "1500000000" },
+      "sonar": { "input": "1000000000", "output": "1000000000" },
+      "sonar-deep-research": { "input": "2000000000", "output": "8000000000" },
+      "sonar-pro": { "input": "3000000000", "output": "15000000000" },
+      "sonar-reasoning": { "input": "1000000000", "output": "5000000000" },
+      "sonar-reasoning-pro": { "input": "2000000000", "output": "8000000000" }
+    },
+    "hetzner": {
+      "Qwen/Qwen3.6-35B-A3B-FP8": { "input": "0", "output": "0", "cacheRead": "0" },
+      "Qwen3.8-27B": { "input": "0", "output": "0", "cacheRead": "0" }
+    },
+    "hpc-ai": {
+      "anthropic/claude-opus-4.7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "deepseek/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "145000000"
+      },
+      "minimax/minimax-m2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "moonshotai/kimi-k2.5": {
+        "input": "600000000",
+        "output": "3000000000",
+        "cacheRead": "100000000"
+      },
+      "moonshotai/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "zai-org/glm-5.1": { "input": "615000000", "output": "2460000000", "cacheRead": "133000000" },
+      "zai-org/glm-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" }
+    },
+    "huggingface": {
+      "deepseek-ai/DeepSeek-R1": { "input": "700000000", "output": "2500000000" },
+      "deepseek-ai/DeepSeek-R1-0528": { "input": "3000000000", "output": "5000000000" },
+      "deepseek-ai/DeepSeek-V3": { "input": "400000000", "output": "1300000000" },
+      "deepseek-ai/DeepSeek-V3-0324": { "input": "270000000", "output": "1120000000" },
+      "deepseek-ai/DeepSeek-V3.1": { "input": "270000000", "output": "1000000000" },
+      "deepseek-ai/DeepSeek-V3.2": { "input": "280000000", "output": "400000000" },
+      "deepseek-ai/DeepSeek-V4-Flash": { "input": "140000000", "output": "280000000" },
+      "deepseek-ai/DeepSeek-V4-Flash-0731": { "input": "140000000", "output": "280000000" },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "3625000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro-0813": { "input": "1320000000", "output": "3960000000" },
+      "google/gemma-4-26B-A4B-it": { "input": "130000000", "output": "400000000" },
+      "google/gemma-4-31B-it": { "input": "140000000", "output": "400000000" },
+      "meta-llama/Llama-3.1-8B-Instruct": { "input": "60000000", "output": "60000000" },
+      "meta-llama/Llama-3.3-70B-Instruct": { "input": "590000000", "output": "790000000" },
+      "MiniMaxAI/MiniMax-M2": { "input": "300000000", "output": "1200000000" },
+      "MiniMaxAI/MiniMax-M2.1": { "input": "300000000", "output": "1200000000" },
+      "MiniMaxAI/MiniMax-M2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "MiniMaxAI/MiniMax-M2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "MiniMaxAI/MiniMax-M3": { "input": "300000000", "output": "1200000000" },
+      "moonshotai/Kimi-K2-Instruct": { "input": "1000000000", "output": "3000000000" },
+      "moonshotai/Kimi-K2-Instruct-0905": { "input": "1000000000", "output": "3000000000" },
+      "moonshotai/Kimi-K2-Thinking": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "150000000"
+      },
+      "moonshotai/Kimi-K2.5": {
+        "input": "600000000",
+        "output": "3000000000",
+        "cacheRead": "100000000"
+      },
+      "moonshotai/Kimi-K2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "moonshotai/Kimi-K2.7-Code": { "input": "950000000", "output": "4000000000" },
+      "moonshotai/Kimi-K3": { "input": "3000000000", "output": "15000000000" },
+      "openai/gpt-oss-120b": { "input": "250000000", "output": "690000000" },
+      "openai/gpt-oss-20b": { "input": "100000000", "output": "500000000" },
+      "Qwen/Qwen2.5-Coder-32B-Instruct": { "input": "60000000", "output": "200000000" },
+      "Qwen/Qwen3-235B-A22B": { "input": "200000000", "output": "800000000" },
+      "Qwen/Qwen3-235B-A22B-Instruct-2507": { "input": "855000000", "output": "2565000000" },
+      "Qwen/Qwen3-235B-A22B-Thinking-2507": { "input": "300000000", "output": "3000000000" },
+      "Qwen/Qwen3-30B-A3B": { "input": "120000000", "output": "500000000" },
+      "Qwen/Qwen3-32B": { "input": "290000000", "output": "590000000" },
+      "Qwen/Qwen3-Coder-30B-A3B-Instruct": { "input": "70000000", "output": "260000000" },
+      "Qwen/Qwen3-Coder-480B-A35B-Instruct": { "input": "2000000000", "output": "2000000000" },
+      "Qwen/Qwen3-Coder-Next": { "input": "200000000", "output": "1500000000" },
+      "Qwen/Qwen3-Embedding-4B": { "input": "10000000", "output": "0" },
+      "Qwen/Qwen3-Embedding-8B": { "input": "10000000", "output": "0" },
+      "Qwen/Qwen3-Next-80B-A3B-Instruct": { "input": "250000000", "output": "1000000000" },
+      "Qwen/Qwen3-Next-80B-A3B-Thinking": { "input": "300000000", "output": "2000000000" },
+      "Qwen/Qwen3-VL-235B-A22B-Instruct": { "input": "300000000", "output": "1500000000" },
+      "Qwen/Qwen3-VL-235B-A22B-Thinking": { "input": "980000000", "output": "3950000000" },
+      "Qwen/Qwen3.5-122B-A10B": { "input": "400000000", "output": "3200000000" },
+      "Qwen/Qwen3.5-27B": { "input": "300000000", "output": "2400000000" },
+      "Qwen/Qwen3.5-35B-A3B": { "input": "250000000", "output": "2000000000" },
+      "Qwen/Qwen3.5-397B-A17B": { "input": "600000000", "output": "3600000000" },
+      "Qwen/Qwen3.5-9B": { "input": "170000000", "output": "250000000" },
+      "Qwen/Qwen3.6-27B": { "input": "470000000", "output": "3190000000" },
+      "Qwen/Qwen3.6-35B-A3B": { "input": "150000000", "output": "950000000" },
+      "Qwen/Qwen3.8-2.4T-A95B": { "input": "2500000000", "output": "6250000000" },
+      "stepfun-ai/Step-3.5-Flash": { "input": "100000000", "output": "300000000" },
+      "stepfun-ai/Step-3.7-Flash": { "input": "200000000", "output": "1150000000" },
+      "tencent/Hy3": { "input": "140000000", "output": "580000000" },
+      "thinkingmachines/Inkling": { "input": "1000000000", "output": "4050000000" },
+      "thinkingmachines/Inkling-Small": { "input": "500000000", "output": "1200000000" },
+      "XiaomiMiMo/MiMo-V2-Flash": { "input": "100000000", "output": "300000000" },
+      "XiaomiMiMo/MiMo-V2.5": { "input": "400000000", "output": "2000000000" },
+      "XiaomiMiMo/MiMo-V2.5-Pro": { "input": "1000000000", "output": "3000000000" },
+      "zai-org/GLM-4.5": { "input": "600000000", "output": "2200000000" },
+      "zai-org/GLM-4.5-Air": { "input": "130000000", "output": "850000000" },
+      "zai-org/GLM-4.5V": { "input": "600000000", "output": "1800000000" },
+      "zai-org/GLM-4.6": { "input": "550000000", "output": "2200000000" },
+      "zai-org/GLM-4.6V-Flash": { "input": "300000000", "output": "900000000" },
+      "zai-org/GLM-4.7": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "zai-org/GLM-4.7-Flash": { "input": "0", "output": "0" },
+      "zai-org/GLM-5": { "input": "1000000000", "output": "3200000000", "cacheRead": "200000000" },
+      "zai-org/GLM-5.1": {
+        "input": "1000000000",
+        "output": "3200000000",
+        "cacheRead": "200000000"
+      },
+      "zai-org/GLM-5.2": { "input": "1400000000", "output": "4400000000" }
+    },
+    "hyper": {
+      "deepseek-v4-flash": { "input": "200000000", "output": "400000000", "cacheRead": "40000000" },
+      "deepseek-v4-flash-0731": {
+        "input": "440000000",
+        "output": "1320000000",
+        "cacheRead": "44000000"
+      },
+      "deepseek-v4-pro": {
+        "input": "2400000000",
+        "output": "4800000000",
+        "cacheRead": "200000000"
+      },
+      "deepseek-v4-pro-0813": {
+        "input": "1437216000",
+        "output": "4311648000",
+        "cacheRead": "47907000"
+      },
+      "gemma-4-26b-a4b-it": {
+        "input": "120000000",
+        "output": "420000000",
+        "cacheWrite": "60000000"
+      },
+      "glm-5": { "input": "910000000", "output": "2814000000", "cacheWrite": "455000000" },
+      "glm-5.1": { "input": "1360000000", "output": "4400000000", "cacheWrite": "680000000" },
+      "glm-5.2": { "input": "1524320000", "output": "4790720000", "cacheRead": "152432000" },
+      "gpt-oss-120b": { "input": "188000000", "output": "700000000", "cacheWrite": "94000000" },
+      "kimi-k2.5": { "input": "544400000", "output": "2855000000", "cacheWrite": "272200000" },
+      "kimi-k2.6": { "input": "1034360000", "output": "4355200000", "cacheRead": "174208000" },
+      "kimi-k2.7-code": { "input": "1034360000", "output": "4355200000", "cacheRead": "206872000" },
+      "kimi-k3": { "input": "3266400000", "output": "16332000000", "cacheRead": "326640000" },
+      "llama-3.3-70b-instruct": {
+        "input": "598000000",
+        "output": "738000000",
+        "cacheWrite": "299000000"
+      },
+      "llama-4-maverick-17b-128e-instruct-fp8": {
+        "input": "274000000",
+        "output": "899200000",
+        "cacheWrite": "137000000"
+      },
+      "minimax-m2.7": { "input": "410000000", "output": "1520000000", "cacheWrite": "205000000" },
+      "minimax-m3": { "input": "326640000", "output": "1306560000", "cacheRead": "64239000" },
+      "qwen3-coder-480b-a35b-instruct-int4-mixed-ar": {
+        "input": "445000000",
+        "output": "2145000000",
+        "cacheWrite": "222500000"
+      },
+      "qwen3-next-80b-a3b-instruct": {
+        "input": "117500000",
+        "output": "1136000000",
+        "cacheWrite": "58750000"
+      },
+      "qwen3.6-flash": {
+        "input": "1000000000",
+        "output": "4000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "qwen3.6-max": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "qwen3.6-plus": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "qwen3.7-flash": { "input": "200000000", "output": "800000000", "cacheRead": "40000000" },
+      "qwen3.7-max": { "input": "2500000000", "output": "7500000000", "cacheRead": "500000000" },
+      "qwen3.7-plus": { "input": "1200000000", "output": "4800000000", "cacheRead": "240000000" },
+      "qwen3.8-max": { "input": "2000000000", "output": "6000000000", "cacheRead": "250000000" }
+    },
+    "iflowcn": {
+      "deepseek-r1": { "input": "0", "output": "0" },
+      "deepseek-v3": { "input": "0", "output": "0" },
+      "deepseek-v3.2": { "input": "0", "output": "0" },
+      "glm-4.6": { "input": "0", "output": "0" },
+      "kimi-k2": { "input": "0", "output": "0" },
+      "kimi-k2-0905": { "input": "0", "output": "0" },
+      "qwen3-235b": { "input": "0", "output": "0" },
+      "qwen3-235b-a22b-instruct": { "input": "0", "output": "0" },
+      "qwen3-235b-a22b-thinking-2507": { "input": "0", "output": "0" },
+      "qwen3-32b": { "input": "0", "output": "0" },
+      "qwen3-coder-plus": { "input": "0", "output": "0" },
+      "qwen3-max": { "input": "0", "output": "0" },
+      "qwen3-max-preview": { "input": "0", "output": "0" },
+      "qwen3-vl-plus": { "input": "0", "output": "0" }
+    },
+    "impossibl": {
+      "anthropic/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic/claude-opus-4-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "cerebras/gpt-oss-120b": { "input": "350000000", "output": "750000000" },
+      "deepseek/deepseek-v4-flash": {
+        "input": "190000000",
+        "output": "510000000",
+        "cacheRead": "28000000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "145000000"
+      },
+      "fireworks/glm-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "140000000"
+      },
+      "fireworks/gpt-oss-120b": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000"
+      },
+      "fireworks/gpt-oss-20b": {
+        "input": "70000000",
+        "output": "300000000",
+        "cacheRead": "35000000"
+      },
+      "google/gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "google/gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000"
+      },
+      "google/gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000"
+      },
+      "google/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000"
+      },
+      "google/gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "google/gemini-3.6-flash": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000"
+      },
+      "groq/gpt-oss-120b": { "input": "150000000", "output": "600000000", "cacheRead": "75000000" },
+      "groq/gpt-oss-20b": { "input": "75000000", "output": "300000000", "cacheRead": "37500000" },
+      "moonshotai/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "openai/gpt-3.5-turbo": { "input": "500000000", "output": "1500000000" },
+      "openai/gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "openai/gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/gpt-4.1-mini": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "100000000"
+      },
+      "openai/gpt-4.1-nano": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-4o": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-mini": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "openai/gpt-5-codex": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "openai/gpt-5-pro": { "input": "15000000000", "output": "120000000000" },
+      "openai/gpt-5.1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-codex": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5.2": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.3-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "openai/gpt-5.4-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "cacheRead": "3000000000",
+        "tiers": [
+          {
+            "input": "60000000000",
+            "output": "270000000000",
+            "cacheRead": "3000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.5-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "cacheRead": "3000000000",
+        "tiers": [
+          {
+            "input": "60000000000",
+            "output": "270000000000",
+            "cacheRead": "3000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000",
+        "tiers": [
+          {
+            "input": "400000000",
+            "output": "1800000000",
+            "cacheRead": "40000000",
+            "cacheWrite": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "5000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "openai/o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "openai/o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "qwen/qwen3.6-flash": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "50000000",
+        "tiers": [
+          {
+            "input": "1000000000",
+            "output": "4000000000",
+            "cacheRead": "200000000",
+            "aboveInputTokens": "262144"
+          }
+        ]
+      },
+      "qwen/qwen3.7-max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "500000000"
+      },
+      "qwen/qwen3.7-plus": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "80000000",
+        "tiers": [
+          {
+            "input": "1200000000",
+            "output": "4800000000",
+            "cacheRead": "240000000",
+            "aboveInputTokens": "262144"
+          }
+        ]
+      },
+      "qwen/qwen3.8-max-preview": { "input": "2500000000", "output": "7500000000" },
+      "thinkingmachines/inkling": {
+        "input": "1870000000",
+        "output": "4680000000",
+        "cacheRead": "374000000"
+      },
+      "xai/grok-4.20-0309-non-reasoning": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000"
+      },
+      "xai/grok-4.20-0309-reasoning": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000"
+      },
+      "xai/grok-4.3": { "input": "1250000000", "output": "2500000000", "cacheRead": "200000000" },
+      "xai/grok-4.5": { "input": "2000000000", "output": "6000000000", "cacheRead": "300000000" },
+      "xai/grok-build-0.1": {
+        "input": "1000000000",
+        "output": "2000000000",
+        "cacheRead": "200000000"
+      },
+      "xiaomi/mimo-v2.5": { "input": "140000000", "output": "280000000", "cacheRead": "3000000" },
+      "zai/glm-4.5": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "zai/glm-4.5-air": { "input": "200000000", "output": "1100000000", "cacheRead": "30000000" },
+      "zai/glm-4.6": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "zai/glm-4.7": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "zai/glm-5": { "input": "1000000000", "output": "3200000000", "cacheRead": "200000000" },
+      "zai/glm-5-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      },
+      "zai/glm-5.1": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "zai/glm-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" }
+    },
+    "inception": {
+      "mercury-2": { "input": "250000000", "output": "750000000", "cacheRead": "25000000" },
+      "mercury-edit-2": { "input": "250000000", "output": "750000000", "cacheRead": "25000000" }
+    },
+    "inceptron": {
+      "deepseek-ai/DeepSeek-V4-Flash-0731": {
+        "input": "130000000",
+        "output": "280000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "0"
+      },
+      "moonshotai/Kimi-K2.6": {
+        "input": "570000000",
+        "output": "3390000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "0"
+      },
+      "moonshotai/Kimi-K2.7-Code": {
+        "input": "670000000",
+        "output": "3400000000",
+        "cacheRead": "190000000",
+        "cacheWrite": "0"
+      },
+      "zai-org/GLM-5.2": {
+        "input": "750000000",
+        "output": "2400000000",
+        "cacheRead": "170000000",
+        "cacheWrite": "0"
+      }
+    },
+    "inference": {
+      "google/gemma-3": { "input": "150000000", "output": "300000000" },
+      "meta/llama-3.1-8b-instruct": { "input": "25000000", "output": "25000000" },
+      "meta/llama-3.2-11b-vision-instruct": { "input": "55000000", "output": "55000000" },
+      "meta/llama-3.2-1b-instruct": { "input": "10000000", "output": "10000000" },
+      "meta/llama-3.2-3b-instruct": { "input": "20000000", "output": "20000000" },
+      "mistral/mistral-nemo-12b-instruct": { "input": "38000000", "output": "100000000" },
+      "osmosis/osmosis-structure-0.6b": { "input": "100000000", "output": "500000000" },
+      "qwen/qwen-2.5-7b-vision-instruct": { "input": "200000000", "output": "200000000" },
+      "qwen/qwen3-embedding-4b": { "input": "10000000", "output": "0" }
+    },
+    "inferx": {
+      "Agents-A1": { "input": "0", "output": "0" },
+      "deepseek-v4-flash": { "input": "0", "output": "0" },
+      "Devstral-2-123B-Instruct-2512-int4-AutoRound": { "input": "0", "output": "0" },
+      "gemma-4-31B-it-fp8": { "input": "0", "output": "0" },
+      "mimo-v25": { "input": "0", "output": "0" },
+      "Ornith-1.0-35B-FP8": { "input": "0", "output": "0" },
+      "Qwen3-Coder-Next-FP8": { "input": "0", "output": "0" },
+      "Qwen3-Coder-Next-FP8-no-thinking": { "input": "0", "output": "0" },
+      "Qwen3-Embedding-8B": { "input": "0", "output": "0" },
+      "Qwen3.6-27B-FP8": { "input": "0", "output": "0" },
+      "Qwen3.6-35B-A3B-FP8": { "input": "0", "output": "0" },
+      "Qwen3.6-35B-A3B-fp8-no-thinking": { "input": "0", "output": "0" }
+    },
+    "infomaniak": {
+      "bge_multilingual_gemma2": { "input": "80000000", "output": "0" },
+      "google/gemma-4-31B-it": { "input": "250000000", "output": "500000000" },
+      "mini_lm_l12_v2": { "input": "0", "output": "0" },
+      "mistralai/Ministral-3-14B-Instruct-2512": { "input": "370000000", "output": "500000000" },
+      "mistralai/Mistral-Small-4-119B-2603": { "input": "250000000", "output": "930000000" },
+      "moonshotai/Kimi-K2.6": { "input": "740000000", "output": "3720000000" },
+      "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8": { "input": "60000000", "output": "250000000" },
+      "Qwen/Qwen3.5-122B-A10B-FP8": { "input": "500000000", "output": "3970000000" },
+      "Qwen/Qwen3.5-397B-A17B-FP8": { "input": "990000000", "output": "4460000000" },
+      "swiss-ai/Apertus-v1.5-70B": { "input": "870000000", "output": "3100000000" }
+    },
+    "io-net": {
+      "deepseek-ai/DeepSeek-R1-0528": {
+        "input": "2000000000",
+        "output": "8750000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "4000000000"
+      },
+      "Intel/Qwen3-Coder-480B-A35B-Instruct-int4-mixed-ar": {
+        "input": "220000000",
+        "output": "950000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "440000000"
+      },
+      "meta-llama/Llama-3.2-90B-Vision-Instruct": {
+        "input": "350000000",
+        "output": "400000000",
+        "cacheRead": "175000000",
+        "cacheWrite": "700000000"
+      },
+      "meta-llama/Llama-3.3-70B-Instruct": {
+        "input": "130000000",
+        "output": "380000000",
+        "cacheRead": "65000000",
+        "cacheWrite": "260000000"
+      },
+      "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "300000000"
+      },
+      "mistralai/Devstral-Small-2505": {
+        "input": "50000000",
+        "output": "220000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "100000000"
+      },
+      "mistralai/Magistral-Small-2506": {
+        "input": "500000000",
+        "output": "1500000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "1000000000"
+      },
+      "mistralai/Mistral-Large-Instruct-2411": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "4000000000"
+      },
+      "mistralai/Mistral-Nemo-Instruct-2407": {
+        "input": "20000000",
+        "output": "40000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "40000000"
+      },
+      "moonshotai/Kimi-K2-Instruct-0905": {
+        "input": "390000000",
+        "output": "1900000000",
+        "cacheRead": "195000000",
+        "cacheWrite": "780000000"
+      },
+      "moonshotai/Kimi-K2-Thinking": {
+        "input": "550000000",
+        "output": "2250000000",
+        "cacheRead": "275000000",
+        "cacheWrite": "1100000000"
+      },
+      "openai/gpt-oss-120b": {
+        "input": "40000000",
+        "output": "400000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "80000000"
+      },
+      "openai/gpt-oss-20b": {
+        "input": "30000000",
+        "output": "140000000",
+        "cacheRead": "15000000",
+        "cacheWrite": "60000000"
+      },
+      "Qwen/Qwen2.5-VL-32B-Instruct": {
+        "input": "50000000",
+        "output": "220000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "100000000"
+      },
+      "Qwen/Qwen3-235B-A22B-Thinking-2507": {
+        "input": "110000000",
+        "output": "600000000",
+        "cacheRead": "55000000",
+        "cacheWrite": "220000000"
+      },
+      "Qwen/Qwen3-Next-80B-A3B-Instruct": {
+        "input": "100000000",
+        "output": "800000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "200000000"
+      },
+      "zai-org/GLM-4.6": {
+        "input": "400000000",
+        "output": "1750000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "800000000"
+      }
+    },
+    "iteracompute": {
+      "iteracompute/qwen3.8-27b": {
+        "input": "350000000",
+        "output": "3000000000",
+        "cacheRead": "100000000"
+      }
+    },
+    "jalapeno": {
+      "DeepSeek-V4-Flash": { "input": "140000000", "output": "280000000" },
+      "DeepSeek-V4-Pro": { "input": "1600000000", "output": "3380000000" },
+      "GLM-5.1": { "input": "1380000000", "output": "4400000000" },
+      "GLM-5.2": { "input": "1400000000", "output": "4400000000" },
+      "Hy3": { "input": "140000000", "output": "580000000" },
+      "Kimi-K2.5": { "input": "600000000", "output": "3000000000" },
+      "Kimi-K2.7-Code": { "input": "950000000", "output": "4000000000" },
+      "Kimi-K3": { "input": "3000000000", "output": "15000000000" },
+      "MiniMax-M3": { "input": "300000000", "output": "1200000000" },
+      "Qwen3-Next-80B-A3B-Instruct": { "input": "150000000", "output": "1500000000" },
+      "Qwen3-Next-80B-A3B-Thinking": { "input": "150000000", "output": "1500000000" },
+      "Qwen3-VL-235B-A22B-Instruct": { "input": "300000000", "output": "1500000000" },
+      "Qwen3-VL-235B-A22B-Thinking": { "input": "980000000", "output": "3950000000" },
+      "Qwen3.5-122B-A10B": { "input": "400000000", "output": "3200000000" },
+      "Qwen3.5-27B": { "input": "300000000", "output": "2400000000" },
+      "Qwen3.5-35B-A3B": { "input": "250000000", "output": "2000000000" },
+      "Qwen3.5-397B-A17B": { "input": "600000000", "output": "3600000000" }
+    },
+    "jiekou": {
+      "baidu/ernie-4.5-300b-a47b-paddle": { "input": "280000000", "output": "1100000000" },
+      "baidu/ernie-4.5-vl-424b-a47b": { "input": "420000000", "output": "1250000000" },
+      "claude-haiku-4-5-20251001": { "input": "900000000", "output": "4500000000" },
+      "claude-opus-4-1-20250805": { "input": "13500000000", "output": "67500000000" },
+      "claude-opus-4-20250514": { "input": "13500000000", "output": "67500000000" },
+      "claude-opus-4-5-20251101": { "input": "4500000000", "output": "22500000000" },
+      "claude-opus-4-6": { "input": "5000000000", "output": "25000000000" },
+      "claude-sonnet-4-20250514": { "input": "2700000000", "output": "13500000000" },
+      "claude-sonnet-4-5-20250929": { "input": "2700000000", "output": "13500000000" },
+      "deepseek/deepseek-r1-0528": { "input": "700000000", "output": "2500000000" },
+      "deepseek/deepseek-v3-0324": { "input": "280000000", "output": "1140000000" },
+      "deepseek/deepseek-v3.1": { "input": "270000000", "output": "1000000000" },
+      "gemini-2.5-flash": { "input": "270000000", "output": "2250000000" },
+      "gemini-2.5-flash-lite": { "input": "90000000", "output": "360000000" },
+      "gemini-2.5-flash-lite-preview-06-17": { "input": "90000000", "output": "360000000" },
+      "gemini-2.5-flash-lite-preview-09-2025": { "input": "90000000", "output": "360000000" },
+      "gemini-2.5-flash-preview-05-20": { "input": "135000000", "output": "3150000000" },
+      "gemini-2.5-pro": { "input": "1125000000", "output": "9000000000" },
+      "gemini-2.5-pro-preview-06-05": { "input": "1125000000", "output": "9000000000" },
+      "gemini-3-flash-preview": { "input": "500000000", "output": "3000000000" },
+      "gemini-3-pro-preview": { "input": "1800000000", "output": "10800000000" },
+      "gpt-5-chat-latest": { "input": "1125000000", "output": "9000000000" },
+      "gpt-5-codex": { "input": "1125000000", "output": "9000000000" },
+      "gpt-5-mini": { "input": "225000000", "output": "1800000000" },
+      "gpt-5-nano": { "input": "45000000", "output": "360000000" },
+      "gpt-5-pro": { "input": "13500000000", "output": "108000000000" },
+      "gpt-5.1": { "input": "1125000000", "output": "9000000000" },
+      "gpt-5.1-codex": { "input": "1125000000", "output": "9000000000" },
+      "gpt-5.1-codex-max": { "input": "1125000000", "output": "9000000000" },
+      "gpt-5.1-codex-mini": { "input": "225000000", "output": "1800000000" },
+      "gpt-5.2": { "input": "1575000000", "output": "12600000000" },
+      "gpt-5.2-codex": { "input": "1750000000", "output": "14000000000" },
+      "gpt-5.2-pro": { "input": "18900000000", "output": "151200000000" },
+      "grok-4-0709": { "input": "2700000000", "output": "13500000000" },
+      "grok-4-1-fast-non-reasoning": { "input": "180000000", "output": "450000000" },
+      "grok-4-1-fast-reasoning": { "input": "180000000", "output": "450000000" },
+      "grok-4-fast-non-reasoning": { "input": "180000000", "output": "450000000" },
+      "grok-4-fast-reasoning": { "input": "180000000", "output": "450000000" },
+      "grok-code-fast-1": { "input": "180000000", "output": "1350000000" },
+      "minimax/minimax-m2.1": { "input": "300000000", "output": "1200000000" },
+      "minimaxai/minimax-m1-80k": { "input": "550000000", "output": "2200000000" },
+      "moonshotai/kimi-k2-0905": { "input": "600000000", "output": "2500000000" },
+      "moonshotai/kimi-k2-instruct": { "input": "570000000", "output": "2300000000" },
+      "moonshotai/kimi-k2.5": { "input": "600000000", "output": "3000000000" },
+      "o3": { "input": "10000000000", "output": "40000000000" },
+      "o3-mini": { "input": "1100000000", "output": "4400000000" },
+      "o4-mini": { "input": "1100000000", "output": "4400000000" },
+      "qwen/qwen3-235b-a22b-fp8": { "input": "200000000", "output": "800000000" },
+      "qwen/qwen3-235b-a22b-instruct-2507": { "input": "150000000", "output": "800000000" },
+      "qwen/qwen3-235b-a22b-thinking-2507": { "input": "300000000", "output": "3000000000" },
+      "qwen/qwen3-30b-a3b-fp8": { "input": "90000000", "output": "450000000" },
+      "qwen/qwen3-32b-fp8": { "input": "100000000", "output": "450000000" },
+      "qwen/qwen3-coder-480b-a35b-instruct": { "input": "290000000", "output": "1200000000" },
+      "qwen/qwen3-coder-next": { "input": "200000000", "output": "1500000000" },
+      "qwen/qwen3-next-80b-a3b-instruct": { "input": "150000000", "output": "1500000000" },
+      "qwen/qwen3-next-80b-a3b-thinking": { "input": "150000000", "output": "1500000000" },
+      "xiaomimimo/mimo-v2-flash": { "input": "0", "output": "0" },
+      "zai-org/glm-4.5": { "input": "600000000", "output": "2200000000" },
+      "zai-org/glm-4.5v": { "input": "600000000", "output": "1800000000" },
+      "zai-org/glm-4.7": { "input": "600000000", "output": "2200000000" },
+      "zai-org/glm-4.7-flash": { "input": "70000000", "output": "400000000" }
+    },
+    "kenari": {
+      "claude-fable-5": { "input": "0", "output": "0" },
+      "claude-opus-4-7": { "input": "0", "output": "0" },
+      "claude-opus-4-8": { "input": "0", "output": "0" },
+      "claude-sonnet-5": { "input": "0", "output": "0" },
+      "deepseek-v4-flash": { "input": "0", "output": "0" },
+      "deepseek-v4-flash:free": { "input": "0", "output": "0" },
+      "deepseek-v4-pro": { "input": "0", "output": "0" },
+      "gemini-2-5-flash": { "input": "0", "output": "0" },
+      "gemini-2-5-flash-lite": { "input": "0", "output": "0" },
+      "gemini-3-1-flash-lite": { "input": "0", "output": "0" },
+      "gemma-4-31b-it": { "input": "0", "output": "0" },
+      "glm-4-7-flash:free": { "input": "0", "output": "0" },
+      "glm-5-1": { "input": "0", "output": "0" },
+      "glm-5-2": { "input": "0", "output": "0" },
+      "gpt-5-4-mini": { "input": "0", "output": "0" },
+      "gpt-5-5": { "input": "0", "output": "0" },
+      "gpt-5-6-luna": { "input": "0", "output": "0" },
+      "gpt-5-6-sol": { "input": "0", "output": "0" },
+      "gpt-5-6-terra": { "input": "0", "output": "0" },
+      "gpt-image-2": { "input": "0", "output": "0" },
+      "gpt-oss-120b": { "input": "0", "output": "0" },
+      "gpt-oss-20b": { "input": "0", "output": "0" },
+      "grok-4-5": { "input": "0", "output": "0" },
+      "grok-build-0-1": { "input": "0", "output": "0" },
+      "kimi-k2-6": { "input": "0", "output": "0" },
+      "kimi-k2-6:free": { "input": "0", "output": "0" },
+      "kimi-k2-7-code": { "input": "0", "output": "0" },
+      "kimi-k2-7-code:free": { "input": "0", "output": "0" },
+      "kimi-k3": { "input": "0", "output": "0" },
+      "mimo-v2-5": { "input": "0", "output": "0" },
+      "mimo-v2-5-pro": { "input": "0", "output": "0" },
+      "mimo-v2-5:free": { "input": "0", "output": "0" },
+      "minimax-m3": { "input": "0", "output": "0" },
+      "nemotron-3-nano-30b-a3b": { "input": "0", "output": "0" },
+      "nemotron-3-super-120b-a12b": { "input": "0", "output": "0" },
+      "nemotron-3-super-120b-a12b:free": { "input": "0", "output": "0" },
+      "nemotron-3-ultra-550b-a55b": { "input": "0", "output": "0" },
+      "qwen3-7-plus": { "input": "0", "output": "0" }
+    },
+    "kilo": {
+      "~anthropic/claude-fable-latest": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "~anthropic/claude-haiku-latest": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "~anthropic/claude-opus-latest": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "~anthropic/claude-sonnet-latest": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "~deepseek/deepseek-v4-flash-latest": {
+        "input": "35000000",
+        "output": "100000000",
+        "cacheRead": "8000000"
+      },
+      "~google/gemini-flash-latest": {
+        "input": "375000000",
+        "output": "1875000000",
+        "cacheRead": "37500000",
+        "cacheWrite": "20833000",
+        "reasoning": "1875000000"
+      },
+      "~google/gemini-pro-latest": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000"
+      },
+      "~moonshotai/kimi-latest": {
+        "input": "2800000000",
+        "output": "14000000000",
+        "cacheRead": "290000000"
+      },
+      "~openai/gpt-latest": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "~openai/gpt-mini-latest": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "~x-ai/grok-latest": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000"
+      },
+      "~z-ai/glm-latest": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "aion-labs/aion-2.0": {
+        "input": "800000000",
+        "output": "1600000000",
+        "cacheRead": "200000000"
+      },
+      "aion-labs/aion-3.0": {
+        "input": "3000000000",
+        "output": "6000000000",
+        "cacheRead": "750000000"
+      },
+      "aion-labs/aion-3.0-mini": {
+        "input": "700000000",
+        "output": "1400000000",
+        "cacheRead": "180000000"
+      },
+      "aion-labs/aion-rp-llama-3.1-8b": { "input": "800000000", "output": "1600000000" },
+      "allenai/olmo-3-32b-think": { "input": "150000000", "output": "500000000" },
+      "amazon/nova-2-lite-v1": { "input": "300000000", "output": "2500000000" },
+      "amazon/nova-lite-v1": { "input": "60000000", "output": "240000000" },
+      "amazon/nova-micro-v1": { "input": "35000000", "output": "140000000" },
+      "amazon/nova-premier-v1": {
+        "input": "2500000000",
+        "output": "12500000000",
+        "cacheRead": "625000000"
+      },
+      "amazon/nova-pro-v1": { "input": "800000000", "output": "3200000000" },
+      "anthracite-org/magnum-v4-72b": { "input": "3000000000", "output": "5000000000" },
+      "anthropic/claude-3-haiku": {
+        "input": "250000000",
+        "output": "1250000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "300000000"
+      },
+      "anthropic/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-haiku-4.5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic/claude-opus-4": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic/claude-opus-4.1": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic/claude-opus-4.5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.7-fast": {
+        "input": "30000000000",
+        "output": "150000000000",
+        "cacheRead": "3000000000",
+        "cacheWrite": "37500000000"
+      },
+      "anthropic/claude-opus-4.8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.8-fast": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-5-fast": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-sonnet-4": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4.5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4.6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "arcee-ai/trinity-large-thinking": {
+        "input": "220000000",
+        "output": "850000000",
+        "cacheRead": "60000000"
+      },
+      "arcee-ai/virtuoso-large": { "input": "750000000", "output": "1200000000" },
+      "baidu/ernie-4.5-vl-424b-a47b": { "input": "420000000", "output": "1250000000" },
+      "bytedance-seed/seed-1.6": { "input": "250000000", "output": "2000000000" },
+      "bytedance-seed/seed-1.6-flash": { "input": "75000000", "output": "300000000" },
+      "bytedance-seed/seed-2-1-turbo": { "input": "500000000", "output": "2500000000" },
+      "bytedance-seed/seed-2.0-code": { "input": "500000000", "output": "3000000000" },
+      "bytedance-seed/seed-2.0-lite": { "input": "250000000", "output": "2000000000" },
+      "bytedance-seed/seed-2.0-mini": { "input": "100000000", "output": "400000000" },
+      "bytedance/ui-tars-1.5-7b": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "100000000"
+      },
+      "cognitivecomputations/dolphin-mistral-24b-venice-edition": {
+        "input": "200000000",
+        "output": "900000000"
+      },
+      "cohere/command-a": { "input": "2500000000", "output": "10000000000" },
+      "cohere/command-r-08-2024": { "input": "150000000", "output": "600000000" },
+      "cohere/command-r-plus-08-2024": { "input": "2500000000", "output": "10000000000" },
+      "cohere/command-r7b-12-2024": { "input": "37500000", "output": "150000000" },
+      "cohere/north-mini-code:free": { "input": "0", "output": "0" },
+      "deepseek/deepseek-chat": { "input": "400000000", "output": "1300000000" },
+      "deepseek/deepseek-chat-v3-0324": {
+        "input": "270000000",
+        "output": "1120000000",
+        "cacheRead": "135000000"
+      },
+      "deepseek/deepseek-chat-v3.1": {
+        "input": "270000000",
+        "output": "1000000000",
+        "cacheRead": "135000000"
+      },
+      "deepseek/deepseek-r1": { "input": "700000000", "output": "2500000000" },
+      "deepseek/deepseek-r1-0528": {
+        "input": "700000000",
+        "output": "2500000000",
+        "cacheRead": "350000000"
+      },
+      "deepseek/deepseek-r1-distill-llama-70b": { "input": "800000000", "output": "800000000" },
+      "deepseek/deepseek-v3.1-terminus": {
+        "input": "270000000",
+        "output": "1000000000",
+        "cacheRead": "135000000"
+      },
+      "deepseek/deepseek-v3.2": {
+        "input": "269000000",
+        "output": "400000000",
+        "cacheRead": "134500000"
+      },
+      "deepseek/deepseek-v3.2-exp": { "input": "270000000", "output": "410000000" },
+      "deepseek/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "deepseek/deepseek-v4-flash-0731": {
+        "input": "440000000",
+        "output": "1320000000",
+        "cacheRead": "28000000"
+      },
+      "deepseek/deepseek-v4-flash-vision-exp": {
+        "input": "220000000",
+        "output": "660000000",
+        "cacheRead": "7000000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "1600000000",
+        "output": "3200000000",
+        "cacheRead": "135000000"
+      },
+      "deepseek/deepseek-v4-pro-0813": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "132000000"
+      },
+      "dots-studio/dots-3-note-preview:free": { "input": "0", "output": "0" },
+      "google/gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83333000",
+        "reasoning": "2500000000"
+      },
+      "google/gemini-2.5-flash-image": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83333000"
+      },
+      "google/gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "83333000",
+        "reasoning": "400000000"
+      },
+      "google/gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "cacheWrite": "375000000",
+        "reasoning": "10000000000"
+      },
+      "google/gemini-2.5-pro-preview": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "cacheWrite": "375000000",
+        "reasoning": "10000000000"
+      },
+      "google/gemini-2.5-pro-preview-05-06": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "cacheWrite": "375000000",
+        "reasoning": "10000000000"
+      },
+      "google/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "83333000",
+        "reasoning": "3000000000"
+      },
+      "google/gemini-3-pro-image": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000"
+      },
+      "google/gemini-3-pro-image-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000"
+      },
+      "google/gemini-3.1-flash-image": { "input": "500000000", "output": "3000000000" },
+      "google/gemini-3.1-flash-image-preview": { "input": "500000000", "output": "3000000000" },
+      "google/gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "83333000",
+        "reasoning": "1500000000"
+      },
+      "google/gemini-3.1-flash-lite-image": { "input": "250000000", "output": "1500000000" },
+      "google/gemini-3.1-flash-lite-preview": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "83333000",
+        "reasoning": "1500000000"
+      },
+      "google/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000"
+      },
+      "google/gemini-3.1-pro-preview-customtools": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000"
+      },
+      "google/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000",
+        "reasoning": "9000000000"
+      },
+      "google/gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83333000",
+        "reasoning": "2500000000"
+      },
+      "google/gemini-3.6-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "41667000",
+        "reasoning": "3750000000"
+      },
+      "google/gemini-3.7-flash": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000",
+        "reasoning": "7500000000"
+      },
+      "google/gemma-2-27b-it": { "input": "650000000", "output": "650000000" },
+      "google/gemma-3-12b-it": { "input": "50000000", "output": "150000000" },
+      "google/gemma-3-27b-it": { "input": "80000000", "output": "160000000" },
+      "google/gemma-3-4b-it": { "input": "50000000", "output": "100000000" },
+      "google/gemma-3n-e4b-it": { "input": "60000000", "output": "120000000" },
+      "google/gemma-4-26b-a4b-it": { "input": "42000000", "output": "220000000" },
+      "google/gemma-4-31b-it": {
+        "input": "80000000",
+        "output": "350000000",
+        "cacheRead": "10000000"
+      },
+      "google/lyria-3-clip-preview": { "input": "0", "output": "0" },
+      "google/lyria-3-pro-preview": { "input": "0", "output": "0" },
+      "gryphe/mythomax-l2-13b": { "input": "60000000", "output": "60000000" },
+      "ibm-granite/granite-4.0-h-micro": { "input": "17000000", "output": "112000000" },
+      "ibm-granite/granite-4.1-8b": {
+        "input": "50000000",
+        "output": "100000000",
+        "cacheRead": "50000000"
+      },
+      "inception/mercury-2": {
+        "input": "250000000",
+        "output": "750000000",
+        "cacheRead": "25000000"
+      },
+      "inclusionai/ling-3.0-flash": {
+        "input": "60000000",
+        "output": "180000000",
+        "cacheRead": "12000000"
+      },
+      "kilo-auto/balanced": {
+        "input": "325000000",
+        "output": "1950000000",
+        "cacheRead": "32500000",
+        "cacheWrite": "406250000",
+        "reasoning": "0"
+      },
+      "kilo-auto/efficient": {
+        "input": "325000000",
+        "output": "1950000000",
+        "cacheRead": "32500000",
+        "cacheWrite": "406250000",
+        "reasoning": "0"
+      },
+      "kilo-auto/free": {
+        "input": "0",
+        "output": "0",
+        "cacheRead": "0",
+        "cacheWrite": "0",
+        "reasoning": "0"
+      },
+      "kilo-auto/frontier": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "reasoning": "0"
+      },
+      "kilo-auto/small": {
+        "input": "50000000",
+        "output": "400000000",
+        "cacheRead": "5000000",
+        "reasoning": "0"
+      },
+      "kwaipilot/kat-coder-air-v2.5": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "30000000"
+      },
+      "kwaipilot/kat-coder-pro-v2": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "kwaipilot/kat-coder-pro-v2.5": {
+        "input": "740000000",
+        "output": "2960000000",
+        "cacheRead": "150000000"
+      },
+      "liquid/lfm-2.5-2.6b:free": { "input": "0", "output": "0" },
+      "mancer/weaver": { "input": "500000000", "output": "750000000" },
+      "meituan/longcat-2.0": {
+        "input": "750000000",
+        "output": "3000000000",
+        "cacheRead": "15000000"
+      },
+      "meituan/longcat-2.0-free": {
+        "input": "0",
+        "output": "0",
+        "cacheRead": "0",
+        "reasoning": "0"
+      },
+      "meta-llama/llama-3.1-70b-instruct": { "input": "400000000", "output": "400000000" },
+      "meta-llama/llama-3.1-8b-instruct": { "input": "20000000", "output": "40000000" },
+      "meta-llama/llama-3.2-1b-instruct": { "input": "27000000", "output": "201000000" },
+      "meta-llama/llama-3.2-3b-instruct": { "input": "50000000", "output": "330000000" },
+      "meta-llama/llama-3.3-70b-instruct": { "input": "100000000", "output": "320000000" },
+      "meta-llama/llama-4-maverick": { "input": "200000000", "output": "696000000" },
+      "meta-llama/llama-4-scout": { "input": "100000000", "output": "300000000" },
+      "meta-llama/llama-guard-4-12b": { "input": "180000000", "output": "180000000" },
+      "meta/muse-glimmer-30b": {
+        "input": "300000000",
+        "output": "1100000000",
+        "cacheRead": "40000000"
+      },
+      "meta/muse-spark-1.1": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "150000000"
+      },
+      "meta/muse-spark-1.2": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "150000000"
+      },
+      "meta/muse-spark-1.2-contributor": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "2000000"
+      },
+      "microsoft/phi-4": { "input": "70000000", "output": "140000000" },
+      "microsoft/wizardlm-2-8x22b": { "input": "620000000", "output": "620000000" },
+      "minimax/minimax-01": { "input": "200000000", "output": "1100000000" },
+      "minimax/minimax-m1": { "input": "400000000", "output": "2200000000" },
+      "minimax/minimax-m2": { "input": "300000000", "output": "1200000000" },
+      "minimax/minimax-m2-her": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "minimax/minimax-m2.1": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "minimax/minimax-m2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "minimax/minimax-m2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "minimax/minimax-m2.7:free": { "input": "0", "output": "0" },
+      "minimax/minimax-m3": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "minimax/minimax-m3:free": { "input": "0", "output": "0" },
+      "mistralai/codestral-2508": {
+        "input": "300000000",
+        "output": "900000000",
+        "cacheRead": "30000000"
+      },
+      "mistralai/devstral-2512": {
+        "input": "440000000",
+        "output": "2200000000",
+        "cacheRead": "44000000"
+      },
+      "mistralai/ministral-14b-2512": {
+        "input": "200000000",
+        "output": "200000000",
+        "cacheRead": "20000000"
+      },
+      "mistralai/ministral-3b-2512": {
+        "input": "100000000",
+        "output": "100000000",
+        "cacheRead": "10000000"
+      },
+      "mistralai/ministral-8b": { "input": "110000000", "output": "110000000" },
+      "mistralai/ministral-8b-2512": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "15000000"
+      },
+      "mistralai/mistral-large": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000"
+      },
+      "mistralai/mistral-large-2407": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000"
+      },
+      "mistralai/mistral-large-2512": {
+        "input": "500000000",
+        "output": "1500000000",
+        "cacheRead": "50000000"
+      },
+      "mistralai/mistral-medium-3": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "40000000"
+      },
+      "mistralai/mistral-medium-3-5": { "input": "1500000000", "output": "7500000000" },
+      "mistralai/mistral-medium-3.1": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "40000000"
+      },
+      "mistralai/mistral-nemo": {
+        "input": "165000000",
+        "output": "165000000",
+        "cacheRead": "16500000"
+      },
+      "mistralai/mistral-saba": {
+        "input": "200000000",
+        "output": "600000000",
+        "cacheRead": "20000000"
+      },
+      "mistralai/mistral-small-24b-instruct-2501": { "input": "50000000", "output": "80000000" },
+      "mistralai/mistral-small-2603": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000"
+      },
+      "mistralai/mistral-small-3.1-24b-instruct": { "input": "351000000", "output": "555000000" },
+      "mistralai/mistral-small-3.2-24b-instruct": {
+        "input": "110000000",
+        "output": "330000000",
+        "cacheRead": "11000000"
+      },
+      "mistralai/mixtral-8x22b-instruct": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000"
+      },
+      "mistralai/voxtral-small-24b-2507": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "10000000"
+      },
+      "moonshotai/kimi-k2": { "input": "570000000", "output": "2300000000" },
+      "moonshotai/kimi-k2-0905": { "input": "600000000", "output": "2500000000" },
+      "moonshotai/kimi-k2-thinking": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "150000000"
+      },
+      "moonshotai/kimi-k2.5": {
+        "input": "600000000",
+        "output": "3000000000",
+        "cacheRead": "100000000"
+      },
+      "moonshotai/kimi-k2.6": {
+        "input": "800000000",
+        "output": "3400000000",
+        "cacheRead": "160000000"
+      },
+      "moonshotai/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "moonshotai/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "morph/morph-v3-fast": { "input": "800000000", "output": "1200000000" },
+      "morph/morph-v3-large": { "input": "900000000", "output": "1900000000" },
+      "nex-agi/nex-n2-mini": { "input": "25000000", "output": "100000000", "cacheRead": "2500000" },
+      "nex-agi/nex-n2-pro": {
+        "input": "250000000",
+        "output": "1000000000",
+        "cacheRead": "25000000"
+      },
+      "nousresearch/hermes-3-llama-3.1-405b": { "input": "1000000000", "output": "1000000000" },
+      "nousresearch/hermes-3-llama-3.1-70b": { "input": "700000000", "output": "700000000" },
+      "nousresearch/hermes-4-405b": { "input": "1000000000", "output": "3000000000" },
+      "nousresearch/hermes-4-70b": { "input": "130000000", "output": "400000000" },
+      "nvidia/nemotron-3-nano-30b-a3b": {
+        "input": "50000000",
+        "output": "200000000",
+        "cacheRead": "25000000"
+      },
+      "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": { "input": "0", "output": "0" },
+      "nvidia/nemotron-3-super-120b-a12b": { "input": "85000000", "output": "400000000" },
+      "nvidia/nemotron-3-super-120b-a12b:free": { "input": "0", "output": "0" },
+      "nvidia/nemotron-3-ultra-550b-a55b": {
+        "input": "500000000",
+        "output": "2200000000",
+        "cacheRead": "100000000"
+      },
+      "nvidia/nemotron-3-ultra-550b-a55b:free": { "input": "0", "output": "0" },
+      "nvidia/nemotron-3.5-content-safety:free": { "input": "0", "output": "0" },
+      "nvidia/nemotron-3.5-lightning": {
+        "input": "80000000",
+        "output": "200000000",
+        "cacheRead": "40000000"
+      },
+      "nvidia/nemotron-3.5-lightning:free": { "input": "0", "output": "0" },
+      "openai/gpt-3.5-turbo": { "input": "500000000", "output": "1500000000" },
+      "openai/gpt-3.5-turbo-0613": { "input": "1000000000", "output": "2000000000" },
+      "openai/gpt-3.5-turbo-16k": { "input": "3000000000", "output": "4000000000" },
+      "openai/gpt-3.5-turbo-instruct": { "input": "1500000000", "output": "2000000000" },
+      "openai/gpt-4": { "input": "30000000000", "output": "60000000000" },
+      "openai/gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "openai/gpt-4-turbo-preview": { "input": "10000000000", "output": "30000000000" },
+      "openai/gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/gpt-4.1-mini": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "100000000"
+      },
+      "openai/gpt-4.1-nano": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-4o": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-2024-05-13": { "input": "5000000000", "output": "15000000000" },
+      "openai/gpt-4o-2024-08-06": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-2024-11-20": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-mini": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-4o-mini-2024-07-18": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "openai/gpt-5-image": {
+        "input": "10000000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-5-image-mini": {
+        "input": "2500000000",
+        "output": "2000000000",
+        "cacheRead": "250000000"
+      },
+      "openai/gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "openai/gpt-5-pro": { "input": "15000000000", "output": "120000000000" },
+      "openai/gpt-5.1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-codex": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "130000000"
+      },
+      "openai/gpt-5.1-codex-max": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "30000000"
+      },
+      "openai/gpt-5.2": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-chat": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-pro": { "input": "21000000000", "output": "168000000000" },
+      "openai/gpt-5.3-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000"
+      },
+      "openai/gpt-5.4-image-2": {
+        "input": "8000000000",
+        "output": "15000000000",
+        "cacheRead": "2000000000"
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "openai/gpt-5.4-pro": { "input": "30000000000", "output": "180000000000" },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "openai/gpt-5.5-pro": { "input": "30000000000", "output": "180000000000" },
+      "openai/gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000"
+      },
+      "openai/gpt-5.6-luna-pro": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000"
+      },
+      "openai/gpt-5.6-sol": {
+        "input": "4000000000",
+        "output": "20000000000",
+        "cacheRead": "400000000",
+        "cacheWrite": "5000000000"
+      },
+      "openai/gpt-5.6-sol-discounted": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "3125000000",
+        "reasoning": "0"
+      },
+      "openai/gpt-5.6-sol-pro": {
+        "input": "4000000000",
+        "output": "20000000000",
+        "cacheRead": "400000000",
+        "cacheWrite": "5000000000"
+      },
+      "openai/gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "openai/gpt-5.6-terra-pro": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "openai/gpt-audio": { "input": "2500000000", "output": "10000000000" },
+      "openai/gpt-audio-mini": { "input": "600000000", "output": "2400000000" },
+      "openai/gpt-chat-latest": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "openai/gpt-oss-120b": {
+        "input": "30000000",
+        "output": "170000000",
+        "cacheRead": "30000000"
+      },
+      "openai/gpt-oss-20b": { "input": "20000000", "output": "100000000" },
+      "openai/gpt-oss-safeguard-20b": {
+        "input": "75000000",
+        "output": "300000000",
+        "cacheRead": "37500000"
+      },
+      "openai/o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "openai/o1-pro": { "input": "150000000000", "output": "600000000000" },
+      "openai/o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "openai/o3-mini-high": {
+        "input": "1100000000",
+        "output": "4400000000",
+        "cacheRead": "550000000"
+      },
+      "openai/o3-pro": { "input": "20000000000", "output": "80000000000" },
+      "openai/o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "openai/o4-mini-high": {
+        "input": "1100000000",
+        "output": "4400000000",
+        "cacheRead": "275000000"
+      },
+      "openrouter/auto": { "input": "0", "output": "0" },
+      "openrouter/bodybuilder": { "input": "0", "output": "0" },
+      "openrouter/free": { "input": "0", "output": "0" },
+      "openrouter/pareto-code": { "input": "0", "output": "0" },
+      "perceptron/perceptron-mk1": { "input": "150000000", "output": "1500000000" },
+      "perplexity/sonar": { "input": "1000000000", "output": "1000000000" },
+      "perplexity/sonar-deep-research": {
+        "input": "2000000000",
+        "output": "8000000000",
+        "reasoning": "3000000000"
+      },
+      "perplexity/sonar-pro": { "input": "3000000000", "output": "15000000000" },
+      "perplexity/sonar-pro-search": { "input": "3000000000", "output": "15000000000" },
+      "perplexity/sonar-reasoning-pro": { "input": "2000000000", "output": "8000000000" },
+      "poolside/laguna-s-2.1": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "10000000"
+      },
+      "poolside/laguna-s-2.1:free": { "input": "0", "output": "0" },
+      "poolside/laguna-xs-2.1": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "50000000"
+      },
+      "poolside/laguna-xs-2.1:free": { "input": "0", "output": "0" },
+      "qwen/qwen-2.5-72b-instruct": { "input": "360000000", "output": "400000000" },
+      "qwen/qwen-2.5-7b-instruct": { "input": "100000000", "output": "200000000" },
+      "qwen/qwen-2.5-coder-32b-instruct": { "input": "660000000", "output": "1000000000" },
+      "qwen/qwen-plus": {
+        "input": "260000000",
+        "output": "780000000",
+        "cacheRead": "52000000",
+        "cacheWrite": "325000000"
+      },
+      "qwen/qwen-plus-2025-07-28": { "input": "260000000", "output": "780000000" },
+      "qwen/qwen2.5-vl-72b-instruct": {
+        "input": "800000000",
+        "output": "1000000000",
+        "cacheRead": "400000000"
+      },
+      "qwen/qwen3-14b": { "input": "227500000", "output": "910000000" },
+      "qwen/qwen3-235b-a22b": { "input": "455000000", "output": "1820000000" },
+      "qwen/qwen3-235b-a22b-2507": { "input": "149500000", "output": "598000000" },
+      "qwen/qwen3-235b-a22b-thinking-2507": { "input": "230000000", "output": "2300000000" },
+      "qwen/qwen3-30b-a3b": { "input": "130000000", "output": "520000000" },
+      "qwen/qwen3-30b-a3b-instruct-2507": { "input": "130000000", "output": "520000000" },
+      "qwen/qwen3-30b-a3b-thinking-2507": { "input": "200000000", "output": "2400000000" },
+      "qwen/qwen3-32b": { "input": "80000000", "output": "280000000" },
+      "qwen/qwen3-8b": { "input": "117000000", "output": "455000000" },
+      "qwen/qwen3-coder": { "input": "975000000", "output": "4875000000" },
+      "qwen/qwen3-coder-30b-a3b-instruct": { "input": "292500000", "output": "1462500000" },
+      "qwen/qwen3-coder-flash": {
+        "input": "195000000",
+        "output": "975000000",
+        "cacheRead": "39000000",
+        "cacheWrite": "243750000"
+      },
+      "qwen/qwen3-coder-next": { "input": "300000000", "output": "1500000000" },
+      "qwen/qwen3-coder-plus": {
+        "input": "650000000",
+        "output": "3250000000",
+        "cacheRead": "130000000",
+        "cacheWrite": "812500000"
+      },
+      "qwen/qwen3-max": {
+        "input": "780000000",
+        "output": "3900000000",
+        "cacheRead": "156000000",
+        "cacheWrite": "975000000"
+      },
+      "qwen/qwen3-max-thinking": { "input": "780000000", "output": "3900000000" },
+      "qwen/qwen3-next-80b-a3b-instruct": { "input": "97500000", "output": "780000000" },
+      "qwen/qwen3-next-80b-a3b-thinking": { "input": "150000000", "output": "1200000000" },
+      "qwen/qwen3-vl-235b-a22b-instruct": { "input": "260000000", "output": "1040000000" },
+      "qwen/qwen3-vl-235b-a22b-thinking": { "input": "400000000", "output": "4000000000" },
+      "qwen/qwen3-vl-30b-a3b-instruct": { "input": "130000000", "output": "520000000" },
+      "qwen/qwen3-vl-30b-a3b-thinking": { "input": "200000000", "output": "2400000000" },
+      "qwen/qwen3-vl-32b-instruct": { "input": "104000000", "output": "416000000" },
+      "qwen/qwen3-vl-8b-instruct": { "input": "117000000", "output": "455000000" },
+      "qwen/qwen3-vl-8b-thinking": { "input": "180000000", "output": "2100000000" },
+      "qwen/qwen3.5-122b-a10b": { "input": "260000000", "output": "2080000000" },
+      "qwen/qwen3.5-27b": { "input": "195000000", "output": "1560000000" },
+      "qwen/qwen3.5-35b-a3b": { "input": "162500000", "output": "1300000000" },
+      "qwen/qwen3.5-397b-a17b": { "input": "390000000", "output": "2340000000" },
+      "qwen/qwen3.5-9b": { "input": "100000000", "output": "150000000" },
+      "qwen/qwen3.5-flash-02-23": { "input": "65000000", "output": "260000000" },
+      "qwen/qwen3.5-plus-02-15": { "input": "260000000", "output": "1560000000" },
+      "qwen/qwen3.5-plus-20260420": {
+        "input": "300000000",
+        "output": "1800000000",
+        "cacheWrite": "375000000"
+      },
+      "qwen/qwen3.6-27b": { "input": "450000000", "output": "2700000000" },
+      "qwen/qwen3.6-35b-a3b": {
+        "input": "140000000",
+        "output": "1000000000",
+        "cacheRead": "50000000"
+      },
+      "qwen/qwen3.6-flash": {
+        "input": "187500000",
+        "output": "1125000000",
+        "cacheWrite": "234375000"
+      },
+      "qwen/qwen3.6-max-preview": {
+        "input": "1027000000",
+        "output": "6162000000",
+        "cacheWrite": "1283750000"
+      },
+      "qwen/qwen3.6-plus": {
+        "input": "325000000",
+        "output": "1950000000",
+        "cacheWrite": "406250000"
+      },
+      "qwen/qwen3.7-flash": {
+        "input": "30000000",
+        "output": "130000000",
+        "cacheRead": "6000000",
+        "cacheWrite": "38000000"
+      },
+      "qwen/qwen3.7-max": {
+        "input": "1250000000",
+        "output": "3750000000",
+        "cacheRead": "125000000",
+        "cacheWrite": "1562500000"
+      },
+      "qwen/qwen3.7-plus": {
+        "input": "320000000",
+        "output": "1280000000",
+        "cacheRead": "32000000",
+        "cacheWrite": "400000000"
+      },
+      "qwen/qwen3.8-2.4t-a95b": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      },
+      "qwen/qwen3.8-27b": {
+        "input": "425000000",
+        "output": "2550000000",
+        "cacheRead": "85000000",
+        "cacheWrite": "531250000"
+      },
+      "qwen/qwen3.8-max": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      },
+      "rekaai/reka-edge": { "input": "100000000", "output": "100000000" },
+      "rekaai/reka-flash-3": { "input": "100000000", "output": "200000000" },
+      "relace/relace-apply-3": { "input": "850000000", "output": "1250000000" },
+      "relace/relace-search": { "input": "1000000000", "output": "3000000000" },
+      "sakana/fugu-ultra": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "sakana/sakana-namazu": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "150000000"
+      },
+      "sao10k/l3-lunaris-8b": { "input": "40000000", "output": "50000000" },
+      "sao10k/l3.1-euryale-70b": { "input": "850000000", "output": "850000000" },
+      "sao10k/l3.3-euryale-70b": { "input": "650000000", "output": "750000000" },
+      "stealth/claude-opus-4.6": {
+        "input": "4000000000",
+        "output": "20000000000",
+        "cacheRead": "400000000",
+        "cacheWrite": "5000000000",
+        "reasoning": "0"
+      },
+      "stealth/claude-opus-4.7": {
+        "input": "4000000000",
+        "output": "20000000000",
+        "cacheRead": "400000000",
+        "cacheWrite": "5000000000",
+        "reasoning": "0"
+      },
+      "stealth/claude-opus-4.8": {
+        "input": "4000000000",
+        "output": "20000000000",
+        "cacheRead": "400000000",
+        "cacheWrite": "5000000000",
+        "reasoning": "0"
+      },
+      "stealth/claude-sonnet-4.6": {
+        "input": "2400000000",
+        "output": "12000000000",
+        "cacheRead": "240000000",
+        "cacheWrite": "3000000000",
+        "reasoning": "0"
+      },
+      "stealth/ox-alpha": { "input": "0", "output": "0" },
+      "stealth/qwen3.6-plus": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "312500000",
+        "reasoning": "0"
+      },
+      "stepfun/step-3.5-flash": { "input": "100000000", "output": "300000000" },
+      "stepfun/step-3.7-flash": {
+        "input": "200000000",
+        "output": "1150000000",
+        "cacheRead": "40000000"
+      },
+      "stepfun/step-3.7-flash:free": {
+        "input": "0",
+        "output": "0",
+        "cacheRead": "0",
+        "reasoning": "0"
+      },
+      "tencent/hunyuan-a13b-instruct": { "input": "140000000", "output": "570000000" },
+      "tencent/hy-mt2-1.8b": { "input": "44000000", "output": "177000000" },
+      "tencent/hy-mt2-30b-a3b": { "input": "74000000", "output": "295000000" },
+      "tencent/hy-mt2-7b": { "input": "74000000", "output": "295000000" },
+      "tencent/hy3": { "input": "140000000", "output": "580000000", "cacheRead": "35000000" },
+      "tencent/hy3-preview": {
+        "input": "180000000",
+        "output": "600000000",
+        "cacheRead": "60000000"
+      },
+      "tencent/hy3:free": { "input": "0", "output": "0", "cacheRead": "0", "reasoning": "0" },
+      "thedrummer/cydonia-24b-v4.1": {
+        "input": "300000000",
+        "output": "500000000",
+        "cacheRead": "150000000"
+      },
+      "thedrummer/rocinante-12b": { "input": "250000000", "output": "500000000" },
+      "thedrummer/skyfall-36b-v2": {
+        "input": "550000000",
+        "output": "800000000",
+        "cacheRead": "250000000"
+      },
+      "thedrummer/unslopnemo-12b": { "input": "400000000", "output": "400000000" },
+      "thinkingmachines/inkling": {
+        "input": "950000000",
+        "output": "4050000000",
+        "cacheRead": "160000000"
+      },
+      "thinkingmachines/inkling-small": {
+        "input": "450000000",
+        "output": "1200000000",
+        "cacheRead": "100000000"
+      },
+      "thinkingmachines/inkling-small:free": { "input": "0", "output": "0" },
+      "thinkingmachines/inkling:free": { "input": "0", "output": "0" },
+      "undi95/remm-slerp-l2-13b": { "input": "450000000", "output": "650000000" },
+      "upstage/solar-pro-3": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000"
+      },
+      "upstage/solar-pro4": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "writer/palmyra-x5": { "input": "600000000", "output": "6000000000" },
+      "x-ai/grok-4.20": { "input": "1250000000", "output": "2500000000", "cacheRead": "200000000" },
+      "x-ai/grok-4.20-multi-agent": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000"
+      },
+      "x-ai/grok-4.3": { "input": "1250000000", "output": "2500000000", "cacheRead": "200000000" },
+      "x-ai/grok-4.5": { "input": "2000000000", "output": "6000000000", "cacheRead": "300000000" },
+      "x-ai/grok-4.6": { "input": "2000000000", "output": "6000000000", "cacheRead": "500000000" },
+      "x-ai/grok-build-0.1": {
+        "input": "1000000000",
+        "output": "2000000000",
+        "cacheRead": "200000000"
+      },
+      "xiaomi/mimo-v2.5": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "3000000",
+        "tiers": [
+          {
+            "input": "800000000",
+            "output": "4000000000",
+            "cacheRead": "160000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "xiaomi/mimo-v2.5-pro": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "4000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "z-ai/glm-4.5": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "z-ai/glm-4.5-air": { "input": "130000000", "output": "850000000", "cacheRead": "25000000" },
+      "z-ai/glm-4.5v": { "input": "600000000", "output": "1800000000", "cacheRead": "110000000" },
+      "z-ai/glm-4.6": { "input": "500000000", "output": "2000000000", "cacheRead": "100000000" },
+      "z-ai/glm-4.6v": { "input": "300000000", "output": "900000000", "cacheRead": "55000000" },
+      "z-ai/glm-4.7": { "input": "400000000", "output": "1750000000", "cacheRead": "80000000" },
+      "z-ai/glm-4.7-flash": { "input": "60000000", "output": "400000000", "cacheRead": "10000000" },
+      "z-ai/glm-5": { "input": "600000000", "output": "1920000000", "cacheRead": "120000000" },
+      "z-ai/glm-5-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      },
+      "z-ai/glm-5.1": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "z-ai/glm-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "z-ai/glm-5.3": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "z-ai/glm-5v-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      }
+    },
+    "kimi-for-coding": {
+      "k3": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "k3-256k": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "kimi-for-coding": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "kimi-for-coding-highspeed": {
+        "input": "0",
+        "output": "0",
+        "cacheRead": "0",
+        "cacheWrite": "0"
+      }
+    },
+    "kosmik": {
+      "qwen/qwen3.8-27b": { "input": "350000000", "output": "2200000000", "cacheRead": "90000000" }
+    },
+    "kuae-cloud-coding-plan": {
+      "GLM-4.7": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" }
+    },
+    "lilac": {
+      "google/gemma-4-31b-it": { "input": "110000000", "output": "350000000" },
+      "minimaxai/minimax-m3": {
+        "input": "280000000",
+        "output": "1100000000",
+        "cacheRead": "50000000"
+      },
+      "moonshotai/kimi-k2.6": {
+        "input": "700000000",
+        "output": "3500000000",
+        "cacheRead": "200000000"
+      },
+      "zai-org/glm-5.2": { "input": "900000000", "output": "3000000000", "cacheRead": "270000000" }
+    },
+    "llama": {
+      "cerebras-llama-4-maverick-17b-128e-instruct": { "input": "0", "output": "0" },
+      "cerebras-llama-4-scout-17b-16e-instruct": { "input": "0", "output": "0" },
+      "groq-llama-4-maverick-17b-128e-instruct": { "input": "0", "output": "0" },
+      "llama-3.3-70b-instruct": { "input": "0", "output": "0" },
+      "llama-3.3-8b-instruct": { "input": "0", "output": "0" },
+      "llama-4-maverick-17b-128e-instruct-fp8": { "input": "0", "output": "0" },
+      "llama-4-scout-17b-16e-instruct-fp8": { "input": "0", "output": "0" }
+    },
+    "llmgateway": {
+      "auto": { "input": "0", "output": "0" },
+      "claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-haiku-4-5-20251001": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-opus-4-1-20250805": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "claude-opus-4-5-20251101": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-4-5-20250929": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "codestral-2508": { "input": "300000000", "output": "900000000" },
+      "cosmos3-super-reasoner": { "input": "100000000", "output": "300000000" },
+      "custom": { "input": "0", "output": "0" },
+      "deepseek-v3.2": { "input": "260000000", "output": "380000000", "cacheRead": "130000000" },
+      "deepseek-v4-flash": { "input": "76000000", "output": "153000000", "cacheRead": "14000000" },
+      "deepseek-v4-pro": { "input": "435000000", "output": "870000000", "cacheRead": "3625000" },
+      "devstral-2512": { "input": "400000000", "output": "2000000000" },
+      "ernie-4.5-vl-424b-a47b": { "input": "420000000", "output": "1250000000" },
+      "fugu-ultra": { "input": "5000000000", "output": "30000000000", "cacheRead": "500000000" },
+      "gemini-2.5-flash": { "input": "300000000", "output": "2500000000", "cacheRead": "30000000" },
+      "gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000"
+      },
+      "gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000"
+      },
+      "gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "83330000"
+      },
+      "gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83330000"
+      },
+      "gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83330000"
+      },
+      "gemini-3.6-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "83330000"
+      },
+      "gemini-3.7-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "83330000"
+      },
+      "gemini-pro-latest": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000"
+      },
+      "gemma-3-27b": { "input": "100000000", "output": "300000000" },
+      "gemma-4-26b-a4b-it": { "input": "70000000", "output": "340000000" },
+      "gemma-4-31b-it": { "input": "102000000", "output": "297000000", "cacheRead": "12000000" },
+      "glm-4-32b-0414-128k": { "input": "100000000", "output": "100000000" },
+      "glm-4.5": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "glm-4.5-air": {
+        "input": "130000000",
+        "output": "850000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "0"
+      },
+      "glm-4.5-airx": { "input": "1100000000", "output": "4500000000", "cacheRead": "220000000" },
+      "glm-4.5-x": { "input": "2200000000", "output": "8900000000", "cacheRead": "450000000" },
+      "glm-4.5v": { "input": "600000000", "output": "1800000000", "cacheRead": "110000000" },
+      "glm-4.6": {
+        "input": "550000000",
+        "output": "2200000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "glm-4.6v": { "input": "300000000", "output": "900000000", "cacheRead": "50000000" },
+      "glm-4.6v-flashx": { "input": "40000000", "output": "400000000", "cacheRead": "4000000" },
+      "glm-4.7": {
+        "input": "380000000",
+        "output": "1980000000",
+        "cacheRead": "190000000",
+        "cacheWrite": "0"
+      },
+      "glm-4.7-flash": {
+        "input": "60000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "0"
+      },
+      "glm-4.7-flashx": {
+        "input": "70000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "0"
+      },
+      "glm-5": {
+        "input": "720000000",
+        "output": "2300000000",
+        "cacheRead": "144000000",
+        "cacheWrite": "0"
+      },
+      "glm-5.1": {
+        "input": "931000000",
+        "output": "2930000000",
+        "cacheRead": "173000000",
+        "cacheWrite": "0"
+      },
+      "glm-5.2": {
+        "input": "550000000",
+        "output": "1784000000",
+        "cacheRead": "111000000",
+        "cacheWrite": "0"
+      },
+      "glm-5.2-fast": { "input": "1990000000", "output": "6160000000", "cacheRead": "400000000" },
+      "glm-5.3": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "gpt-3.5-turbo": { "input": "500000000", "output": "1500000000", "cacheRead": "0" },
+      "gpt-4": { "input": "30000000000", "output": "60000000000" },
+      "gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "gpt-4.1-mini": { "input": "400000000", "output": "1600000000", "cacheRead": "100000000" },
+      "gpt-4.1-nano": { "input": "100000000", "output": "400000000", "cacheRead": "25000000" },
+      "gpt-4o": { "input": "2500000000", "output": "10000000000", "cacheRead": "1250000000" },
+      "gpt-4o-mini": { "input": "150000000", "output": "600000000", "cacheRead": "75000000" },
+      "gpt-4o-mini-transcribe": { "input": "1250000000", "output": "5000000000" },
+      "gpt-4o-transcribe": { "input": "2500000000", "output": "10000000000" },
+      "gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5-mini": { "input": "250000000", "output": "2000000000", "cacheRead": "25000000" },
+      "gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "gpt-5-pro": { "input": "15000000000", "output": "120000000000" },
+      "gpt-5.1": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5.1-codex": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "gpt-5.2": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.2-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.2-pro": { "input": "21000000000", "output": "168000000000" },
+      "gpt-5.3-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.4": { "input": "2500000000", "output": "15000000000", "cacheRead": "250000000" },
+      "gpt-5.4-mini": { "input": "750000000", "output": "4500000000", "cacheRead": "75000000" },
+      "gpt-5.4-nano": { "input": "200000000", "output": "1250000000", "cacheRead": "20000000" },
+      "gpt-5.4-pro": { "input": "30000000000", "output": "180000000000" },
+      "gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.5-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000"
+      },
+      "gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "gpt-oss-120b": { "input": "32000000", "output": "140000000", "cacheRead": "32000000" },
+      "gpt-oss-20b": { "input": "50000000", "output": "200000000" },
+      "grok-4": { "input": "3000000000", "output": "15000000000", "cacheRead": "750000000" },
+      "grok-4-1-fast-non-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "grok-4-1-fast-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "grok-4-20-beta-0309-non-reasoning": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4-20-beta-0309-reasoning": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4-20-non-reasoning": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4-20-reasoning": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4-3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4-5": { "input": "2000000000", "output": "6000000000", "cacheRead": "300000000" },
+      "grok-4-6": { "input": "2000000000", "output": "6000000000", "cacheRead": "500000000" },
+      "grok-build-0-1": {
+        "input": "1000000000",
+        "output": "2000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "4000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "hermes-4-405b": { "input": "1000000000", "output": "3000000000" },
+      "hermes-4-70b": { "input": "130000000", "output": "400000000" },
+      "hy3": { "input": "140000000", "output": "580000000", "cacheRead": "35000000" },
+      "kimi-k2": { "input": "570000000", "output": "2300000000", "cacheRead": "500000000" },
+      "kimi-k2-thinking": { "input": "600000000", "output": "2500000000", "cacheRead": "60000000" },
+      "kimi-k2.5": { "input": "405000000", "output": "1980000000", "cacheRead": "225000000" },
+      "kimi-k2.6": { "input": "220000000", "output": "1137000000", "cacheRead": "48000000" },
+      "kimi-k2.7-code": { "input": "950000000", "output": "4000000000", "cacheRead": "190000000" },
+      "kimi-k2.7-code-highspeed": {
+        "input": "1900000000",
+        "output": "8000000000",
+        "cacheRead": "380000000"
+      },
+      "kimi-k3": { "input": "3000000000", "output": "15000000000", "cacheRead": "300000000" },
+      "kimi-k3-fast": { "input": "4500000000", "output": "22500000000", "cacheRead": "450000000" },
+      "ling-3.0-flash": { "input": "60000000", "output": "180000000", "cacheRead": "12000000" },
+      "llama-3-70b-instruct": { "input": "510000000", "output": "740000000" },
+      "llama-3.1-70b-instruct": { "input": "720000000", "output": "720000000" },
+      "llama-3.1-nemotron-ultra-253b": { "input": "600000000", "output": "1800000000" },
+      "llama-3.2-11b-instruct": { "input": "70000000", "output": "330000000" },
+      "llama-3.2-3b-instruct": { "input": "30000000", "output": "50000000" },
+      "llama-3.3-70b-instruct": { "input": "130000000", "output": "400000000" },
+      "llama-4-maverick-17b-instruct": { "input": "270000000", "output": "850000000" },
+      "llama-4-scout-17b-instruct": { "input": "180000000", "output": "590000000" },
+      "mimo-v2.5": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "2800000",
+        "tiers": [
+          {
+            "input": "800000000",
+            "output": "4000000000",
+            "cacheRead": "160000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "mimo-v2.5-pro": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "3600000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "minicpm-v-4.5": { "input": "658000000", "output": "1110000000" },
+      "minimax-m2": { "input": "200000000", "output": "1000000000", "cacheRead": "30000000" },
+      "minimax-m2.1": { "input": "270000000", "output": "1100000000" },
+      "minimax-m2.1-lightning": { "input": "120000000", "output": "480000000" },
+      "minimax-m2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax-m2.5-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax-m2.7": {
+        "input": "80000000",
+        "output": "320000000",
+        "cacheRead": "17000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax-m2.7-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax-m3": { "input": "300000000", "output": "1200000000", "cacheRead": "60000000" },
+      "minimax-text-01": { "input": "200000000", "output": "1100000000" },
+      "ministral-14b-2512": { "input": "200000000", "output": "200000000" },
+      "ministral-3b-2512": { "input": "100000000", "output": "100000000" },
+      "ministral-8b-2512": { "input": "150000000", "output": "150000000" },
+      "mistral-large-2512": { "input": "500000000", "output": "1500000000" },
+      "mistral-large-latest": { "input": "4000000000", "output": "12000000000" },
+      "mistral-small-2506": { "input": "100000000", "output": "300000000" },
+      "muse-spark-1.1": { "input": "1250000000", "output": "4250000000", "cacheRead": "150000000" },
+      "muse-spark-1.2": { "input": "1250000000", "output": "4250000000", "cacheRead": "150000000" },
+      "nemotron-3-nano-30b": { "input": "60000000", "output": "240000000" },
+      "nemotron-3-nano-omni": { "input": "60000000", "output": "240000000" },
+      "nemotron-3-super-120b": { "input": "300000000", "output": "900000000" },
+      "nemotron-3-ultra-550b": {
+        "input": "500000000",
+        "output": "2200000000",
+        "cacheRead": "100000000"
+      },
+      "o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "qwen-coder-plus": { "input": "502000000", "output": "1004000000" },
+      "qwen-flash": {
+        "input": "50000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "62500000"
+      },
+      "qwen-max": { "input": "1600000000", "output": "6400000000" },
+      "qwen-omni-turbo": { "input": "200000000", "output": "800000000" },
+      "qwen-plus": {
+        "input": "400000000",
+        "output": "1200000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "500000000",
+        "reasoning": "4000000000"
+      },
+      "qwen-plus-latest": {
+        "input": "400000000",
+        "output": "1200000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "500000000"
+      },
+      "qwen2-5-vl-72b-instruct": { "input": "250000000", "output": "750000000" },
+      "qwen3-235b-a22b-fp8": { "input": "200000000", "output": "800000000" },
+      "qwen3-235b-a22b-instruct-2507": { "input": "90000000", "output": "580000000" },
+      "qwen3-235b-a22b-thinking-2507": { "input": "300000000", "output": "3000000000" },
+      "qwen3-30b-a3b-instruct-2507": { "input": "100000000", "output": "300000000" },
+      "qwen3-32b": { "input": "100000000", "output": "300000000", "reasoning": "8400000000" },
+      "qwen3-coder-30b-a3b-instruct": { "input": "70000000", "output": "270000000" },
+      "qwen3-coder-480b-a35b-instruct": { "input": "380000000", "output": "1550000000" },
+      "qwen3-coder-flash": {
+        "input": "300000000",
+        "output": "1500000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "qwen3-coder-next": { "input": "108000000", "output": "675000000", "cacheRead": "60000000" },
+      "qwen3-coder-plus": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "1250000000"
+      },
+      "qwen3-max": {
+        "input": "845000000",
+        "output": "3380000000",
+        "cacheRead": "600000000",
+        "cacheWrite": "3750000000"
+      },
+      "qwen3-next-80b-a3b-instruct": { "input": "150000000", "output": "1200000000" },
+      "qwen3-next-80b-a3b-thinking": { "input": "150000000", "output": "1200000000" },
+      "qwen3-vl-235b-a22b-instruct": {
+        "input": "200000000",
+        "output": "880000000",
+        "cacheRead": "110000000"
+      },
+      "qwen3-vl-235b-a22b-thinking": { "input": "980000000", "output": "3950000000" },
+      "qwen3-vl-30b-a3b-instruct": { "input": "150000000", "output": "600000000" },
+      "qwen3-vl-flash": { "input": "50000000", "output": "400000000", "cacheRead": "10000000" },
+      "qwen3-vl-plus": {
+        "input": "200000000",
+        "output": "1600000000",
+        "cacheRead": "40000000",
+        "cacheWrite": "250000000",
+        "reasoning": "4800000000"
+      },
+      "qwen3.5-9b": { "input": "100000000", "output": "150000000" },
+      "qwen3.6-35b-a3b": { "input": "248000000", "output": "1485000000" },
+      "qwen3.6-flash": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "312500000"
+      },
+      "qwen3.6-max-preview": {
+        "input": "1300000000",
+        "output": "7800000000",
+        "cacheRead": "130000000",
+        "cacheWrite": "1625000000"
+      },
+      "qwen3.6-plus": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "200000000",
+            "cacheWrite": "2500000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3.7-flash": {
+        "input": "30000000",
+        "output": "130000000",
+        "cacheRead": "6000000",
+        "cacheWrite": "37500000"
+      },
+      "qwen3.7-max": {
+        "input": "1250000000",
+        "output": "3750000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "3125000000"
+      },
+      "qwen3.7-plus": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "500000000"
+      },
+      "qwen3.8-max": {
+        "input": "1815000000",
+        "output": "5446100000",
+        "cacheRead": "210000000",
+        "cacheWrite": "2500000000"
+      },
+      "qwen35-397b-a17b": { "input": "600000000", "output": "3600000000" },
+      "seed-1-6-250615": { "input": "250000000", "output": "2000000000", "cacheRead": "50000000" },
+      "seed-1-6-250915": { "input": "250000000", "output": "2000000000", "cacheRead": "50000000" },
+      "seed-1-6-flash-250715": {
+        "input": "70000000",
+        "output": "300000000",
+        "cacheRead": "15000000"
+      },
+      "seed-1-8-251228": { "input": "250000000", "output": "2000000000", "cacheRead": "50000000" },
+      "sonar": { "input": "1000000000", "output": "1000000000" },
+      "sonar-pro": { "input": "3000000000", "output": "15000000000" },
+      "sonar-reasoning-pro": { "input": "2000000000", "output": "8000000000" }
+    },
+    "llmgateway-providers": {
+      "alibaba/deepseek-v4-flash": {
+        "input": "200000000",
+        "output": "400000000",
+        "cacheRead": "40000000"
+      },
+      "alibaba/deepseek-v4-pro": {
+        "input": "2400000000",
+        "output": "4800000000",
+        "cacheRead": "200000000"
+      },
+      "alibaba/glm-5": { "input": "573000000", "output": "2580000000" },
+      "alibaba/glm-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "280000000"
+      },
+      "alibaba/kimi-k2.5": { "input": "574000000", "output": "3011000000" },
+      "alibaba/qwen-coder-plus": { "input": "502000000", "output": "1004000000" },
+      "alibaba/qwen-flash": {
+        "input": "50000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "62500000"
+      },
+      "alibaba/qwen-max": { "input": "1600000000", "output": "6400000000" },
+      "alibaba/qwen-omni-turbo": { "input": "200000000", "output": "800000000" },
+      "alibaba/qwen-plus": {
+        "input": "400000000",
+        "output": "1200000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "500000000"
+      },
+      "alibaba/qwen-plus-latest": {
+        "input": "400000000",
+        "output": "1200000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "500000000"
+      },
+      "alibaba/qwen3-coder-flash": {
+        "input": "300000000",
+        "output": "1500000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "alibaba/qwen3-coder-plus": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "1250000000"
+      },
+      "alibaba/qwen3-max": {
+        "input": "1200000000",
+        "output": "6000000000",
+        "cacheRead": "240000000",
+        "cacheWrite": "1500000000"
+      },
+      "alibaba/qwen3-vl-flash": {
+        "input": "50000000",
+        "output": "400000000",
+        "cacheRead": "10000000"
+      },
+      "alibaba/qwen3-vl-plus": {
+        "input": "200000000",
+        "output": "1600000000",
+        "cacheRead": "40000000",
+        "cacheWrite": "250000000"
+      },
+      "alibaba/qwen3.6-35b-a3b": { "input": "375000000", "output": "2250000000" },
+      "alibaba/qwen3.6-flash": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "312500000"
+      },
+      "alibaba/qwen3.6-max-preview": {
+        "input": "1300000000",
+        "output": "7800000000",
+        "cacheRead": "130000000"
+      },
+      "alibaba/qwen3.6-plus": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "200000000",
+            "cacheWrite": "2500000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "alibaba/qwen3.7-flash": {
+        "input": "30000000",
+        "output": "130000000",
+        "cacheRead": "6000000",
+        "cacheWrite": "37500000"
+      },
+      "alibaba/qwen3.7-max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "3125000000"
+      },
+      "alibaba/qwen3.7-plus": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "500000000"
+      },
+      "alibaba/qwen3.8-max": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      },
+      "alibaba/qwen35-397b-a17b": { "input": "600000000", "output": "3600000000" },
+      "anthropic/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic/claude-haiku-4-5-20251001": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic/claude-opus-4-5-20251101": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4-5-20250929": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "aws-bedrock/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "aws-bedrock/claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "aws-bedrock/claude-haiku-4-5-20251001": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "aws-bedrock/claude-opus-4-1-20250805": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "aws-bedrock/claude-opus-4-5-20251101": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "aws-bedrock/claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "aws-bedrock/claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "aws-bedrock/claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "aws-bedrock/claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "aws-bedrock/claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "aws-bedrock/claude-sonnet-4-5-20250929": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "aws-bedrock/claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "aws-bedrock/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "aws-bedrock/grok-4-3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "aws-bedrock/grok-4-6": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000"
+      },
+      "aws-bedrock/llama-3.1-70b-instruct": { "input": "720000000", "output": "720000000" },
+      "aws-bedrock/llama-4-maverick-17b-instruct": { "input": "240000000", "output": "970000000" },
+      "aws-bedrock/llama-4-scout-17b-instruct": { "input": "170000000", "output": "660000000" },
+      "aws-mantle/gpt-5.6-luna": {
+        "input": "220000000",
+        "output": "1320000000",
+        "cacheRead": "22000000",
+        "cacheWrite": "275000000"
+      },
+      "aws-mantle/gpt-5.6-sol": {
+        "input": "5500000000",
+        "output": "33000000000",
+        "cacheRead": "550000000",
+        "cacheWrite": "6875000000"
+      },
+      "aws-mantle/gpt-5.6-terra": {
+        "input": "2200000000",
+        "output": "13200000000",
+        "cacheRead": "220000000",
+        "cacheWrite": "2750000000"
+      },
+      "azure-ai-foundry/grok-4-1-fast-non-reasoning": {
+        "input": "200000000",
+        "output": "500000000"
+      },
+      "azure-ai-foundry/grok-4-1-fast-reasoning": { "input": "200000000", "output": "500000000" },
+      "azure-ai-foundry/grok-4-3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "azure-anthropic/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "azure-anthropic/claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "azure-anthropic/claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "azure-anthropic/claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "azure-anthropic/claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "azure-anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "azure/gpt-3.5-turbo": { "input": "500000000", "output": "1500000000" },
+      "azure/gpt-4": { "input": "30000000000", "output": "60000000000" },
+      "azure/gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "azure/gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "azure/gpt-4.1-mini": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "100000000"
+      },
+      "azure/gpt-4.1-nano": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "25000000"
+      },
+      "azure/gpt-4o": { "input": "2500000000", "output": "10000000000", "cacheRead": "1250000000" },
+      "azure/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "azure/gpt-5-mini": { "input": "250000000", "output": "2000000000", "cacheRead": "25000000" },
+      "azure/gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "azure/gpt-5.1": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "azure/gpt-5.1-codex": { "input": "1250000000", "output": "10000000000" },
+      "azure/gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "azure/gpt-5.2": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "azure/gpt-5.2-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "azure/gpt-5.2-pro": { "input": "21000000000", "output": "168000000000" },
+      "azure/gpt-5.3-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "azure/gpt-5.4": { "input": "2500000000", "output": "15000000000", "cacheRead": "250000000" },
+      "azure/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "azure/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "azure/gpt-5.4-pro": { "input": "30000000000", "output": "180000000000" },
+      "azure/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "azure/gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000"
+      },
+      "azure/gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "azure/gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "azure/gpt-oss-120b": { "input": "150000000", "output": "600000000" },
+      "azure/o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "azure/o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "azure/o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "azure/o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "baidu/deepseek-v4-flash": {
+        "input": "440000000",
+        "output": "1320000000",
+        "cacheRead": "44000000"
+      },
+      "baidu/deepseek-v4-pro": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "132000000"
+      },
+      "baidu/glm-5": { "input": "1000000000", "output": "3200000000", "cacheRead": "200000000" },
+      "baidu/glm-5.1": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "baidu/glm-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "baidu/glm-5.3": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "baidu/kimi-k2.6": { "input": "950000000", "output": "4000000000", "cacheRead": "160000000" },
+      "bytedance/deepseek-v3.2": {
+        "input": "280000000",
+        "output": "420000000",
+        "cacheRead": "56000000"
+      },
+      "bytedance/deepseek-v4-flash": {
+        "input": "440000000",
+        "output": "1320000000",
+        "cacheRead": "14000000"
+      },
+      "bytedance/deepseek-v4-pro": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "44000000"
+      },
+      "bytedance/glm-4.7": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000"
+      },
+      "bytedance/glm-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "bytedance/gpt-oss-120b": {
+        "input": "100000000",
+        "output": "500000000",
+        "cacheRead": "20000000"
+      },
+      "bytedance/seed-1-6-250615": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "50000000"
+      },
+      "bytedance/seed-1-6-250915": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "50000000"
+      },
+      "bytedance/seed-1-6-flash-250715": {
+        "input": "70000000",
+        "output": "300000000",
+        "cacheRead": "15000000"
+      },
+      "bytedance/seed-1-8-251228": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "50000000"
+      },
+      "canopywave/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "30000000"
+      },
+      "canopywave/deepseek-v4-pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "10000000"
+      },
+      "canopywave/glm-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "canopywave/kimi-k2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "canopywave/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "cerebras/gemma-4-31b-it": { "input": "990000000", "output": "1490000000" },
+      "cerebras/glm-4.7": { "input": "2250000000", "output": "2750000000" },
+      "cerebras/gpt-oss-120b": { "input": "350000000", "output": "750000000" },
+      "cerebras/llama-3.3-70b-instruct": { "input": "850000000", "output": "1200000000" },
+      "cerebras/qwen3-235b-a22b-instruct-2507": { "input": "600000000", "output": "1200000000" },
+      "deepinfra/deepseek-v3.2": {
+        "input": "260000000",
+        "output": "380000000",
+        "cacheRead": "130000000"
+      },
+      "deepinfra/deepseek-v4-flash": {
+        "input": "80000000",
+        "output": "180000000",
+        "cacheRead": "16000000"
+      },
+      "deepinfra/deepseek-v4-pro": {
+        "input": "1300000000",
+        "output": "2600000000",
+        "cacheRead": "100000000"
+      },
+      "deepinfra/gemma-4-26b-a4b-it": { "input": "70000000", "output": "340000000" },
+      "deepinfra/gemma-4-31b-it": { "input": "130000000", "output": "380000000" },
+      "deepinfra/glm-5.1": {
+        "input": "1050000000",
+        "output": "3500000000",
+        "cacheRead": "205000000"
+      },
+      "deepinfra/hy3": { "input": "140000000", "output": "580000000", "cacheRead": "35000000" },
+      "deepinfra/kimi-k2.5": {
+        "input": "450000000",
+        "output": "2250000000",
+        "cacheRead": "70000000"
+      },
+      "deepinfra/ling-3.0-flash": {
+        "input": "60000000",
+        "output": "180000000",
+        "cacheRead": "12000000"
+      },
+      "deepinfra/mimo-v2.5": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "80000000",
+        "tiers": [
+          {
+            "input": "800000000",
+            "output": "4000000000",
+            "cacheRead": "160000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "deepinfra/mimo-v2.5-pro": {
+        "input": "1000000000",
+        "output": "3000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "deepinfra/nemotron-3-ultra-550b": {
+        "input": "500000000",
+        "output": "2200000000",
+        "cacheRead": "100000000"
+      },
+      "deepinfra/qwen3-vl-235b-a22b-instruct": {
+        "input": "200000000",
+        "output": "880000000",
+        "cacheRead": "110000000"
+      },
+      "deepinfra/qwen3-vl-30b-a3b-instruct": { "input": "150000000", "output": "600000000" },
+      "deepinfra/qwen3.5-9b": { "input": "100000000", "output": "150000000" },
+      "deepseek/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "2800000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "3625000"
+      },
+      "embercloud/glm-4.5": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000"
+      },
+      "embercloud/glm-4.5-air": {
+        "input": "130000000",
+        "output": "850000000",
+        "cacheRead": "25000000"
+      },
+      "embercloud/glm-4.7": {
+        "input": "380000000",
+        "output": "1980000000",
+        "cacheRead": "190000000"
+      },
+      "embercloud/glm-4.7-flash": {
+        "input": "60000000",
+        "output": "400000000",
+        "cacheRead": "10000000"
+      },
+      "embercloud/glm-5": {
+        "input": "720000000",
+        "output": "2300000000",
+        "cacheRead": "144000000"
+      },
+      "embercloud/glm-5.1": {
+        "input": "931000000",
+        "output": "2930000000",
+        "cacheRead": "173000000"
+      },
+      "embercloud/glm-5.2": {
+        "input": "1260000000",
+        "output": "3960000000",
+        "cacheRead": "234000000"
+      },
+      "embercloud/kimi-k2.5": {
+        "input": "405000000",
+        "output": "1980000000",
+        "cacheRead": "225000000"
+      },
+      "embercloud/qwen3-coder-next": {
+        "input": "108000000",
+        "output": "675000000",
+        "cacheRead": "60000000"
+      },
+      "fireworks/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "fireworks/deepseek-v4-pro": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "44000000"
+      },
+      "fireworks/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "fireworks/kimi-k3-fast": {
+        "input": "4500000000",
+        "output": "22500000000",
+        "cacheRead": "450000000"
+      },
+      "gonka24/deepseek-v4-flash": {
+        "input": "75000000",
+        "output": "175000000",
+        "cacheRead": "15500000"
+      },
+      "gonka24/kimi-k2.6": {
+        "input": "220000000",
+        "output": "1137000000",
+        "cacheRead": "48000000"
+      },
+      "gonka24/minimax-m2.7": {
+        "input": "80000000",
+        "output": "320000000",
+        "cacheRead": "17000000"
+      },
+      "google-ai-studio/gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "google-ai-studio/gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000"
+      },
+      "google-ai-studio/gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google-ai-studio/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000"
+      },
+      "google-ai-studio/gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "83330000"
+      },
+      "google-ai-studio/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google-ai-studio/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83330000"
+      },
+      "google-ai-studio/gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83330000"
+      },
+      "google-ai-studio/gemini-3.6-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "83330000"
+      },
+      "google-ai-studio/gemini-3.7-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "83330000"
+      },
+      "google-ai-studio/gemini-pro-latest": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000"
+      },
+      "google-vertex/gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "google-vertex/gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000"
+      },
+      "google-vertex/gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google-vertex/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000"
+      },
+      "google-vertex/gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "83330000"
+      },
+      "google-vertex/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google-vertex/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83330000"
+      },
+      "google-vertex/gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83330000"
+      },
+      "google-vertex/gemini-3.6-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "83330000"
+      },
+      "google-vertex/gemini-3.7-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "83330000"
+      },
+      "groq/gpt-oss-120b": { "input": "150000000", "output": "750000000" },
+      "groq/gpt-oss-20b": { "input": "100000000", "output": "500000000" },
+      "iceberg/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000"
+      },
+      "iceberg/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "iceberg/gemini-3.6-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "83330000"
+      },
+      "inference.net/llama-3.2-11b-instruct": { "input": "70000000", "output": "330000000" },
+      "meta/muse-spark-1.1": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "150000000"
+      },
+      "meta/muse-spark-1.2": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "150000000"
+      },
+      "minimax/minimax-m2": {
+        "input": "200000000",
+        "output": "1000000000",
+        "cacheRead": "30000000"
+      },
+      "minimax/minimax-m2.1": { "input": "270000000", "output": "1100000000" },
+      "minimax/minimax-m2.1-lightning": { "input": "120000000", "output": "480000000" },
+      "minimax/minimax-m2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "minimax/minimax-m2.5-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "30000000"
+      },
+      "minimax/minimax-m2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "minimax/minimax-m2.7-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "60000000"
+      },
+      "minimax/minimax-m3": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "120000000"
+      },
+      "minimax/minimax-text-01": { "input": "200000000", "output": "1100000000" },
+      "mistral/codestral-2508": { "input": "300000000", "output": "900000000" },
+      "mistral/devstral-2512": { "input": "400000000", "output": "2000000000" },
+      "mistral/ministral-14b-2512": { "input": "200000000", "output": "200000000" },
+      "mistral/ministral-3b-2512": { "input": "100000000", "output": "100000000" },
+      "mistral/ministral-8b-2512": { "input": "150000000", "output": "150000000" },
+      "mistral/mistral-large-2512": { "input": "500000000", "output": "1500000000" },
+      "mistral/mistral-large-latest": { "input": "4000000000", "output": "12000000000" },
+      "mistral/mistral-small-2506": { "input": "100000000", "output": "300000000" },
+      "moonshot/kimi-k2.5": {
+        "input": "600000000",
+        "output": "3000000000",
+        "cacheRead": "100000000"
+      },
+      "moonshot/kimi-k2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "moonshot/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "moonshot/kimi-k2.7-code-highspeed": {
+        "input": "1900000000",
+        "output": "8000000000",
+        "cacheRead": "380000000"
+      },
+      "moonshot/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "nebius/cosmos3-super-reasoner": { "input": "100000000", "output": "300000000" },
+      "nebius/deepseek-v4-pro": { "input": "1750000000", "output": "3500000000" },
+      "nebius/gemma-3-27b": { "input": "100000000", "output": "300000000" },
+      "nebius/glm-5.1": { "input": "1400000000", "output": "4400000000" },
+      "nebius/glm-5.2": { "input": "1400000000", "output": "4400000000" },
+      "nebius/gpt-oss-120b": { "input": "150000000", "output": "600000000" },
+      "nebius/hermes-4-405b": { "input": "1000000000", "output": "3000000000" },
+      "nebius/hermes-4-70b": { "input": "130000000", "output": "400000000" },
+      "nebius/kimi-k2.6": { "input": "950000000", "output": "4000000000" },
+      "nebius/kimi-k2.7-code": { "input": "950000000", "output": "4000000000" },
+      "nebius/kimi-k3": { "input": "3000000000", "output": "15000000000" },
+      "nebius/llama-3.1-nemotron-ultra-253b": { "input": "600000000", "output": "1800000000" },
+      "nebius/llama-3.3-70b-instruct": { "input": "130000000", "output": "400000000" },
+      "nebius/minicpm-v-4.5": { "input": "658000000", "output": "1110000000" },
+      "nebius/minimax-m2.5": { "input": "300000000", "output": "1200000000" },
+      "nebius/minimax-m3": { "input": "300000000", "output": "1200000000" },
+      "nebius/nemotron-3-nano-30b": { "input": "60000000", "output": "240000000" },
+      "nebius/nemotron-3-nano-omni": { "input": "60000000", "output": "240000000" },
+      "nebius/nemotron-3-super-120b": { "input": "300000000", "output": "900000000" },
+      "nebius/nemotron-3-ultra-550b": { "input": "1000000000", "output": "3000000000" },
+      "nebius/qwen2-5-vl-72b-instruct": { "input": "250000000", "output": "750000000" },
+      "nebius/qwen3-235b-a22b-instruct-2507": { "input": "200000000", "output": "600000000" },
+      "nebius/qwen3-30b-a3b-instruct-2507": { "input": "100000000", "output": "300000000" },
+      "nebius/qwen3-32b": { "input": "100000000", "output": "300000000" },
+      "nebius/qwen3-next-80b-a3b-thinking": { "input": "150000000", "output": "1200000000" },
+      "novita/deepseek-v3.2": {
+        "input": "269000000",
+        "output": "400000000",
+        "cacheRead": "134500000"
+      },
+      "novita/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "novita/ernie-4.5-vl-424b-a47b": { "input": "420000000", "output": "1250000000" },
+      "novita/gemma-4-26b-a4b-it": { "input": "130000000", "output": "400000000" },
+      "novita/gemma-4-31b-it": { "input": "140000000", "output": "400000000" },
+      "novita/glm-4.5v": { "input": "600000000", "output": "1800000000", "cacheRead": "110000000" },
+      "novita/glm-4.6": { "input": "550000000", "output": "2200000000", "cacheRead": "110000000" },
+      "novita/glm-4.6v": { "input": "300000000", "output": "900000000", "cacheRead": "55000000" },
+      "novita/glm-4.7": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "novita/glm-5": { "input": "1000000000", "output": "3200000000", "cacheRead": "200000000" },
+      "novita/glm-5.1": { "input": "1380000000", "output": "4400000000", "cacheRead": "260000000" },
+      "novita/glm-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "novita/hy3": { "input": "140000000", "output": "580000000", "cacheRead": "35000000" },
+      "novita/kimi-k2": { "input": "570000000", "output": "2300000000" },
+      "novita/kimi-k2.6": {
+        "input": "800000000",
+        "output": "3400000000",
+        "cacheRead": "160000000"
+      },
+      "novita/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "novita/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "novita/ling-3.0-flash": {
+        "input": "60000000",
+        "output": "180000000",
+        "cacheRead": "12000000"
+      },
+      "novita/llama-3-70b-instruct": { "input": "510000000", "output": "740000000" },
+      "novita/llama-3.2-3b-instruct": { "input": "30000000", "output": "50000000" },
+      "novita/llama-3.3-70b-instruct": { "input": "135000000", "output": "400000000" },
+      "novita/llama-4-maverick-17b-instruct": { "input": "270000000", "output": "850000000" },
+      "novita/llama-4-scout-17b-instruct": { "input": "180000000", "output": "590000000" },
+      "novita/mimo-v2.5": {
+        "input": "168000000",
+        "output": "336000000",
+        "cacheRead": "3400000",
+        "tiers": [
+          {
+            "input": "800000000",
+            "output": "4000000000",
+            "cacheRead": "160000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "novita/mimo-v2.5-pro": {
+        "input": "522000000",
+        "output": "1044000000",
+        "cacheRead": "4300000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "novita/minimax-m2.1": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "novita/minimax-m2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "novita/minimax-m2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "novita/qwen3-235b-a22b-fp8": { "input": "200000000", "output": "800000000" },
+      "novita/qwen3-235b-a22b-instruct-2507": { "input": "90000000", "output": "580000000" },
+      "novita/qwen3-235b-a22b-thinking-2507": { "input": "300000000", "output": "3000000000" },
+      "novita/qwen3-coder-30b-a3b-instruct": { "input": "70000000", "output": "270000000" },
+      "novita/qwen3-coder-480b-a35b-instruct": { "input": "380000000", "output": "1550000000" },
+      "novita/qwen3-max": { "input": "845000000", "output": "3380000000" },
+      "novita/qwen3-next-80b-a3b-instruct": { "input": "150000000", "output": "1500000000" },
+      "novita/qwen3-vl-235b-a22b-instruct": { "input": "300000000", "output": "1500000000" },
+      "novita/qwen3-vl-235b-a22b-thinking": { "input": "980000000", "output": "3950000000" },
+      "novita/qwen3-vl-30b-a3b-instruct": { "input": "200000000", "output": "700000000" },
+      "novita/qwen3.6-35b-a3b": { "input": "248000000", "output": "1485000000" },
+      "novita/qwen3.7-max": {
+        "input": "1250000000",
+        "output": "3750000000",
+        "cacheRead": "250000000"
+      },
+      "novita/qwen3.8-max": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000"
+      },
+      "novita/qwen35-397b-a17b": { "input": "600000000", "output": "3600000000" },
+      "openai/gpt-3.5-turbo": { "input": "500000000", "output": "1500000000" },
+      "openai/gpt-4": { "input": "30000000000", "output": "60000000000" },
+      "openai/gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "openai/gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/gpt-4.1-mini": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "100000000"
+      },
+      "openai/gpt-4.1-nano": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-4o": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-mini": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-4o-mini-transcribe": { "input": "1250000000", "output": "5000000000" },
+      "openai/gpt-4o-transcribe": { "input": "2500000000", "output": "10000000000" },
+      "openai/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "openai/gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "openai/gpt-5-pro": { "input": "15000000000", "output": "120000000000" },
+      "openai/gpt-5.1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.2": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-pro": { "input": "21000000000", "output": "168000000000" },
+      "openai/gpt-5.3-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000"
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "openai/gpt-5.4-pro": { "input": "30000000000", "output": "180000000000" },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.5-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "openai/gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000"
+      },
+      "openai/gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "openai/gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "openai/o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "openai/o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "openai/o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "permafrost/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "600000000"
+      },
+      "perplexity/sonar": { "input": "1000000000", "output": "1000000000" },
+      "perplexity/sonar-pro": { "input": "3000000000", "output": "15000000000" },
+      "perplexity/sonar-reasoning-pro": { "input": "2000000000", "output": "8000000000" },
+      "quartz/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "ranoai/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "runware/deepseek-v4-flash": {
+        "input": "76000000",
+        "output": "153000000",
+        "cacheRead": "14000000"
+      },
+      "runware/deepseek-v4-pro": {
+        "input": "961000000",
+        "output": "1922000000",
+        "cacheRead": "79000000"
+      },
+      "runware/gemma-4-31b-it": {
+        "input": "102000000",
+        "output": "297000000",
+        "cacheRead": "12000000"
+      },
+      "runware/glm-5.2": { "input": "800000000", "output": "2550000000", "cacheRead": "160000000" },
+      "runware/gpt-oss-120b": {
+        "input": "32000000",
+        "output": "140000000",
+        "cacheRead": "32000000"
+      },
+      "runware/kimi-k2.6": {
+        "input": "600000000",
+        "output": "3050000000",
+        "cacheRead": "130000000"
+      },
+      "sakana/fugu-ultra": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "scx-ai-gp/glm-5.2": {
+        "input": "550000000",
+        "output": "1784000000",
+        "cacheRead": "111000000"
+      },
+      "scx-ai-gp/glm-5.2-fast": {
+        "input": "1990000000",
+        "output": "6160000000",
+        "cacheRead": "400000000"
+      },
+      "scx-ai-gp/qwen3.8-max": {
+        "input": "1815000000",
+        "output": "5446100000",
+        "cacheRead": "210000000",
+        "cacheWrite": "2500000000"
+      },
+      "scx-ai/gemma-4-31b-it": { "input": "300000000", "output": "910000000" },
+      "scx-ai/gpt-oss-120b": { "input": "170000000", "output": "550000000" },
+      "scx-ai/llama-4-maverick-17b-instruct": { "input": "530000000", "output": "1620000000" },
+      "scx-ai/minimax-m2.7": {
+        "input": "480000000",
+        "output": "1790000000",
+        "cacheRead": "50000000"
+      },
+      "scx-ai/qwen3-32b": { "input": "360000000", "output": "870000000" },
+      "together-ai/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "30000000"
+      },
+      "together-ai/deepseek-v4-pro": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "130000000"
+      },
+      "together-ai/gemma-4-31b-it": { "input": "390000000", "output": "970000000" },
+      "together-ai/glm-4.7": { "input": "450000000", "output": "2000000000" },
+      "together-ai/gpt-oss-120b": { "input": "150000000", "output": "600000000" },
+      "together-ai/gpt-oss-20b": { "input": "50000000", "output": "200000000" },
+      "together-ai/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "together-ai/minimax-m3": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "tundra/kimi-k2.6": { "input": "400000000", "output": "2200000000", "cacheRead": "80000000" },
+      "vertex-anthropic/claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000"
+      },
+      "vertex-anthropic/claude-opus-4-5-20251101": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "vertex-anthropic/claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "vertex-anthropic/claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "vertex-anthropic/claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "vertex-anthropic/claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "vertex-anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "vertex-openai/deepseek-v3.2": {
+        "input": "560000000",
+        "output": "1680000000",
+        "cacheRead": "56000000"
+      },
+      "vertex-openai/glm-4.7": { "input": "600000000", "output": "2200000000" },
+      "vertex-openai/glm-5": {
+        "input": "1000000000",
+        "output": "3200000000",
+        "cacheRead": "100000000"
+      },
+      "vertex-openai/grok-4-20-non-reasoning": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "vertex-openai/grok-4-20-reasoning": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "vertex-openai/grok-4-6": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000"
+      },
+      "vertex-openai/kimi-k2-thinking": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "60000000"
+      },
+      "vertex-openai/qwen3-235b-a22b-instruct-2507": {
+        "input": "220000000",
+        "output": "880000000"
+      },
+      "vertex-openai/qwen3-coder-480b-a35b-instruct": {
+        "input": "220000000",
+        "output": "1800000000",
+        "cacheRead": "22000000"
+      },
+      "vertex-openai/qwen3-next-80b-a3b-instruct": { "input": "150000000", "output": "1200000000" },
+      "vertex-openai/qwen3-next-80b-a3b-thinking": { "input": "150000000", "output": "1200000000" },
+      "xai/grok-4": { "input": "3000000000", "output": "15000000000", "cacheRead": "750000000" },
+      "xai/grok-4-20-beta-0309-non-reasoning": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-4-20-beta-0309-reasoning": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-4-3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-4-5": { "input": "2000000000", "output": "6000000000", "cacheRead": "300000000" },
+      "xai/grok-4-6": { "input": "2000000000", "output": "6000000000", "cacheRead": "500000000" },
+      "xai/grok-build-0-1": {
+        "input": "1000000000",
+        "output": "2000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "4000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xiaomi/mimo-v2.5": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "2800000",
+        "tiers": [
+          {
+            "input": "800000000",
+            "output": "4000000000",
+            "cacheRead": "160000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "xiaomi/mimo-v2.5-pro": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "3600000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "zai/glm-4-32b-0414-128k": { "input": "100000000", "output": "100000000" },
+      "zai/glm-4.5": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "zai/glm-4.5-air": { "input": "200000000", "output": "1100000000", "cacheRead": "30000000" },
+      "zai/glm-4.5-airx": {
+        "input": "1100000000",
+        "output": "4500000000",
+        "cacheRead": "220000000"
+      },
+      "zai/glm-4.5-x": { "input": "2200000000", "output": "8900000000", "cacheRead": "450000000" },
+      "zai/glm-4.5v": { "input": "600000000", "output": "1800000000", "cacheRead": "110000000" },
+      "zai/glm-4.6": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "zai/glm-4.6v": { "input": "300000000", "output": "900000000", "cacheRead": "50000000" },
+      "zai/glm-4.6v-flashx": { "input": "40000000", "output": "400000000", "cacheRead": "4000000" },
+      "zai/glm-4.7": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "zai/glm-4.7-flashx": { "input": "70000000", "output": "400000000", "cacheRead": "10000000" },
+      "zai/glm-5": { "input": "1000000000", "output": "3200000000", "cacheRead": "200000000" },
+      "zai/glm-5.1": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "zai/glm-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "zai/glm-5.3": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" }
+    },
+    "llmtr": {
+      "gemma-4": { "input": "2000000000", "output": "5000000000", "cacheRead": "500000000" },
+      "google/gemini-2.5-flash-lite": { "input": "100000000", "output": "100000000" },
+      "magibu-11b-v8": { "input": "100000000", "output": "500000000" },
+      "medgemma-4b": { "input": "3000000000", "output": "5000000000" },
+      "meta/muse-spark-1.2-contributor": { "input": "100000000", "output": "200000000" },
+      "mimo/mimo-v2.5": { "input": "140000000", "output": "280000000" },
+      "mimo/mimo-v2.5-pro": { "input": "435000000", "output": "870000000" },
+      "mistral/voxtral-small-latest": { "input": "100000000", "output": "300000000" },
+      "muse-glimmer-30b-tr": {
+        "input": "2000000000",
+        "output": "5000000000",
+        "cacheRead": "500000000"
+      },
+      "perplexity/sonar-deep-research": {
+        "input": "2000000000",
+        "output": "8000000000",
+        "reasoning": "3000000000"
+      },
+      "poolside/laguna-xs-2.1": { "input": "0", "output": "0" },
+      "publicai/apertus-70b-instruct": { "input": "820000000", "output": "2920000000" },
+      "publicai/apertus-8b-instruct": { "input": "100000000", "output": "200000000" },
+      "qwen/qwen-flash": { "input": "50000000", "output": "400000000" },
+      "qwen/qwen-plus": { "input": "400000000", "output": "1200000000" },
+      "qwen/qwen3-coder-flash": { "input": "300000000", "output": "1500000000" },
+      "qwen/qwen3-coder-plus": { "input": "1000000000", "output": "5000000000" },
+      "qwen/qwen3-max": { "input": "1200000000", "output": "6000000000" },
+      "qwen/qwen3-vl-plus": { "input": "200000000", "output": "1600000000" },
+      "qwen/qwen3.5-397b-a17b": { "input": "600000000", "output": "3600000000" },
+      "qwen/qwen3.5-plus": { "input": "400000000", "output": "2400000000" },
+      "qwen/qwen3.6-flash": { "input": "250000000", "output": "1500000000" },
+      "qwen/qwen3.6-plus": { "input": "500000000", "output": "3000000000" },
+      "qwen/qwen3.7-plus": { "input": "400000000", "output": "1600000000" },
+      "qwen3-6-35b": { "input": "5000000000", "output": "10000000000" },
+      "sakana/fugu-ultra": { "input": "5000000000", "output": "30000000000" },
+      "thinkingmachines/inkling": { "input": "1870000000", "output": "4680000000" },
+      "thinkingmachines/inkling-small": { "input": "580000000", "output": "1440000000" },
+      "trendyol-asure-12b": {
+        "input": "100000000",
+        "output": "500000000",
+        "cacheRead": "25000000"
+      },
+      "upstage/solar-pro2": { "input": "150000000", "output": "600000000" },
+      "upstage/solar-pro3": { "input": "150000000", "output": "600000000" },
+      "upstage/solar-pro4": { "input": "30000000", "output": "120000000" }
+    },
+    "lmstudio": {
+      "openai/gpt-oss-20b": { "input": "0", "output": "0" },
+      "qwen/qwen3-30b-a3b-2507": { "input": "0", "output": "0" },
+      "qwen/qwen3-coder-30b": { "input": "0", "output": "0" }
+    },
+    "longcat": {
+      "LongCat-2.0": { "input": "750000000", "output": "2950000000", "cacheRead": "15000000" }
+    },
+    "lucidquery": {
+      "lucidnova-rf1-100b": { "input": "2000000000", "output": "5000000000" },
+      "lucidquery-agi-01-frontier": { "input": "4500000000", "output": "22000000000" },
+      "lucidquery-agi-01-swift": { "input": "2500000000", "output": "15000000000" },
+      "lucidquery-nexus-coder": { "input": "2000000000", "output": "5000000000" }
+    },
+    "lynkr": { "lynkr-auto": { "input": "0", "output": "0" } },
+    "meganova": {
+      "deepseek-ai/DeepSeek-R1-0528": { "input": "500000000", "output": "2150000000" },
+      "deepseek-ai/DeepSeek-V3-0324": { "input": "250000000", "output": "880000000" },
+      "deepseek-ai/DeepSeek-V3.1": { "input": "270000000", "output": "1000000000" },
+      "deepseek-ai/DeepSeek-V3.2": { "input": "260000000", "output": "380000000" },
+      "deepseek-ai/DeepSeek-V3.2-Exp": { "input": "270000000", "output": "400000000" },
+      "meta-llama/Llama-3.3-70B-Instruct": { "input": "100000000", "output": "300000000" },
+      "MiniMaxAI/MiniMax-M2.1": { "input": "280000000", "output": "1200000000" },
+      "MiniMaxAI/MiniMax-M2.5": { "input": "300000000", "output": "1200000000" },
+      "mistralai/Mistral-Nemo-Instruct-2407": { "input": "20000000", "output": "40000000" },
+      "mistralai/Mistral-Small-3.2-24B-Instruct-2506": { "input": "0", "output": "0" },
+      "moonshotai/Kimi-K2-Thinking": { "input": "600000000", "output": "2600000000" },
+      "moonshotai/Kimi-K2.5": { "input": "450000000", "output": "2800000000" },
+      "Qwen/Qwen2.5-VL-32B-Instruct": { "input": "200000000", "output": "600000000" },
+      "Qwen/Qwen3-235B-A22B-Instruct-2507": { "input": "90000000", "output": "600000000" },
+      "Qwen/Qwen3.5-Plus": {
+        "input": "400000000",
+        "output": "2400000000",
+        "reasoning": "2400000000"
+      },
+      "XiaomiMiMo/MiMo-V2-Flash": { "input": "100000000", "output": "300000000" },
+      "zai-org/GLM-4.6": { "input": "450000000", "output": "1900000000" },
+      "zai-org/GLM-4.7": { "input": "200000000", "output": "800000000" },
+      "zai-org/GLM-5": { "input": "800000000", "output": "2560000000" }
+    },
+    "merge-gateway": {
+      "anthropic/claude-3-7-sonnet-20250219": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-haiku-4-5-20251001": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic/claude-opus-4-1-20250805": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic/claude-opus-4-20250514": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic/claude-opus-4-5-20251101": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "modes": {
+          "fast": {
+            "input": "30000000000",
+            "output": "150000000000",
+            "cacheRead": "3000000000",
+            "cacheWrite": "37500000000"
+          }
+        }
+      },
+      "anthropic/claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "modes": {
+          "fast": {
+            "input": "30000000000",
+            "output": "150000000000",
+            "cacheRead": "3000000000",
+            "cacheWrite": "37500000000"
+          }
+        }
+      },
+      "anthropic/claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-sonnet-4-20250514": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4-5-20250929": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "bytedance/dola-seed-2.0-code": { "input": "400000000", "output": "2400000000" },
+      "bytedance/dola-seed-2.0-code-preview": { "input": "500000000", "output": "3000000000" },
+      "bytedance/dola-seed-2.0-lite": { "input": "250000000", "output": "2000000000" },
+      "bytedance/dola-seed-2.0-mini": { "input": "100000000", "output": "400000000" },
+      "bytedance/dola-seed-2.0-pro": { "input": "500000000", "output": "3000000000" },
+      "cohere/command-a-03-2025": { "input": "2500000000", "output": "10000000000" },
+      "cohere/command-r-08-2024": { "input": "150000000", "output": "600000000" },
+      "cohere/command-r-plus-08-2024": { "input": "2500000000", "output": "10000000000" },
+      "cohere/command-r7b-12-2024": { "input": "37500000", "output": "150000000" },
+      "deepseek/deepseek-r1": { "input": "1350000000", "output": "5400000000" },
+      "deepseek/deepseek-v3": { "input": "580000000", "output": "1680000000" },
+      "deepseek/deepseek-v3.1": { "input": "500000000", "output": "1500000000" },
+      "deepseek/deepseek-v3.2": {
+        "input": "280000000",
+        "output": "450000000",
+        "cacheRead": "140000000"
+      },
+      "deepseek/deepseek-v4-flash": {
+        "input": "220000000",
+        "output": "660000000",
+        "cacheRead": "7000000"
+      },
+      "deepseek/deepseek-v4-flash-0731": {
+        "input": "35000000",
+        "output": "70000000",
+        "cacheRead": "7000000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "660000000",
+        "output": "1980000000",
+        "cacheRead": "22000000"
+      },
+      "deepseek/deepseek-v4-pro-0423": { "input": "1650000000", "output": "3300000000" },
+      "deepseek/deepseek-v4-pro-0813": {
+        "input": "660000000",
+        "output": "1980000000",
+        "cacheRead": "22000000"
+      },
+      "google/gemini-2.5-computer-use-preview-10-2025": {
+        "input": "1250000000",
+        "output": "10000000000"
+      },
+      "google/gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "inputAudio": "1000000000"
+      },
+      "google/gemini-2.5-flash-image": { "input": "300000000", "output": "2500000000" },
+      "google/gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "inputAudio": "300000000"
+      },
+      "google/gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "inputAudio": "1000000000"
+      },
+      "google/gemini-3-pro-image": { "input": "2000000000", "output": "12000000000" },
+      "google/gemini-3-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3.1-flash-image": { "input": "500000000", "output": "3000000000" },
+      "google/gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "inputAudio": "500000000"
+      },
+      "google/gemini-3.1-flash-lite-preview": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "inputAudio": "500000000"
+      },
+      "google/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3.1-pro-preview-customtools": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "inputAudio": "1500000000"
+      },
+      "google/gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "google/gemini-3.6-flash": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000"
+      },
+      "google/gemini-3.7-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000"
+      },
+      "google/gemini-embedding-001": { "input": "150000000", "output": "0" },
+      "google/gemini-flash-latest": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "inputAudio": "1500000000"
+      },
+      "google/gemini-flash-lite-latest": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "inputAudio": "500000000"
+      },
+      "google/gemma-4-26b-a4b-it": { "input": "130000000", "output": "400000000" },
+      "google/gemma-4-31b-it": { "input": "140000000", "output": "400000000" },
+      "meta/llama-3.1-8b-instruct": { "input": "220000000", "output": "220000000" },
+      "meta/llama-3.3-70b-instruct": {
+        "input": "220000000",
+        "output": "500000000",
+        "cacheRead": "110000000"
+      },
+      "meta/muse-spark-1.1": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "150000000"
+      },
+      "meta/muse-spark-1.2": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "150000000"
+      },
+      "minimax/minimax-m2": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.1": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.5-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.7-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m3": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "mistral/codestral-latest": { "input": "300000000", "output": "900000000" },
+      "mistral/devstral-2512": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "40000000"
+      },
+      "mistral/devstral-medium-2507": { "input": "400000000", "output": "2000000000" },
+      "mistral/devstral-medium-latest": { "input": "400000000", "output": "2000000000" },
+      "mistral/devstral-small-2507": { "input": "100000000", "output": "300000000" },
+      "mistral/magistral-medium-latest": { "input": "2000000000", "output": "5000000000" },
+      "mistral/mistral-large-2411": { "input": "2000000000", "output": "6000000000" },
+      "mistral/mistral-large-2512": {
+        "input": "500000000",
+        "output": "1500000000",
+        "cacheRead": "50000000"
+      },
+      "mistral/mistral-large-latest": { "input": "500000000", "output": "1500000000" },
+      "mistral/mistral-medium-2505": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "40000000"
+      },
+      "mistral/mistral-medium-latest": { "input": "400000000", "output": "2000000000" },
+      "mistral/mistral-small-latest": { "input": "150000000", "output": "600000000" },
+      "mistral/pixtral-large-latest": { "input": "2000000000", "output": "6000000000" },
+      "moonshot/kimi-k2.5": {
+        "input": "600000000",
+        "output": "3000000000",
+        "cacheRead": "100000000"
+      },
+      "moonshot/kimi-k2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "moonshot/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "moonshot/kimi-k2.7-code-highspeed": {
+        "input": "1900000000",
+        "output": "8000000000",
+        "cacheRead": "380000000"
+      },
+      "moonshot/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "moonshotai/kimi-k2-thinking": { "input": "600000000", "output": "2500000000" },
+      "nvidia/nemotron-3.5-lightning-30b-a3b": { "input": "0", "output": "0" },
+      "nvidia/nemotron-nano-9b-v2": { "input": "60000000", "output": "230000000" },
+      "openai/gpt-3.5-turbo": { "input": "500000000", "output": "1500000000" },
+      "openai/gpt-4": { "input": "30000000000", "output": "60000000000" },
+      "openai/gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "openai/gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/gpt-4.1-mini": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "100000000"
+      },
+      "openai/gpt-4.1-nano": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-4o": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-2024-05-13": { "input": "5000000000", "output": "15000000000" },
+      "openai/gpt-4o-2024-08-06": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-2024-11-20": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-mini": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "openai/gpt-5-chat-latest": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "openai/gpt-5.1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-chat-latest": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.2": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-chat-latest": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.3-chat-latest": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": { "input": "5000000000", "output": "30000000000", "cacheRead": "500000000" }
+        }
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000",
+        "modes": {
+          "fast": { "input": "1500000000", "output": "9000000000", "cacheRead": "150000000" }
+        }
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": { "input": "12500000000", "output": "75000000000", "cacheRead": "1250000000" }
+        }
+      },
+      "openai/gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000"
+      },
+      "openai/gpt-5.6-sol": {
+        "input": "4000000000",
+        "output": "24000000000",
+        "cacheRead": "500000000"
+      },
+      "openai/gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000"
+      },
+      "openai/gpt-oss-120b": { "input": "90000000", "output": "360000000" },
+      "openai/gpt-oss-20b": { "input": "40000000", "output": "200000000", "cacheRead": "20000000" },
+      "openai/gpt-oss-safeguard-120b": { "input": "150000000", "output": "600000000" },
+      "openai/o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "openai/o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "openai/o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "qwen/qwen-flash": { "input": "22000000", "output": "216000000", "cacheRead": "4400000" },
+      "qwen/qwen-plus": { "input": "115000000", "output": "287000000", "cacheRead": "23000000" },
+      "qwen/qwen3-235b-a22b": {
+        "input": "287000000",
+        "output": "1147000000",
+        "cacheRead": "57400000"
+      },
+      "qwen/qwen3-235b-a22b-instruct-2507": {
+        "input": "100000000",
+        "output": "600000000",
+        "cacheRead": "50000000"
+      },
+      "qwen/qwen3-30b-a3b": {
+        "input": "108000000",
+        "output": "1076000000",
+        "cacheRead": "21600000"
+      },
+      "qwen/qwen3-32b": { "input": "150000000", "output": "600000000" },
+      "qwen/qwen3-coder-480b-a35b-instruct": { "input": "220000000", "output": "1800000000" },
+      "qwen/qwen3-coder-flash": {
+        "input": "144000000",
+        "output": "574000000",
+        "cacheRead": "28800000"
+      },
+      "qwen/qwen3-coder-next": {
+        "input": "150000000",
+        "output": "800000000",
+        "cacheRead": "75000000"
+      },
+      "qwen/qwen3-coder-plus": {
+        "input": "574000000",
+        "output": "2294000000",
+        "cacheRead": "114800000"
+      },
+      "qwen/qwen3-max": { "input": "359000000", "output": "1434000000", "cacheRead": "71800000" },
+      "qwen/qwen3-next-80b-a3b-instruct": {
+        "input": "144000000",
+        "output": "574000000",
+        "cacheRead": "28800000"
+      },
+      "qwen/qwen3-next-80b-a3b-thinking": { "input": "150000000", "output": "1200000000" },
+      "qwen/qwen3-vl-235b-a22b-instruct": {
+        "input": "287000000",
+        "output": "1147000000",
+        "cacheRead": "157850000"
+      },
+      "qwen/qwen3-vl-235b-a22b-thinking": {
+        "input": "287000000",
+        "output": "2867000000",
+        "cacheRead": "57400000"
+      },
+      "qwen/qwen3-vl-plus": {
+        "input": "143000000",
+        "output": "1434000000",
+        "cacheRead": "28600000"
+      },
+      "qwen/qwen3.5-122b-a10b": {
+        "input": "115000000",
+        "output": "917000000",
+        "cacheRead": "23000000"
+      },
+      "qwen/qwen3.5-27b": { "input": "86000000", "output": "688000000", "cacheRead": "17200000" },
+      "qwen/qwen3.5-35b-a3b": {
+        "input": "57000000",
+        "output": "459000000",
+        "cacheRead": "20357000"
+      },
+      "qwen/qwen3.5-397b-a17b": {
+        "input": "172000000",
+        "output": "1032000000",
+        "cacheRead": "34400000"
+      },
+      "qwen/qwen3.5-9b": { "input": "90000000", "output": "130000000" },
+      "qwen/qwen3.5-flash": { "input": "29000000", "output": "287000000", "cacheRead": "5800000" },
+      "qwen/qwen3.5-plus": { "input": "115000000", "output": "688000000", "cacheRead": "23000000" },
+      "qwen/qwen3.6-27b": { "input": "289000000", "output": "2400000000" },
+      "qwen/qwen3.6-35b-a3b": {
+        "input": "248000000",
+        "output": "1485000000",
+        "cacheRead": "49600000"
+      },
+      "qwen/qwen3.6-flash": {
+        "input": "165000000",
+        "output": "990000000",
+        "cacheRead": "33000000"
+      },
+      "qwen/qwen3.6-max-preview": { "input": "1310000000", "output": "7880000000" },
+      "qwen/qwen3.6-plus": {
+        "input": "276000000",
+        "output": "1651000000",
+        "cacheRead": "55200000"
+      },
+      "qwen/qwen3.7-max": {
+        "input": "825000000",
+        "output": "2475500000",
+        "cacheRead": "165000000"
+      },
+      "qwen/qwen3.7-plus": { "input": "400000000", "output": "1600000000" },
+      "qwen/qwen3.8-2.4t-a95b": {
+        "input": "2500000000",
+        "output": "6250000000",
+        "cacheRead": "500000000"
+      },
+      "qwen/qwen3.8-max": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000"
+      },
+      "sakana/fugu-ultra": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "sakana/sakana-namazu": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "150000000"
+      },
+      "thinkingmachines/inkling": {
+        "input": "1000000000",
+        "output": "4050000000",
+        "cacheRead": "170000000"
+      },
+      "writer/palmyra-x4": { "input": "2500000000", "output": "10000000000" },
+      "writer/palmyra-x5": { "input": "600000000", "output": "6000000000" },
+      "xai/grok-4.20-0309-non-reasoning": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000"
+      },
+      "xai/grok-4.20-0309-reasoning": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-4.3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-4.5": { "input": "2000000000", "output": "6000000000", "cacheRead": "500000000" },
+      "xai/grok-4.6": { "input": "1500000000", "output": "4500000000", "cacheRead": "375000000" },
+      "xai/grok-build-0.1": {
+        "input": "1000000000",
+        "output": "2000000000",
+        "cacheRead": "200000000"
+      },
+      "zai/glm-4.5": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "zai/glm-4.5-air": {
+        "input": "200000000",
+        "output": "1100000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "0"
+      },
+      "zai/glm-4.5v": {
+        "input": "600000000",
+        "output": "1800000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "zai/glm-4.6": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "zai/glm-4.7": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "zai/glm-4.7-flash": { "input": "70000000", "output": "400000000" },
+      "zai/glm-4.7-flashx": {
+        "input": "70000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "0"
+      },
+      "zai/glm-5": {
+        "input": "1000000000",
+        "output": "3200000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "0"
+      },
+      "zai/glm-5-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000",
+        "cacheWrite": "0"
+      },
+      "zai/glm-5.1": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "0"
+      },
+      "zai/glm-5.2": { "input": "1050000000", "output": "3300000000", "cacheRead": "195000000" },
+      "zai/glm-5.3": { "input": "700000000", "output": "2200000000", "cacheRead": "130000000" }
+    },
+    "meta": {
+      "muse-spark-1.1": { "input": "1250000000", "output": "4250000000", "cacheRead": "150000000" },
+      "muse-spark-1.2": { "input": "1250000000", "output": "4250000000", "cacheRead": "150000000" },
+      "muse-spark-1.2-contributor": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "2000000"
+      }
+    },
+    "minimax": {
+      "MiniMax-M2": { "input": "300000000", "output": "1200000000" },
+      "MiniMax-M2.1": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "MiniMax-M2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "MiniMax-M2.5-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "MiniMax-M2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "MiniMax-M2.7-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "MiniMax-M3": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000",
+        "tiers": [
+          {
+            "input": "600000000",
+            "output": "2400000000",
+            "cacheRead": "120000000",
+            "aboveInputTokens": "512000"
+          }
+        ]
+      }
+    },
+    "minimax-cn": {
+      "MiniMax-M2": { "input": "300000000", "output": "1200000000" },
+      "MiniMax-M2.1": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "MiniMax-M2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "MiniMax-M2.5-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "MiniMax-M2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "MiniMax-M2.7-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "MiniMax-M3": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000",
+        "tiers": [
+          {
+            "input": "600000000",
+            "output": "2400000000",
+            "cacheRead": "120000000",
+            "aboveInputTokens": "512000"
+          }
+        ]
+      }
+    },
+    "minimax-cn-coding-plan": {
+      "MiniMax-M2": { "input": "0", "output": "0" },
+      "MiniMax-M2.1": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "MiniMax-M2.5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "MiniMax-M2.5-highspeed": {
+        "input": "0",
+        "output": "0",
+        "cacheRead": "0",
+        "cacheWrite": "0"
+      },
+      "MiniMax-M2.7": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "MiniMax-M2.7-highspeed": {
+        "input": "0",
+        "output": "0",
+        "cacheRead": "0",
+        "cacheWrite": "0"
+      },
+      "MiniMax-M3": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" }
+    },
+    "minimax-coding-plan": {
+      "MiniMax-M2": { "input": "0", "output": "0" },
+      "MiniMax-M2.1": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "MiniMax-M2.5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "MiniMax-M2.5-highspeed": {
+        "input": "0",
+        "output": "0",
+        "cacheRead": "0",
+        "cacheWrite": "0"
+      },
+      "MiniMax-M2.7": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "MiniMax-M2.7-highspeed": {
+        "input": "0",
+        "output": "0",
+        "cacheRead": "0",
+        "cacheWrite": "0"
+      },
+      "MiniMax-M3": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" }
+    },
+    "mistral": {
+      "codestral-latest": { "input": "300000000", "output": "900000000" },
+      "devstral-2512": { "input": "400000000", "output": "2000000000" },
+      "devstral-latest": { "input": "400000000", "output": "2000000000" },
+      "devstral-medium-2507": { "input": "400000000", "output": "2000000000" },
+      "devstral-medium-latest": { "input": "400000000", "output": "2000000000" },
+      "devstral-small-2505": { "input": "100000000", "output": "300000000" },
+      "devstral-small-2507": { "input": "100000000", "output": "300000000" },
+      "labs-devstral-small-2512": { "input": "0", "output": "0" },
+      "magistral-medium-latest": { "input": "2000000000", "output": "5000000000" },
+      "magistral-small": { "input": "500000000", "output": "1500000000" },
+      "ministral-3b-latest": { "input": "40000000", "output": "40000000" },
+      "ministral-8b-latest": { "input": "100000000", "output": "100000000" },
+      "mistral-embed": { "input": "100000000", "output": "0" },
+      "mistral-large-2411": { "input": "2000000000", "output": "6000000000" },
+      "mistral-large-2512": { "input": "500000000", "output": "1500000000" },
+      "mistral-large-latest": { "input": "500000000", "output": "1500000000" },
+      "mistral-medium-2505": { "input": "400000000", "output": "2000000000" },
+      "mistral-medium-2508": { "input": "400000000", "output": "2000000000" },
+      "mistral-medium-2604": { "input": "1500000000", "output": "7500000000" },
+      "mistral-medium-latest": { "input": "1500000000", "output": "7500000000" },
+      "mistral-nemo": { "input": "150000000", "output": "150000000" },
+      "mistral-small-2506": { "input": "100000000", "output": "300000000" },
+      "mistral-small-2603": { "input": "150000000", "output": "600000000" },
+      "mistral-small-latest": { "input": "150000000", "output": "600000000" },
+      "open-mistral-7b": { "input": "250000000", "output": "250000000" },
+      "open-mistral-nemo": { "input": "150000000", "output": "150000000" },
+      "open-mixtral-8x22b": { "input": "2000000000", "output": "6000000000" },
+      "open-mixtral-8x7b": { "input": "700000000", "output": "700000000" },
+      "pixtral-12b": { "input": "150000000", "output": "150000000" },
+      "pixtral-large-latest": { "input": "2000000000", "output": "6000000000" },
+      "voxtral-small-latest": { "input": "100000000", "output": "300000000" }
+    },
+    "mixlayer": {
+      "qwen/qwen3.5-122b-a10b": { "input": "400000000", "output": "3200000000" },
+      "qwen/qwen3.5-27b": { "input": "300000000", "output": "2400000000" },
+      "qwen/qwen3.5-35b-a3b": { "input": "250000000", "output": "1300000000" },
+      "qwen/qwen3.5-397b-a17b": { "input": "600000000", "output": "3600000000" },
+      "qwen/qwen3.5-9b": { "input": "100000000", "output": "400000000" }
+    },
+    "moark": {
+      "GLM-4.7": { "input": "3500000000", "output": "14000000000" },
+      "MiniMax-M2.1": {
+        "input": "2100000000",
+        "output": "8400000000",
+        "cacheRead": "2100000000",
+        "cacheWrite": "8400000000"
+      }
+    },
+    "modal": {
+      "moonshotai/Kimi-K3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "reasoning": "15000000000"
+      },
+      "thinkingmachines/Inkling-NVFP4": {
+        "input": "1200000000",
+        "output": "5000000000",
+        "cacheRead": "270000000"
+      }
+    },
+    "modelis": {
+      "claude-fable-5": { "input": "10000000000", "output": "50000000000" },
+      "claude-opus-4-8": { "input": "5000000000", "output": "25000000000" },
+      "claude-sonnet-4-6": { "input": "3000000000", "output": "15000000000" },
+      "deepseek-v4-flash": { "input": "98300000", "output": "196600000" },
+      "deepseek-v4-pro": { "input": "435000000", "output": "870000000" },
+      "gemini-2.5-flash": { "input": "300000000", "output": "2500000000" },
+      "gemini-2.5-pro": { "input": "1250000000", "output": "10000000000" },
+      "qwen/qwen3.7-max": { "input": "3000000000", "output": "9000000000" },
+      "qwen/qwen3.7-plus": { "input": "768000000", "output": "3072000000" }
+    },
+    "modelscope": {
+      "Qwen/Qwen3-235B-A22B-Instruct-2507": { "input": "0", "output": "0" },
+      "Qwen/Qwen3-235B-A22B-Thinking-2507": { "input": "0", "output": "0" },
+      "Qwen/Qwen3-30B-A3B-Instruct-2507": { "input": "0", "output": "0" },
+      "Qwen/Qwen3-30B-A3B-Thinking-2507": { "input": "0", "output": "0" },
+      "Qwen/Qwen3-Coder-30B-A3B-Instruct": { "input": "0", "output": "0" },
+      "ZhipuAI/GLM-4.5": { "input": "0", "output": "0" },
+      "ZhipuAI/GLM-4.6": { "input": "0", "output": "0" }
+    },
+    "moonshotai": {
+      "kimi-k2-0711-preview": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "150000000"
+      },
+      "kimi-k2-0905-preview": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "150000000"
+      },
+      "kimi-k2-thinking": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "150000000"
+      },
+      "kimi-k2-thinking-turbo": {
+        "input": "1150000000",
+        "output": "8000000000",
+        "cacheRead": "150000000"
+      },
+      "kimi-k2-turbo-preview": {
+        "input": "2400000000",
+        "output": "10000000000",
+        "cacheRead": "600000000"
+      },
+      "kimi-k2.5": { "input": "600000000", "output": "3000000000", "cacheRead": "100000000" },
+      "kimi-k2.6": { "input": "950000000", "output": "4000000000", "cacheRead": "160000000" },
+      "kimi-k2.7-code": { "input": "950000000", "output": "4000000000", "cacheRead": "190000000" },
+      "kimi-k2.7-code-highspeed": {
+        "input": "1900000000",
+        "output": "8000000000",
+        "cacheRead": "380000000"
+      },
+      "kimi-k3": { "input": "3000000000", "output": "15000000000", "cacheRead": "300000000" }
+    },
+    "moonshotai-cn": {
+      "kimi-k2-0711-preview": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "150000000"
+      },
+      "kimi-k2-0905-preview": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "150000000"
+      },
+      "kimi-k2-thinking": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "150000000"
+      },
+      "kimi-k2-thinking-turbo": {
+        "input": "1150000000",
+        "output": "8000000000",
+        "cacheRead": "150000000"
+      },
+      "kimi-k2-turbo-preview": {
+        "input": "2400000000",
+        "output": "10000000000",
+        "cacheRead": "600000000"
+      },
+      "kimi-k2.5": { "input": "600000000", "output": "3000000000", "cacheRead": "100000000" },
+      "kimi-k2.6": { "input": "950000000", "output": "4000000000", "cacheRead": "160000000" },
+      "kimi-k2.7-code": { "input": "950000000", "output": "4000000000", "cacheRead": "190000000" },
+      "kimi-k2.7-code-highspeed": {
+        "input": "1900000000",
+        "output": "8000000000",
+        "cacheRead": "380000000"
+      },
+      "kimi-k3": { "input": "3000000000", "output": "15000000000", "cacheRead": "300000000" }
+    },
+    "morph": {
+      "auto": { "input": "850000000", "output": "1550000000" },
+      "morph-v3-fast": { "input": "800000000", "output": "1200000000" },
+      "morph-v3-large": { "input": "900000000", "output": "1900000000" }
+    },
+    "nano-gpt": {
+      "abacusai/Dracarys-72B-Instruct": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "aion-labs/aion-2.0": {
+        "input": "800000000",
+        "output": "1600000000",
+        "cacheRead": "200000000"
+      },
+      "aion-labs/aion-3.0": {
+        "input": "3000000000",
+        "output": "6000000000",
+        "cacheRead": "750000000"
+      },
+      "aion-labs/aion-3.0-mini": {
+        "input": "700000000",
+        "output": "1400000000",
+        "cacheRead": "180000000"
+      },
+      "aion-labs/aion-rp-llama-3.1-8b": {
+        "input": "800000000",
+        "output": "1600000000",
+        "cacheRead": "400000000"
+      },
+      "alibaba/qwen3.6-27b": {
+        "input": "203000000",
+        "output": "2240000000",
+        "cacheRead": "101500000"
+      },
+      "alibaba/qwen3.6-27b:thinking": {
+        "input": "203000000",
+        "output": "2240000000",
+        "cacheRead": "101500000"
+      },
+      "alibaba/qwen3.6-flash": {
+        "input": "190000000",
+        "output": "1160000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "240000000"
+      },
+      "amazon/nova-2-lite-v1": {
+        "input": "510000000",
+        "output": "4250000000",
+        "cacheRead": "255000000"
+      },
+      "amazon/nova-lite-v1": {
+        "input": "59500000",
+        "output": "238000000",
+        "cacheRead": "29750000"
+      },
+      "amazon/nova-pro-v1": {
+        "input": "799000000",
+        "output": "3196000000",
+        "cacheRead": "399500000"
+      },
+      "anthracite-org/magnum-v2-72b": {
+        "input": "2006000000",
+        "output": "2992000000",
+        "cacheRead": "1003000000"
+      },
+      "anthracite-org/magnum-v4-72b": {
+        "input": "2006000000",
+        "output": "2992000000",
+        "cacheRead": "1003000000"
+      },
+      "anthropic/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-fable-latest": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-haiku-latest": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000"
+      },
+      "anthropic/claude-opus-4.6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "anthropic/claude-opus-4.6:thinking": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "anthropic/claude-opus-4.6:thinking:low": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "anthropic/claude-opus-4.6:thinking:max": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "anthropic/claude-opus-4.6:thinking:medium": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "anthropic/claude-opus-4.7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "anthropic/claude-opus-4.7:thinking": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "anthropic/claude-opus-4.8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "anthropic/claude-opus-4.8:thinking": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "anthropic/claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-latest": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-sonnet-4.6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "anthropic/claude-sonnet-4.6:thinking": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "anthropic/claude-sonnet-5:thinking": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "anthropic/claude-sonnet-latest": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "arcee-ai/trinity-large-thinking": {
+        "input": "250000000",
+        "output": "900000000",
+        "cacheRead": "125000000"
+      },
+      "asi1-mini": { "input": "1000000000", "output": "1000000000", "cacheRead": "500000000" },
+      "auto-model": { "input": "0", "output": "0" },
+      "auto-model-basic": {
+        "input": "9996000000",
+        "output": "19992000000",
+        "cacheRead": "4998000000"
+      },
+      "auto-model-premium": {
+        "input": "9996000000",
+        "output": "19992000000",
+        "cacheRead": "4998000000"
+      },
+      "auto-model-standard": {
+        "input": "9996000000",
+        "output": "19992000000",
+        "cacheRead": "4998000000"
+      },
+      "azure-gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "azure-gpt-4o": { "input": "2500000000", "output": "10000000000", "cacheRead": "1250000000" },
+      "azure-gpt-4o-mini": { "input": "150000000", "output": "600000000", "cacheRead": "75000000" },
+      "azure-o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "azure-o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "Baichuan-M2": { "input": "15730000000", "output": "15730000000", "cacheRead": "7865000000" },
+      "Baichuan4-Air": { "input": "157000000", "output": "157000000", "cacheRead": "78500000" },
+      "Baichuan4-Turbo": {
+        "input": "2420000000",
+        "output": "2420000000",
+        "cacheRead": "1210000000"
+      },
+      "baseten/Kimi-K2-Instruct-FP4": {
+        "input": "400000000",
+        "output": "1800000000",
+        "cacheRead": "200000000"
+      },
+      "brave": { "input": "5000000000", "output": "5000000000" },
+      "brave-pro": { "input": "5000000000", "output": "5000000000" },
+      "brave-research": { "input": "5000000000", "output": "5000000000" },
+      "bytedance-seed/seed-2-1-turbo": {
+        "input": "500000000",
+        "output": "2500000000",
+        "cacheRead": "250000000"
+      },
+      "bytedance-seed/seed-2.0-code": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "250000000"
+      },
+      "bytedance-seed/seed-2.0-lite": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "125000000"
+      },
+      "bytedance/doubao-seed-2.1-pro": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "500000000"
+      },
+      "bytedance/doubao-seed-2.1-turbo": {
+        "input": "500000000",
+        "output": "2500000000",
+        "cacheRead": "250000000"
+      },
+      "bytedance/doubao-seed-character": {
+        "input": "117900000",
+        "output": "294700000",
+        "cacheRead": "23600000",
+        "cacheWrite": "2500000"
+      },
+      "celeris-1": { "input": "2000000000", "output": "6000000000", "cacheRead": "1000000000" },
+      "chutesai/Mistral-Small-3.2-24B-Instruct-2506": {
+        "input": "200000000",
+        "output": "400000000",
+        "cacheRead": "100000000"
+      },
+      "claude-haiku-4-5-20251001": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000"
+      },
+      "claude-haiku-4-5-20251001-thinking": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000"
+      },
+      "claude-opus-4-1-20250805": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000"
+      },
+      "claude-opus-4-1-thinking": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000"
+      },
+      "claude-opus-4-1-thinking:1024": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000"
+      },
+      "claude-opus-4-1-thinking:32000": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000"
+      },
+      "claude-opus-4-1-thinking:32768": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000"
+      },
+      "claude-opus-4-1-thinking:8192": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000"
+      },
+      "claude-opus-4-20250514": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000"
+      },
+      "claude-opus-4-5-20251101": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "claude-opus-4-5-20251101:thinking": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "claude-opus-4-thinking": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000"
+      },
+      "claude-opus-4-thinking:1024": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000"
+      },
+      "claude-opus-4-thinking:32000": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000"
+      },
+      "claude-opus-4-thinking:32768": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000"
+      },
+      "claude-opus-4-thinking:8192": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000"
+      },
+      "claude-sonnet-4-20250514": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "claude-sonnet-4-5-20250929": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "claude-sonnet-4-5-20250929-thinking": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "claude-sonnet-4-thinking": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "claude-sonnet-4-thinking:1024": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "claude-sonnet-4-thinking:32768": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "claude-sonnet-4-thinking:64000": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "claude-sonnet-4-thinking:8192": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "claw-high": { "input": "5000000000", "output": "25000000000", "cacheRead": "2500000000" },
+      "claw-low": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "83330000"
+      },
+      "claw-medium": { "input": "315000000", "output": "1260000000", "cacheRead": "157500000" },
+      "cohere/command-r-plus-08-2024": {
+        "input": "2856000000",
+        "output": "14246000000",
+        "cacheRead": "1428000000"
+      },
+      "cohere/north-mini-code": {
+        "input": "200000000",
+        "output": "800000000",
+        "cacheRead": "100000000"
+      },
+      "command-a-plus-05-2026": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "command-a-reasoning-08-2025": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "crofai/greg-2-super": {
+        "input": "1500000000",
+        "output": "5000000000",
+        "cacheRead": "250000000"
+      },
+      "crofai/greg-2-ultra": {
+        "input": "3000000000",
+        "output": "10000000000",
+        "cacheRead": "500000000"
+      },
+      "deepclaude": { "input": "3000000000", "output": "15000000000", "cacheRead": "300000000" },
+      "deepcogito/cogito-v1-preview-qwen-32B": {
+        "input": "1800000000",
+        "output": "1800000000",
+        "cacheRead": "900000000"
+      },
+      "deepseek-ai/DeepSeek-R1-0528": {
+        "input": "400000000",
+        "output": "1700000000",
+        "cacheRead": "200000000"
+      },
+      "deepseek-ai/DeepSeek-V3.1": {
+        "input": "200000000",
+        "output": "700000000",
+        "cacheRead": "100000000"
+      },
+      "deepseek-ai/DeepSeek-V3.1-Terminus": {
+        "input": "250000000",
+        "output": "700000000",
+        "cacheRead": "125000000"
+      },
+      "deepseek-ai/DeepSeek-V3.1-Terminus:thinking": {
+        "input": "250000000",
+        "output": "700000000",
+        "cacheRead": "125000000"
+      },
+      "deepseek-ai/DeepSeek-V3.1:thinking": {
+        "input": "200000000",
+        "output": "700000000",
+        "cacheRead": "100000000"
+      },
+      "deepseek-ai/deepseek-v3.2-exp": {
+        "input": "280000000",
+        "output": "420000000",
+        "cacheRead": "140000000"
+      },
+      "deepseek-ai/deepseek-v3.2-exp-thinking": {
+        "input": "280000000",
+        "output": "420000000",
+        "cacheRead": "140000000"
+      },
+      "deepseek-chat": { "input": "100000000", "output": "425000000", "cacheRead": "50000000" },
+      "deepseek-chat-cheaper": {
+        "input": "100000000",
+        "output": "425000000",
+        "cacheRead": "50000000"
+      },
+      "deepseek-r1": { "input": "400000000", "output": "1700000000", "cacheRead": "200000000" },
+      "deepseek-r1-sambanova": {
+        "input": "4998000000",
+        "output": "6987000000",
+        "cacheRead": "2499000000"
+      },
+      "deepseek-reasoner": {
+        "input": "400000000",
+        "output": "1700000000",
+        "cacheRead": "200000000"
+      },
+      "deepseek-reasoner-cheaper": {
+        "input": "400000000",
+        "output": "1700000000",
+        "cacheRead": "200000000"
+      },
+      "deepseek-v3-0324": { "input": "200000000", "output": "770000000", "cacheRead": "135000000" },
+      "deepseek/deepseek-latest": {
+        "input": "1100000000",
+        "output": "2500000000",
+        "cacheRead": "40000000"
+      },
+      "deepseek/deepseek-prover-v2-671b": {
+        "input": "1000000000",
+        "output": "2500000000",
+        "cacheRead": "500000000"
+      },
+      "deepseek/deepseek-v3.2": {
+        "input": "280000000",
+        "output": "420000000",
+        "cacheRead": "140000000"
+      },
+      "deepseek/deepseek-v3.2:thinking": {
+        "input": "280000000",
+        "output": "420000000",
+        "cacheRead": "140000000"
+      },
+      "deepseek/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "2800000"
+      },
+      "deepseek/deepseek-v4-flash-0731": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "14000000"
+      },
+      "deepseek/deepseek-v4-flash-0731:thinking": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "14000000"
+      },
+      "deepseek/deepseek-v4-flash-latest": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "14000000"
+      },
+      "deepseek/deepseek-v4-flash-vision-exp": {
+        "input": "220000000",
+        "output": "660000000",
+        "cacheRead": "7000000"
+      },
+      "deepseek/deepseek-v4-flash:thinking": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "2800000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "1100000000",
+        "output": "2200000000",
+        "cacheRead": "110000000"
+      },
+      "deepseek/deepseek-v4-pro-0813": {
+        "input": "1100000000",
+        "output": "2500000000",
+        "cacheRead": "40000000"
+      },
+      "deepseek/deepseek-v4-pro-0813:thinking": {
+        "input": "1100000000",
+        "output": "2500000000",
+        "cacheRead": "40000000"
+      },
+      "deepseek/deepseek-v4-pro:thinking": {
+        "input": "1100000000",
+        "output": "2200000000",
+        "cacheRead": "110000000"
+      },
+      "dmind/dmind-1-mini": {
+        "input": "200000000",
+        "output": "400000000",
+        "cacheRead": "100000000"
+      },
+      "Doctor-Shotgun/MS3.2-24B-Magnum-Diamond": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "dots-studio/dots-3-note-preview": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "50000000"
+      },
+      "doubao-1.5-pro-256k": {
+        "input": "799000000",
+        "output": "1445000000",
+        "cacheRead": "399500000"
+      },
+      "doubao-1.5-pro-32k": {
+        "input": "134300000",
+        "output": "334900000",
+        "cacheRead": "67150000"
+      },
+      "doubao-1.5-vision-pro-32k": {
+        "input": "459000000",
+        "output": "1377000000",
+        "cacheRead": "229500000"
+      },
+      "doubao-seed-1-6-250615": {
+        "input": "204000000",
+        "output": "510000000",
+        "cacheRead": "102000000"
+      },
+      "doubao-seed-1-6-flash-250615": {
+        "input": "37400000",
+        "output": "374000000",
+        "cacheRead": "18700000"
+      },
+      "doubao-seed-2-0-code-preview-260215": {
+        "input": "782000000",
+        "output": "3893000000",
+        "cacheRead": "391000000"
+      },
+      "doubao-seed-2-0-lite-260215": {
+        "input": "146200000",
+        "output": "873800000",
+        "cacheRead": "73100000"
+      },
+      "doubao-seed-2-0-mini-260215": {
+        "input": "49300000",
+        "output": "484500000",
+        "cacheRead": "24650000"
+      },
+      "doubao-seed-2-0-pro-260215": {
+        "input": "782000000",
+        "output": "3876000000",
+        "cacheRead": "391000000"
+      },
+      "Envoid/Llama-3.05-Nemotron-Tenyxchat-Storybreaker-70B": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "Envoid/Llama-3.05-NT-Storybreaker-Ministral-70B": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "ernie-5.0-thinking-preview": {
+        "input": "1000000000",
+        "output": "3500000000",
+        "cacheRead": "500000000"
+      },
+      "ernie-5.1": { "input": "750000000", "output": "3000000000", "cacheRead": "750000000" },
+      "ernie-5.1:thinking": {
+        "input": "750000000",
+        "output": "3000000000",
+        "cacheRead": "750000000"
+      },
+      "ernie-x1.1-preview": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "EVA-UNIT-01/EVA-LLaMA-3.33-70B-v0.0": {
+        "input": "2006000000",
+        "output": "2006000000",
+        "cacheRead": "1003000000"
+      },
+      "EVA-UNIT-01/EVA-LLaMA-3.33-70B-v0.1": {
+        "input": "2006000000",
+        "output": "2006000000",
+        "cacheRead": "1003000000"
+      },
+      "EVA-UNIT-01/EVA-Qwen2.5-32B-v0.2": {
+        "input": "799000000",
+        "output": "799000000",
+        "cacheRead": "399500000"
+      },
+      "EVA-UNIT-01/EVA-Qwen2.5-72B-v0.2": {
+        "input": "799000000",
+        "output": "799000000",
+        "cacheRead": "399500000"
+      },
+      "exa-answer": { "input": "2500000000", "output": "2500000000" },
+      "failspy/Meta-Llama-3-70B-Instruct-abliterated-v3.5": {
+        "input": "700000000",
+        "output": "700000000",
+        "cacheRead": "350000000"
+      },
+      "fastgpt": { "input": "7500000000", "output": "7500000000" },
+      "featherless-ai/Qwerky-72B": {
+        "input": "500000000",
+        "output": "500000000",
+        "cacheRead": "250000000"
+      },
+      "GalrionSoftworks/MN-LooseCannon-12B-v1": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "gemini-2.0-pro-exp-02-05": {
+        "input": "1989000000",
+        "output": "7956000000",
+        "cacheRead": "497250000"
+      },
+      "gemini-2.0-pro-reasoner": {
+        "input": "1292000000",
+        "output": "4998000000",
+        "cacheRead": "323000000"
+      },
+      "gemini-2.5-flash": { "input": "300000000", "output": "2500000000", "cacheRead": "30000000" },
+      "gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000"
+      },
+      "gemini-2.5-flash-lite-preview-06-17": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000"
+      },
+      "gemini-2.5-flash-lite-preview-09-2025": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000"
+      },
+      "gemini-2.5-flash-lite-preview-09-2025-thinking": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000"
+      },
+      "gemini-2.5-flash-nothinking": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "gemini-2.5-flash-preview-04-17": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000"
+      },
+      "gemini-2.5-flash-preview-04-17:thinking": {
+        "input": "150000000",
+        "output": "3500000000",
+        "cacheRead": "15000000"
+      },
+      "gemini-2.5-flash-preview-05-20": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000"
+      },
+      "gemini-2.5-flash-preview-05-20:thinking": {
+        "input": "150000000",
+        "output": "3500000000",
+        "cacheRead": "15000000"
+      },
+      "gemini-2.5-flash-preview-09-2025": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "gemini-2.5-flash-preview-09-2025-thinking": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "cacheWrite": "375000000"
+      },
+      "gemini-2.5-pro-exp-03-25": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "250000000"
+      },
+      "gemini-2.5-pro-preview-03-25": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "250000000"
+      },
+      "gemini-2.5-pro-preview-05-06": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "250000000"
+      },
+      "gemini-2.5-pro-preview-06-05": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "250000000"
+      },
+      "gemini-3-pro-image-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000"
+      },
+      "gemini-exp-1206": {
+        "input": "1258000000",
+        "output": "4998000000",
+        "cacheRead": "629000000"
+      },
+      "gemma-4-12b-it": { "input": "60000000", "output": "300000000", "cacheRead": "30000000" },
+      "Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled": {
+        "input": "306000000",
+        "output": "306000000",
+        "cacheRead": "30600000"
+      },
+      "Gemma-4-31B-Cognitive-Unshackled": {
+        "input": "306000000",
+        "output": "306000000",
+        "cacheRead": "153000000"
+      },
+      "Gemma-4-31B-DarkIdol": {
+        "input": "306000000",
+        "output": "306000000",
+        "cacheRead": "153000000"
+      },
+      "Gemma-4-31B-GarnetV2": {
+        "input": "306000000",
+        "output": "306000000",
+        "cacheRead": "153000000"
+      },
+      "Gemma-4-31B-MeroMero-v2": {
+        "input": "80000000",
+        "output": "330000000",
+        "cacheRead": "40000000"
+      },
+      "Gemma-4-31B-MeroMero-v2:thinking": {
+        "input": "80000000",
+        "output": "330000000",
+        "cacheRead": "40000000"
+      },
+      "Gemma-4-31B-Queen": {
+        "input": "306000000",
+        "output": "306000000",
+        "cacheRead": "153000000"
+      },
+      "gemma-4-e2b-it": { "input": "20000000", "output": "100000000", "cacheRead": "10000000" },
+      "gemma-4-e4b-it": { "input": "40000000", "output": "200000000", "cacheRead": "20000000" },
+      "glm-4": { "input": "14994000000", "output": "14994000000", "cacheRead": "7497000000" },
+      "glm-4-air": { "input": "200600000", "output": "200600000", "cacheRead": "100300000" },
+      "glm-4-air-0111": { "input": "139400000", "output": "139400000", "cacheRead": "69700000" },
+      "glm-4-airx": { "input": "2006000000", "output": "2006000000", "cacheRead": "1003000000" },
+      "glm-4-flash": { "input": "100300000", "output": "100300000", "cacheRead": "50150000" },
+      "glm-4-long": { "input": "200600000", "output": "200600000", "cacheRead": "100300000" },
+      "glm-4-plus": { "input": "7497000000", "output": "7497000000", "cacheRead": "3748500000" },
+      "glm-4-plus-0111": {
+        "input": "9996000000",
+        "output": "9996000000",
+        "cacheRead": "4998000000"
+      },
+      "glm-4.1v-thinking-flash": {
+        "input": "300000000",
+        "output": "300000000",
+        "cacheRead": "150000000"
+      },
+      "glm-4.1v-thinking-flashx": {
+        "input": "300000000",
+        "output": "300000000",
+        "cacheRead": "150000000"
+      },
+      "GLM-4.6-Derestricted-v5": {
+        "input": "400000000",
+        "output": "1500000000",
+        "cacheRead": "200000000"
+      },
+      "glm-z1-air": { "input": "70000000", "output": "70000000", "cacheRead": "35000000" },
+      "glm-z1-airx": { "input": "700000000", "output": "700000000", "cacheRead": "350000000" },
+      "glm-zero-preview": {
+        "input": "1802000000",
+        "output": "1802000000",
+        "cacheRead": "901000000"
+      },
+      "google/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000"
+      },
+      "google/gemini-3-flash-preview-thinking": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000"
+      },
+      "google/gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "83330000"
+      },
+      "google/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000"
+      },
+      "google/gemini-3.1-pro-preview-customtools": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000"
+      },
+      "google/gemini-3.1-pro-preview-high": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000"
+      },
+      "google/gemini-3.1-pro-preview-low": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000"
+      },
+      "google/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000"
+      },
+      "google/gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83330000"
+      },
+      "google/gemini-3.5-flash-thinking": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000"
+      },
+      "google/gemini-3.6-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "41667000"
+      },
+      "google/gemini-3.7-flash": {
+        "input": "375000000",
+        "output": "1875000000",
+        "cacheRead": "37500000",
+        "cacheWrite": "20833000"
+      },
+      "google/gemini-flash-latest": {
+        "input": "375000000",
+        "output": "1875000000",
+        "cacheRead": "37500000",
+        "cacheWrite": "20833000"
+      },
+      "google/gemini-flash-lite-latest": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83330000"
+      },
+      "google/gemini-pro-latest": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000"
+      },
+      "google/gemma-4-26b-a4b-it": {
+        "input": "80000000",
+        "output": "330000000",
+        "cacheRead": "40000000"
+      },
+      "google/gemma-4-26b-a4b-it:thinking": {
+        "input": "130000000",
+        "output": "400000000",
+        "cacheRead": "65000000"
+      },
+      "google/gemma-4-26b-a4b-uncensored": {
+        "input": "80000000",
+        "output": "330000000",
+        "cacheRead": "40000000"
+      },
+      "google/gemma-4-26b-a4b-uncensored:thinking": {
+        "input": "80000000",
+        "output": "330000000",
+        "cacheRead": "40000000"
+      },
+      "google/gemma-4-31b-it": {
+        "input": "80000000",
+        "output": "330000000",
+        "cacheRead": "40000000"
+      },
+      "google/gemma-4-31b-it:thinking": {
+        "input": "100000000",
+        "output": "350000000",
+        "cacheRead": "50000000"
+      },
+      "Gryphe/MythoMax-L2-13b": {
+        "input": "100300000",
+        "output": "100300000",
+        "cacheRead": "50150000"
+      },
+      "hermes-high": { "input": "5000000000", "output": "25000000000", "cacheRead": "2500000000" },
+      "hermes-low": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "83330000"
+      },
+      "hermes-medium": { "input": "315000000", "output": "1260000000", "cacheRead": "157500000" },
+      "holo3-35b-a3b": { "input": "250000000", "output": "1800000000", "cacheRead": "125000000" },
+      "holo3-35b-a3b:thinking": {
+        "input": "250000000",
+        "output": "1800000000",
+        "cacheRead": "125000000"
+      },
+      "huihui-ai/DeepSeek-R1-Distill-Llama-70B-abliterated": {
+        "input": "700000000",
+        "output": "700000000",
+        "cacheRead": "350000000"
+      },
+      "huihui-ai/DeepSeek-R1-Distill-Qwen-32B-abliterated": {
+        "input": "1400000000",
+        "output": "1400000000",
+        "cacheRead": "700000000"
+      },
+      "huihui-ai/Llama-3.3-70B-Instruct-abliterated": {
+        "input": "700000000",
+        "output": "700000000",
+        "cacheRead": "350000000"
+      },
+      "huihui-ai/Qwen2.5-32B-Instruct-abliterated": {
+        "input": "700000000",
+        "output": "700000000",
+        "cacheRead": "350000000"
+      },
+      "hunyuan-turbos-20250226": {
+        "input": "187000000",
+        "output": "374000000",
+        "cacheRead": "93500000"
+      },
+      "ibm-granite/granite-4.1-8b": {
+        "input": "50000000",
+        "output": "100000000",
+        "cacheRead": "50000000"
+      },
+      "inclusionai/ling-3.0-flash": {
+        "input": "75000000",
+        "output": "220000000",
+        "cacheRead": "15000000"
+      },
+      "inclusionai/ling-3.0-flash:thinking": {
+        "input": "75000000",
+        "output": "220000000",
+        "cacheRead": "15000000"
+      },
+      "inflatebot/MN-12B-Mag-Mell-R1": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "inflection/inflection-3-pi": {
+        "input": "2499000000",
+        "output": "9996000000",
+        "cacheRead": "1249500000"
+      },
+      "inflection/inflection-3-productivity": {
+        "input": "2499000000",
+        "output": "9996000000",
+        "cacheRead": "1249500000"
+      },
+      "jamba-large": { "input": "1989000000", "output": "7990000000", "cacheRead": "994500000" },
+      "jamba-large-1.6": {
+        "input": "1989000000",
+        "output": "7990000000",
+        "cacheRead": "994500000"
+      },
+      "jamba-large-1.7": {
+        "input": "1989000000",
+        "output": "7990000000",
+        "cacheRead": "994500000"
+      },
+      "jamba-mini": { "input": "198900000", "output": "408000000", "cacheRead": "99450000" },
+      "jamba-mini-1.6": { "input": "198900000", "output": "408000000", "cacheRead": "99450000" },
+      "jamba-mini-1.7": { "input": "198900000", "output": "408000000", "cacheRead": "99450000" },
+      "kimi-k2-instruct-fast": {
+        "input": "400000000",
+        "output": "1800000000",
+        "cacheRead": "200000000"
+      },
+      "kwaipilot/kat-coder-air-v2.5": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "30000000"
+      },
+      "kwaipilot/kat-coder-pro-v2": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "150000000"
+      },
+      "kwaipilot/kat-coder-pro-v2.5": {
+        "input": "740000000",
+        "output": "2960000000",
+        "cacheRead": "150000000"
+      },
+      "LatitudeGames/Wayfarer-Large-70B-Llama-3.3": {
+        "input": "700000000",
+        "output": "700000000",
+        "cacheRead": "350000000"
+      },
+      "learnlm-1.5-pro-experimental": {
+        "input": "3502000000",
+        "output": "10506000000",
+        "cacheRead": "1751000000"
+      },
+      "liquid/lfm-2.5-2.6b": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "50000000"
+      },
+      "LLM360/K2-Think": { "input": "170000000", "output": "680000000", "cacheRead": "85000000" },
+      "longcat-2.0": { "input": "750000000", "output": "3000000000", "cacheRead": "15000000" },
+      "longcat-2.0:thinking": {
+        "input": "750000000",
+        "output": "3000000000",
+        "cacheRead": "15000000"
+      },
+      "MarinaraSpaghetti/NemoMix-Unleashed-12B": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "meganova-ai/manta-flash-1.0": {
+        "input": "20000000",
+        "output": "160000000",
+        "cacheRead": "10000000"
+      },
+      "meganova-ai/manta-mini-1.0": {
+        "input": "20000000",
+        "output": "160000000",
+        "cacheRead": "10000000"
+      },
+      "meganova-ai/manta-pro-1.0": {
+        "input": "60000000",
+        "output": "500000000",
+        "cacheRead": "30000000"
+      },
+      "mercury-2": { "input": "250000000", "output": "750000000", "cacheRead": "25000000" },
+      "mercury-coder-small": {
+        "input": "250000000",
+        "output": "1000000000",
+        "cacheRead": "125000000"
+      },
+      "Meta-Llama-3-1-8B-Instruct-FP8": {
+        "input": "20000000",
+        "output": "30000000",
+        "cacheRead": "10000000"
+      },
+      "meta-llama/llama-3.1-8b-instruct": {
+        "input": "54400000",
+        "output": "85000000",
+        "cacheRead": "27200000"
+      },
+      "meta-llama/llama-3.2-3b-instruct": {
+        "input": "30600000",
+        "output": "49300000",
+        "cacheRead": "15300000"
+      },
+      "meta-llama/llama-3.3-70b-instruct": {
+        "input": "50000000",
+        "output": "230000000",
+        "cacheRead": "25000000"
+      },
+      "meta-llama/llama-4-maverick": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "meta-llama/llama-4-scout": {
+        "input": "85000000",
+        "output": "460000000",
+        "cacheRead": "42500000"
+      },
+      "meta/muse-glimmer-30b": {
+        "input": "350000000",
+        "output": "1500000000",
+        "cacheRead": "40000000"
+      },
+      "meta/muse-spark-1.1": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "150000000"
+      },
+      "meta/muse-spark-1.2": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "150000000"
+      },
+      "meta/muse-spark-1.2-contributor": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "2000000"
+      },
+      "microsoft/wizardlm-2-8x22b": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "MiniMax-M1": { "input": "139400000", "output": "1332800000", "cacheRead": "69700000" },
+      "MiniMax-M2": { "input": "170000000", "output": "1530000000", "cacheRead": "85000000" },
+      "minimax/minimax-01": {
+        "input": "139400000",
+        "output": "1122000000",
+        "cacheRead": "69700000"
+      },
+      "minimax/minimax-latest": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "minimax/minimax-m2-her": {
+        "input": "302000000",
+        "output": "1207000000",
+        "cacheRead": "151000000"
+      },
+      "minimax/minimax-m2.1": {
+        "input": "330000000",
+        "output": "1320000000",
+        "cacheRead": "165000000"
+      },
+      "minimax/minimax-m2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "150000000"
+      },
+      "minimax/minimax-m2.7": {
+        "input": "315000000",
+        "output": "1260000000",
+        "cacheRead": "157500000"
+      },
+      "minimax/minimax-m2.7-turbo": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "300000000"
+      },
+      "minimax/minimax-m3": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "minimax/minimax-m3:thinking": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "MiniMaxAI/MiniMax-M1-80k": {
+        "input": "605200000",
+        "output": "2422500000",
+        "cacheRead": "302600000"
+      },
+      "mistral-code-agent-latest": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "200000000"
+      },
+      "mistral-code-latest": {
+        "input": "300000000",
+        "output": "900000000",
+        "cacheRead": "150000000"
+      },
+      "mistral-small-31-24b-instruct": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "50000000"
+      },
+      "mistral/mistral-medium-3.5": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "750000000"
+      },
+      "mistral/mistral-medium-3.5:thinking": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "750000000"
+      },
+      "mistralai/codestral-2508": {
+        "input": "300000000",
+        "output": "900000000",
+        "cacheRead": "150000000"
+      },
+      "mistralai/devstral-2-123b-instruct-2512": {
+        "input": "400000000",
+        "output": "1400000000",
+        "cacheRead": "200000000"
+      },
+      "mistralai/Devstral-Small-2505": {
+        "input": "60000000",
+        "output": "60000000",
+        "cacheRead": "30000000"
+      },
+      "mistralai/ministral-14b-2512": {
+        "input": "200000000",
+        "output": "200000000",
+        "cacheRead": "100000000"
+      },
+      "mistralai/ministral-14b-instruct-2512": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "50000000"
+      },
+      "mistralai/ministral-3b-2512": {
+        "input": "100000000",
+        "output": "100000000",
+        "cacheRead": "50000000"
+      },
+      "mistralai/ministral-8b-2512": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "75000000"
+      },
+      "mistralai/mistral-large": {
+        "input": "2006000000",
+        "output": "6001000000",
+        "cacheRead": "200000000"
+      },
+      "mistralai/mistral-large-3-675b-instruct-2512": {
+        "input": "1000000000",
+        "output": "3000000000",
+        "cacheRead": "500000000"
+      },
+      "mistralai/mistral-medium-3": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "200000000"
+      },
+      "mistralai/mistral-medium-3.1": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "200000000"
+      },
+      "mistralai/Mistral-Nemo-Instruct-2407": {
+        "input": "100300000",
+        "output": "120700000",
+        "cacheRead": "50150000"
+      },
+      "mistralai/mistral-saba": {
+        "input": "198900000",
+        "output": "595000000",
+        "cacheRead": "99450000"
+      },
+      "mistralai/mistral-small-4-119b-2603": {
+        "input": "400000000",
+        "output": "1400000000",
+        "cacheRead": "200000000"
+      },
+      "mistralai/mistral-small-4-119b-2603:thinking": {
+        "input": "400000000",
+        "output": "1400000000",
+        "cacheRead": "200000000"
+      },
+      "mistralai/mixtral-8x22b-instruct-v0.1": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000"
+      },
+      "mlabonne/NeuralDaredevil-8B-abliterated": {
+        "input": "440000000",
+        "output": "440000000",
+        "cacheRead": "220000000"
+      },
+      "moonshotai/kimi-k2-instruct": {
+        "input": "400000000",
+        "output": "1800000000",
+        "cacheRead": "200000000"
+      },
+      "moonshotai/kimi-k2-instruct-0711": {
+        "input": "400000000",
+        "output": "1800000000",
+        "cacheRead": "200000000"
+      },
+      "moonshotai/Kimi-K2-Instruct-0905": {
+        "input": "400000000",
+        "output": "1800000000",
+        "cacheRead": "200000000"
+      },
+      "moonshotai/kimi-k2-thinking": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "150000000"
+      },
+      "moonshotai/kimi-k2.5": {
+        "input": "300000000",
+        "output": "1900000000",
+        "cacheRead": "150000000"
+      },
+      "moonshotai/kimi-k2.5:thinking": {
+        "input": "300000000",
+        "output": "1900000000",
+        "cacheRead": "150000000"
+      },
+      "moonshotai/kimi-k2.6": {
+        "input": "500000000",
+        "output": "2600000000",
+        "cacheRead": "125000000"
+      },
+      "moonshotai/kimi-k2.6:thinking": {
+        "input": "500000000",
+        "output": "2600000000",
+        "cacheRead": "125000000"
+      },
+      "moonshotai/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "moonshotai/kimi-k2.7-code-highspeed": {
+        "input": "1900000000",
+        "output": "8000000000",
+        "cacheRead": "320000000"
+      },
+      "moonshotai/kimi-k3": {
+        "input": "2500000000",
+        "output": "13500000000",
+        "cacheRead": "250000000"
+      },
+      "moonshotai/kimi-latest": {
+        "input": "2500000000",
+        "output": "13500000000",
+        "cacheRead": "250000000"
+      },
+      "nano-gpt-help": { "input": "0", "output": "0" },
+      "nanogpt/coding-router": {
+        "input": "1100000000",
+        "output": "2200000000",
+        "cacheRead": "110000000"
+      },
+      "nanogpt/coding-router:high": {
+        "input": "1100000000",
+        "output": "2200000000",
+        "cacheRead": "110000000"
+      },
+      "nanogpt/coding-router:low": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "nanogpt/coding-router:max": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "nanogpt/coding-router:medium": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "NeverSleep/Lumimaid-v0.2-70B": {
+        "input": "1000000000",
+        "output": "1500000000",
+        "cacheRead": "500000000"
+      },
+      "nex-agi/nex-n2-mini": { "input": "25000000", "output": "100000000", "cacheRead": "2500000" },
+      "nex-agi/nex-n2-pro": {
+        "input": "500000000",
+        "output": "2500000000",
+        "cacheRead": "250000000"
+      },
+      "nothingiisreal/L3.1-70B-Celeste-V0.1-BF16": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "NousResearch/hermes-3-llama-3.1-70b": {
+        "input": "408000000",
+        "output": "408000000",
+        "cacheRead": "204000000"
+      },
+      "NousResearch/hermes-4-405b": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "150000000"
+      },
+      "NousResearch/hermes-4-405b:thinking": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "150000000"
+      },
+      "NousResearch/hermes-4-70b": {
+        "input": "200600000",
+        "output": "399500000",
+        "cacheRead": "100300000"
+      },
+      "NousResearch/Hermes-4-70B:thinking": {
+        "input": "200600000",
+        "output": "399500000",
+        "cacheRead": "100300000"
+      },
+      "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF": {
+        "input": "357000000",
+        "output": "408000000",
+        "cacheRead": "178500000"
+      },
+      "nvidia/Llama-3.3-Nemotron-Super-49B-v1": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "75000000"
+      },
+      "nvidia/nemotron-3-nano-30b-a3b": {
+        "input": "170000000",
+        "output": "680000000",
+        "cacheRead": "85000000"
+      },
+      "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {
+        "input": "105000000",
+        "output": "420000000",
+        "cacheRead": "52500000"
+      },
+      "nvidia/nemotron-3-super-120b-a12b": {
+        "input": "50000000",
+        "output": "250000000",
+        "cacheRead": "25000000"
+      },
+      "nvidia/nemotron-3-super-120b-a12b:thinking": {
+        "input": "50000000",
+        "output": "250000000",
+        "cacheRead": "25000000"
+      },
+      "nvidia/nemotron-3-ultra-550b-a55b": {
+        "input": "500000000",
+        "output": "2500000000",
+        "cacheRead": "250000000"
+      },
+      "nvidia/nemotron-3-ultra-550b-a55b:thinking": {
+        "input": "500000000",
+        "output": "2500000000",
+        "cacheRead": "250000000"
+      },
+      "nvidia/nemotron-3.5-lightning": {
+        "input": "50000000",
+        "output": "200000000",
+        "cacheRead": "10000000"
+      },
+      "nvidia/nemotron-3.5-lightning:thinking": {
+        "input": "50000000",
+        "output": "200000000",
+        "cacheRead": "10000000"
+      },
+      "openai/gpt-3.5-turbo": { "input": "500000000", "output": "1500000000" },
+      "openai/gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "openai/gpt-4-turbo-preview": { "input": "10000000000", "output": "30000000000" },
+      "openai/gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/gpt-4.1-mini": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "100000000"
+      },
+      "openai/gpt-4.1-nano": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-4o": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-2024-08-06": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-2024-11-20": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-mini": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-4o-mini-search-preview": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-4o-search-preview": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "openai/gpt-5-codex": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "openai/gpt-5-pro": {
+        "input": "15000000000",
+        "output": "120000000000",
+        "cacheRead": "1500000000"
+      },
+      "openai/gpt-5.1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-2025-11-13": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-codex": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-codex-max": {
+        "input": "2500000000",
+        "output": "20000000000",
+        "cacheRead": "250000000"
+      },
+      "openai/gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5.2": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.3-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000"
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "openai/gpt-5.6-luna": {
+        "input": "100000000",
+        "output": "600000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "125000000"
+      },
+      "openai/gpt-5.6-luna-pro": {
+        "input": "100000000",
+        "output": "600000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "125000000"
+      },
+      "openai/gpt-5.6-sol": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "openai/gpt-5.6-sol-pro": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "openai/gpt-5.6-terra": {
+        "input": "1000000000",
+        "output": "6000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "openai/gpt-5.6-terra-pro": {
+        "input": "1000000000",
+        "output": "6000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "openai/gpt-chat-latest": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "openai/gpt-latest": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "openai/gpt-oss-120b": { "input": "350000000", "output": "750000000" },
+      "openai/gpt-oss-20b": { "input": "200000000", "output": "300000000" },
+      "openai/gpt-oss-safeguard-20b": { "input": "75000000", "output": "300000000" },
+      "openai/o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "openai/o1-preview": {
+        "input": "15000000000",
+        "output": "60000000000",
+        "cacheRead": "7500000000"
+      },
+      "openai/o1-pro": {
+        "input": "150000000000",
+        "output": "600000000000",
+        "cacheRead": "75000000000"
+      },
+      "openai/o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "1000000000" },
+      "openai/o3-deep-research": {
+        "input": "11000000000",
+        "output": "44000000000",
+        "cacheRead": "5500000000"
+      },
+      "openai/o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "openai/o3-mini-high": {
+        "input": "1100000000",
+        "output": "4400000000",
+        "cacheRead": "550000000"
+      },
+      "openai/o3-mini-low": {
+        "input": "1100000000",
+        "output": "4400000000",
+        "cacheRead": "550000000"
+      },
+      "openai/o3-pro-2025-06-10": {
+        "input": "22000000000",
+        "output": "88000000000",
+        "cacheRead": "11000000000"
+      },
+      "openai/o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "openai/o4-mini-deep-research": {
+        "input": "2200000000",
+        "output": "8800000000",
+        "cacheRead": "1100000000"
+      },
+      "openai/o4-mini-high": {
+        "input": "1100000000",
+        "output": "4400000000",
+        "cacheRead": "550000000"
+      },
+      "ornith-ai/ornith-1.5-35b-a3b": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "50000000"
+      },
+      "ornith-ai/ornith-1.5-35b-a3b:thinking": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "50000000"
+      },
+      "ornith-ai/ornith-1.5-397b": {
+        "input": "900000000",
+        "output": "3600000000",
+        "cacheRead": "45000000"
+      },
+      "ornith-ai/ornith-1.5-397b:thinking": {
+        "input": "900000000",
+        "output": "3600000000",
+        "cacheRead": "45000000"
+      },
+      "ornith-ai/ornith-1.5-9b": {
+        "input": "50000000",
+        "output": "100000000",
+        "cacheRead": "25000000"
+      },
+      "ornith-ai/ornith-1.5-9b:thinking": {
+        "input": "50000000",
+        "output": "100000000",
+        "cacheRead": "25000000"
+      },
+      "pamanseau/OpenReasoning-Nemotron-32B": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "50000000"
+      },
+      "perceptron/perceptron-mk1": {
+        "input": "150000000",
+        "output": "1500000000",
+        "cacheRead": "75000000"
+      },
+      "perplexity-academic-researcher": {
+        "input": "2000000000",
+        "output": "8000000000",
+        "cacheRead": "1000000000"
+      },
+      "phi-4-mini-instruct": {
+        "input": "170000000",
+        "output": "680000000",
+        "cacheRead": "85000000"
+      },
+      "phi-4-multimodal-instruct": {
+        "input": "70000000",
+        "output": "110000000",
+        "cacheRead": "35000000"
+      },
+      "pokee-isaac": { "input": "150000000", "output": "1000000000", "cacheRead": "75000000" },
+      "poolside/laguna-m.1": {
+        "input": "200000000",
+        "output": "400000000",
+        "cacheRead": "100000000"
+      },
+      "poolside/laguna-s-2.1": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "10000000"
+      },
+      "poolside/laguna-s-2.1:thinking": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "10000000"
+      },
+      "qvq-max": { "input": "1200000000", "output": "4800000000", "cacheRead": "600000000" },
+      "qwen-3.6-plus": {
+        "input": "325000000",
+        "output": "1950000000",
+        "cacheRead": "32500000",
+        "cacheWrite": "406250000"
+      },
+      "qwen-long": { "input": "100300000", "output": "408000000", "cacheRead": "50150000" },
+      "qwen-max": { "input": "1599700000", "output": "6392000000", "cacheRead": "799850000" },
+      "qwen-plus": { "input": "399500000", "output": "1200200000", "cacheRead": "199750000" },
+      "qwen-turbo": { "input": "49980000", "output": "200600000", "cacheRead": "24990000" },
+      "qwen/qwen-2.5-72b-instruct": {
+        "input": "357000000",
+        "output": "408000000",
+        "cacheRead": "178500000"
+      },
+      "qwen/Qwen2.5-Coder-32B-Instruct": {
+        "input": "200600000",
+        "output": "200600000",
+        "cacheRead": "100300000"
+      },
+      "qwen/qwen3-14b": { "input": "80000000", "output": "240000000", "cacheRead": "40000000" },
+      "qwen/qwen3-235b-a22b": {
+        "input": "300000000",
+        "output": "500000000",
+        "cacheRead": "150000000"
+      },
+      "qwen/Qwen3-235B-A22B-Instruct-2507": {
+        "input": "130000000",
+        "output": "500000000",
+        "cacheRead": "65000000"
+      },
+      "qwen/Qwen3-235B-A22B-Thinking-2507": {
+        "input": "300000000",
+        "output": "500000000",
+        "cacheRead": "150000000"
+      },
+      "qwen/qwen3-30b-a3b": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "50000000"
+      },
+      "qwen/qwen3-32b": { "input": "100000000", "output": "300000000", "cacheRead": "50000000" },
+      "qwen/Qwen3-8B": { "input": "470000000", "output": "470000000", "cacheRead": "235000000" },
+      "qwen/qwen3-coder": { "input": "130000000", "output": "500000000", "cacheRead": "65000000" },
+      "qwen/qwen3-coder-flash": {
+        "input": "300000000",
+        "output": "1500000000",
+        "cacheRead": "150000000"
+      },
+      "qwen/qwen3-coder-next": {
+        "input": "200000000",
+        "output": "1500000000",
+        "cacheRead": "100000000"
+      },
+      "qwen/qwen3-coder-plus": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "500000000"
+      },
+      "qwen/qwen3-max": { "input": "1200200000", "output": "6001000000", "cacheRead": "600100000" },
+      "qwen/Qwen3-Next-80B-A3B-Instruct": {
+        "input": "150000000",
+        "output": "650000000",
+        "cacheRead": "75000000"
+      },
+      "qwen/qwen3-next-80b-a3b-thinking": {
+        "input": "150000000",
+        "output": "650000000",
+        "cacheRead": "75000000"
+      },
+      "qwen/Qwen3-VL-235B-A22B-Instruct": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "150000000"
+      },
+      "qwen/qwen3.5-397b-a17b": {
+        "input": "600000000",
+        "output": "3600000000",
+        "cacheRead": "300000000"
+      },
+      "qwen/qwen3.5-397b-a17b-thinking": {
+        "input": "600000000",
+        "output": "3600000000",
+        "cacheRead": "300000000"
+      },
+      "qwen/qwen3.5-9b": { "input": "50000000", "output": "150000000", "cacheRead": "25000000" },
+      "qwen/qwen3.5-plus": {
+        "input": "400000000",
+        "output": "2400000000",
+        "cacheRead": "40000000"
+      },
+      "qwen/qwen3.5-plus-thinking": {
+        "input": "400000000",
+        "output": "2400000000",
+        "cacheRead": "40000000"
+      },
+      "qwen/Qwen3.6-35B-A3B": {
+        "input": "112000000",
+        "output": "800000000",
+        "cacheRead": "56000000"
+      },
+      "qwen/qwen3.6-35b-a3b-uncensored": {
+        "input": "150000000",
+        "output": "500000000",
+        "cacheRead": "75000000"
+      },
+      "qwen/qwen3.6-35b-a3b-uncensored:thinking": {
+        "input": "150000000",
+        "output": "500000000",
+        "cacheRead": "75000000"
+      },
+      "qwen/Qwen3.6-35B-A3B:thinking": {
+        "input": "112000000",
+        "output": "800000000",
+        "cacheRead": "56000000"
+      },
+      "qwen/qwen3.8-27b-obliterated": {
+        "input": "180000000",
+        "output": "500000000",
+        "cacheRead": "75000000"
+      },
+      "qwen/qwen3.8-27b-obliterated:thinking": {
+        "input": "180000000",
+        "output": "500000000",
+        "cacheRead": "75000000"
+      },
+      "qwen25-vl-72b-instruct": {
+        "input": "699890000",
+        "output": "699890000",
+        "cacheRead": "349945000"
+      },
+      "qwen3-30b-a3b-instruct-2507": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "100000000"
+      },
+      "qwen3-coder-30b-a3b-instruct": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "50000000"
+      },
+      "qwen3-max-2026-01-23": {
+        "input": "1200200000",
+        "output": "6001000000",
+        "cacheRead": "600100000"
+      },
+      "qwen3-vl-235b-a22b-instruct-original": {
+        "input": "500000000",
+        "output": "1200000000",
+        "cacheRead": "250000000"
+      },
+      "qwen3-vl-235b-a22b-thinking": {
+        "input": "500000000",
+        "output": "6000000000",
+        "cacheRead": "250000000"
+      },
+      "qwen3.5-0.8b": { "input": "60000000", "output": "120000000", "cacheRead": "30000000" },
+      "qwen3.5-122b-a10b": {
+        "input": "437000000",
+        "output": "3496000000",
+        "cacheRead": "103788000"
+      },
+      "qwen3.5-122b-a10b:thinking": {
+        "input": "437000000",
+        "output": "3496000000",
+        "cacheRead": "103788000"
+      },
+      "qwen3.5-27b": { "input": "270000000", "output": "2160000000", "cacheRead": "135000000" },
+      "Qwen3.5-27B-BlueStar-v3-Derestricted": {
+        "input": "306000000",
+        "output": "306000000",
+        "cacheRead": "153000000"
+      },
+      "Qwen3.5-27B-Queen-Derestricted": {
+        "input": "306000000",
+        "output": "306000000",
+        "cacheRead": "153000000"
+      },
+      "qwen3.5-27b:thinking": {
+        "input": "270000000",
+        "output": "2160000000",
+        "cacheRead": "135000000"
+      },
+      "qwen3.5-2b": { "input": "80000000", "output": "160000000", "cacheRead": "40000000" },
+      "qwen3.5-35b-a3b": { "input": "225000000", "output": "1800000000", "cacheRead": "112500000" },
+      "qwen3.5-35b-a3b:thinking": {
+        "input": "225000000",
+        "output": "1800000000",
+        "cacheRead": "112500000"
+      },
+      "qwen3.5-4b": { "input": "100000000", "output": "200000000", "cacheRead": "50000000" },
+      "qwen3.5-flash": { "input": "100000000", "output": "400000000", "cacheRead": "50000000" },
+      "qwen3.5-flash:thinking": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "50000000"
+      },
+      "qwen3.5-omni-flash": { "input": "0", "output": "0" },
+      "qwen3.5-omni-plus": { "input": "0", "output": "0" },
+      "qwen3.6-max-preview": {
+        "input": "1040000000",
+        "output": "6240000000",
+        "cacheRead": "520000000"
+      },
+      "qwen3.7-flash": {
+        "input": "30000000",
+        "output": "130000000",
+        "cacheRead": "6000000",
+        "cacheWrite": "38000000"
+      },
+      "qwen3.7-flash:thinking": {
+        "input": "30000000",
+        "output": "130000000",
+        "cacheRead": "6000000",
+        "cacheWrite": "38000000"
+      },
+      "qwen3.7-max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "3125000000"
+      },
+      "qwen3.7-max:thinking": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "3125000000"
+      },
+      "qwen3.7-plus": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "500000000"
+      },
+      "qwen3.7-plus:thinking": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "500000000"
+      },
+      "qwen3.8-27b": { "input": "200000000", "output": "1400000000", "cacheRead": "40000000" },
+      "qwen3.8-27b:thinking": {
+        "input": "200000000",
+        "output": "1400000000",
+        "cacheRead": "40000000"
+      },
+      "qwen3.8-max": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      },
+      "qwen3.8-max:thinking": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      },
+      "ReadyArt/MS3.2-The-Omega-Directive-24B-Unslop-v2.0": {
+        "input": "500000000",
+        "output": "500000000",
+        "cacheRead": "250000000"
+      },
+      "sakana/fugu-ultra": {
+        "input": "5250000000",
+        "output": "31500000000",
+        "cacheRead": "525000000"
+      },
+      "sakana/fugu-ultra-v1.1": {
+        "input": "5250000000",
+        "output": "31500000000",
+        "cacheRead": "525000000"
+      },
+      "Salesforce/Llama-xLAM-2-70b-fc-r": {
+        "input": "2500000000",
+        "output": "2500000000",
+        "cacheRead": "1250000000"
+      },
+      "Sao10K/L3-8B-Stheno-v3.2": {
+        "input": "200600000",
+        "output": "200600000",
+        "cacheRead": "100300000"
+      },
+      "Sao10K/L3.1-70B-Euryale-v2.2": {
+        "input": "306000000",
+        "output": "357000000",
+        "cacheRead": "153000000"
+      },
+      "Sao10K/L3.1-70B-Hanami-x1": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "Sao10K/L3.3-70B-Euryale-v2.3": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "sarvam-105b": { "input": "45000000", "output": "177000000", "cacheRead": "28000000" },
+      "sarvam-30b": { "input": "28000000", "output": "111000000", "cacheRead": "17000000" },
+      "shisa-ai/shisa-v2-llama3.3-70b": {
+        "input": "500000000",
+        "output": "500000000",
+        "cacheRead": "250000000"
+      },
+      "shisa-ai/shisa-v2.1-llama3.3-70b": {
+        "input": "500000000",
+        "output": "500000000",
+        "cacheRead": "250000000"
+      },
+      "sonar": { "input": "1000000000", "output": "1000000000", "cacheRead": "500000000" },
+      "sonar-deep-research": {
+        "input": "3400000000",
+        "output": "13600000000",
+        "cacheRead": "1700000000"
+      },
+      "sonar-pro": { "input": "3000000000", "output": "15000000000", "cacheRead": "1500000000" },
+      "sonar-reasoning-pro": {
+        "input": "2000000000",
+        "output": "8000000000",
+        "cacheRead": "1000000000"
+      },
+      "soob3123/amoral-gemma3-27B-v2": {
+        "input": "300000000",
+        "output": "300000000",
+        "cacheRead": "150000000"
+      },
+      "soob3123/GrayLine-Qwen3-8B": {
+        "input": "300000000",
+        "output": "300000000",
+        "cacheRead": "150000000"
+      },
+      "soob3123/Veiled-Calla-12B": {
+        "input": "300000000",
+        "output": "300000000",
+        "cacheRead": "150000000"
+      },
+      "stealth/ox-alpha": { "input": "50000000", "output": "50000000", "cacheRead": "25000000" },
+      "Steelskull/L3.3-Cu-Mai-R1-70b": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "Steelskull/L3.3-Electra-R1-70b": {
+        "input": "699890000",
+        "output": "699890000",
+        "cacheRead": "349945000"
+      },
+      "Steelskull/L3.3-MS-Evayale-70B": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "Steelskull/L3.3-MS-Nevoria-70b": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "Steelskull/L3.3-Nevoria-R1-70b": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "step-r1-v-mini": {
+        "input": "2500000000",
+        "output": "11000000000",
+        "cacheRead": "1250000000"
+      },
+      "stepfun-ai/step-3.5-flash": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "50000000"
+      },
+      "stepfun-ai/step-3.5-flash-2603": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "50000000"
+      },
+      "stepfun/step-3.7-flash:thinking": {
+        "input": "200000000",
+        "output": "1150000000",
+        "cacheRead": "40000000"
+      },
+      "TEE/deepseek-v3.2": {
+        "input": "500000000",
+        "output": "1000000000",
+        "cacheRead": "250000000"
+      },
+      "TEE/deepseek-v4-flash": {
+        "input": "200000000",
+        "output": "400000000",
+        "cacheRead": "40000000"
+      },
+      "TEE/gemma-3-27b-it": {
+        "input": "200000000",
+        "output": "800000000",
+        "cacheRead": "100000000"
+      },
+      "TEE/gemma-4-26b-a4b-uncensored": {
+        "input": "150000000",
+        "output": "700000000",
+        "cacheRead": "75000000"
+      },
+      "TEE/gemma-4-31b-it": {
+        "input": "150000000",
+        "output": "460000000",
+        "cacheRead": "75000000"
+      },
+      "TEE/gemma4-31b": { "input": "400000000", "output": "1000000000", "cacheRead": "400000000" },
+      "TEE/gemma4-31b:thinking": {
+        "input": "400000000",
+        "output": "1000000000",
+        "cacheRead": "400000000"
+      },
+      "TEE/glm-4.7": { "input": "850000000", "output": "3300000000", "cacheRead": "425000000" },
+      "TEE/glm-5.1": { "input": "1500000000", "output": "5250000000", "cacheRead": "300000000" },
+      "TEE/glm-5.1-thinking": {
+        "input": "1500000000",
+        "output": "5250000000",
+        "cacheRead": "300000000"
+      },
+      "TEE/glm-5.2": { "input": "1400000000", "output": "4600000000", "cacheRead": "500000000" },
+      "TEE/glm-5.2:thinking": {
+        "input": "1400000000",
+        "output": "4600000000",
+        "cacheRead": "500000000"
+      },
+      "TEE/gpt-oss-120b": {
+        "input": "2000000000",
+        "output": "2000000000",
+        "cacheRead": "2000000000"
+      },
+      "TEE/gpt-oss-20b": { "input": "200000000", "output": "800000000", "cacheRead": "100000000" },
+      "TEE/kimi-k2.6": { "input": "1500000000", "output": "5250000000", "cacheRead": "375000000" },
+      "TEE/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "TEE/kimi-k3": { "input": "3000000000", "output": "15000000000", "cacheRead": "1500000000" },
+      "TEE/llama3-3-70b": {
+        "input": "1750000000",
+        "output": "2750000000",
+        "cacheRead": "1750000000"
+      },
+      "TEE/muse-glimmer-30b": {
+        "input": "350000000",
+        "output": "1500000000",
+        "cacheRead": "40000000"
+      },
+      "TEE/qwen2.5-vl-72b-instruct": {
+        "input": "700000000",
+        "output": "700000000",
+        "cacheRead": "350000000"
+      },
+      "TEE/qwen3.5-122b-a10b": {
+        "input": "460000000",
+        "output": "3680000000",
+        "cacheRead": "230000000"
+      },
+      "TEE/qwen3.5-27b": { "input": "300000000", "output": "2400000000", "cacheRead": "150000000" },
+      "TEE/qwen3.5-397b-a17b": {
+        "input": "550000000",
+        "output": "3500000000",
+        "cacheRead": "275000000"
+      },
+      "TEE/qwen3.6-27b": { "input": "320000000", "output": "2700000000", "cacheRead": "160000000" },
+      "TEE/qwen3.6-35b-a3b": {
+        "input": "200000000",
+        "output": "1270000000",
+        "cacheRead": "100000000"
+      },
+      "TEE/qwen3.6-35b-a3b-uncensored": {
+        "input": "300000000",
+        "output": "1500000000",
+        "cacheRead": "150000000"
+      },
+      "TEE/qwen3.8-27b": { "input": "400000000", "output": "3000000000", "cacheRead": "150000000" },
+      "tencent/Hunyuan-MT-7B": {
+        "input": "10000000000",
+        "output": "20000000000",
+        "cacheRead": "5000000000"
+      },
+      "tencent/hy3": { "input": "66000000", "output": "260000000", "cacheRead": "29000000" },
+      "TheDrummer/Anubis-70B-v1": {
+        "input": "310000000",
+        "output": "310000000",
+        "cacheRead": "155000000"
+      },
+      "TheDrummer/Anubis-70B-v1.1": {
+        "input": "310000000",
+        "output": "310000000",
+        "cacheRead": "155000000"
+      },
+      "TheDrummer/Cydonia-24B-v2": {
+        "input": "100300000",
+        "output": "120700000",
+        "cacheRead": "50150000"
+      },
+      "TheDrummer/Cydonia-24B-v4": {
+        "input": "200600000",
+        "output": "241400000",
+        "cacheRead": "100300000"
+      },
+      "TheDrummer/Cydonia-24B-v4.1": {
+        "input": "350000000",
+        "output": "550000000",
+        "cacheRead": "160000000"
+      },
+      "TheDrummer/Cydonia-24B-v4.3": {
+        "input": "120000000",
+        "output": "150000000",
+        "cacheRead": "60000000"
+      },
+      "TheDrummer/Magidonia-24B-v4.3": {
+        "input": "100300000",
+        "output": "120700000",
+        "cacheRead": "50150000"
+      },
+      "TheDrummer/Rocinante-12B-v1.1": {
+        "input": "408000000",
+        "output": "595000000",
+        "cacheRead": "204000000"
+      },
+      "TheDrummer/skyfall-36b-v2": {
+        "input": "550000000",
+        "output": "800000000",
+        "cacheRead": "250000000"
+      },
+      "TheDrummer/UnslopNemo-12B-v4.1": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "thinkingmachines/inkling": {
+        "input": "1000000000",
+        "output": "4050000000",
+        "cacheRead": "170000000"
+      },
+      "thinkingmachines/Inkling-Small": {
+        "input": "500000000",
+        "output": "1200000000",
+        "cacheRead": "100000000"
+      },
+      "thinkingmachines/Inkling-Small:thinking": {
+        "input": "500000000",
+        "output": "1200000000",
+        "cacheRead": "100000000"
+      },
+      "thinkingmachines/inkling:thinking": {
+        "input": "1000000000",
+        "output": "4050000000",
+        "cacheRead": "170000000"
+      },
+      "THUDM/GLM-4-32B-0414": {
+        "input": "200000000",
+        "output": "200000000",
+        "cacheRead": "100000000"
+      },
+      "THUDM/GLM-4-9B-0414": {
+        "input": "200000000",
+        "output": "200000000",
+        "cacheRead": "100000000"
+      },
+      "THUDM/GLM-Z1-9B-0414": {
+        "input": "200000000",
+        "output": "200000000",
+        "cacheRead": "100000000"
+      },
+      "Tongyi-Zhiwen/QwenLong-L1-32B": {
+        "input": "140000000",
+        "output": "600000000",
+        "cacheRead": "70000000"
+      },
+      "undi95/remm-slerp-l2-13b": {
+        "input": "799000000",
+        "output": "1207000000",
+        "cacheRead": "399500000"
+      },
+      "universal-summarizer": { "input": "30000000000", "output": "30000000000" },
+      "unsloth/gemma-3-12b-it": {
+        "input": "272000000",
+        "output": "272000000",
+        "cacheRead": "136000000"
+      },
+      "unsloth/gemma-3-27b-it": {
+        "input": "299200000",
+        "output": "299200000",
+        "cacheRead": "149600000"
+      },
+      "unsloth/gemma-3-4b-it": {
+        "input": "200600000",
+        "output": "200600000",
+        "cacheRead": "100300000"
+      },
+      "upstage/solar-pro-3": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000"
+      },
+      "upstage/solar-pro4": { "input": "30000000", "output": "120000000", "cacheRead": "6000000" },
+      "upstage/solar-pro4:thinking": {
+        "input": "30000000",
+        "output": "120000000",
+        "cacheRead": "6000000"
+      },
+      "venice-uncensored": {
+        "input": "400000000",
+        "output": "1800000000",
+        "cacheRead": "400000000"
+      },
+      "VongolaChouko/Starcannon-Unleashed-12B-v1.0": {
+        "input": "493000000",
+        "output": "493000000",
+        "cacheRead": "246500000"
+      },
+      "x-ai/grok-4.20": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "1000000000"
+      },
+      "x-ai/grok-4.20-multi-agent": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "1000000000"
+      },
+      "x-ai/grok-4.3": { "input": "1250000000", "output": "2500000000", "cacheRead": "200000000" },
+      "x-ai/grok-4.5": { "input": "2000000000", "output": "6000000000", "cacheRead": "500000000" },
+      "x-ai/grok-4.6": { "input": "2000000000", "output": "6000000000", "cacheRead": "500000000" },
+      "x-ai/grok-build-0.1": {
+        "input": "1000000000",
+        "output": "2000000000",
+        "cacheRead": "200000000"
+      },
+      "x-ai/grok-latest": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000"
+      },
+      "xiaomi/mimo-v2.5": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "2800000",
+        "cacheWrite": "0"
+      },
+      "xiaomi/mimo-v2.5-pro": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "3600000",
+        "cacheWrite": "0"
+      },
+      "xiaomi/mimo-v2.5-pro-crof": {
+        "input": "400000000",
+        "output": "800000000",
+        "cacheRead": "3000000"
+      },
+      "xiaomi/mimo-v2.5-pro-crof:thinking": {
+        "input": "400000000",
+        "output": "800000000",
+        "cacheRead": "3000000"
+      },
+      "xiaomi/mimo-v2.5-pro:thinking": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "3600000",
+        "cacheWrite": "0"
+      },
+      "xiaomi/mimo-v2.5:thinking": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "2800000",
+        "cacheWrite": "0"
+      },
+      "yi-large": { "input": "3196000000", "output": "3196000000", "cacheRead": "1598000000" },
+      "yi-lightning": { "input": "200600000", "output": "200600000", "cacheRead": "100300000" },
+      "yi-medium-200k": {
+        "input": "2499000000",
+        "output": "2499000000",
+        "cacheRead": "1249500000"
+      },
+      "z-ai/glm-4.5v": { "input": "600000000", "output": "1800000000", "cacheRead": "300000000" },
+      "z-ai/glm-4.5v:thinking": {
+        "input": "600000000",
+        "output": "1800000000",
+        "cacheRead": "300000000"
+      },
+      "z-ai/glm-4.6": { "input": "350000000", "output": "1400000000", "cacheRead": "175000000" },
+      "z-ai/glm-4.6:thinking": {
+        "input": "350000000",
+        "output": "1400000000",
+        "cacheRead": "175000000"
+      },
+      "z-ai/glm-5-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      },
+      "z-ai/glm-5v-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      },
+      "z-ai/glm-5v-turbo:thinking": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      },
+      "zai-org/glm-4.5": { "input": "300000000", "output": "1300000000", "cacheRead": "150000000" },
+      "zai-org/GLM-4.5-Air": {
+        "input": "120000000",
+        "output": "800000000",
+        "cacheRead": "60000000"
+      },
+      "zai-org/GLM-4.5-Air:thinking": {
+        "input": "120000000",
+        "output": "800000000",
+        "cacheRead": "60000000"
+      },
+      "zai-org/GLM-4.5:thinking": {
+        "input": "300000000",
+        "output": "1300000000",
+        "cacheRead": "150000000"
+      },
+      "zai-org/glm-4.6-original": {
+        "input": "350000000",
+        "output": "1400000000",
+        "cacheRead": "175000000"
+      },
+      "zai-org/GLM-4.6-turbo": {
+        "input": "1000000000",
+        "output": "3000000000",
+        "cacheRead": "500000000"
+      },
+      "zai-org/GLM-4.6-turbo:thinking": {
+        "input": "1000000000",
+        "output": "3000000000",
+        "cacheRead": "500000000"
+      },
+      "zai-org/glm-4.6v": { "input": "300000000", "output": "900000000", "cacheRead": "150000000" },
+      "zai-org/glm-4.6v-flash-original": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "50000000"
+      },
+      "zai-org/glm-4.6v-original": {
+        "input": "600000000",
+        "output": "900000000",
+        "cacheRead": "300000000"
+      },
+      "zai-org/glm-4.7": { "input": "200000000", "output": "800000000", "cacheRead": "100000000" },
+      "zai-org/glm-4.7-flash": {
+        "input": "70000000",
+        "output": "400000000",
+        "cacheRead": "35000000"
+      },
+      "zai-org/glm-4.7-flash-original": {
+        "input": "70000000",
+        "output": "400000000",
+        "cacheRead": "35000000"
+      },
+      "zai-org/glm-4.7-flash-original:thinking": {
+        "input": "70000000",
+        "output": "400000000",
+        "cacheRead": "35000000"
+      },
+      "zai-org/glm-4.7-flash:thinking": {
+        "input": "70000000",
+        "output": "400000000",
+        "cacheRead": "35000000"
+      },
+      "zai-org/glm-4.7-original": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000"
+      },
+      "zai-org/glm-4.7-original:thinking": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000"
+      },
+      "zai-org/glm-4.7:thinking": {
+        "input": "200000000",
+        "output": "800000000",
+        "cacheRead": "100000000"
+      },
+      "zai-org/glm-5": { "input": "500000000", "output": "2550000000", "cacheRead": "130000000" },
+      "zai-org/glm-5-original": {
+        "input": "1000000000",
+        "output": "3200000000",
+        "cacheRead": "200000000"
+      },
+      "zai-org/glm-5-original:thinking": {
+        "input": "1000000000",
+        "output": "3200000000",
+        "cacheRead": "200000000"
+      },
+      "zai-org/glm-5:thinking": {
+        "input": "500000000",
+        "output": "2550000000",
+        "cacheRead": "130000000"
+      },
+      "zai-org/glm-5.1": { "input": "750000000", "output": "2600000000", "cacheRead": "150000000" },
+      "zai-org/glm-5.1:thinking": {
+        "input": "750000000",
+        "output": "2600000000",
+        "cacheRead": "150000000"
+      },
+      "zai-org/glm-5.2": { "input": "420000000", "output": "1320000000", "cacheRead": "78000000" },
+      "zai-org/glm-5.2:thinking": {
+        "input": "420000000",
+        "output": "1320000000",
+        "cacheRead": "78000000"
+      },
+      "zai-org/glm-5.3": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "zai-org/glm-5.3:thinking": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "zai-org/glm-latest": {
+        "input": "420000000",
+        "output": "1320000000",
+        "cacheRead": "78000000"
+      }
+    },
+    "nearai": {
+      "anthropic/claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic/claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15500000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "black-forest-labs/FLUX.2-klein-4B": { "input": "1000000000", "output": "1000000000" },
+      "google/gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "inputAudio": "1000000000"
+      },
+      "google/gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "inputAudio": "300000000"
+      },
+      "google/gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3-pro": { "input": "1250000000", "output": "15000000000", "cacheRead": "0" },
+      "google/gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "inputAudio": "500000000"
+      },
+      "google/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "inputAudio": "1500000000"
+      },
+      "google/gemma-4-31B-it": {
+        "input": "130000000",
+        "output": "400000000",
+        "cacheRead": "26000000"
+      },
+      "openai/gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/gpt-4.1-mini": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "100000000"
+      },
+      "openai/gpt-4.1-nano": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "openai/gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "openai/gpt-5.1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.2": {
+        "input": "1800000000",
+        "output": "15500000000",
+        "cacheRead": "180000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-oss-120b": { "input": "150000000", "output": "550000000" },
+      "openai/o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "openai/o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "openai/whisper-large-v3": { "input": "10000000", "output": "0" },
+      "Qwen/Qwen3-30B-A3B-Instruct-2507": { "input": "150000000", "output": "550000000" },
+      "Qwen/Qwen3-Embedding-0.6B": { "input": "10000000", "output": "0" },
+      "Qwen/Qwen3-Reranker-0.6B": { "input": "10000000", "output": "10000000" },
+      "Qwen/Qwen3-VL-30B-A3B-Instruct": { "input": "150000000", "output": "550000000" },
+      "Qwen/Qwen3.5-122B-A10B": { "input": "400000000", "output": "3200000000" },
+      "Qwen/Qwen3.6-35B-A3B-FP8": {
+        "input": "170000000",
+        "output": "1100000000",
+        "cacheRead": "56000000"
+      },
+      "zai-org/GLM-5.1-FP8": { "input": "850000000", "output": "3300000000" }
+    },
+    "nebius": {
+      "deepseek-ai/DeepSeek-V3.2": {
+        "input": "300000000",
+        "output": "450000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000",
+        "reasoning": "450000000"
+      },
+      "deepseek-ai/DeepSeek-V3.2-fast": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "40000000",
+        "cacheWrite": "500000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "140000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "input": "1750000000",
+        "output": "3500000000",
+        "cacheRead": "150000000"
+      },
+      "google/gemma-3-27b-it": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "125000000"
+      },
+      "meta-llama/Llama-3.3-70B-Instruct": {
+        "input": "130000000",
+        "output": "400000000",
+        "cacheRead": "13000000",
+        "cacheWrite": "160000000"
+      },
+      "MiniMaxAI/MiniMax-M2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "MiniMaxAI/MiniMax-M2.5-fast": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "MiniMaxAI/MiniMax-M3": { "input": "300000000", "output": "1200000000" },
+      "moonshotai/Kimi-K2.5": {
+        "input": "500000000",
+        "output": "2500000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000",
+        "reasoning": "2500000000"
+      },
+      "moonshotai/Kimi-K2.5-fast": {
+        "input": "500000000",
+        "output": "2500000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000"
+      },
+      "moonshotai/Kimi-K2.7-Code": { "input": "950000000", "output": "4000000000" },
+      "moonshotai/Kimi-K3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "3000000000"
+      },
+      "NousResearch/Hermes-4-405B": {
+        "input": "1000000000",
+        "output": "3000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000",
+        "reasoning": "3000000000"
+      },
+      "NousResearch/Hermes-4-70B": {
+        "input": "130000000",
+        "output": "400000000",
+        "cacheRead": "13000000",
+        "cacheWrite": "160000000",
+        "reasoning": "400000000"
+      },
+      "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1": {
+        "input": "600000000",
+        "output": "1800000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "750000000"
+      },
+      "nvidia/Nemotron-3-Nano-Omni": {
+        "input": "60000000",
+        "output": "240000000",
+        "cacheRead": "6000000",
+        "cacheWrite": "75000000"
+      },
+      "nvidia/nemotron-3-super-120b-a12b": { "input": "300000000", "output": "900000000" },
+      "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B": {
+        "input": "60000000",
+        "output": "240000000",
+        "cacheRead": "6000000",
+        "cacheWrite": "75000000"
+      },
+      "openai/gpt-oss-120b": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000",
+        "cacheWrite": "180000000",
+        "reasoning": "600000000"
+      },
+      "openai/gpt-oss-120b-fast": {
+        "input": "100000000",
+        "output": "500000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "125000000"
+      },
+      "PrimeIntellect/INTELLECT-3": {
+        "input": "200000000",
+        "output": "1100000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000"
+      },
+      "Qwen/Qwen2.5-VL-72B-Instruct": {
+        "input": "250000000",
+        "output": "750000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "310000000"
+      },
+      "Qwen/Qwen3-235B-A22B-Instruct-2507": { "input": "200000000", "output": "600000000" },
+      "Qwen/Qwen3-235B-A22B-Thinking-2507-fast": {
+        "input": "500000000",
+        "output": "2000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000"
+      },
+      "Qwen/Qwen3-30B-A3B-Instruct-2507": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "125000000"
+      },
+      "Qwen/Qwen3-32B": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "125000000"
+      },
+      "Qwen/Qwen3-Embedding-8B": { "input": "10000000", "output": "0" },
+      "Qwen/Qwen3-Next-80B-A3B-Thinking": {
+        "input": "150000000",
+        "output": "1200000000",
+        "cacheRead": "15000000",
+        "cacheWrite": "180000000",
+        "reasoning": "1200000000"
+      },
+      "Qwen/Qwen3-Next-80B-A3B-Thinking-fast": {
+        "input": "150000000",
+        "output": "1200000000",
+        "cacheRead": "15000000",
+        "cacheWrite": "187500000"
+      },
+      "Qwen/Qwen3.5-397B-A17B": {
+        "input": "600000000",
+        "output": "3600000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "750000000"
+      },
+      "Qwen/Qwen3.5-397B-A17B-fast": {
+        "input": "600000000",
+        "output": "3600000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "750000000"
+      },
+      "zai-org/GLM-5": {
+        "input": "1000000000",
+        "output": "3200000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1000000000"
+      },
+      "zai-org/GLM-5.2": { "input": "1400000000", "output": "4400000000" }
+    },
+    "neon": {
+      "claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-opus-4-1": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "claude-opus-4-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "gemini-3-1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "inputAudio": "500000000"
+      },
+      "gemini-3-1-pro": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3-5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "inputAudio": "1500000000"
+      },
+      "gemini-3-5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "gemini-3-6-flash": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000",
+        "inputAudio": "1500000000"
+      },
+      "gemini-3-flash": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "inputAudio": "1000000000"
+      },
+      "gemma-3-12b": { "input": "150000000", "output": "500000000" },
+      "glm-5-2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5-1": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5-2": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5-3-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5-4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5-4-mini": { "input": "750000000", "output": "4500000000", "cacheRead": "75000000" },
+      "gpt-5-4-nano": { "input": "200000000", "output": "1250000000", "cacheRead": "20000000" },
+      "gpt-5-5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5-5-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "gpt-5-6-luna": {
+        "input": "1000000000",
+        "output": "6000000000",
+        "cacheRead": "100000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "9000000000",
+            "cacheRead": "200000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5-6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5-6-terra": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5-mini": { "input": "250000000", "output": "2000000000", "cacheRead": "25000000" },
+      "gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "gpt-oss-120b": { "input": "72000000", "output": "280000000" },
+      "gpt-oss-20b": { "input": "50000000", "output": "200000000" },
+      "kimi-k3": { "input": "3000000000", "output": "15000000000", "cacheRead": "300000000" },
+      "llama-4-maverick": { "input": "500000000", "output": "1500000000" },
+      "meta-llama-3-1-8b-instruct": { "input": "150000000", "output": "450000000" },
+      "meta-llama-3-3-70b-instruct": { "input": "500000000", "output": "1500000000" },
+      "qwen3-next-80b-a3b-instruct": { "input": "150000000", "output": "1200000000" },
+      "qwen35-122b-a10b": { "input": "220000000", "output": "2200000000" }
+    },
+    "neosmith": {
+      "neosmith.intelligent-basic": {
+        "input": "1170000000",
+        "output": "4370000000",
+        "cacheRead": "220000000",
+        "cacheWrite": "0"
+      },
+      "neosmith.intelligent-maestro": {
+        "input": "2400000000",
+        "output": "12000000000",
+        "cacheRead": "350000000",
+        "cacheWrite": "0"
+      },
+      "neosmith.intelligent-pro": {
+        "input": "1810000000",
+        "output": "8390000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "0"
+      },
+      "neosmith.neolite": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "0"
+      }
+    },
+    "neuralwatt": {
+      "deepseek-v4-flash": { "input": "104000000", "output": "207000000", "cacheRead": "26000000" },
+      "gemma-4-31b": { "input": "144000000", "output": "420000000", "cacheRead": "36000000" },
+      "glm-5.2": { "input": "1450000000", "output": "4500000000", "cacheRead": "362500000" },
+      "glm-5.2-fast": { "input": "1450000000", "output": "4500000000", "cacheRead": "362500000" },
+      "glm-5.2-flex": { "input": "725000000", "output": "2250000000", "cacheRead": "181250000" },
+      "glm-5.2-short": { "input": "1450000000", "output": "4500000000", "cacheRead": "362500000" },
+      "glm-5.2-short-fast": {
+        "input": "1450000000",
+        "output": "4500000000",
+        "cacheRead": "362500000"
+      },
+      "glm-5.2-short-fast-flex": {
+        "input": "725000000",
+        "output": "2250000000",
+        "cacheRead": "181250000"
+      },
+      "glm-5.2-short-flex": {
+        "input": "725000000",
+        "output": "2250000000",
+        "cacheRead": "181250000"
+      },
+      "kimi-k2.5-fast": { "input": "520000000", "output": "2590000000", "cacheRead": "130000000" },
+      "kimi-k2.6-fast": { "input": "690000000", "output": "3220000000", "cacheRead": "172500000" },
+      "kimi-k2.6-flex": { "input": "345000000", "output": "1610000000", "cacheRead": "86250000" },
+      "kimi-k2.7-code-flex": {
+        "input": "475000000",
+        "output": "2000000000",
+        "cacheRead": "118750000"
+      },
+      "kimi-k3": { "input": "3000000000", "output": "15000000000", "cacheRead": "300000000" },
+      "kimi-k3-fast": { "input": "3000000000", "output": "15000000000", "cacheRead": "300000000" },
+      "moonshotai/Kimi-K2.5": {
+        "input": "520000000",
+        "output": "2590000000",
+        "cacheRead": "130000000"
+      },
+      "moonshotai/Kimi-K2.6": {
+        "input": "690000000",
+        "output": "3220000000",
+        "cacheRead": "172500000"
+      },
+      "moonshotai/Kimi-K2.7-Code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "237500000"
+      },
+      "Qwen/Qwen3.5-397B-A17B-FP8": {
+        "input": "690000000",
+        "output": "4140000000",
+        "cacheRead": "172500000"
+      },
+      "Qwen/Qwen3.6-35B-A3B": {
+        "input": "290000000",
+        "output": "1150000000",
+        "cacheRead": "72500000"
+      },
+      "qwen3.5-397b-fast": {
+        "input": "690000000",
+        "output": "4140000000",
+        "cacheRead": "172500000"
+      },
+      "qwen3.6-35b-fast": { "input": "290000000", "output": "1150000000", "cacheRead": "72500000" }
+    },
+    "nova": {
+      "nova-2-lite-v1": { "input": "0", "output": "0", "reasoning": "0" },
+      "nova-2-pro-v1": { "input": "0", "output": "0", "reasoning": "0" }
+    },
+    "novita-ai": {
+      "baichuan/baichuan-m2-32b": { "input": "70000000", "output": "70000000" },
+      "baidu/ernie-4.5-21B-a3b": { "input": "70000000", "output": "280000000" },
+      "baidu/ernie-4.5-21B-a3b-thinking": { "input": "70000000", "output": "280000000" },
+      "baidu/ernie-4.5-300b-a47b-paddle": { "input": "280000000", "output": "1100000000" },
+      "baidu/ernie-4.5-vl-28b-a3b": { "input": "140000000", "output": "560000000" },
+      "baidu/ernie-4.5-vl-28b-a3b-thinking": { "input": "390000000", "output": "390000000" },
+      "baidu/ernie-4.5-vl-424b-a47b": { "input": "420000000", "output": "1250000000" },
+      "deepseek/deepseek-ocr": { "input": "30000000", "output": "30000000" },
+      "deepseek/deepseek-ocr-2": { "input": "30000000", "output": "30000000" },
+      "deepseek/deepseek-prover-v2-671b": { "input": "700000000", "output": "2500000000" },
+      "deepseek/deepseek-r1-0528": {
+        "input": "700000000",
+        "output": "2500000000",
+        "cacheRead": "350000000"
+      },
+      "deepseek/deepseek-r1-0528-qwen3-8b": { "input": "60000000", "output": "90000000" },
+      "deepseek/deepseek-r1-distill-llama-70b": { "input": "800000000", "output": "800000000" },
+      "deepseek/deepseek-r1-distill-qwen-14b": { "input": "150000000", "output": "150000000" },
+      "deepseek/deepseek-r1-distill-qwen-32b": { "input": "300000000", "output": "300000000" },
+      "deepseek/deepseek-r1-turbo": { "input": "700000000", "output": "2500000000" },
+      "deepseek/deepseek-v3-0324": {
+        "input": "270000000",
+        "output": "1120000000",
+        "cacheRead": "135000000"
+      },
+      "deepseek/deepseek-v3-turbo": { "input": "400000000", "output": "1300000000" },
+      "deepseek/deepseek-v3.1": {
+        "input": "270000000",
+        "output": "1000000000",
+        "cacheRead": "135000000"
+      },
+      "deepseek/deepseek-v3.1-terminus": {
+        "input": "270000000",
+        "output": "1000000000",
+        "cacheRead": "135000000"
+      },
+      "deepseek/deepseek-v3.2": {
+        "input": "269000000",
+        "output": "400000000",
+        "cacheRead": "134500000"
+      },
+      "deepseek/deepseek-v3.2-exp": { "input": "270000000", "output": "410000000" },
+      "deepseek/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "1600000000",
+        "output": "3200000000",
+        "cacheRead": "135000000"
+      },
+      "google/gemma-3-12b-it": { "input": "50000000", "output": "100000000" },
+      "google/gemma-3-27b-it": { "input": "119000000", "output": "200000000" },
+      "google/gemma-4-26b-a4b-it": { "input": "130000000", "output": "400000000" },
+      "google/gemma-4-31b-it": { "input": "140000000", "output": "400000000" },
+      "gryphe/mythomax-l2-13b": { "input": "90000000", "output": "90000000" },
+      "inclusionai/ling-2.6-1t": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "60000000"
+      },
+      "inclusionai/ling-2.6-flash": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "20000000"
+      },
+      "inclusionai/ring-2.6-1t": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "60000000"
+      },
+      "kwaipilot/kat-coder-pro": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "meta-llama/llama-3-70b-instruct": { "input": "510000000", "output": "740000000" },
+      "meta-llama/llama-3-8b-instruct": { "input": "40000000", "output": "40000000" },
+      "meta-llama/llama-3.1-8b-instruct": { "input": "20000000", "output": "50000000" },
+      "meta-llama/llama-3.2-3b-instruct": { "input": "30000000", "output": "50000000" },
+      "meta-llama/llama-3.3-70b-instruct": { "input": "135000000", "output": "400000000" },
+      "meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+        "input": "270000000",
+        "output": "850000000"
+      },
+      "meta-llama/llama-4-scout-17b-16e-instruct": { "input": "180000000", "output": "590000000" },
+      "microsoft/wizardlm-2-8x22b": { "input": "620000000", "output": "620000000" },
+      "minimax/minimax-m2": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "minimax/minimax-m2.1": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "minimax/minimax-m2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "minimax/minimax-m2.5-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "30000000"
+      },
+      "minimax/minimax-m2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "minimax/minimax-m2.7-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "minimaxai/minimax-m1-80k": { "input": "550000000", "output": "2200000000" },
+      "mistralai/mistral-nemo": { "input": "40000000", "output": "170000000" },
+      "moonshotai/kimi-k2-0905": { "input": "600000000", "output": "2500000000" },
+      "moonshotai/kimi-k2-instruct": { "input": "570000000", "output": "2300000000" },
+      "moonshotai/kimi-k2-thinking": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "150000000"
+      },
+      "moonshotai/kimi-k2.5": {
+        "input": "600000000",
+        "output": "3000000000",
+        "cacheRead": "100000000"
+      },
+      "moonshotai/kimi-k2.6": {
+        "input": "800000000",
+        "output": "3400000000",
+        "cacheRead": "160000000"
+      },
+      "moonshotai/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "moonshotai/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "nousresearch/hermes-2-pro-llama-3-8b": { "input": "140000000", "output": "140000000" },
+      "openai/gpt-oss-120b": { "input": "50000000", "output": "250000000" },
+      "openai/gpt-oss-20b": { "input": "40000000", "output": "150000000" },
+      "paddlepaddle/paddleocr-vl": { "input": "20000000", "output": "20000000" },
+      "qwen/qwen-2.5-72b-instruct": { "input": "380000000", "output": "400000000" },
+      "qwen/qwen-mt-plus": { "input": "250000000", "output": "750000000" },
+      "qwen/qwen2.5-7b-instruct": { "input": "70000000", "output": "70000000" },
+      "qwen/qwen2.5-vl-72b-instruct": { "input": "800000000", "output": "800000000" },
+      "qwen/qwen3-235b-a22b-fp8": { "input": "200000000", "output": "800000000" },
+      "qwen/qwen3-235b-a22b-instruct-2507": { "input": "90000000", "output": "580000000" },
+      "qwen/qwen3-235b-a22b-thinking-2507": { "input": "300000000", "output": "3000000000" },
+      "qwen/qwen3-30b-a3b-fp8": { "input": "90000000", "output": "450000000" },
+      "qwen/qwen3-32b-fp8": { "input": "100000000", "output": "450000000" },
+      "qwen/qwen3-4b-fp8": { "input": "30000000", "output": "30000000" },
+      "qwen/qwen3-8b-fp8": { "input": "35000000", "output": "138000000" },
+      "qwen/qwen3-coder-30b-a3b-instruct": { "input": "70000000", "output": "270000000" },
+      "qwen/qwen3-coder-480b-a35b-instruct": { "input": "380000000", "output": "1550000000" },
+      "qwen/qwen3-coder-next": { "input": "200000000", "output": "1500000000" },
+      "qwen/qwen3-max": { "input": "2110000000", "output": "8450000000" },
+      "qwen/qwen3-next-80b-a3b-instruct": { "input": "150000000", "output": "1500000000" },
+      "qwen/qwen3-next-80b-a3b-thinking": { "input": "150000000", "output": "1500000000" },
+      "qwen/qwen3-omni-30b-a3b-instruct": {
+        "input": "250000000",
+        "output": "970000000",
+        "inputAudio": "2200000000",
+        "outputAudio": "1788000000"
+      },
+      "qwen/qwen3-omni-30b-a3b-thinking": {
+        "input": "250000000",
+        "output": "970000000",
+        "inputAudio": "2200000000",
+        "outputAudio": "1788000000"
+      },
+      "qwen/qwen3-vl-235b-a22b-instruct": { "input": "300000000", "output": "1500000000" },
+      "qwen/qwen3-vl-235b-a22b-thinking": { "input": "980000000", "output": "3950000000" },
+      "qwen/qwen3-vl-30b-a3b-instruct": { "input": "200000000", "output": "700000000" },
+      "qwen/qwen3-vl-30b-a3b-thinking": { "input": "200000000", "output": "1000000000" },
+      "qwen/qwen3-vl-8b-instruct": { "input": "80000000", "output": "500000000" },
+      "qwen/qwen3.5-122b-a10b": { "input": "400000000", "output": "3200000000" },
+      "qwen/qwen3.5-27b": { "input": "300000000", "output": "2400000000" },
+      "qwen/qwen3.5-35b-a3b": { "input": "250000000", "output": "2000000000" },
+      "qwen/qwen3.5-397b-a17b": { "input": "600000000", "output": "3600000000" },
+      "qwen/qwen3.7-max": {
+        "input": "1250000000",
+        "output": "3750000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "1562500000"
+      },
+      "sao10K/l3-70b-euryale-v2.1": { "input": "1480000000", "output": "1480000000" },
+      "sao10K/l3-8b-lunaris": { "input": "50000000", "output": "50000000" },
+      "sao10K/L3-8B-stheno-v3.2": { "input": "50000000", "output": "50000000" },
+      "sao10K/l31-70b-euryale-v2.2": { "input": "1480000000", "output": "1480000000" },
+      "xiaomimimo/mimo-v2-flash": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "300000000"
+      },
+      "xiaomimimo/mimo-v2-pro": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "400000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "xiaomimimo/mimo-v2.5-pro": {
+        "input": "522000000",
+        "output": "1044000000",
+        "cacheRead": "4300000",
+        "tiers": [
+          {
+            "input": "522000000",
+            "output": "1044000000",
+            "cacheRead": "4300000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "zai-org/autoglm-phone-9b-multilingual": { "input": "35000000", "output": "138000000" },
+      "zai-org/glm-4.5": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "zai-org/glm-4.5-air": {
+        "input": "130000000",
+        "output": "850000000",
+        "cacheRead": "25000000"
+      },
+      "zai-org/glm-4.5v": {
+        "input": "600000000",
+        "output": "1800000000",
+        "cacheRead": "110000000"
+      },
+      "zai-org/glm-4.6": { "input": "550000000", "output": "2200000000", "cacheRead": "110000000" },
+      "zai-org/glm-4.6v": { "input": "300000000", "output": "900000000", "cacheRead": "55000000" },
+      "zai-org/glm-4.7": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "zai-org/glm-4.7-flash": {
+        "input": "70000000",
+        "output": "400000000",
+        "cacheRead": "10000000"
+      },
+      "zai-org/glm-5": { "input": "1000000000", "output": "3200000000", "cacheRead": "200000000" },
+      "zai-org/glm-5.1": {
+        "input": "1380000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "zai-org/glm-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" }
+    },
+    "nvidia": {
+      "abacusai/dracarys-llama-3.1-70b-instruct": { "input": "0", "output": "0" },
+      "baai/bge-m3": { "input": "0", "output": "0" },
+      "black-forest-labs/flux_1-kontext-dev": { "input": "0", "output": "0" },
+      "black-forest-labs/flux_1-schnell": { "input": "0", "output": "0" },
+      "black-forest-labs/flux_2-klein-4b": { "input": "0", "output": "0" },
+      "black-forest-labs/flux.1-dev": { "input": "0", "output": "0" },
+      "bytedance/seed-oss-36b-instruct": { "input": "0", "output": "0" },
+      "deepseek-ai/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "2800000"
+      },
+      "deepseek-ai/deepseek-v4-flash-0731": { "input": "0", "output": "0" },
+      "deepseek-ai/deepseek-v4-pro": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "3625000"
+      },
+      "google/gemma-2-2b-it": { "input": "0", "output": "0" },
+      "google/gemma-3-12b-it": { "input": "0", "output": "0" },
+      "google/gemma-3-4b-it": { "input": "0", "output": "0" },
+      "google/gemma-3n-e2b-it": { "input": "0", "output": "0" },
+      "google/gemma-3n-e4b-it": { "input": "0", "output": "0" },
+      "google/gemma-4-31b-it": { "input": "0", "output": "0" },
+      "google/google-paligemma": { "input": "0", "output": "0" },
+      "meta/esm2-650m": { "input": "0", "output": "0" },
+      "meta/esmfold": { "input": "0", "output": "0" },
+      "meta/llama-3.1-70b-instruct": { "input": "0", "output": "0" },
+      "meta/llama-3.1-8b-instruct": { "input": "0", "output": "0" },
+      "meta/llama-3.2-11b-vision-instruct": { "input": "0", "output": "0" },
+      "meta/llama-3.2-1b-instruct": { "input": "0", "output": "0" },
+      "meta/llama-3.2-3b-instruct": { "input": "0", "output": "0" },
+      "meta/llama-3.2-90b-vision-instruct": { "input": "0", "output": "0" },
+      "meta/llama-3.3-70b-instruct": { "input": "0", "output": "0" },
+      "meta/llama-4-maverick-17b-128e-instruct": { "input": "0", "output": "0" },
+      "meta/llama-guard-4-12b": { "input": "0", "output": "0" },
+      "meta/muse-glimmer-30b": { "input": "0", "output": "0" },
+      "microsoft/phi-4-mini-instruct": { "input": "0", "output": "0" },
+      "microsoft/phi-4-multimodal-instruct": { "input": "0", "output": "0" },
+      "minimaxai/minimax-m2.7": { "input": "0", "output": "0" },
+      "minimaxai/minimax-m3": { "input": "0", "output": "0" },
+      "mistralai/magistral-small-2506": { "input": "0", "output": "0" },
+      "mistralai/ministral-14b-instruct-2512": { "input": "0", "output": "0" },
+      "mistralai/mistral-7b-instruct-v0.3": { "input": "0", "output": "0" },
+      "mistralai/mistral-large-3-675b-instruct-2512": { "input": "0", "output": "0" },
+      "mistralai/mistral-medium-3-instruct": { "input": "0", "output": "0" },
+      "mistralai/mistral-medium-3.5-128b": { "input": "0", "output": "0" },
+      "mistralai/mistral-nemotron": { "input": "0", "output": "0" },
+      "mistralai/mistral-small-4-119b-2603": { "input": "0", "output": "0" },
+      "mistralai/mixtral-8x22b-instruct": { "input": "0", "output": "0" },
+      "mistralai/mixtral-8x7b-instruct": { "input": "0", "output": "0" },
+      "moonshotai/kimi-k2-instruct-0905": { "input": "0", "output": "0" },
+      "moonshotai/kimi-k2.6": { "input": "0", "output": "0" },
+      "moonshotai/kimi-k3": { "input": "0", "output": "0" },
+      "nvidia/active-speaker-detection": { "input": "0", "output": "0" },
+      "nvidia/bevformer": { "input": "0", "output": "0" },
+      "nvidia/cosmos-predict1-5b": { "input": "0", "output": "0" },
+      "nvidia/cosmos-reason2-8b": { "input": "0", "output": "0" },
+      "nvidia/cosmos-transfer1-7b": { "input": "0", "output": "0" },
+      "nvidia/cosmos-transfer2_5-2b": { "input": "0", "output": "0" },
+      "nvidia/gliner-pii": { "input": "0", "output": "0" },
+      "nvidia/llama-3_2-nemoretriever-300m-embed-v1": { "input": "0", "output": "0" },
+      "nvidia/llama-3.1-nemotron-70b-instruct": { "input": "0", "output": "0" },
+      "nvidia/llama-3.1-nemotron-nano-8b-v1": { "input": "0", "output": "0" },
+      "nvidia/llama-3.1-nemotron-nano-vl-8b-v1": { "input": "0", "output": "0" },
+      "nvidia/llama-3.1-nemotron-safety-guard-8b-v3": { "input": "0", "output": "0" },
+      "nvidia/llama-3.1-nemotron-ultra-253b-v1": { "input": "0", "output": "0" },
+      "nvidia/llama-3.3-nemotron-super-49b-v1": { "input": "0", "output": "0" },
+      "nvidia/llama-3.3-nemotron-super-49b-v1.5": { "input": "0", "output": "0" },
+      "nvidia/llama-nemotron-embed-vl-1b-v2": { "input": "0", "output": "0" },
+      "nvidia/llama-nemotron-rerank-vl-1b-v2": { "input": "0", "output": "0" },
+      "nvidia/magpie-tts-zeroshot": { "input": "0", "output": "0" },
+      "nvidia/nemotron-3-content-safety": { "input": "0", "output": "0" },
+      "nvidia/nemotron-3-nano-30b-a3b": { "input": "0", "output": "0" },
+      "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": { "input": "0", "output": "0" },
+      "nvidia/nemotron-3-super-120b-a12b": { "input": "200000000", "output": "800000000" },
+      "nvidia/nemotron-3-ultra-550b-a55b": {
+        "input": "500000000",
+        "output": "2500000000",
+        "cacheRead": "150000000"
+      },
+      "nvidia/nemotron-3.5-lightning-30b-a3b": { "input": "0", "output": "0" },
+      "nvidia/nemotron-content-safety-reasoning-4b": { "input": "0", "output": "0" },
+      "nvidia/nemotron-mini-4b-instruct": { "input": "0", "output": "0" },
+      "nvidia/nemotron-nano-12b-v2-vl": { "input": "0", "output": "0" },
+      "nvidia/nemotron-voicechat": { "input": "0", "output": "0" },
+      "nvidia/nv-embed-v1": { "input": "0", "output": "0" },
+      "nvidia/nv-embedcode-7b-v1": { "input": "0", "output": "0" },
+      "nvidia/nvidia-nemotron-nano-9b-v2": { "input": "0", "output": "0" },
+      "nvidia/rerank-qa-mistral-4b": { "input": "0", "output": "0" },
+      "nvidia/riva-translate-4b-instruct-v1.1": { "input": "0", "output": "0" },
+      "nvidia/sparsedrive": { "input": "0", "output": "0" },
+      "nvidia/streampetr": { "input": "0", "output": "0" },
+      "nvidia/studiovoice": { "input": "0", "output": "0" },
+      "nvidia/synthetic-video-detector": { "input": "0", "output": "0" },
+      "nvidia/usdcode": { "input": "0", "output": "0" },
+      "nvidia/usdvalidate": { "input": "0", "output": "0" },
+      "openai/gpt-oss-120b": { "input": "0", "output": "0" },
+      "openai/gpt-oss-20b": { "input": "0", "output": "0" },
+      "openai/whisper-large-v3": { "input": "0", "output": "0" },
+      "poolside/laguna-xs-2.1": { "input": "0", "output": "0" },
+      "qwen/qwen-image": { "input": "0", "output": "0" },
+      "qwen/qwen-image-edit": { "input": "0", "output": "0" },
+      "qwen/qwen2.5-coder-32b-instruct": { "input": "0", "output": "0" },
+      "qwen/qwen3-coder-480b-a35b-instruct": { "input": "0", "output": "0" },
+      "qwen/qwen3-next-80b-a3b-instruct": { "input": "0", "output": "0" },
+      "qwen/qwen3.5-122b-a10b": { "input": "0", "output": "0" },
+      "qwen/qwen3.5-397b-a17b": { "input": "0", "output": "0" },
+      "sarvamai/sarvam-m": { "input": "0", "output": "0" },
+      "stepfun-ai/step-3.5-flash": { "input": "0", "output": "0" },
+      "stepfun-ai/step-3.7-flash": { "input": "0", "output": "0" },
+      "thinkingmachines/inkling": { "input": "0", "output": "0" },
+      "upstage/solar-10.7b-instruct": { "input": "0", "output": "0" },
+      "z-ai/glm-5.2": { "input": "0", "output": "0" }
+    },
+    "ofox": {
+      "anthropic/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-haiku-4.5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic/claude-opus-4.5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-sonnet-4.5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4.6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "bailian/qwen-flash": {
+        "input": "22000000",
+        "output": "220000000",
+        "cacheRead": "4300000",
+        "cacheWrite": "27000000"
+      },
+      "bailian/qwen-max": { "input": "350000000", "output": "1380000000", "cacheRead": "69000000" },
+      "bailian/qwen-plus": { "input": "120000000", "output": "290000000", "cacheRead": "23000000" },
+      "bailian/qwen-turbo": { "input": "50000000", "output": "90000000", "cacheRead": "8600000" },
+      "bailian/qwen-vl-max": {
+        "input": "230000000",
+        "output": "580000000",
+        "cacheRead": "46000000"
+      },
+      "bailian/qwen3-coder-flash": {
+        "input": "500000000",
+        "output": "2500000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "270000000"
+      },
+      "bailian/qwen3-coder-next": { "input": "200000000", "output": "1500000000" },
+      "bailian/qwen3-coder-plus": {
+        "input": "1800000000",
+        "output": "9000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "1000000000"
+      },
+      "bailian/qwen3-max": {
+        "input": "360000000",
+        "output": "1430000000",
+        "cacheRead": "72000000"
+      },
+      "bailian/qwen3.5-122b-a10b": {
+        "input": "290000000",
+        "output": "2290000000",
+        "cacheRead": "290000000"
+      },
+      "bailian/qwen3.5-27b": {
+        "input": "290000000",
+        "output": "2050000000",
+        "cacheRead": "290000000"
+      },
+      "bailian/qwen3.5-35b-a3b": {
+        "input": "290000000",
+        "output": "1830000000",
+        "cacheRead": "290000000"
+      },
+      "bailian/qwen3.5-397b-a17b": {
+        "input": "550000000",
+        "output": "3500000000",
+        "cacheRead": "550000000"
+      },
+      "bailian/qwen3.5-flash": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "125000000"
+      },
+      "bailian/qwen3.5-plus": {
+        "input": "400000000",
+        "output": "2400000000",
+        "cacheRead": "40000000",
+        "cacheWrite": "400000000"
+      },
+      "bailian/qwen3.6-27b": { "input": "600000000", "output": "3600000000" },
+      "bailian/qwen3.6-flash": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "310000000"
+      },
+      "bailian/qwen3.6-max-preview": {
+        "input": "2150000000",
+        "output": "12860000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "1170000000"
+      },
+      "bailian/qwen3.6-plus": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000"
+      },
+      "bailian/qwen3.7-max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "3125000000"
+      },
+      "bailian/qwen3.7-plus": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "500000000"
+      },
+      "bailian/qwen3.8-27b": {
+        "input": "450000000",
+        "output": "3200000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "562500000"
+      },
+      "bailian/qwen3.8-max": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      },
+      "deepseek/deepseek-v3.2": {
+        "input": "290000000",
+        "output": "430000000",
+        "cacheRead": "60000000"
+      },
+      "deepseek/deepseek-v4-flash": {
+        "input": "440000000",
+        "output": "1320000000",
+        "cacheRead": "14000000"
+      },
+      "deepseek/deepseek-v4-flash-0731": {
+        "input": "440000000",
+        "output": "1320000000",
+        "cacheRead": "14000000"
+      },
+      "deepseek/deepseek-v4-flash-vision-exp": {
+        "input": "440000000",
+        "output": "1320000000",
+        "cacheRead": "14000000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "44000000"
+      },
+      "deepseek/deepseek-v4-pro-0423": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "44000000"
+      },
+      "deepseek/deepseek-v4-pro-0813": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "44000000"
+      },
+      "google/gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "1000000000",
+        "inputAudio": "1000000000"
+      },
+      "google/gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "1000000000",
+        "inputAudio": "300000000"
+      },
+      "google/gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "cacheWrite": "4500000000"
+      },
+      "google/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "1000000000"
+      },
+      "google/gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "1000000000",
+        "inputAudio": "500000000"
+      },
+      "google/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "4500000000"
+      },
+      "google/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83000000",
+        "inputAudio": "3000000000"
+      },
+      "google/gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83000000"
+      },
+      "google/gemini-3.6-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "41500000",
+        "inputAudio": "1500000000"
+      },
+      "google/gemini-3.7-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "41500000",
+        "inputAudio": "1500000000"
+      },
+      "minimax/m2-her": { "input": "300000000", "output": "1200000000" },
+      "minimax/minimax-m2": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.1": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.1-lightning": {
+        "input": "300000000",
+        "output": "2400000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.5-lightning": {
+        "input": "300000000",
+        "output": "2400000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.7-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m3": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "120000000"
+      },
+      "moonshotai/kimi-k2.5": {
+        "input": "600000000",
+        "output": "3000000000",
+        "cacheRead": "100000000"
+      },
+      "moonshotai/kimi-k2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "moonshotai/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "moonshotai/kimi-k2.7-code-highspeed": {
+        "input": "1900000000",
+        "output": "8000000000",
+        "cacheRead": "380000000"
+      },
+      "moonshotai/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "openai/gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/gpt-4.1-mini": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "100000000"
+      },
+      "openai/gpt-4o": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-mini": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "130000000" },
+      "openai/gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "30000000"
+      },
+      "openai/gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "10000000" },
+      "openai/gpt-5.1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "130000000"
+      },
+      "openai/gpt-5.1-codex-max": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "130000000"
+      },
+      "openai/gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "30000000"
+      },
+      "openai/gpt-5.2": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "180000000"
+      },
+      "openai/gpt-5.2-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "180000000"
+      },
+      "openai/gpt-5.3-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "180000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000"
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "openai/gpt-5.4-pro": { "input": "30000000000", "output": "180000000000" },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "openai/gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000"
+      },
+      "openai/gpt-5.6-sol": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "3125000000"
+      },
+      "openai/gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "volcengine/doubao-seed-1-6": {
+        "input": "120000000",
+        "output": "290000000",
+        "cacheRead": "23000000"
+      },
+      "volcengine/doubao-seed-1-6-flash": {
+        "input": "30000000",
+        "output": "220000000",
+        "cacheRead": "4300000"
+      },
+      "volcengine/doubao-seed-1-6-vision": {
+        "input": "120000000",
+        "output": "1150000000",
+        "cacheRead": "23000000"
+      },
+      "volcengine/doubao-seed-1-8": {
+        "input": "120000000",
+        "output": "290000000",
+        "cacheRead": "23000000"
+      },
+      "volcengine/doubao-seed-2.0-code": {
+        "input": "670000000",
+        "output": "3360000000",
+        "cacheRead": "140000000",
+        "cacheWrite": "2400000"
+      },
+      "volcengine/doubao-seed-2.0-lite": {
+        "input": "130000000",
+        "output": "760000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "2400000"
+      },
+      "volcengine/doubao-seed-2.0-mini": {
+        "input": "60000000",
+        "output": "560000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "2400000"
+      },
+      "volcengine/doubao-seed-2.0-pro": {
+        "input": "670000000",
+        "output": "3360000000",
+        "cacheRead": "140000000",
+        "cacheWrite": "2400000"
+      },
+      "volcengine/doubao-seed-2.1-pro": {
+        "input": "707200000",
+        "output": "3536000000",
+        "cacheRead": "141600000",
+        "cacheWrite": "2000000"
+      },
+      "volcengine/doubao-seed-2.1-turbo": {
+        "input": "353600000",
+        "output": "1769600000",
+        "cacheRead": "68000000",
+        "cacheWrite": "1900000"
+      },
+      "volcengine/doubao-seed-character": {
+        "input": "177000000",
+        "output": "884000000",
+        "cacheRead": "24000000",
+        "cacheWrite": "2500000"
+      },
+      "volcengine/doubao-seed-evolving": {
+        "input": "884000000",
+        "output": "4420000000",
+        "cacheRead": "177000000",
+        "cacheWrite": "2500000"
+      },
+      "x-ai/grok-4.1-fast": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "x-ai/grok-4.20": {
+        "input": "4000000000",
+        "output": "12000000000",
+        "cacheRead": "400000000"
+      },
+      "x-ai/grok-4.3": { "input": "1250000000", "output": "2500000000", "cacheRead": "200000000" },
+      "x-ai/grok-4.5": { "input": "2000000000", "output": "6000000000", "cacheRead": "300000000" },
+      "x-ai/grok-4.6": { "input": "2000000000", "output": "6000000000", "cacheRead": "500000000" },
+      "z-ai/glm-4.6": { "input": "400000000", "output": "1900000000", "cacheRead": "110000000" },
+      "z-ai/glm-4.7": { "input": "400000000", "output": "2000000000", "cacheRead": "80000000" },
+      "z-ai/glm-4.7-flashx": {
+        "input": "72000000",
+        "output": "430000000",
+        "cacheRead": "15000000"
+      },
+      "z-ai/glm-5": { "input": "1000000000", "output": "3200000000", "cacheRead": "200000000" },
+      "z-ai/glm-5-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      },
+      "z-ai/glm-5.1": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "z-ai/glm-5.2": { "input": "980000000", "output": "3080000000", "cacheRead": "182000000" },
+      "z-ai/glm-5.3": { "input": "1260000000", "output": "3960000000", "cacheRead": "234000000" },
+      "z-ai/glm-5v-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      }
+    },
+    "openai": {
+      "gpt-3.5-turbo": { "input": "500000000", "output": "1500000000", "cacheRead": "0" },
+      "gpt-4": { "input": "30000000000", "output": "60000000000" },
+      "gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "gpt-4.1-mini": { "input": "400000000", "output": "1600000000", "cacheRead": "100000000" },
+      "gpt-4.1-nano": { "input": "100000000", "output": "400000000", "cacheRead": "25000000" },
+      "gpt-4o": { "input": "2500000000", "output": "10000000000", "cacheRead": "1250000000" },
+      "gpt-4o-2024-05-13": { "input": "5000000000", "output": "15000000000" },
+      "gpt-4o-2024-08-06": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "gpt-4o-2024-11-20": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "gpt-4o-mini": { "input": "150000000", "output": "600000000", "cacheRead": "75000000" },
+      "gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5-mini": { "input": "250000000", "output": "2000000000", "cacheRead": "25000000" },
+      "gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "gpt-5-pro": { "input": "15000000000", "output": "120000000000" },
+      "gpt-5.1": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5.2": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.2-chat-latest": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "gpt-5.2-pro": { "input": "21000000000", "output": "168000000000" },
+      "gpt-5.3-chat-latest": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "gpt-5.3-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.3-codex-spark": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": { "input": "5000000000", "output": "30000000000", "cacheRead": "500000000" }
+        }
+      },
+      "gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000",
+        "modes": {
+          "fast": { "input": "1500000000", "output": "9000000000", "cacheRead": "150000000" }
+        }
+      },
+      "gpt-5.4-nano": { "input": "200000000", "output": "1250000000", "cacheRead": "20000000" },
+      "gpt-5.4-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": { "input": "12500000000", "output": "75000000000", "cacheRead": "1250000000" }
+        }
+      },
+      "gpt-5.5-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "gpt-5.6": {
+        "input": "4000000000",
+        "output": "20000000000",
+        "cacheRead": "400000000",
+        "cacheWrite": "5000000000",
+        "tiers": [
+          {
+            "input": "8000000000",
+            "output": "30000000000",
+            "cacheRead": "800000000",
+            "cacheWrite": "10000000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": {
+            "input": "8000000000",
+            "output": "40000000000",
+            "cacheRead": "800000000",
+            "cacheWrite": "10000000000"
+          }
+        }
+      },
+      "gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000",
+        "tiers": [
+          {
+            "input": "400000000",
+            "output": "1800000000",
+            "cacheRead": "40000000",
+            "cacheWrite": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": {
+            "input": "400000000",
+            "output": "2400000000",
+            "cacheRead": "40000000",
+            "cacheWrite": "500000000"
+          }
+        }
+      },
+      "gpt-5.6-sol": {
+        "input": "4000000000",
+        "output": "20000000000",
+        "cacheRead": "400000000",
+        "cacheWrite": "5000000000",
+        "tiers": [
+          {
+            "input": "8000000000",
+            "output": "30000000000",
+            "cacheRead": "800000000",
+            "cacheWrite": "10000000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": {
+            "input": "8000000000",
+            "output": "40000000000",
+            "cacheRead": "800000000",
+            "cacheWrite": "10000000000"
+          }
+        }
+      },
+      "gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "5000000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": {
+            "input": "4000000000",
+            "output": "24000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "5000000000"
+          }
+        }
+      },
+      "gpt-image-2": { "input": "5000000000", "output": "30000000000", "cacheRead": "1250000000" },
+      "gpt-realtime-2.1": {
+        "input": "4000000000",
+        "output": "24000000000",
+        "cacheRead": "400000000",
+        "inputAudio": "32000000000",
+        "outputAudio": "64000000000"
+      },
+      "o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "o1-pro": { "input": "150000000000", "output": "600000000000" },
+      "o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "o3-pro": { "input": "20000000000", "output": "80000000000" },
+      "o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "text-embedding-3-large": { "input": "130000000", "output": "0" },
+      "text-embedding-3-small": { "input": "20000000", "output": "0" },
+      "text-embedding-ada-002": { "input": "100000000", "output": "0" }
+    },
+    "opencode": {
+      "big-pickle": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "claude-3-5-haiku": {
+        "input": "800000000",
+        "output": "4000000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "1000000000"
+      },
+      "claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-opus-4-1": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "claude-opus-4-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-sonnet-4": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000",
+        "tiers": [
+          {
+            "input": "6000000000",
+            "output": "22500000000",
+            "cacheRead": "600000000",
+            "cacheWrite": "7500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000",
+        "tiers": [
+          {
+            "input": "6000000000",
+            "output": "22500000000",
+            "cacheRead": "600000000",
+            "cacheWrite": "7500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "deepseek-v4-flash": { "input": "140000000", "output": "280000000", "cacheRead": "28000000" },
+      "deepseek-v4-flash-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "deepseek-v4-pro": {
+        "input": "1740000000",
+        "output": "3840000000",
+        "cacheRead": "145000000"
+      },
+      "gemini-3-flash": { "input": "500000000", "output": "3000000000", "cacheRead": "50000000" },
+      "gemini-3-pro": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.1-pro": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "inputAudio": "1500000000"
+      },
+      "gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "gemini-3.6-flash": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000",
+        "inputAudio": "1500000000"
+      },
+      "gemini-3.7-flash": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000",
+        "inputAudio": "1500000000"
+      },
+      "glm-4.6": { "input": "600000000", "output": "2200000000", "cacheRead": "100000000" },
+      "glm-4.7": { "input": "600000000", "output": "2200000000", "cacheRead": "100000000" },
+      "glm-4.7-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "glm-5": { "input": "1000000000", "output": "3200000000", "cacheRead": "200000000" },
+      "glm-5-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "glm-5.1": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "glm-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "gpt-5": { "input": "1070000000", "output": "8500000000", "cacheRead": "107000000" },
+      "gpt-5-codex": { "input": "1070000000", "output": "8500000000", "cacheRead": "107000000" },
+      "gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "gpt-5.1": { "input": "1070000000", "output": "8500000000", "cacheRead": "107000000" },
+      "gpt-5.1-codex": { "input": "1070000000", "output": "8500000000", "cacheRead": "107000000" },
+      "gpt-5.1-codex-max": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "gpt-5.2": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.2-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.3-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.3-codex-spark": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.4-mini": { "input": "750000000", "output": "4500000000", "cacheRead": "75000000" },
+      "gpt-5.4-nano": { "input": "200000000", "output": "1250000000", "cacheRead": "20000000" },
+      "gpt-5.4-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "cacheRead": "30000000000"
+      },
+      "gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.5-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "cacheRead": "30000000000"
+      },
+      "gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000",
+        "tiers": [
+          {
+            "input": "400000000",
+            "output": "1800000000",
+            "cacheRead": "40000000",
+            "cacheWrite": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-sol": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "15000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "5000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-terra": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "3125000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "cacheWrite": "6250000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "grok-4.5": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4.6": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-build-0.1": { "input": "1000000000", "output": "2000000000", "cacheRead": "200000000" },
+      "grok-code": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "hy3-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "hy3-preview-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "kimi-k2": { "input": "400000000", "output": "2500000000", "cacheRead": "400000000" },
+      "kimi-k2-thinking": {
+        "input": "400000000",
+        "output": "2500000000",
+        "cacheRead": "400000000"
+      },
+      "kimi-k2.5": { "input": "600000000", "output": "3000000000", "cacheRead": "80000000" },
+      "kimi-k2.5-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "kimi-k2.6": { "input": "950000000", "output": "4000000000", "cacheRead": "160000000" },
+      "kimi-k2.7-code": { "input": "950000000", "output": "4000000000", "cacheRead": "190000000" },
+      "kimi-k3": { "input": "3000000000", "output": "15000000000", "cacheRead": "300000000" },
+      "laguna-s-2.1-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "ling-2.6-flash-free": { "input": "0", "output": "0" },
+      "ling-3.0-flash-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "ling-3.0-tiny-free": { "input": "0", "output": "0" },
+      "longcat-2.0-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "mimo-v2-flash-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "mimo-v2-omni-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "mimo-v2-pro-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "mimo-v2.5-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "minimax-m2.1": { "input": "300000000", "output": "1200000000", "cacheRead": "100000000" },
+      "minimax-m2.1-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "minimax-m2.5": { "input": "300000000", "output": "1200000000", "cacheRead": "60000000" },
+      "minimax-m2.5-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "minimax-m2.7": { "input": "300000000", "output": "1200000000", "cacheRead": "60000000" },
+      "minimax-m3": { "input": "300000000", "output": "1200000000", "cacheRead": "60000000" },
+      "minimax-m3-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "muse-spark-1.2": { "input": "1250000000", "output": "4250000000", "cacheRead": "150000000" },
+      "muse-spark-1.2-contributor-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "nemotron-3-super-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "nemotron-3-ultra-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "nemotron-3.5-lightning-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "north-mini-code-free": { "input": "0", "output": "0" },
+      "qwen3-coder": { "input": "450000000", "output": "1800000000" },
+      "qwen3.5-plus": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000"
+      },
+      "qwen3.6-plus": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000"
+      },
+      "qwen3.6-plus-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "ring-2.6-1t-free": { "input": "0", "output": "0" },
+      "trinity-large-preview-free": { "input": "0", "output": "0" },
+      "x-preview-f-free": { "input": "0", "output": "0", "cacheRead": "0" }
+    },
+    "opencode-go": {
+      "deepseek-v4-flash": { "input": "220000000", "output": "660000000", "cacheRead": "7000000" },
+      "deepseek-v4-flash-vision-exp": {
+        "input": "220000000",
+        "output": "660000000",
+        "cacheRead": "7000000"
+      },
+      "deepseek-v4-pro": { "input": "660000000", "output": "1980000000", "cacheRead": "22000000" },
+      "glm-5": { "input": "1000000000", "output": "3200000000", "cacheRead": "200000000" },
+      "glm-5.1": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "glm-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "glm-5.3": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000",
+        "tiers": [
+          {
+            "input": "400000000",
+            "output": "1800000000",
+            "cacheRead": "40000000",
+            "cacheWrite": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "grok-4.5": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "hy3": { "input": "17500000", "output": "72500000", "cacheRead": "4375000" },
+      "kimi-k2.5": { "input": "600000000", "output": "3000000000", "cacheRead": "100000000" },
+      "kimi-k2.6": { "input": "950000000", "output": "4000000000", "cacheRead": "160000000" },
+      "kimi-k2.7-code": { "input": "950000000", "output": "4000000000", "cacheRead": "190000000" },
+      "kimi-k3": { "input": "3000000000", "output": "15000000000", "cacheRead": "300000000" },
+      "longcat-2.0": { "input": "300000000", "output": "1200000000", "cacheRead": "6000000" },
+      "mimo-v2-omni": { "input": "400000000", "output": "2000000000", "cacheRead": "80000000" },
+      "mimo-v2-pro": {
+        "input": "1000000000",
+        "output": "3000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "mimo-v2.5": { "input": "140000000", "output": "280000000", "cacheRead": "2800000" },
+      "mimo-v2.5-pro": { "input": "435000000", "output": "870000000", "cacheRead": "3625000" },
+      "minimax-m2.5": { "input": "300000000", "output": "1200000000", "cacheRead": "30000000" },
+      "minimax-m2.7": { "input": "300000000", "output": "1200000000", "cacheRead": "60000000" },
+      "minimax-m3": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000",
+        "tiers": [
+          {
+            "input": "600000000",
+            "output": "2400000000",
+            "cacheRead": "120000000",
+            "aboveInputTokens": "512000"
+          }
+        ]
+      },
+      "muse-spark-1.2-contributor": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "2000000"
+      },
+      "ox-alpha-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "qwen3.5-plus": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000"
+      },
+      "qwen3.6-plus": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "200000000",
+            "cacheWrite": "2500000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3.7-max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "3125000000"
+      },
+      "qwen3.7-plus": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "40000000",
+        "cacheWrite": "500000000",
+        "tiers": [
+          {
+            "input": "1200000000",
+            "output": "4800000000",
+            "cacheRead": "120000000",
+            "cacheWrite": "1500000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen3.8-max": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      }
+    },
+    "openrouter": {
+      "~anthropic/claude-fable-latest": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "~anthropic/claude-haiku-latest": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "~anthropic/claude-opus-latest": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "~anthropic/claude-sonnet-latest": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "~deepseek/deepseek-v4-flash-latest": {
+        "input": "35000000",
+        "output": "100000000",
+        "cacheRead": "8000000"
+      },
+      "~google/gemini-flash-latest": {
+        "input": "375000000",
+        "output": "1875000000",
+        "cacheRead": "37500000",
+        "cacheWrite": "20833000",
+        "reasoning": "1875000000"
+      },
+      "~google/gemini-pro-latest": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "~moonshotai/kimi-latest": {
+        "input": "2800000000",
+        "output": "14000000000",
+        "cacheRead": "290000000"
+      },
+      "~openai/gpt-latest": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "15000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "5000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "~openai/gpt-mini-latest": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "~x-ai/grok-latest": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "~z-ai/glm-latest": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "aion-labs/aion-2.0": {
+        "input": "800000000",
+        "output": "1600000000",
+        "cacheRead": "200000000"
+      },
+      "aion-labs/aion-3.0": {
+        "input": "3000000000",
+        "output": "6000000000",
+        "cacheRead": "750000000"
+      },
+      "aion-labs/aion-3.0-mini": {
+        "input": "700000000",
+        "output": "1400000000",
+        "cacheRead": "180000000"
+      },
+      "aion-labs/aion-rp-llama-3.1-8b": { "input": "800000000", "output": "1600000000" },
+      "allenai/olmo-3-32b-think": { "input": "150000000", "output": "500000000" },
+      "amazon/nova-2-lite-v1": { "input": "300000000", "output": "2500000000" },
+      "amazon/nova-lite-v1": { "input": "60000000", "output": "240000000" },
+      "amazon/nova-micro-v1": { "input": "35000000", "output": "140000000" },
+      "amazon/nova-premier-v1": {
+        "input": "2500000000",
+        "output": "12500000000",
+        "cacheRead": "625000000"
+      },
+      "amazon/nova-pro-v1": { "input": "800000000", "output": "3200000000" },
+      "anthracite-org/magnum-v4-72b": { "input": "3000000000", "output": "5000000000" },
+      "anthropic/claude-3-haiku": {
+        "input": "250000000",
+        "output": "1250000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "300000000"
+      },
+      "anthropic/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-haiku-4.5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic/claude-opus-4": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic/claude-opus-4.1": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic/claude-opus-4.5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "anthropic/claude-opus-4.7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "37500000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "anthropic/claude-opus-4.7-fast": {
+        "input": "30000000000",
+        "output": "150000000000",
+        "cacheRead": "3000000000",
+        "cacheWrite": "37500000000"
+      },
+      "anthropic/claude-opus-4.8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.8-fast": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-5-fast": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-sonnet-4": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000",
+        "tiers": [
+          {
+            "input": "6000000000",
+            "output": "22500000000",
+            "cacheRead": "600000000",
+            "cacheWrite": "7500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "anthropic/claude-sonnet-4.5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000",
+        "tiers": [
+          {
+            "input": "6000000000",
+            "output": "22500000000",
+            "cacheRead": "600000000",
+            "cacheWrite": "7500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "anthropic/claude-sonnet-4.6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000",
+        "tiers": [
+          {
+            "input": "6000000000",
+            "output": "22500000000",
+            "cacheRead": "600000000",
+            "cacheWrite": "7500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "arcee-ai/trinity-large-thinking": {
+        "input": "220000000",
+        "output": "850000000",
+        "cacheRead": "60000000"
+      },
+      "arcee-ai/virtuoso-large": { "input": "750000000", "output": "1200000000" },
+      "baidu/ernie-4.5-vl-424b-a47b": { "input": "420000000", "output": "1250000000" },
+      "bytedance-seed/seed-1.6": {
+        "input": "250000000",
+        "output": "2000000000",
+        "tiers": [{ "input": "500000000", "output": "4000000000", "aboveInputTokens": "128000" }]
+      },
+      "bytedance-seed/seed-1.6-flash": {
+        "input": "75000000",
+        "output": "300000000",
+        "tiers": [{ "input": "100000000", "output": "800000000", "aboveInputTokens": "128000" }]
+      },
+      "bytedance-seed/seed-2-1-turbo": { "input": "500000000", "output": "2500000000" },
+      "bytedance-seed/seed-2.0-code": {
+        "input": "500000000",
+        "output": "3000000000",
+        "tiers": [{ "input": "1000000000", "output": "6000000000", "aboveInputTokens": "128000" }]
+      },
+      "bytedance-seed/seed-2.0-lite": {
+        "input": "250000000",
+        "output": "2000000000",
+        "tiers": [{ "input": "500000000", "output": "4000000000", "aboveInputTokens": "128000" }]
+      },
+      "bytedance-seed/seed-2.0-mini": {
+        "input": "100000000",
+        "output": "400000000",
+        "tiers": [{ "input": "200000000", "output": "800000000", "aboveInputTokens": "128000" }]
+      },
+      "bytedance/ui-tars-1.5-7b": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "100000000"
+      },
+      "cognitivecomputations/dolphin-mistral-24b-venice-edition": {
+        "input": "200000000",
+        "output": "900000000"
+      },
+      "cohere/command-a": { "input": "2500000000", "output": "10000000000" },
+      "cohere/command-r-08-2024": { "input": "150000000", "output": "600000000" },
+      "cohere/command-r-plus-08-2024": { "input": "2500000000", "output": "10000000000" },
+      "cohere/command-r7b-12-2024": { "input": "37500000", "output": "150000000" },
+      "cohere/north-mini-code:free": { "input": "0", "output": "0" },
+      "deepseek/deepseek-chat": { "input": "257400000", "output": "1028700000" },
+      "deepseek/deepseek-chat-v3-0324": { "input": "250000000", "output": "1000000000" },
+      "deepseek/deepseek-chat-v3.1": {
+        "input": "550000000",
+        "output": "1650000000",
+        "cacheRead": "550000000"
+      },
+      "deepseek/deepseek-r1": { "input": "700000000", "output": "2500000000" },
+      "deepseek/deepseek-r1-0528": {
+        "input": "500000000",
+        "output": "2150000000",
+        "cacheRead": "350000000"
+      },
+      "deepseek/deepseek-r1-distill-llama-70b": { "input": "800000000", "output": "800000000" },
+      "deepseek/deepseek-v3.1-terminus": {
+        "input": "270000000",
+        "output": "1000000000",
+        "cacheRead": "135000000"
+      },
+      "deepseek/deepseek-v3.2": {
+        "input": "260000000",
+        "output": "380000000",
+        "cacheRead": "130000000"
+      },
+      "deepseek/deepseek-v3.2-exp": { "input": "270000000", "output": "410000000" },
+      "deepseek/deepseek-v4-flash": {
+        "input": "82600000",
+        "output": "165200000",
+        "cacheRead": "16520000"
+      },
+      "deepseek/deepseek-v4-flash-0731": {
+        "input": "40000000",
+        "output": "80000000",
+        "cacheRead": "8000000"
+      },
+      "deepseek/deepseek-v4-flash-vision-exp": {
+        "input": "220000000",
+        "output": "660000000",
+        "cacheRead": "7000000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "572808000",
+        "output": "1145616000",
+        "cacheRead": "47734000"
+      },
+      "deepseek/deepseek-v4-pro-0813": {
+        "input": "1122000000",
+        "output": "3366000000",
+        "cacheRead": "37400000"
+      },
+      "dots-studio/dots-3-note-preview:free": { "input": "0", "output": "0" },
+      "google/gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83333000",
+        "reasoning": "2500000000"
+      },
+      "google/gemini-2.5-flash-image": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83333000"
+      },
+      "google/gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "83333000",
+        "reasoning": "400000000"
+      },
+      "google/gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "cacheWrite": "375000000",
+        "reasoning": "10000000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-2.5-pro-preview": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "cacheWrite": "375000000",
+        "reasoning": "10000000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-2.5-pro-preview-05-06": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "cacheWrite": "375000000",
+        "reasoning": "10000000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "83333000",
+        "reasoning": "3000000000"
+      },
+      "google/gemini-3-pro-image": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000"
+      },
+      "google/gemini-3-pro-image-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000"
+      },
+      "google/gemini-3.1-flash-image": { "input": "500000000", "output": "3000000000" },
+      "google/gemini-3.1-flash-image-preview": { "input": "500000000", "output": "3000000000" },
+      "google/gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "83333000",
+        "reasoning": "1500000000"
+      },
+      "google/gemini-3.1-flash-lite-image": { "input": "250000000", "output": "1500000000" },
+      "google/gemini-3.1-flash-lite-preview": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "83333000",
+        "reasoning": "1500000000"
+      },
+      "google/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3.1-pro-preview-customtools": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000",
+        "reasoning": "12000000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000",
+        "reasoning": "9000000000"
+      },
+      "google/gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "83333000",
+        "reasoning": "2500000000"
+      },
+      "google/gemini-3.6-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "41667000",
+        "reasoning": "3750000000"
+      },
+      "google/gemini-3.7-flash": {
+        "input": "375000000",
+        "output": "1875000000",
+        "cacheRead": "37500000",
+        "cacheWrite": "20833000",
+        "reasoning": "1875000000"
+      },
+      "google/gemma-2-27b-it": { "input": "650000000", "output": "650000000" },
+      "google/gemma-3-12b-it": { "input": "50000000", "output": "150000000" },
+      "google/gemma-3-27b-it": {
+        "input": "80000000",
+        "output": "450000000",
+        "cacheRead": "40000000"
+      },
+      "google/gemma-3-4b-it": { "input": "50000000", "output": "100000000" },
+      "google/gemma-3n-e4b-it": { "input": "60000000", "output": "120000000" },
+      "google/gemma-4-26b-a4b-it": { "input": "70000000", "output": "340000000" },
+      "google/gemma-4-26b-a4b-it:free": { "input": "0", "output": "0" },
+      "google/gemma-4-31b-it": {
+        "input": "100000000",
+        "output": "340000000",
+        "cacheRead": "100000000"
+      },
+      "google/gemma-4-31b-it:free": { "input": "0", "output": "0" },
+      "google/lyria-3-clip-preview": { "input": "0", "output": "0" },
+      "google/lyria-3-pro-preview": { "input": "0", "output": "0" },
+      "gryphe/mythomax-l2-13b": { "input": "60000000", "output": "60000000" },
+      "ibm-granite/granite-4.0-h-micro": { "input": "17000000", "output": "112000000" },
+      "ibm-granite/granite-4.1-8b": {
+        "input": "50000000",
+        "output": "100000000",
+        "cacheRead": "50000000"
+      },
+      "inception/mercury-2": {
+        "input": "250000000",
+        "output": "750000000",
+        "cacheRead": "25000000"
+      },
+      "inclusionai/ling-3.0-flash": {
+        "input": "21000000",
+        "output": "63000000",
+        "cacheRead": "4200000"
+      },
+      "kwaipilot/kat-coder-air-v2.5": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "30000000"
+      },
+      "kwaipilot/kat-coder-pro-v2": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "kwaipilot/kat-coder-pro-v2.5": {
+        "input": "740000000",
+        "output": "2960000000",
+        "cacheRead": "150000000"
+      },
+      "liquid/lfm-2.5-2.6b:free": { "input": "0", "output": "0" },
+      "mancer/weaver": { "input": "500000000", "output": "750000000" },
+      "meituan/longcat-2.0": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "6000000"
+      },
+      "meta-llama/llama-3.1-70b-instruct": { "input": "400000000", "output": "400000000" },
+      "meta-llama/llama-3.1-8b-instruct": {
+        "input": "50000000",
+        "output": "80000000",
+        "cacheRead": "25000000"
+      },
+      "meta-llama/llama-3.2-1b-instruct": { "input": "27000000", "output": "201000000" },
+      "meta-llama/llama-3.2-3b-instruct": { "input": "50000000", "output": "330000000" },
+      "meta-llama/llama-3.3-70b-instruct": { "input": "100000000", "output": "320000000" },
+      "meta-llama/llama-4-maverick": { "input": "200000000", "output": "800000000" },
+      "meta-llama/llama-4-scout": { "input": "100000000", "output": "300000000" },
+      "meta-llama/llama-guard-4-12b": { "input": "180000000", "output": "180000000" },
+      "meta/muse-glimmer-30b": {
+        "input": "350000000",
+        "output": "1500000000",
+        "cacheRead": "40000000"
+      },
+      "meta/muse-spark-1.1": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "150000000"
+      },
+      "meta/muse-spark-1.2": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "150000000"
+      },
+      "meta/muse-spark-1.2-contributor": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "2000000"
+      },
+      "microsoft/phi-4": { "input": "70000000", "output": "140000000" },
+      "microsoft/wizardlm-2-8x22b": { "input": "620000000", "output": "620000000" },
+      "minimax/minimax-01": { "input": "200000000", "output": "1100000000" },
+      "minimax/minimax-m1": { "input": "550000000", "output": "2200000000" },
+      "minimax/minimax-m2": { "input": "255000000", "output": "1020000000" },
+      "minimax/minimax-m2-her": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "minimax/minimax-m2.1": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "minimax/minimax-m2.5": {
+        "input": "270000000",
+        "output": "1080000000",
+        "cacheRead": "27000000"
+      },
+      "minimax/minimax-m2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "minimax/minimax-m2.7:free": { "input": "0", "output": "0" },
+      "minimax/minimax-m3": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "minimax/minimax-m3:free": { "input": "0", "output": "0" },
+      "mistralai/codestral-2508": {
+        "input": "300000000",
+        "output": "900000000",
+        "cacheRead": "30000000"
+      },
+      "mistralai/devstral-2512": {
+        "input": "440000000",
+        "output": "2200000000",
+        "cacheRead": "44000000"
+      },
+      "mistralai/ministral-14b-2512": {
+        "input": "200000000",
+        "output": "200000000",
+        "cacheRead": "20000000"
+      },
+      "mistralai/ministral-3b-2512": {
+        "input": "100000000",
+        "output": "100000000",
+        "cacheRead": "10000000"
+      },
+      "mistralai/ministral-8b": { "input": "110000000", "output": "110000000" },
+      "mistralai/ministral-8b-2512": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "15000000"
+      },
+      "mistralai/mistral-large": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000"
+      },
+      "mistralai/mistral-large-2407": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000"
+      },
+      "mistralai/mistral-large-2512": {
+        "input": "500000000",
+        "output": "1500000000",
+        "cacheRead": "50000000"
+      },
+      "mistralai/mistral-medium-3": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "40000000"
+      },
+      "mistralai/mistral-medium-3-5": { "input": "1500000000", "output": "7500000000" },
+      "mistralai/mistral-medium-3.1": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "40000000"
+      },
+      "mistralai/mistral-nemo": { "input": "19000000", "output": "30000000" },
+      "mistralai/mistral-saba": {
+        "input": "200000000",
+        "output": "600000000",
+        "cacheRead": "20000000"
+      },
+      "mistralai/mistral-small-24b-instruct-2501": { "input": "50000000", "output": "80000000" },
+      "mistralai/mistral-small-2603": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000"
+      },
+      "mistralai/mistral-small-3.1-24b-instruct": { "input": "351000000", "output": "555000000" },
+      "mistralai/mistral-small-3.2-24b-instruct": { "input": "75000000", "output": "200000000" },
+      "mistralai/mixtral-8x22b-instruct": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000"
+      },
+      "mistralai/voxtral-small-24b-2507": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "10000000"
+      },
+      "moonshotai/kimi-k2": { "input": "570000000", "output": "2300000000" },
+      "moonshotai/kimi-k2-0905": { "input": "600000000", "output": "2500000000" },
+      "moonshotai/kimi-k2-thinking": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "150000000"
+      },
+      "moonshotai/kimi-k2.5": {
+        "input": "600000000",
+        "output": "3000000000",
+        "cacheRead": "100000000"
+      },
+      "moonshotai/kimi-k2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "moonshotai/kimi-k2.7-code": {
+        "input": "670000000",
+        "output": "3400000000",
+        "cacheRead": "190000000"
+      },
+      "moonshotai/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "morph/morph-v3-fast": { "input": "800000000", "output": "1200000000" },
+      "morph/morph-v3-large": { "input": "900000000", "output": "1900000000" },
+      "nex-agi/nex-n2-mini": { "input": "25000000", "output": "100000000", "cacheRead": "2500000" },
+      "nex-agi/nex-n2-pro": {
+        "input": "250000000",
+        "output": "1000000000",
+        "cacheRead": "25000000"
+      },
+      "nousresearch/hermes-3-llama-3.1-405b": { "input": "1000000000", "output": "1000000000" },
+      "nousresearch/hermes-3-llama-3.1-70b": { "input": "700000000", "output": "700000000" },
+      "nousresearch/hermes-4-405b": { "input": "1000000000", "output": "3000000000" },
+      "nousresearch/hermes-4-70b": { "input": "130000000", "output": "400000000" },
+      "nvidia/nemotron-3-nano-30b-a3b": {
+        "input": "50000000",
+        "output": "200000000",
+        "cacheRead": "30000000"
+      },
+      "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": { "input": "0", "output": "0" },
+      "nvidia/nemotron-3-super-120b-a12b": { "input": "85000000", "output": "400000000" },
+      "nvidia/nemotron-3-super-120b-a12b:free": { "input": "0", "output": "0" },
+      "nvidia/nemotron-3-ultra-550b-a55b": {
+        "input": "600000000",
+        "output": "3600000000",
+        "cacheRead": "200000000"
+      },
+      "nvidia/nemotron-3-ultra-550b-a55b:free": { "input": "0", "output": "0" },
+      "nvidia/nemotron-3.5-content-safety:free": { "input": "0", "output": "0" },
+      "nvidia/nemotron-3.5-lightning": {
+        "input": "80000000",
+        "output": "200000000",
+        "cacheRead": "40000000"
+      },
+      "nvidia/nemotron-3.5-lightning:free": { "input": "0", "output": "0" },
+      "openai/gpt-3.5-turbo": { "input": "500000000", "output": "1500000000" },
+      "openai/gpt-3.5-turbo-0613": { "input": "1000000000", "output": "2000000000" },
+      "openai/gpt-3.5-turbo-16k": { "input": "3000000000", "output": "4000000000" },
+      "openai/gpt-3.5-turbo-instruct": { "input": "1500000000", "output": "2000000000" },
+      "openai/gpt-4": { "input": "30000000000", "output": "60000000000" },
+      "openai/gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "openai/gpt-4-turbo-preview": { "input": "10000000000", "output": "30000000000" },
+      "openai/gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/gpt-4.1-mini": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "100000000"
+      },
+      "openai/gpt-4.1-nano": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-4o": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-2024-05-13": { "input": "5000000000", "output": "15000000000" },
+      "openai/gpt-4o-2024-08-06": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-2024-11-20": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-mini": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-4o-mini-2024-07-18": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "openai/gpt-5-image": {
+        "input": "10000000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-5-image-mini": {
+        "input": "2500000000",
+        "output": "2000000000",
+        "cacheRead": "250000000"
+      },
+      "openai/gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "openai/gpt-5-pro": { "input": "15000000000", "output": "120000000000" },
+      "openai/gpt-5.1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-codex": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "130000000"
+      },
+      "openai/gpt-5.1-codex-max": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "30000000"
+      },
+      "openai/gpt-5.2": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-chat": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-pro": { "input": "21000000000", "output": "168000000000" },
+      "openai/gpt-5.3-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.4-image-2": {
+        "input": "8000000000",
+        "output": "15000000000",
+        "cacheRead": "2000000000"
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "openai/gpt-5.4-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.5-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "openai/gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000",
+        "tiers": [
+          {
+            "input": "400000000",
+            "output": "1800000000",
+            "cacheRead": "40000000",
+            "cacheWrite": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-luna-pro": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000",
+        "tiers": [
+          {
+            "input": "400000000",
+            "output": "1800000000",
+            "cacheRead": "40000000",
+            "cacheWrite": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-sol": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "15000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "5000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-sol-pro": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "15000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "5000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "5000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-terra-pro": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "5000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-audio": { "input": "2500000000", "output": "10000000000" },
+      "openai/gpt-audio-mini": { "input": "600000000", "output": "2400000000" },
+      "openai/gpt-chat-latest": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "openai/gpt-oss-120b": { "input": "37000000", "output": "170000000" },
+      "openai/gpt-oss-20b": { "input": "30000000", "output": "130000000", "cacheRead": "30000000" },
+      "openai/gpt-oss-safeguard-20b": {
+        "input": "75000000",
+        "output": "300000000",
+        "cacheRead": "37500000"
+      },
+      "openai/o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "openai/o1-pro": { "input": "150000000000", "output": "600000000000" },
+      "openai/o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "openai/o3-mini-high": {
+        "input": "1100000000",
+        "output": "4400000000",
+        "cacheRead": "550000000"
+      },
+      "openai/o3-pro": { "input": "20000000000", "output": "80000000000" },
+      "openai/o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "openai/o4-mini-high": {
+        "input": "1100000000",
+        "output": "4400000000",
+        "cacheRead": "275000000"
+      },
+      "openrouter/free": { "input": "0", "output": "0" },
+      "perceptron/perceptron-mk1": { "input": "150000000", "output": "1500000000" },
+      "perplexity/sonar": { "input": "1000000000", "output": "1000000000" },
+      "perplexity/sonar-deep-research": {
+        "input": "2000000000",
+        "output": "8000000000",
+        "reasoning": "3000000000"
+      },
+      "perplexity/sonar-pro": { "input": "3000000000", "output": "15000000000" },
+      "perplexity/sonar-pro-search": { "input": "3000000000", "output": "15000000000" },
+      "perplexity/sonar-reasoning-pro": { "input": "2000000000", "output": "8000000000" },
+      "poolside/laguna-s-2.1": {
+        "input": "90000000",
+        "output": "180000000",
+        "cacheRead": "9000000"
+      },
+      "poolside/laguna-s-2.1:free": { "input": "0", "output": "0" },
+      "poolside/laguna-xs-2.1": {
+        "input": "60000000",
+        "output": "120000000",
+        "cacheRead": "30000000"
+      },
+      "poolside/laguna-xs-2.1:free": { "input": "0", "output": "0" },
+      "qwen/qwen-2.5-72b-instruct": { "input": "360000000", "output": "400000000" },
+      "qwen/qwen-2.5-7b-instruct": { "input": "100000000", "output": "200000000" },
+      "qwen/qwen-2.5-coder-32b-instruct": { "input": "660000000", "output": "1000000000" },
+      "qwen/qwen-plus": {
+        "input": "260000000",
+        "output": "780000000",
+        "cacheRead": "52000000",
+        "cacheWrite": "325000000",
+        "tiers": [
+          {
+            "input": "780000000",
+            "output": "2340000000",
+            "cacheRead": "156000000",
+            "cacheWrite": "975000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen/qwen-plus-2025-07-28": {
+        "input": "260000000",
+        "output": "780000000",
+        "tiers": [{ "input": "780000000", "output": "2340000000", "aboveInputTokens": "256000" }]
+      },
+      "qwen/qwen2.5-vl-72b-instruct": {
+        "input": "800000000",
+        "output": "1000000000",
+        "cacheRead": "400000000"
+      },
+      "qwen/qwen3-14b": { "input": "120000000", "output": "240000000" },
+      "qwen/qwen3-235b-a22b": { "input": "455000000", "output": "1820000000" },
+      "qwen/qwen3-235b-a22b-2507": { "input": "90000000", "output": "550000000" },
+      "qwen/qwen3-235b-a22b-thinking-2507": { "input": "230000000", "output": "2300000000" },
+      "qwen/qwen3-30b-a3b": { "input": "120000000", "output": "500000000" },
+      "qwen/qwen3-30b-a3b-instruct-2507": { "input": "48150000", "output": "193050000" },
+      "qwen/qwen3-30b-a3b-thinking-2507": { "input": "200000000", "output": "2400000000" },
+      "qwen/qwen3-32b": { "input": "80000000", "output": "280000000" },
+      "qwen/qwen3-8b": { "input": "117000000", "output": "455000000" },
+      "qwen/qwen3-coder": {
+        "input": "300000000",
+        "output": "1000000000",
+        "cacheRead": "100000000"
+      },
+      "qwen/qwen3-coder-30b-a3b-instruct": { "input": "70000000", "output": "280000000" },
+      "qwen/qwen3-coder-flash": {
+        "input": "195000000",
+        "output": "975000000",
+        "cacheRead": "39000000",
+        "cacheWrite": "243750000",
+        "tiers": [
+          {
+            "input": "325000000",
+            "output": "1625000000",
+            "cacheRead": "65000000",
+            "cacheWrite": "406250000",
+            "aboveInputTokens": "32000"
+          },
+          {
+            "input": "520000000",
+            "output": "2600000000",
+            "cacheRead": "104000000",
+            "cacheWrite": "650000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "qwen/qwen3-coder-next": {
+        "input": "120000000",
+        "output": "800000000",
+        "cacheRead": "70000000"
+      },
+      "qwen/qwen3-coder-plus": {
+        "input": "650000000",
+        "output": "3250000000",
+        "cacheRead": "130000000",
+        "cacheWrite": "812500000",
+        "tiers": [
+          {
+            "input": "1170000000",
+            "output": "5850000000",
+            "cacheRead": "234000000",
+            "cacheWrite": "1462500000",
+            "aboveInputTokens": "32000"
+          },
+          {
+            "input": "1950000000",
+            "output": "9750000000",
+            "cacheRead": "390000000",
+            "cacheWrite": "2437500000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "qwen/qwen3-max": {
+        "input": "780000000",
+        "output": "3900000000",
+        "cacheRead": "156000000",
+        "cacheWrite": "975000000",
+        "tiers": [
+          {
+            "input": "1560000000",
+            "output": "7800000000",
+            "cacheRead": "312000000",
+            "cacheWrite": "1950000000",
+            "aboveInputTokens": "32000"
+          },
+          {
+            "input": "1950000000",
+            "output": "9750000000",
+            "cacheRead": "390000000",
+            "cacheWrite": "2437500000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "qwen/qwen3-max-thinking": {
+        "input": "780000000",
+        "output": "3900000000",
+        "tiers": [
+          { "input": "1560000000", "output": "7800000000", "aboveInputTokens": "32000" },
+          { "input": "1950000000", "output": "9750000000", "aboveInputTokens": "128000" }
+        ]
+      },
+      "qwen/qwen3-next-80b-a3b-instruct": {
+        "input": "100000000",
+        "output": "1100000000",
+        "cacheRead": "70000000"
+      },
+      "qwen/qwen3-next-80b-a3b-thinking": { "input": "150000000", "output": "1200000000" },
+      "qwen/qwen3-vl-235b-a22b-instruct": {
+        "input": "210000000",
+        "output": "1900000000",
+        "cacheRead": "100000000"
+      },
+      "qwen/qwen3-vl-235b-a22b-thinking": { "input": "400000000", "output": "4000000000" },
+      "qwen/qwen3-vl-30b-a3b-instruct": { "input": "130000000", "output": "520000000" },
+      "qwen/qwen3-vl-30b-a3b-thinking": { "input": "200000000", "output": "2400000000" },
+      "qwen/qwen3-vl-32b-instruct": { "input": "104000000", "output": "416000000" },
+      "qwen/qwen3-vl-8b-instruct": { "input": "117000000", "output": "455000000" },
+      "qwen/qwen3-vl-8b-thinking": { "input": "180000000", "output": "2100000000" },
+      "qwen/qwen3.5-122b-a10b": { "input": "260000000", "output": "2080000000" },
+      "qwen/qwen3.5-27b": { "input": "195000000", "output": "1560000000" },
+      "qwen/qwen3.5-35b-a3b": {
+        "input": "250000000",
+        "output": "1250000000",
+        "cacheRead": "250000000"
+      },
+      "qwen/qwen3.5-397b-a17b": {
+        "input": "500000000",
+        "output": "3600000000",
+        "cacheRead": "300000000"
+      },
+      "qwen/qwen3.5-9b": { "input": "100000000", "output": "150000000" },
+      "qwen/qwen3.5-flash-02-23": { "input": "65000000", "output": "260000000" },
+      "qwen/qwen3.5-plus-02-15": {
+        "input": "260000000",
+        "output": "1560000000",
+        "tiers": [{ "input": "325000000", "output": "1950000000", "aboveInputTokens": "256000" }]
+      },
+      "qwen/qwen3.5-plus-20260420": {
+        "input": "300000000",
+        "output": "1800000000",
+        "cacheWrite": "375000000",
+        "tiers": [
+          {
+            "input": "375000000",
+            "output": "2250000000",
+            "cacheWrite": "468750000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen/qwen3.6-27b": { "input": "320000000", "output": "3200000000" },
+      "qwen/qwen3.6-35b-a3b": {
+        "input": "140000000",
+        "output": "1000000000",
+        "cacheRead": "50000000"
+      },
+      "qwen/qwen3.6-flash": {
+        "input": "187500000",
+        "output": "1125000000",
+        "cacheWrite": "234375000",
+        "tiers": [
+          {
+            "input": "750000000",
+            "output": "3000000000",
+            "cacheWrite": "937500000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen/qwen3.6-max-preview": {
+        "input": "1027000000",
+        "output": "6162000000",
+        "cacheWrite": "1283750000",
+        "tiers": [
+          {
+            "input": "1580000000",
+            "output": "9480000000",
+            "cacheWrite": "1975000000",
+            "aboveInputTokens": "128000"
+          }
+        ]
+      },
+      "qwen/qwen3.6-plus": {
+        "input": "325000000",
+        "output": "1950000000",
+        "cacheWrite": "406250000",
+        "tiers": [
+          {
+            "input": "1300000000",
+            "output": "3900000000",
+            "cacheWrite": "1625000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen/qwen3.7-flash": {
+        "input": "30000000",
+        "output": "130000000",
+        "cacheRead": "6000000",
+        "cacheWrite": "38000000",
+        "tiers": [
+          {
+            "input": "100000000",
+            "output": "400000000",
+            "cacheRead": "20000000",
+            "cacheWrite": "125000000",
+            "aboveInputTokens": "32000"
+          },
+          {
+            "input": "200000000",
+            "output": "800000000",
+            "cacheRead": "40000000",
+            "cacheWrite": "250000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen/qwen3.7-max": {
+        "input": "1475000000",
+        "output": "4425000000",
+        "cacheRead": "295000000",
+        "cacheWrite": "1843750000"
+      },
+      "qwen/qwen3.7-plus": {
+        "input": "320000000",
+        "output": "1280000000",
+        "cacheRead": "64000000",
+        "cacheWrite": "400000000",
+        "tiers": [
+          {
+            "input": "960000000",
+            "output": "3840000000",
+            "cacheRead": "192000000",
+            "cacheWrite": "1200000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen/qwen3.8-2.4t-a95b": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000"
+      },
+      "qwen/qwen3.8-27b": {
+        "input": "425000000",
+        "output": "2550000000",
+        "cacheRead": "85000000",
+        "cacheWrite": "531250000"
+      },
+      "qwen/qwen3.8-max": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      },
+      "rekaai/reka-edge": { "input": "100000000", "output": "100000000" },
+      "rekaai/reka-flash-3": { "input": "100000000", "output": "200000000" },
+      "relace/relace-apply-3": { "input": "850000000", "output": "1250000000" },
+      "relace/relace-search": { "input": "1000000000", "output": "3000000000" },
+      "sakana/fugu-ultra": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "sakana/sakana-namazu": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "150000000"
+      },
+      "sao10k/l3-lunaris-8b": { "input": "40000000", "output": "50000000" },
+      "sao10k/l3.1-euryale-70b": { "input": "850000000", "output": "850000000" },
+      "sao10k/l3.3-euryale-70b": { "input": "650000000", "output": "750000000" },
+      "stealth/ox-alpha": { "input": "0", "output": "0" },
+      "stepfun/step-3.5-flash": { "input": "100000000", "output": "300000000" },
+      "stepfun/step-3.7-flash": {
+        "input": "200000000",
+        "output": "1150000000",
+        "cacheRead": "40000000"
+      },
+      "tencent/hunyuan-a13b-instruct": { "input": "140000000", "output": "570000000" },
+      "tencent/hy-mt2-1.8b": { "input": "44000000", "output": "177000000" },
+      "tencent/hy-mt2-30b-a3b": { "input": "74000000", "output": "295000000" },
+      "tencent/hy-mt2-7b": { "input": "74000000", "output": "295000000" },
+      "tencent/hy3": { "input": "132000000", "output": "528000000", "cacheRead": "33000000" },
+      "tencent/hy3-preview": {
+        "input": "180000000",
+        "output": "600000000",
+        "cacheRead": "60000000"
+      },
+      "thedrummer/cydonia-24b-v4.1": {
+        "input": "300000000",
+        "output": "500000000",
+        "cacheRead": "150000000"
+      },
+      "thedrummer/rocinante-12b": { "input": "250000000", "output": "500000000" },
+      "thedrummer/skyfall-36b-v2": {
+        "input": "550000000",
+        "output": "800000000",
+        "cacheRead": "250000000"
+      },
+      "thedrummer/unslopnemo-12b": { "input": "400000000", "output": "400000000" },
+      "thinkingmachines/inkling": {
+        "input": "950000000",
+        "output": "4050000000",
+        "cacheRead": "160000000"
+      },
+      "thinkingmachines/inkling-small": {
+        "input": "450000000",
+        "output": "1200000000",
+        "cacheRead": "100000000"
+      },
+      "thinkingmachines/inkling-small:free": { "input": "0", "output": "0" },
+      "thinkingmachines/inkling:free": { "input": "0", "output": "0" },
+      "undi95/remm-slerp-l2-13b": { "input": "450000000", "output": "650000000" },
+      "upstage/solar-pro-3": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000"
+      },
+      "upstage/solar-pro4": { "input": "30000000", "output": "120000000", "cacheRead": "6000000" },
+      "writer/palmyra-x5": { "input": "600000000", "output": "6000000000" },
+      "x-ai/grok-4.20": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "x-ai/grok-4.20-multi-agent": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "x-ai/grok-4.3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "x-ai/grok-4.5": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "300000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "600000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "x-ai/grok-4.6": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "x-ai/grok-build-0.1": {
+        "input": "1000000000",
+        "output": "2000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "4000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xiaomi/mimo-v2.5": { "input": "140000000", "output": "280000000", "cacheRead": "2800000" },
+      "xiaomi/mimo-v2.5-pro": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "3600000"
+      },
+      "z-ai/glm-4.5": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "z-ai/glm-4.5-air": { "input": "130000000", "output": "850000000", "cacheRead": "25000000" },
+      "z-ai/glm-4.5v": { "input": "600000000", "output": "1800000000", "cacheRead": "110000000" },
+      "z-ai/glm-4.6": { "input": "500000000", "output": "2000000000", "cacheRead": "100000000" },
+      "z-ai/glm-4.6v": { "input": "300000000", "output": "900000000", "cacheRead": "55000000" },
+      "z-ai/glm-4.7": { "input": "400000000", "output": "1750000000", "cacheRead": "80000000" },
+      "z-ai/glm-4.7-flash": { "input": "60000000", "output": "400000000", "cacheRead": "10000000" },
+      "z-ai/glm-5": { "input": "600000000", "output": "1920000000", "cacheRead": "120000000" },
+      "z-ai/glm-5-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      },
+      "z-ai/glm-5.1": { "input": "1260000000", "output": "3960000000", "cacheRead": "234000000" },
+      "z-ai/glm-5.2": { "input": "1190000000", "output": "3740000000", "cacheRead": "221000000" },
+      "z-ai/glm-5.2:free": { "input": "0", "output": "0" },
+      "z-ai/glm-5.3": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "z-ai/glm-5v-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      }
+    },
+    "opper": {
+      "anthropic/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic/claude-opus-4-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "gemini/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000"
+      },
+      "gemini/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000"
+      },
+      "gemini/gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "meta/muse-spark-1.2": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "150000000"
+      },
+      "minimax/m3": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "120000000",
+        "tiers": [
+          {
+            "input": "1200000000",
+            "output": "4800000000",
+            "cacheRead": "240000000",
+            "aboveInputTokens": "524288"
+          }
+        ]
+      },
+      "mistral/devstral-2512": { "input": "400000000", "output": "2000000000" },
+      "mistral/mistral-large-2512": { "input": "500000000", "output": "1500000000" },
+      "mistral/mistral-small-2603": { "input": "150000000", "output": "600000000" },
+      "moonshot/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "openai/gpt-5.3-chat-latest": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.3-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "openai/gpt-5.4-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.5-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "openai/gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000",
+        "tiers": [
+          {
+            "input": "400000000",
+            "output": "1800000000",
+            "cacheRead": "40000000",
+            "cacheWrite": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "5000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "perplexity/sonar": { "input": "1000000000", "output": "1000000000" },
+      "perplexity/sonar-pro": { "input": "3000000000", "output": "15000000000" },
+      "perplexity/sonar-reasoning-pro": { "input": "2000000000", "output": "8000000000" },
+      "vertexai/gemini-3.7-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000"
+      },
+      "vertexai/gemini-3.7-flash-eu": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000"
+      },
+      "xai/grok-4.3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-4.5": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "300000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "600000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-4.6": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "xai/grok-build-0.1": {
+        "input": "1000000000",
+        "output": "2000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "4000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      }
+    },
+    "orcarouter": {
+      "anthropic/claude-haiku-4.5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic/claude-opus-4": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic/claude-opus-4.1": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic/claude-opus-4.5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "modes": {
+          "fast": {
+            "input": "30000000000",
+            "output": "150000000000",
+            "cacheRead": "3000000000",
+            "cacheWrite": "37500000000"
+          }
+        }
+      },
+      "anthropic/claude-opus-4.7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "modes": {
+          "fast": {
+            "input": "30000000000",
+            "output": "150000000000",
+            "cacheRead": "3000000000",
+            "cacheWrite": "37500000000"
+          }
+        }
+      },
+      "anthropic/claude-sonnet-4": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4.5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4.6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "deepseek/deepseek-chat": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "deepseek/deepseek-reasoner": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "28000000"
+      },
+      "deepseek/deepseek-v4-flash": {
+        "input": "190000000",
+        "output": "370000000",
+        "cacheRead": "2800000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "560000000",
+        "output": "1120000000",
+        "cacheRead": "3625000"
+      },
+      "google/gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "inputAudio": "1000000000"
+      },
+      "google/gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "inputAudio": "300000000"
+      },
+      "google/gemini-2.5-pro": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "125000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "inputAudio": "1000000000"
+      },
+      "google/gemini-3-pro-preview": {
+        "input": "4000000000",
+        "output": "18000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3.1-flash-lite-preview": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "inputAudio": "500000000"
+      },
+      "google/gemini-3.1-pro-preview": {
+        "input": "4000000000",
+        "output": "18000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3.1-pro-preview-customtools": {
+        "input": "4000000000",
+        "output": "18000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-flash-latest": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "inputAudio": "1500000000"
+      },
+      "google/gemini-flash-lite-latest": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "inputAudio": "500000000"
+      },
+      "google/gemma-4-26b-a4b-it": { "input": "60000000", "output": "330000000" },
+      "google/gemma-4-31b-it": { "input": "130000000", "output": "380000000" },
+      "grok/grok-4.3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "kimi/kimi-k2.5": { "input": "600000000", "output": "3000000000", "cacheRead": "100000000" },
+      "kimi/kimi-k2.6": { "input": "950000000", "output": "4000000000", "cacheRead": "160000000" },
+      "minimax/minimax-m2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.5-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.7-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "openai/gpt-3.5-turbo": { "input": "500000000", "output": "1500000000", "cacheRead": "0" },
+      "openai/gpt-4": { "input": "30000000000", "output": "60000000000" },
+      "openai/gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "openai/gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/gpt-4.1-mini": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "100000000"
+      },
+      "openai/gpt-4.1-nano": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-4o": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-2024-05-13": { "input": "5000000000", "output": "15000000000" },
+      "openai/gpt-4o-2024-08-06": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-2024-11-20": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-mini": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "openai/gpt-5-chat-latest": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5-codex": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "openai/gpt-5-pro": { "input": "15000000000", "output": "120000000000" },
+      "openai/gpt-5.1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-chat-latest": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-codex": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-codex-max": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5.2": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-chat-latest": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-pro": { "input": "21000000000", "output": "168000000000" },
+      "openai/gpt-5.3-chat-latest": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.3-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "5000000000",
+        "output": "22500000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": { "input": "5000000000", "output": "30000000000", "cacheRead": "500000000" }
+        }
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000",
+        "modes": {
+          "fast": { "input": "1500000000", "output": "9000000000", "cacheRead": "150000000" }
+        }
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "openai/gpt-5.4-pro": {
+        "input": "60000000000",
+        "output": "270000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": { "input": "12500000000", "output": "75000000000", "cacheRead": "1250000000" }
+        }
+      },
+      "openai/gpt-5.5-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "orcarouter/auto": { "input": "0", "output": "0" },
+      "qwen/qwen3-max": { "input": "359000000", "output": "1434000000" },
+      "qwen/qwen3.5-122b-a10b": { "input": "115000000", "output": "917000000" },
+      "qwen/qwen3.5-27b": { "input": "86000000", "output": "688000000" },
+      "qwen/qwen3.5-35b-a3b": { "input": "57000000", "output": "459000000" },
+      "qwen/qwen3.5-397b-a17b": { "input": "172000000", "output": "1032000000" },
+      "qwen/qwen3.5-plus": {
+        "input": "115000000",
+        "output": "688000000",
+        "reasoning": "2400000000"
+      },
+      "qwen/qwen3.6-35b-a3b": { "input": "248000000", "output": "1485000000" },
+      "qwen/qwen3.6-plus": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "200000000",
+            "cacheWrite": "2500000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "z-ai/glm-4.5": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "z-ai/glm-4.5-air": {
+        "input": "200000000",
+        "output": "1100000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "0"
+      },
+      "z-ai/glm-4.6": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "z-ai/glm-4.7": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "z-ai/glm-5": {
+        "input": "1000000000",
+        "output": "3200000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "0"
+      },
+      "z-ai/glm-5.1": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "0"
+      }
+    },
+    "ovhcloud": {
+      "gpt-oss-120b": { "input": "90000000", "output": "470000000" },
+      "gpt-oss-20b": { "input": "50000000", "output": "180000000" },
+      "meta-llama-3_3-70b-instruct": { "input": "740000000", "output": "740000000" },
+      "mistral-7b-instruct-v0.3": { "input": "110000000", "output": "110000000" },
+      "mistral-nemo-instruct-2407": { "input": "140000000", "output": "140000000" },
+      "mistral-small-3.2-24b-instruct-2506": { "input": "100000000", "output": "310000000" },
+      "qwen2.5-vl-72b-instruct": { "input": "1010000000", "output": "1010000000" },
+      "qwen3-32b": { "input": "90000000", "output": "250000000" },
+      "qwen3-coder-30b-a3b-instruct": { "input": "70000000", "output": "260000000" },
+      "qwen3.5-397b-a17b": { "input": "710000000", "output": "4250000000" },
+      "qwen3.5-9b": { "input": "120000000", "output": "180000000" },
+      "qwen3.6-27b": { "input": "470000000", "output": "3190000000" }
+    },
+    "pendra": {
+      "deepseek-v4-flash": { "input": "0", "output": "0" },
+      "glm-4.7-flash": { "input": "0", "output": "0" },
+      "gpt-oss:120b": { "input": "0", "output": "0" },
+      "llama3.3:70b": { "input": "0", "output": "0" },
+      "qwen3-coder:30b": { "input": "0", "output": "0" },
+      "qwen3.6:27b": { "input": "0", "output": "0" }
+    },
+    "perplexity": {
+      "sonar": { "input": "1000000000", "output": "1000000000" },
+      "sonar-deep-research": {
+        "input": "2000000000",
+        "output": "8000000000",
+        "reasoning": "3000000000"
+      },
+      "sonar-pro": { "input": "3000000000", "output": "15000000000" },
+      "sonar-reasoning-pro": { "input": "2000000000", "output": "8000000000" }
+    },
+    "perplexity-agent": {
+      "anthropic/claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000"
+      },
+      "anthropic/claude-opus-4-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "anthropic/claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "anthropic/claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000"
+      },
+      "anthropic/claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "anthropic/claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "deepseek/deepseek-v4-flash-0731": {
+        "input": "130000000",
+        "output": "260000000",
+        "cacheRead": "28000000"
+      },
+      "google/gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "google/gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "tiers": [
+          {
+            "input": "500000000",
+            "output": "3000000000",
+            "cacheRead": "50000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "moonshot-ai/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "moonshot-ai/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "nvidia/nemotron-3-super-120b-a12b": { "input": "250000000", "output": "2500000000" },
+      "openai/gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5.1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.2": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000"
+      },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "perplexity/sonar": { "input": "250000000", "output": "2500000000", "cacheRead": "62500000" },
+      "xai/grok-4-1-fast-non-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "xai/grok-4.6": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      }
+    },
+    "pioneer": {
+      "claude-3-7-sonnet-latest": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-fable-5": {
+        "input": "11000000000",
+        "output": "55000000000",
+        "cacheRead": "1100000000",
+        "cacheWrite": "13750000000"
+      },
+      "claude-haiku-4-5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "claude-opus-4-1": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "claude-opus-4-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-4-8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "claude-sonnet-4-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-4-6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "deepseek-ai/DeepSeek-V3": {
+        "input": "270000000",
+        "output": "1120000000",
+        "cacheRead": "135000000",
+        "cacheWrite": "270000000"
+      },
+      "deepseek-ai/DeepSeek-V3.1": {
+        "input": "560000000",
+        "output": "1680000000",
+        "cacheRead": "560000000",
+        "cacheWrite": "560000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Flash": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "19700000",
+        "cacheWrite": "100000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "3625000",
+        "cacheWrite": "435000000"
+      },
+      "devstral-2": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "400000000",
+        "cacheWrite": "400000000"
+      },
+      "fastino/gliguard-LLMGuardrails-300M": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "150000000"
+      },
+      "fastino/gliner2-base-v1": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "150000000"
+      },
+      "fastino/gliner2-large-v1": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "150000000"
+      },
+      "fastino/gliner2-multi-large-v1": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "150000000"
+      },
+      "fastino/gliner2-multi-v1": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "150000000"
+      },
+      "fastino/gliner2-privacy-filter-PII-multi": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "150000000"
+      },
+      "gemini-3-flash": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "83333000"
+      },
+      "gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "250000000"
+      },
+      "gemini-3.1-pro": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "375000000"
+      },
+      "gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "83333000"
+      },
+      "gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "300000000"
+      },
+      "gemini-3.6-flash": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "1500000000"
+      },
+      "google/diffusiongemma-26B-A4B-it": {
+        "input": "500000000",
+        "output": "500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "500000000"
+      },
+      "google/gemma-3-4b-pt": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "150000000"
+      },
+      "google/gemma-4-12B-it": {
+        "input": "250000000",
+        "output": "250000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "250000000"
+      },
+      "google/gemma-4-31B-it": {
+        "input": "500000000",
+        "output": "500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "500000000"
+      },
+      "google/gemma-4-E2B-it": {
+        "input": "100000000",
+        "output": "100000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "100000000"
+      },
+      "google/gemma-4-E4B-it": {
+        "input": "200000000",
+        "output": "200000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "200000000"
+      },
+      "gpt-4.1": {
+        "input": "2000000000",
+        "output": "8000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "2000000000"
+      },
+      "gpt-4.1-mini": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "400000000"
+      },
+      "gpt-4.1-nano": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "100000000"
+      },
+      "gpt-4o": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000",
+        "cacheWrite": "2500000000"
+      },
+      "gpt-4o-mini": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "150000000"
+      },
+      "gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "250000000"
+      },
+      "gpt-5-nano": {
+        "input": "50000000",
+        "output": "400000000",
+        "cacheRead": "5000000",
+        "cacheWrite": "50000000"
+      },
+      "gpt-5.1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "cacheWrite": "1250000000"
+      },
+      "gpt-5.3-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000",
+        "cacheWrite": "1750000000"
+      },
+      "gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      },
+      "gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "750000000"
+      },
+      "gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "200000000"
+      },
+      "gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "5000000000"
+      },
+      "gpt-5.6-luna": {
+        "input": "1000000000",
+        "output": "6000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "gpt-5.6-terra": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "3125000000"
+      },
+      "grok-4.5": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "2000000000"
+      },
+      "HuggingFaceTB/SmolLM3-3B-Base": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "150000000"
+      },
+      "LiquidAI/LFM2-24B-A2B": {
+        "input": "30000000",
+        "output": "120000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "30000000"
+      },
+      "meta-llama/Llama-3.1-8B-Instruct": {
+        "input": "200000000",
+        "output": "200000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "200000000"
+      },
+      "meta-llama/Llama-3.2-1B": {
+        "input": "100000000",
+        "output": "100000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "100000000"
+      },
+      "meta-llama/Llama-3.2-1B-Instruct": {
+        "input": "100000000",
+        "output": "201000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "100000000"
+      },
+      "meta-llama/Llama-3.2-3B": {
+        "input": "100000000",
+        "output": "100000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "100000000"
+      },
+      "meta-llama/Llama-3.2-3B-Instruct": {
+        "input": "100000000",
+        "output": "335000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "100000000"
+      },
+      "meta-llama/Llama-3.3-70B-Instruct": {
+        "input": "900000000",
+        "output": "900000000",
+        "cacheRead": "900000000",
+        "cacheWrite": "900000000"
+      },
+      "meta/muse-spark-1.1": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "1250000000"
+      },
+      "MiniMaxAI/MiniMax-M2.7": {
+        "input": "279000000",
+        "output": "1200000000",
+        "cacheRead": "279000000",
+        "cacheWrite": "279000000"
+      },
+      "MiniMaxAI/MiniMax-M3": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "300000000"
+      },
+      "mistral-large-3": {
+        "input": "500000000",
+        "output": "1500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "500000000"
+      },
+      "mistral-medium-3.5": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "1500000000"
+      },
+      "mistralai/Codestral-22B-v0.1": {
+        "input": "300000000",
+        "output": "900000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "300000000"
+      },
+      "mistralai/Magistral-Small-2506": {
+        "input": "500000000",
+        "output": "1500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "500000000"
+      },
+      "mistralai/Ministral-8B-Instruct-2410": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "150000000"
+      },
+      "mistralai/Mistral-7B-Instruct-v0.3": {
+        "input": "200000000",
+        "output": "200000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "200000000"
+      },
+      "mistralai/Mistral-Nemo-Instruct-2407": {
+        "input": "20000000",
+        "output": "30000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "20000000"
+      },
+      "mistralai/Mistral-Small-4-119B-2603": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000",
+        "cacheWrite": "150000000"
+      },
+      "mistralai/Pixtral-12B-2409": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "150000000"
+      },
+      "moonshotai/Kimi-K2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "340000000",
+        "cacheWrite": "950000000"
+      },
+      "moonshotai/Kimi-K2.7-Code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000",
+        "cacheWrite": "950000000"
+      },
+      "moonshotai/Kimi-K3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3000000000"
+      },
+      "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": {
+        "input": "50000000",
+        "output": "200000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "50000000"
+      },
+      "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
+        "input": "90000000",
+        "output": "450000000",
+        "cacheRead": "90000000",
+        "cacheWrite": "90000000"
+      },
+      "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16": {
+        "input": "500000000",
+        "output": "2500000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "500000000"
+      },
+      "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16": {
+        "input": "500000000",
+        "output": "500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "500000000"
+      },
+      "openai/gpt-oss-120b": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000",
+        "cacheWrite": "150000000"
+      },
+      "openai/gpt-oss-20b": {
+        "input": "70000000",
+        "output": "300000000",
+        "cacheRead": "35000000",
+        "cacheWrite": "70000000"
+      },
+      "poolside/laguna-s-2.1": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "100000000"
+      },
+      "Qwen/Qwen2.5-Coder-0.5B": {
+        "input": "100000000",
+        "output": "100000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "100000000"
+      },
+      "Qwen/Qwen3-1.7B-Base": {
+        "input": "100000000",
+        "output": "100000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "100000000"
+      },
+      "Qwen/Qwen3-235B-A22B-Instruct-2507": {
+        "input": "1200000000",
+        "output": "1200000000",
+        "cacheRead": "1200000000",
+        "cacheWrite": "1200000000"
+      },
+      "Qwen/Qwen3-32B": {
+        "input": "900000000",
+        "output": "900000000",
+        "cacheRead": "900000000",
+        "cacheWrite": "900000000"
+      },
+      "Qwen/Qwen3-4B-Base": {
+        "input": "150000000",
+        "output": "150000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "150000000"
+      },
+      "Qwen/Qwen3-4B-Instruct-2507": {
+        "input": "200000000",
+        "output": "200000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "200000000"
+      },
+      "Qwen/Qwen3-8B": {
+        "input": "200000000",
+        "output": "200000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "200000000"
+      },
+      "Qwen/Qwen3.5-9B": {
+        "input": "300000000",
+        "output": "300000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "300000000"
+      },
+      "Qwen/Qwen3.6-27B": {
+        "input": "600000000",
+        "output": "600000000",
+        "cacheRead": "600000000",
+        "cacheWrite": "600000000"
+      },
+      "Qwen/Qwen3.6-35B-A3B": {
+        "input": "140000000",
+        "output": "1000000000",
+        "cacheRead": "28000000",
+        "cacheWrite": "175000000"
+      },
+      "qwen3.6-flash": {
+        "input": "187500000",
+        "output": "1125000000",
+        "cacheRead": "37500000",
+        "cacheWrite": "234375000"
+      },
+      "qwen3.6-max-preview": {
+        "input": "1040000000",
+        "output": "6240000000",
+        "cacheRead": "208000000",
+        "cacheWrite": "1300000000"
+      },
+      "qwen3.6-plus": {
+        "input": "325000000",
+        "output": "1950000000",
+        "cacheRead": "65000000",
+        "cacheWrite": "406250000"
+      },
+      "qwen3.7-max": {
+        "input": "1250000000",
+        "output": "3750000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "1562500000"
+      },
+      "qwen3.7-plus": {
+        "input": "320000000",
+        "output": "1280000000",
+        "cacheRead": "64000000",
+        "cacheWrite": "400000000"
+      },
+      "sakana/fugu-ultra": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "5000000000"
+      },
+      "XiaomiMiMo/MiMo-V2.5": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "2800000",
+        "cacheWrite": "140000000"
+      },
+      "XiaomiMiMo/MiMo-V2.5-Pro": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "3600000",
+        "cacheWrite": "435000000"
+      },
+      "zai-org/GLM-5.1": {
+        "input": "980000000",
+        "output": "3080000000",
+        "cacheRead": "182000000",
+        "cacheWrite": "980000000"
+      },
+      "zai-org/GLM-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "1400000000"
+      }
+    },
+    "poe": {
+      "anthropic/claude-haiku-3": {
+        "input": "210000000",
+        "output": "1100000000",
+        "cacheRead": "21000000",
+        "cacheWrite": "260000000"
+      },
+      "anthropic/claude-haiku-3.5": {
+        "input": "680000000",
+        "output": "3400000000",
+        "cacheRead": "68000000",
+        "cacheWrite": "850000000"
+      },
+      "anthropic/claude-haiku-4.5": {
+        "input": "850000000",
+        "output": "4300000000",
+        "cacheRead": "85000000",
+        "cacheWrite": "1100000000"
+      },
+      "anthropic/claude-opus-4": {
+        "input": "13000000000",
+        "output": "64000000000",
+        "cacheRead": "1300000000",
+        "cacheWrite": "16000000000"
+      },
+      "anthropic/claude-opus-4.1": {
+        "input": "13000000000",
+        "output": "64000000000",
+        "cacheRead": "1300000000",
+        "cacheWrite": "16000000000"
+      },
+      "anthropic/claude-opus-4.5": {
+        "input": "4300000000",
+        "output": "21000000000",
+        "cacheRead": "430000000",
+        "cacheWrite": "5300000000"
+      },
+      "anthropic/claude-opus-4.6": {
+        "input": "4300000000",
+        "output": "21000000000",
+        "cacheRead": "430000000",
+        "cacheWrite": "5300000000"
+      },
+      "anthropic/claude-opus-4.7": {
+        "input": "4300000000",
+        "output": "21000000000",
+        "cacheRead": "430000000",
+        "cacheWrite": "5400000000"
+      },
+      "anthropic/claude-opus-4.8": { "input": "4292900000", "output": "21464600000" },
+      "anthropic/claude-sonnet-3.5": {
+        "input": "2600000000",
+        "output": "13000000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "3200000000"
+      },
+      "anthropic/claude-sonnet-3.5-june": {
+        "input": "2600000000",
+        "output": "13000000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "3200000000"
+      },
+      "anthropic/claude-sonnet-3.7": {
+        "input": "2600000000",
+        "output": "13000000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "3200000000"
+      },
+      "anthropic/claude-sonnet-4": {
+        "input": "2600000000",
+        "output": "13000000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "3200000000"
+      },
+      "anthropic/claude-sonnet-4.5": {
+        "input": "2600000000",
+        "output": "13000000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "3200000000"
+      },
+      "anthropic/claude-sonnet-4.6": {
+        "input": "2600000000",
+        "output": "13000000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "3200000000"
+      },
+      "cerebras/gpt-oss-120b-cs": { "input": "350000000", "output": "750000000" },
+      "cerebras/llama-3.1-8b-cs": { "input": "100000000", "output": "100000000" },
+      "empiriolabs/deepseek-v4-flash-el": { "input": "140000000", "output": "280000000" },
+      "empiriolabs/deepseek-v4-pro-el": { "input": "1670000000", "output": "3330000000" },
+      "fireworks-ai/kimi-k2.5-fw": { "input": "0", "output": "0" },
+      "google/gemini-2.0-flash": { "input": "100000000", "output": "420000000" },
+      "google/gemini-2.0-flash-lite": { "input": "52000000", "output": "210000000" },
+      "google/gemini-2.5-flash": {
+        "input": "210000000",
+        "output": "1800000000",
+        "cacheRead": "21000000"
+      },
+      "google/gemini-2.5-flash-lite": { "input": "70000000", "output": "280000000" },
+      "google/gemini-2.5-pro": {
+        "input": "870000000",
+        "output": "7000000000",
+        "cacheRead": "87000000"
+      },
+      "google/gemini-3-flash": {
+        "input": "400000000",
+        "output": "2400000000",
+        "cacheRead": "40000000"
+      },
+      "google/gemini-3-pro": {
+        "input": "1600000000",
+        "output": "9600000000",
+        "cacheRead": "160000000"
+      },
+      "google/gemini-3.1-flash-lite": { "input": "250000000", "output": "1500000000" },
+      "google/gemini-3.1-pro": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000"
+      },
+      "google/gemini-3.5-flash": {
+        "input": "1515200000",
+        "output": "9090900000",
+        "cacheRead": "151500000"
+      },
+      "google/gemini-deep-research": { "input": "1600000000", "output": "9600000000" },
+      "google/gemma-4-31b": { "input": "0", "output": "0" },
+      "google/nano-banana": {
+        "input": "210000000",
+        "output": "1800000000",
+        "cacheRead": "21000000"
+      },
+      "google/nano-banana-pro": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000"
+      },
+      "novita/deepseek-v3.2": {
+        "input": "270000000",
+        "output": "400000000",
+        "cacheRead": "130000000"
+      },
+      "novita/glm-5": { "input": "1000000000", "output": "3200000000", "cacheRead": "200000000" },
+      "novita/kimi-k2.5": {
+        "input": "600000000",
+        "output": "3000000000",
+        "cacheRead": "100000000"
+      },
+      "novita/kimi-k2.6": {
+        "input": "960000000",
+        "output": "4040000000",
+        "cacheRead": "160000000"
+      },
+      "openai/chatgpt-4o-latest": { "input": "4500000000", "output": "14000000000" },
+      "openai/gpt-3.5-turbo": { "input": "450000000", "output": "1400000000" },
+      "openai/gpt-3.5-turbo-instruct": { "input": "1400000000", "output": "1800000000" },
+      "openai/gpt-3.5-turbo-raw": { "input": "450000000", "output": "1400000000" },
+      "openai/gpt-4-classic": { "input": "27000000000", "output": "54000000000" },
+      "openai/gpt-4-classic-0314": { "input": "27000000000", "output": "54000000000" },
+      "openai/gpt-4-turbo": { "input": "9000000000", "output": "27000000000" },
+      "openai/gpt-4.1": { "input": "1800000000", "output": "7200000000", "cacheRead": "450000000" },
+      "openai/gpt-4.1-mini": {
+        "input": "360000000",
+        "output": "1400000000",
+        "cacheRead": "90000000"
+      },
+      "openai/gpt-4.1-nano": {
+        "input": "90000000",
+        "output": "360000000",
+        "cacheRead": "22000000"
+      },
+      "openai/gpt-4o-aug": {
+        "input": "2200000000",
+        "output": "9000000000",
+        "cacheRead": "1100000000"
+      },
+      "openai/gpt-4o-mini": {
+        "input": "140000000",
+        "output": "540000000",
+        "cacheRead": "68000000"
+      },
+      "openai/gpt-4o-mini-search": { "input": "140000000", "output": "540000000" },
+      "openai/gpt-4o-search": { "input": "2200000000", "output": "9000000000" },
+      "openai/gpt-5": { "input": "1100000000", "output": "9000000000", "cacheRead": "110000000" },
+      "openai/gpt-5-chat": {
+        "input": "1100000000",
+        "output": "9000000000",
+        "cacheRead": "110000000"
+      },
+      "openai/gpt-5-codex": { "input": "1100000000", "output": "9000000000" },
+      "openai/gpt-5-mini": {
+        "input": "220000000",
+        "output": "1800000000",
+        "cacheRead": "22000000"
+      },
+      "openai/gpt-5-nano": { "input": "45000000", "output": "360000000", "cacheRead": "4500000" },
+      "openai/gpt-5-pro": { "input": "14000000000", "output": "110000000000" },
+      "openai/gpt-5.1": { "input": "1100000000", "output": "9000000000", "cacheRead": "110000000" },
+      "openai/gpt-5.1-codex": {
+        "input": "1100000000",
+        "output": "9000000000",
+        "cacheRead": "110000000"
+      },
+      "openai/gpt-5.1-codex-max": {
+        "input": "1100000000",
+        "output": "9000000000",
+        "cacheRead": "110000000"
+      },
+      "openai/gpt-5.1-codex-mini": {
+        "input": "220000000",
+        "output": "1800000000",
+        "cacheRead": "22000000"
+      },
+      "openai/gpt-5.1-instant": {
+        "input": "1100000000",
+        "output": "9000000000",
+        "cacheRead": "110000000"
+      },
+      "openai/gpt-5.2": {
+        "input": "1600000000",
+        "output": "13000000000",
+        "cacheRead": "160000000"
+      },
+      "openai/gpt-5.2-codex": {
+        "input": "1600000000",
+        "output": "13000000000",
+        "cacheRead": "160000000"
+      },
+      "openai/gpt-5.2-instant": {
+        "input": "1600000000",
+        "output": "13000000000",
+        "cacheRead": "160000000"
+      },
+      "openai/gpt-5.2-pro": { "input": "19000000000", "output": "150000000000" },
+      "openai/gpt-5.3-codex": {
+        "input": "1600000000",
+        "output": "13000000000",
+        "cacheRead": "160000000"
+      },
+      "openai/gpt-5.3-codex-spark": { "input": "0", "output": "0" },
+      "openai/gpt-5.3-instant": {
+        "input": "1600000000",
+        "output": "13000000000",
+        "cacheRead": "160000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2200000000",
+        "output": "14000000000",
+        "cacheRead": "220000000"
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "680000000",
+        "output": "4000000000",
+        "cacheRead": "68000000"
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "180000000",
+        "output": "1100000000",
+        "cacheRead": "18000000"
+      },
+      "openai/gpt-5.4-pro": { "input": "27000000000", "output": "160000000000" },
+      "openai/gpt-5.5": {
+        "input": "4545500000",
+        "output": "27272700000",
+        "cacheRead": "454500000"
+      },
+      "openai/gpt-5.5-pro": { "input": "27272700000", "output": "163636400000" },
+      "openai/gpt-image-2": {
+        "input": "5050500000",
+        "output": "32323200000",
+        "cacheRead": "1262600000"
+      },
+      "openai/o1": { "input": "14000000000", "output": "54000000000" },
+      "openai/o1-pro": { "input": "140000000000", "output": "540000000000" },
+      "openai/o3": { "input": "1800000000", "output": "7200000000", "cacheRead": "450000000" },
+      "openai/o3-deep-research": {
+        "input": "9000000000",
+        "output": "36000000000",
+        "cacheRead": "2200000000"
+      },
+      "openai/o3-mini": { "input": "990000000", "output": "4000000000" },
+      "openai/o3-mini-high": { "input": "990000000", "output": "4000000000" },
+      "openai/o3-pro": { "input": "18000000000", "output": "72000000000" },
+      "openai/o4-mini": { "input": "990000000", "output": "4000000000", "cacheRead": "250000000" },
+      "openai/o4-mini-deep-research": {
+        "input": "1800000000",
+        "output": "7200000000",
+        "cacheRead": "450000000"
+      },
+      "xai/grok-3": { "input": "3000000000", "output": "15000000000", "cacheRead": "750000000" },
+      "xai/grok-3-mini": { "input": "300000000", "output": "500000000", "cacheRead": "75000000" },
+      "xai/grok-4": { "input": "3000000000", "output": "15000000000", "cacheRead": "750000000" },
+      "xai/grok-4-fast-non-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "xai/grok-4-fast-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "xai/grok-4.20-multi-agent": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000"
+      },
+      "xai/grok-code-fast-1": {
+        "input": "200000000",
+        "output": "1500000000",
+        "cacheRead": "20000000"
+      }
+    },
+    "poolside": {
+      "poolside/laguna-m.1": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "poolside/laguna-s-2.1": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "poolside/laguna-xs-2.1": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" }
+    },
+    "privatemode-ai": {
+      "deepseek-ocr-2": { "input": "889700000", "output": "1467500000", "cacheRead": "92400000" },
+      "gpt-oss-120b": { "input": "496900000", "output": "1964400000", "cacheRead": "46200000" },
+      "kimi-k2.6": { "input": "1791000000", "output": "8943600000", "cacheRead": "173300000" },
+      "kimi-latest": { "input": "1791000000", "output": "8943600000", "cacheRead": "173300000" },
+      "qwen3-embedding-4b": { "input": "150200000", "output": "0" },
+      "voxtral-mini-3b": { "input": "4620000", "output": "0" },
+      "whisper-large-v3": { "input": "16180000", "output": "0" }
+    },
+    "qihang-ai": {
+      "claude-haiku-4-5-20251001": { "input": "140000000", "output": "710000000" },
+      "claude-opus-4-5-20251101": { "input": "710000000", "output": "3570000000" },
+      "claude-sonnet-4-5-20250929": { "input": "430000000", "output": "2140000000" },
+      "gemini-2.5-flash": {
+        "input": "90000000",
+        "output": "710000000",
+        "tiers": [{ "input": "90000000", "output": "710000000", "aboveInputTokens": "200000" }]
+      },
+      "gemini-3-flash-preview": {
+        "input": "70000000",
+        "output": "430000000",
+        "tiers": [{ "input": "70000000", "output": "430000000", "aboveInputTokens": "200000" }]
+      },
+      "gemini-3-pro-preview": { "input": "570000000", "output": "3430000000" },
+      "gpt-5-mini": { "input": "40000000", "output": "290000000" },
+      "gpt-5.2": { "input": "250000000", "output": "2000000000" },
+      "gpt-5.2-codex": { "input": "140000000", "output": "1140000000" }
+    },
+    "qiniu-ai": {
+      "mimo-v2-flash": { "input": "100000000", "output": "300000000", "cacheRead": "10000000" },
+      "xiaomi/mimo-v2-flash": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "10000000"
+      }
+    },
+    "qvac": {
+      "gemma4-31b": { "input": "0", "output": "0" },
+      "gpt-oss-120b": { "input": "0", "output": "0" },
+      "gpt-oss-20b": { "input": "0", "output": "0" },
+      "qwen3.5-0.8b": { "input": "0", "output": "0" },
+      "qwen3.5-2b": { "input": "0", "output": "0" },
+      "qwen3.5-4b": { "input": "0", "output": "0" },
+      "qwen3.5-9b": { "input": "0", "output": "0" },
+      "qwen3.6-27b": { "input": "0", "output": "0" },
+      "qwen3.6-35b-a3b": { "input": "0", "output": "0" }
+    },
+    "regolo-ai": {
+      "apertus-70b": { "input": "460000000", "output": "2420000000" },
+      "brick-complexity-pro": { "input": "120000000", "output": "460000000" },
+      "brick-v1-beta": { "input": "0", "output": "0" },
+      "deepseek-ocr-2": { "input": "0", "output": "0" },
+      "faster-whisper-large-v3": { "input": "0", "output": "0" },
+      "gemma4-31b": { "input": "460000000", "output": "2420000000" },
+      "glm5.2": { "input": "2310000000", "output": "6000000000" },
+      "gpt-oss-120b": { "input": "1000000000", "output": "4200000000" },
+      "gpt-oss-20b": { "input": "400000000", "output": "1800000000" },
+      "llama-3.3-70b-instruct": { "input": "600000000", "output": "2700000000" },
+      "mistral-small-4-119b": { "input": "750000000", "output": "3000000000" },
+      "qwen-image": { "input": "500000000", "output": "2000000000" },
+      "qwen3-coder-next": { "input": "300000000", "output": "1200000000" },
+      "qwen3-embedding-8b": { "input": "100000000", "output": "100000000" },
+      "qwen3-reranker-4b": { "input": "120000000", "output": "120000000" },
+      "qwen3.5-122b": { "input": "900000000", "output": "3600000000" },
+      "qwen3.5-9b": { "input": "150000000", "output": "600000000" },
+      "qwen3.6-27b": { "input": "580000000", "output": "2420000000" }
+    },
+    "requesty": {
+      "claude-fable-5": {
+        "input": "9000000000",
+        "output": "45000000000",
+        "cacheRead": "900000000",
+        "cacheWrite": "11250000000"
+      },
+      "claude-fable-5@eu": {
+        "input": "9900000000",
+        "output": "49500000000",
+        "cacheRead": "990000000",
+        "cacheWrite": "12375000000"
+      },
+      "claude-haiku-4-5": {
+        "input": "900000000",
+        "output": "4500000000",
+        "cacheRead": "90000000",
+        "cacheWrite": "1125000000"
+      },
+      "claude-haiku-4-5@eu": {
+        "input": "990000000",
+        "output": "4950000000",
+        "cacheRead": "99000000",
+        "cacheWrite": "1237500000"
+      },
+      "claude-opus-4-1": {
+        "input": "13500000000",
+        "output": "67500000000",
+        "cacheRead": "1350000000",
+        "cacheWrite": "16875000000"
+      },
+      "claude-opus-4-5": {
+        "input": "4500000000",
+        "output": "22500000000",
+        "cacheRead": "450000000",
+        "cacheWrite": "5625000000"
+      },
+      "claude-opus-4-5@eu": {
+        "input": "4950000000",
+        "output": "24750000000",
+        "cacheRead": "495000000",
+        "cacheWrite": "6187500000"
+      },
+      "claude-opus-4-6": {
+        "input": "4500000000",
+        "output": "22500000000",
+        "cacheRead": "450000000",
+        "cacheWrite": "5625000000"
+      },
+      "claude-opus-4-6@eu": {
+        "input": "4950000000",
+        "output": "24750000000",
+        "cacheRead": "495000000",
+        "cacheWrite": "6187500000"
+      },
+      "claude-opus-4-7": {
+        "input": "4500000000",
+        "output": "22500000000",
+        "cacheRead": "450000000",
+        "cacheWrite": "5625000000"
+      },
+      "claude-opus-4-7@eu": {
+        "input": "4950000000",
+        "output": "24750000000",
+        "cacheRead": "495000000",
+        "cacheWrite": "6187500000"
+      },
+      "claude-opus-4-8": {
+        "input": "4500000000",
+        "output": "22500000000",
+        "cacheRead": "450000000",
+        "cacheWrite": "5625000000"
+      },
+      "claude-opus-4-8@eu": {
+        "input": "4950000000",
+        "output": "24750000000",
+        "cacheRead": "495000000",
+        "cacheWrite": "6187500000"
+      },
+      "claude-opus-5": {
+        "input": "4500000000",
+        "output": "22500000000",
+        "cacheRead": "450000000",
+        "cacheWrite": "5625000000"
+      },
+      "claude-opus-5@eu": {
+        "input": "4950000000",
+        "output": "24750000000",
+        "cacheRead": "495000000",
+        "cacheWrite": "6187500000"
+      },
+      "claude-sonnet-4-5": {
+        "input": "2700000000",
+        "output": "13500000000",
+        "cacheRead": "270000000",
+        "cacheWrite": "3375000000",
+        "tiers": [
+          {
+            "input": "5400000000",
+            "output": "20250000000",
+            "cacheRead": "540000000",
+            "cacheWrite": "6750000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-sonnet-4-5@eu": {
+        "input": "2970000000",
+        "output": "14850000000",
+        "cacheRead": "270000000",
+        "cacheWrite": "3712500000",
+        "tiers": [
+          {
+            "input": "5940000000",
+            "output": "22275000000",
+            "cacheRead": "540000000",
+            "cacheWrite": "7425000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-sonnet-4-6": {
+        "input": "2700000000",
+        "output": "13500000000",
+        "cacheRead": "270000000",
+        "cacheWrite": "3375000000"
+      },
+      "claude-sonnet-4-6@eu": {
+        "input": "2970000000",
+        "output": "14850000000",
+        "cacheRead": "270000000",
+        "cacheWrite": "3712500000"
+      },
+      "claude-sonnet-4@eu": {
+        "input": "2700000000",
+        "output": "13500000000",
+        "cacheRead": "270000000",
+        "cacheWrite": "3375000000",
+        "tiers": [
+          {
+            "input": "5400000000",
+            "output": "20250000000",
+            "cacheRead": "540000000",
+            "cacheWrite": "6750000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "claude-sonnet-5": {
+        "input": "1800000000",
+        "output": "9000000000",
+        "cacheRead": "180000000",
+        "cacheWrite": "2250000000"
+      },
+      "claude-sonnet-5@eu": {
+        "input": "1980000000",
+        "output": "9900000000",
+        "cacheRead": "198000000",
+        "cacheWrite": "2475000000"
+      },
+      "deepseek-v4-flash": {
+        "input": "396000000",
+        "output": "1188000000",
+        "cacheRead": "12600000"
+      },
+      "deepseek-v4-flash-0731": {
+        "input": "126000000",
+        "output": "252000000",
+        "cacheRead": "63000000"
+      },
+      "deepseek-v4-flash-0731@eu": {
+        "input": "126000000",
+        "output": "252000000",
+        "cacheRead": "63000000"
+      },
+      "deepseek-v4-pro": { "input": "1188000000", "output": "3564000000", "cacheRead": "39600000" },
+      "deepseek-v4-pro-0813": {
+        "input": "1188000000",
+        "output": "3564000000",
+        "cacheRead": "39600000"
+      },
+      "deepseek-v4-pro@eu": {
+        "input": "1575000000",
+        "output": "3150000000",
+        "cacheRead": "396000000"
+      },
+      "devstral-latest": { "input": "396000000", "output": "1980000000", "cacheRead": "396000000" },
+      "devstral-latest@eu": {
+        "input": "396000000",
+        "output": "1980000000",
+        "cacheRead": "396000000"
+      },
+      "fugu-ultra": {
+        "input": "4500000000",
+        "output": "27000000000",
+        "cacheRead": "450000000",
+        "tiers": [
+          {
+            "input": "9000000000",
+            "output": "40500000000",
+            "cacheRead": "900000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gemini-2.5-flash@eu": {
+        "input": "270000000",
+        "output": "2250000000",
+        "cacheRead": "67500000",
+        "cacheWrite": "495000000"
+      },
+      "gemini-3-pro-image": {
+        "input": "1800000000",
+        "output": "10800000000",
+        "cacheRead": "180000000",
+        "cacheWrite": "4050000000",
+        "tiers": [
+          {
+            "input": "3600000000",
+            "output": "16200000000",
+            "cacheRead": "180000000",
+            "cacheWrite": "4050000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.1-flash-image": {
+        "input": "450000000",
+        "output": "1800000000",
+        "tiers": [{ "input": "450000000", "output": "1800000000", "aboveInputTokens": "200000" }]
+      },
+      "gemini-3.1-flash-lite": {
+        "input": "225000000",
+        "output": "1350000000",
+        "cacheRead": "22500000",
+        "cacheWrite": "74997000",
+        "tiers": [
+          {
+            "input": "450000000",
+            "output": "2025000000",
+            "cacheRead": "22500000",
+            "cacheWrite": "74997000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.1-flash-lite@eu": {
+        "input": "247500000",
+        "output": "1485000000",
+        "cacheRead": "24750000",
+        "cacheWrite": "82497000",
+        "tiers": [
+          {
+            "input": "495000000",
+            "output": "2227500000",
+            "cacheRead": "24750000",
+            "cacheWrite": "82497000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.1-pro-preview": {
+        "input": "1800000000",
+        "output": "10800000000",
+        "cacheRead": "180000000",
+        "cacheWrite": "4050000000",
+        "tiers": [
+          {
+            "input": "3600000000",
+            "output": "16200000000",
+            "cacheRead": "180000000",
+            "cacheWrite": "4050000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.5-flash": {
+        "input": "1350000000",
+        "output": "8100000000",
+        "cacheRead": "135000000",
+        "cacheWrite": "1424700000"
+      },
+      "gemini-3.5-flash-lite": {
+        "input": "270000000",
+        "output": "2250000000",
+        "cacheRead": "27000000"
+      },
+      "gemini-3.5-flash-lite@eu": {
+        "input": "297000000",
+        "output": "2475000000",
+        "cacheRead": "29700000"
+      },
+      "gemini-3.5-flash@eu": {
+        "input": "1485000000",
+        "output": "8910000000",
+        "cacheRead": "148500000",
+        "cacheWrite": "1567170000"
+      },
+      "gemini-3.6-flash": {
+        "input": "1350000000",
+        "output": "6300000000",
+        "cacheRead": "135000000"
+      },
+      "gemini-3.7-flash": { "input": "600000000", "output": "3000000000", "cacheRead": "60000000" },
+      "gemini-3.7-flash@eu": {
+        "input": "660000000",
+        "output": "3300000000",
+        "cacheRead": "66000000"
+      },
+      "gemma-4-26b-a4b-it": { "input": "63000000", "output": "306000000", "cacheRead": "63000000" },
+      "gemma-4-31b-it": { "input": "0", "output": "0" },
+      "glm-5.1": { "input": "1260000000", "output": "3960000000", "cacheRead": "234000000" },
+      "glm-5.1@eu": { "input": "1260000000", "output": "3960000000", "cacheRead": "1260000000" },
+      "glm-5.2": { "input": "1080000000", "output": "3780000000", "cacheRead": "234000000" },
+      "glm-5.2-fast": { "input": "1890000000", "output": "5940000000", "cacheRead": "189000000" },
+      "glm-5.2@eu": { "input": "1080000000", "output": "3780000000", "cacheRead": "234000000" },
+      "glm-5.3": { "input": "1260000000", "output": "3960000000", "cacheRead": "234000000" },
+      "gpt-4.1-mini@eu": { "input": "396000000", "output": "1584000000", "cacheRead": "99000000" },
+      "gpt-4.1-nano@eu": { "input": "99000000", "output": "396000000", "cacheRead": "24750000" },
+      "gpt-4.1@eu": { "input": "1980000000", "output": "7920000000", "cacheRead": "495000000" },
+      "gpt-4o-mini@eu": { "input": "148500000", "output": "594000000", "cacheRead": "74250000" },
+      "gpt-5-mini@eu": { "input": "247500000", "output": "1980000000", "cacheRead": "24750000" },
+      "gpt-5-nano@eu": { "input": "49500000", "output": "396000000", "cacheRead": "4950000" },
+      "gpt-5.1@eu": { "input": "1237500000", "output": "9900000000", "cacheRead": "123750000" },
+      "gpt-5.3-chat": { "input": "1575000000", "output": "12600000000", "cacheRead": "157500000" },
+      "gpt-5.3-codex": { "input": "1575000000", "output": "12600000000", "cacheRead": "157500000" },
+      "gpt-5.4": { "input": "2475000000", "output": "14850000000", "cacheRead": "247500000" },
+      "gpt-5.4-mini": { "input": "675000000", "output": "4050000000", "cacheRead": "67500000" },
+      "gpt-5.4-nano": { "input": "180000000", "output": "1125000000", "cacheRead": "18000000" },
+      "gpt-5.4-pro": {
+        "input": "27000000000",
+        "output": "162000000000",
+        "cacheRead": "27000000000"
+      },
+      "gpt-5.4@eu": {
+        "input": "2250000000",
+        "output": "13500000000",
+        "cacheRead": "225000000",
+        "tiers": [
+          {
+            "input": "4500000000",
+            "output": "20250000000",
+            "cacheRead": "450000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.5": { "input": "4950000000", "output": "29700000000", "cacheRead": "495000000" },
+      "gpt-5.5-pro": { "input": "27000000000", "output": "162000000000" },
+      "gpt-5.5@eu": {
+        "input": "4500000000",
+        "output": "27000000000",
+        "cacheRead": "450000000",
+        "tiers": [
+          {
+            "input": "9000000000",
+            "output": "40500000000",
+            "cacheRead": "900000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-luna": {
+        "input": "180000000",
+        "output": "1080000000",
+        "cacheRead": "18000000",
+        "tiers": [
+          {
+            "input": "360000000",
+            "output": "1620000000",
+            "cacheRead": "36000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-luna@eu": { "input": "198000000", "output": "1188000000", "cacheRead": "19800000" },
+      "gpt-5.6-sol": {
+        "input": "3600000000",
+        "output": "18000000000",
+        "cacheRead": "360000000",
+        "cacheWrite": "4500000000",
+        "tiers": [
+          {
+            "input": "7200000000",
+            "output": "27000000000",
+            "cacheRead": "720000000",
+            "cacheWrite": "9000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-sol@eu": {
+        "input": "4950000000",
+        "output": "29700000000",
+        "cacheRead": "495000000"
+      },
+      "gpt-5.6-terra": {
+        "input": "1800000000",
+        "output": "10800000000",
+        "cacheRead": "180000000",
+        "tiers": [
+          {
+            "input": "3600000000",
+            "output": "16200000000",
+            "cacheRead": "360000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-terra@eu": {
+        "input": "1980000000",
+        "output": "11880000000",
+        "cacheRead": "198000000"
+      },
+      "gpt-5@eu": { "input": "1237500000", "output": "9900000000", "cacheRead": "123750000" },
+      "grok-4.2-beta": {
+        "input": "1800000000",
+        "output": "5400000000",
+        "cacheRead": "180000000",
+        "cacheWrite": "1800000000",
+        "tiers": [
+          {
+            "input": "3600000000",
+            "output": "10800000000",
+            "cacheRead": "360000000",
+            "cacheWrite": "3600000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4.3": {
+        "input": "1125000000",
+        "output": "2250000000",
+        "cacheRead": "180000000",
+        "cacheWrite": "1125000000",
+        "tiers": [
+          {
+            "input": "2250000000",
+            "output": "4500000000",
+            "cacheRead": "360000000",
+            "cacheWrite": "2250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4.5": {
+        "input": "1800000000",
+        "output": "5400000000",
+        "cacheRead": "450000000",
+        "cacheWrite": "1800000000",
+        "tiers": [
+          {
+            "input": "3600000000",
+            "output": "10800000000",
+            "cacheRead": "900000000",
+            "cacheWrite": "3600000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4.6": {
+        "input": "1800000000",
+        "output": "5400000000",
+        "cacheRead": "450000000",
+        "cacheWrite": "1800000000",
+        "tiers": [
+          {
+            "input": "3600000000",
+            "output": "10800000000",
+            "cacheRead": "900000000",
+            "cacheWrite": "3600000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-build-0.1": { "input": "900000000", "output": "1800000000", "cacheRead": "90000000" },
+      "hy3": { "input": "126000000", "output": "522000000", "cacheRead": "31500000" },
+      "inkling": { "input": "1683000000", "output": "4212000000", "cacheRead": "336600000" },
+      "inkling-256k": { "input": "1496000000", "output": "3744000000", "cacheRead": "299200000" },
+      "kat-coder-pro": { "input": "270000000", "output": "1080000000" },
+      "kimi-k2.6": { "input": "855000000", "output": "3600000000", "cacheRead": "144000000" },
+      "kimi-k2.6@eu": { "input": "855000000", "output": "3600000000", "cacheRead": "855000000" },
+      "kimi-k2.7-code": { "input": "855000000", "output": "3600000000", "cacheRead": "171000000" },
+      "kimi-k2.7-code@eu": {
+        "input": "1125000000",
+        "output": "4050000000",
+        "cacheRead": "279000000"
+      },
+      "kimi-k3": { "input": "2025000000", "output": "10125000000", "cacheRead": "202500000" },
+      "kimi-k3@eu": { "input": "2025000000", "output": "10125000000", "cacheRead": "202500000" },
+      "laguna-m.1": { "input": "0", "output": "0" },
+      "laguna-xs.2": { "input": "0", "output": "0" },
+      "leanstral-1-5": { "input": "0", "output": "0" },
+      "leanstral-1-5@eu": { "input": "0", "output": "0" },
+      "ling-2.6-1t": { "input": "270000000", "output": "2250000000" },
+      "ling-2.6-flash": { "input": "90000000", "output": "270000000" },
+      "ling-3.0-tiny": { "input": "0", "output": "0" },
+      "mimo-v2.5": { "input": "126000000", "output": "252000000", "cacheRead": "2520000" },
+      "mimo-v2.5-pro": { "input": "391500000", "output": "783000000", "cacheRead": "3240000" },
+      "minimax-m2.7": {
+        "input": "270000000",
+        "output": "1080000000",
+        "cacheRead": "54000000",
+        "cacheWrite": "1080000000"
+      },
+      "minimax-m2.7-highspeed": {
+        "input": "540000000",
+        "output": "2160000000",
+        "cacheRead": "54000000",
+        "cacheWrite": "1080000000"
+      },
+      "minimax-m3": { "input": "240000000", "output": "960000000", "cacheRead": "48000000" },
+      "minimax-m3@eu": { "input": "360000000", "output": "1800000000", "cacheRead": "90000000" },
+      "mistral-medium-3-5": {
+        "input": "1485000000",
+        "output": "7425000000",
+        "cacheRead": "1485000000"
+      },
+      "mistral-medium-3-5@eu": {
+        "input": "1485000000",
+        "output": "7425000000",
+        "cacheRead": "1485000000"
+      },
+      "mistral-medium-latest": {
+        "input": "396000000",
+        "output": "1980000000",
+        "cacheRead": "396000000"
+      },
+      "mistral-medium-latest@eu": {
+        "input": "396000000",
+        "output": "1980000000",
+        "cacheRead": "396000000"
+      },
+      "mistral-small-2603": {
+        "input": "148500000",
+        "output": "594000000",
+        "cacheRead": "148500000"
+      },
+      "mistral-small-2603@eu": {
+        "input": "148500000",
+        "output": "594000000",
+        "cacheRead": "148500000"
+      },
+      "muse-glimmer-30b": { "input": "0", "output": "0" },
+      "nemotron-3-nano-omni": {
+        "input": "54000000",
+        "output": "216000000",
+        "cacheRead": "54000000"
+      },
+      "nemotron-3-nano-omni-30b-a3b-reasoning": { "input": "0", "output": "0" },
+      "nemotron-3-nano-omni@eu": {
+        "input": "54000000",
+        "output": "216000000",
+        "cacheRead": "54000000"
+      },
+      "nemotron-3-super-120b-a12b": { "input": "0", "output": "0" },
+      "nemotron-3-ultra-550b-a55b": { "input": "0", "output": "0" },
+      "nemotron-3-ultra-nvfp4": {
+        "input": "540000000",
+        "output": "2160000000",
+        "cacheRead": "108000000"
+      },
+      "nemotron-3.5-content-safety": { "input": "0", "output": "0" },
+      "nemotron-3.5-lightning-30b-a3b": { "input": "0", "output": "0" },
+      "nemotron-lightning-3.5-30b-a3b": {
+        "input": "45000000",
+        "output": "180000000",
+        "cacheRead": "9000000"
+      },
+      "nvidia-nemotron-3-super-120b-a12b": { "input": "90000000", "output": "450000000" },
+      "nvidia-nemotron-3-ultra": { "input": "450000000", "output": "2250000000" },
+      "o4-mini@eu": { "input": "1089000000", "output": "4356000000", "cacheRead": "272250000" },
+      "qwen3.5-27b": { "input": "234000000", "output": "2340000000" },
+      "qwen3.5-2b": { "input": "18000000", "output": "90000000" },
+      "qwen3.5-35b-a3b": { "input": "126000000", "output": "900000000", "cacheRead": "45000000" },
+      "qwen3.6-plus": {
+        "input": "450000000",
+        "output": "2700000000",
+        "cacheRead": "45000000",
+        "cacheWrite": "562500000"
+      },
+      "qwen3.7-max": {
+        "input": "2250000000",
+        "output": "6750000000",
+        "cacheRead": "225000000",
+        "cacheWrite": "2812500000"
+      },
+      "qwen3.7-plus": {
+        "input": "280000000",
+        "output": "1120000000",
+        "cacheRead": "28000000",
+        "cacheWrite": "350000000"
+      },
+      "qwen3.8-2.4T-A95B": {
+        "input": "1800000000",
+        "output": "5400000000",
+        "cacheRead": "180000000"
+      },
+      "qwen3.8-max": {
+        "input": "1800000000",
+        "output": "5400000000",
+        "cacheRead": "225000000",
+        "cacheWrite": "2250000000"
+      },
+      "ring-2.6-1t": { "input": "270000000", "output": "2250000000" },
+      "seed-1.8": { "input": "225000000", "output": "1800000000", "cacheRead": "45000000" },
+      "seed-2.0-code": { "input": "450000000", "output": "2700000000", "cacheRead": "90000000" },
+      "seed-2.0-mini": { "input": "90000000", "output": "360000000", "cacheRead": "18000000" },
+      "seed-2.0-pro": { "input": "450000000", "output": "2700000000", "cacheRead": "90000000" },
+      "step-3.7-flash": { "input": "180000000", "output": "1035000000", "cacheRead": "36000000" },
+      "thinkingcap-qwen3.6-27b": {
+        "input": "360000000",
+        "output": "2700000000",
+        "cacheRead": "234000000"
+      },
+      "thinkingcap-qwen3.6-27b@eu": {
+        "input": "360000000",
+        "output": "2700000000",
+        "cacheRead": "234000000"
+      }
+    },
+    "routing-run": {
+      "claude-opus-4-8": { "input": "5000000000", "output": "25000000000" },
+      "claude-sonnet-4-6": { "input": "3000000000", "output": "15000000000" },
+      "deepseek-v4-flash": { "input": "112000000", "output": "224000000" },
+      "deepseek-v4-pro": { "input": "348000000", "output": "696000000" },
+      "glm-5.2": { "input": "800000000", "output": "2400000000" },
+      "glm-5.2-nitro": { "input": "800000000", "output": "2400000000" },
+      "gpt-5.6-luna": { "input": "700000000", "output": "4200000000" },
+      "gpt-5.6-sol": { "input": "2500000000", "output": "15000000000" },
+      "gpt-5.6-terra": { "input": "1500000000", "output": "9000000000" },
+      "kimi-k2.6": { "input": "275000000", "output": "1100000000" },
+      "kimi-k2.6-nitro": { "input": "275000000", "output": "1100000000" },
+      "kimi-k2.7-code": { "input": "275000000", "output": "1100000000" },
+      "kimi-k2.7-code-nitro": { "input": "275000000", "output": "1100000000" },
+      "nemotron-3-ultra": { "input": "100000000", "output": "100000000" },
+      "qwen3.5-9b": { "input": "160000000", "output": "480000000" }
+    },
+    "runinfra": {
+      "deepseek-ai/DeepSeek-V4-Flash-0731": {
+        "input": "130000000",
+        "output": "270000000",
+        "cacheRead": "10000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro-0813": {
+        "input": "600000000",
+        "output": "1900000000",
+        "cacheRead": "30000000"
+      },
+      "Inferact/Qwen3.8-2.4T-A95B-NVFP4": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000"
+      },
+      "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16": {
+        "input": "50000000",
+        "output": "150000000"
+      },
+      "Qwen/Qwen3.8-27B": { "input": "100000000", "output": "400000000", "cacheRead": "10000000" }
+    },
+    "sakana": {
+      "fugu-ultra": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "fugu-ultra-20260615": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "sakana-namazu": { "input": "950000000", "output": "4000000000", "cacheRead": "150000000" }
+    },
+    "salad-cloud": { "qwen3.6-35b-a3b": { "input": "90000000", "output": "600000000" } },
+    "sap-ai-core": {
+      "amazon--nova-lite": { "input": "300000000", "output": "2370000000" },
+      "amazon--nova-micro": { "input": "30000000", "output": "100000000" },
+      "amazon--nova-pro": { "input": "560000000", "output": "2130000000" },
+      "amazon--titan-embed-text": { "input": "140000000", "output": "0" },
+      "anthropic--claude-3-haiku": {
+        "input": "250000000",
+        "output": "1250000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "300000000"
+      },
+      "anthropic--claude-3-opus": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic--claude-3-sonnet": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic--claude-3.5-sonnet": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic--claude-3.7-sonnet": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic--claude-4-opus": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic--claude-4-sonnet": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic--claude-4.5-haiku": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic--claude-4.5-opus": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic--claude-4.5-sonnet": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic--claude-4.6-opus": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic--claude-4.6-sonnet": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic--claude-4.7-opus": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic--claude-4.8-opus": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "cohere--command-a-reasoning": { "input": "630000000", "output": "5050000000" },
+      "gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "inputAudio": "1000000000"
+      },
+      "gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "inputAudio": "300000000"
+      },
+      "gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "inputAudio": "500000000"
+      },
+      "gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000",
+        "inputAudio": "1500000000"
+      },
+      "gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "320000000" },
+      "gpt-4.1-mini": { "input": "400000000", "output": "1600000000", "cacheRead": "100000000" },
+      "gpt-4.1-nano": { "input": "80000000", "output": "260000000" },
+      "gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5-mini": { "input": "250000000", "output": "2000000000", "cacheRead": "25000000" },
+      "gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "gpt-5.2": { "input": "1250000000", "output": "9440000000", "cacheRead": "120000000" },
+      "gpt-5.4": { "input": "2500000000", "output": "15000000000", "cacheRead": "250000000" },
+      "gpt-5.5": { "input": "5000000000", "output": "30000000000", "cacheRead": "500000000" },
+      "gpt-5.6-luna": {
+        "input": "1000000000",
+        "output": "6000000000",
+        "cacheRead": "100000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "9000000000",
+            "cacheRead": "200000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-terra": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "mistralai--mistral-medium-instruct": { "input": "360000000", "output": "1220000000" },
+      "mistralai--mistral-small": { "input": "70000000", "output": "280000000" },
+      "nvidia--llama-3.2-nv-embedqa-1b": { "input": "70000000", "output": "0" },
+      "sap-abap-1": { "input": "480000000", "output": "1700000000" },
+      "sonar": { "input": "1000000000", "output": "1000000000" },
+      "sonar-deep-research": {
+        "input": "2000000000",
+        "output": "8000000000",
+        "reasoning": "3000000000"
+      },
+      "sonar-pro": { "input": "3000000000", "output": "15000000000" },
+      "text-embedding-3-large": { "input": "90000000", "output": "0" },
+      "text-embedding-3-small": { "input": "20000000", "output": "0" }
+    },
+    "scaleway": {
+      "bge-multilingual-gemma2": { "input": "100000000", "output": "0" },
+      "deepseek-v4-flash-0731": {
+        "input": "468000000",
+        "output": "936000000",
+        "cacheRead": "93600000",
+        "reasoning": "936000000"
+      },
+      "gemma-4-26b-a4b-it": { "input": "250000000", "output": "500000000" },
+      "glm-5.2": { "input": "1800000000", "output": "5500000000" },
+      "gpt-oss-120b": { "input": "150000000", "output": "600000000" },
+      "llama-3.3-70b-instruct": { "input": "900000000", "output": "900000000" },
+      "mistral-medium-3.5-128b": { "input": "1500000000", "output": "7500000000" },
+      "mistral-small-3.2-24b-instruct-2506": { "input": "150000000", "output": "350000000" },
+      "pixtral-12b-2409": { "input": "200000000", "output": "200000000" },
+      "qwen3-235b-a22b-instruct-2507": {
+        "input": "750000000",
+        "output": "2250000000",
+        "reasoning": "8400000000"
+      },
+      "qwen3-coder-30b-a3b-instruct": { "input": "200000000", "output": "800000000" },
+      "qwen3-embedding-8b": { "input": "100000000", "output": "0" },
+      "qwen3.5-397b-a17b": { "input": "600000000", "output": "3600000000" },
+      "qwen3.6-35b-a3b": { "input": "250000000", "output": "1500000000" },
+      "whisper-large-v3": { "input": "3000000", "output": "0" }
+    },
+    "scnet-token-plan": {
+      "DeepSeek-V3.2": { "input": "0", "output": "0", "cacheRead": "0" },
+      "DeepSeek-V4-Flash": { "input": "0", "output": "0", "cacheRead": "0" },
+      "DeepSeek-V4-Flash-0731": { "input": "0", "output": "0", "cacheRead": "0" },
+      "DeepSeek-V4-Pro": { "input": "0", "output": "0", "cacheRead": "0" },
+      "GLM-5": { "input": "0", "output": "0", "cacheRead": "0" },
+      "GLM-5.1": { "input": "0", "output": "0", "cacheRead": "0" },
+      "GLM-5.2": { "input": "0", "output": "0", "cacheRead": "0" },
+      "Kimi-K2.5": { "input": "0", "output": "0", "cacheRead": "0" },
+      "Kimi-K2.6": { "input": "0", "output": "0", "cacheRead": "0" },
+      "Kimi-K2.7-Code": { "input": "0", "output": "0", "cacheRead": "0" },
+      "Kimi-K3": { "input": "0", "output": "0", "cacheRead": "0" },
+      "MiMo-V2.5-Pro": { "input": "0", "output": "0", "cacheRead": "0" },
+      "MiniMax-M2.5": { "input": "0", "output": "0", "cacheRead": "0" },
+      "MiniMax-M2.7": { "input": "0", "output": "0", "cacheRead": "0" },
+      "MiniMax-M3": { "input": "0", "output": "0", "cacheRead": "0" },
+      "Qwen3.8-Max": { "input": "0", "output": "0", "cacheRead": "0" }
+    },
+    "scx-ai": {
+      "GLM-5.2": { "input": "550000000", "output": "1784000000", "cacheRead": "111000000" },
+      "gpt-oss-120b": { "input": "170000000", "output": "550000000" },
+      "MiniMax-M2.7": { "input": "480000000", "output": "1790000000", "cacheRead": "50000000" },
+      "Qwen3.8-Max": {
+        "input": "1815000000",
+        "output": "5446100000",
+        "cacheRead": "170000000",
+        "cacheWrite": "2500000000"
+      }
+    },
+    "siliconflow": {
+      "baidu/ERNIE-4.5-300B-A47B": { "input": "280000000", "output": "1100000000" },
+      "ByteDance-Seed/Seed-OSS-36B-Instruct": { "input": "210000000", "output": "570000000" },
+      "deepseek-ai/DeepSeek-R1": { "input": "500000000", "output": "2180000000" },
+      "deepseek-ai/DeepSeek-V3": { "input": "250000000", "output": "1000000000" },
+      "deepseek-ai/DeepSeek-V3.1": { "input": "270000000", "output": "1000000000" },
+      "deepseek-ai/DeepSeek-V3.1-Terminus": { "input": "270000000", "output": "1000000000" },
+      "deepseek-ai/DeepSeek-V3.2": { "input": "270000000", "output": "420000000" },
+      "deepseek-ai/DeepSeek-V3.2-Exp": { "input": "270000000", "output": "410000000" },
+      "deepseek-ai/DeepSeek-V4-Flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "145000000"
+      },
+      "google/gemma-4-26B-A4B-it": { "input": "120000000", "output": "400000000" },
+      "google/gemma-4-31B-it": { "input": "130000000", "output": "400000000" },
+      "inclusionAI/Ling-flash-2.0": { "input": "140000000", "output": "570000000" },
+      "MiniMaxAI/MiniMax-M2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000"
+      },
+      "moonshotai/Kimi-K2.5": {
+        "input": "450000000",
+        "output": "2250000000",
+        "cacheRead": "70000000"
+      },
+      "moonshotai/Kimi-K2.6": {
+        "input": "770000000",
+        "output": "4000000000",
+        "cacheRead": "200000000"
+      },
+      "openai/gpt-oss-120b": { "input": "50000000", "output": "450000000" },
+      "openai/gpt-oss-20b": { "input": "40000000", "output": "180000000" },
+      "Qwen/Qwen2.5-72B-Instruct": { "input": "590000000", "output": "590000000" },
+      "Qwen/Qwen2.5-7B-Instruct": { "input": "50000000", "output": "50000000" },
+      "Qwen/Qwen3-14B": { "input": "70000000", "output": "280000000" },
+      "Qwen/Qwen3-235B-A22B-Thinking-2507": { "input": "130000000", "output": "600000000" },
+      "Qwen/Qwen3-30B-A3B-Instruct-2507": { "input": "90000000", "output": "300000000" },
+      "Qwen/Qwen3-32B": { "input": "140000000", "output": "570000000" },
+      "Qwen/Qwen3-8B": { "input": "60000000", "output": "60000000" },
+      "Qwen/Qwen3-Coder-30B-A3B-Instruct": { "input": "70000000", "output": "280000000" },
+      "Qwen/Qwen3-Coder-480B-A35B-Instruct": { "input": "250000000", "output": "1000000000" },
+      "Qwen/Qwen3-VL-235B-A22B-Instruct": { "input": "300000000", "output": "1500000000" },
+      "Qwen/Qwen3-VL-235B-A22B-Thinking": { "input": "450000000", "output": "3500000000" },
+      "Qwen/Qwen3-VL-30B-A3B-Instruct": { "input": "290000000", "output": "1000000000" },
+      "Qwen/Qwen3-VL-30B-A3B-Thinking": { "input": "290000000", "output": "1000000000" },
+      "Qwen/Qwen3-VL-32B-Instruct": { "input": "200000000", "output": "600000000" },
+      "Qwen/Qwen3-VL-32B-Thinking": { "input": "200000000", "output": "1500000000" },
+      "Qwen/Qwen3-VL-8B-Instruct": { "input": "180000000", "output": "680000000" },
+      "Qwen/Qwen3.5-122B-A10B": { "input": "260000000", "output": "2080000000" },
+      "Qwen/Qwen3.5-27B": { "input": "250000000", "output": "2000000000" },
+      "Qwen/Qwen3.5-35B-A3B": { "input": "240000000", "output": "1800000000" },
+      "Qwen/Qwen3.5-397B-A17B": { "input": "390000000", "output": "2340000000" },
+      "Qwen/Qwen3.5-9B": { "input": "100000000", "output": "150000000" },
+      "Qwen/Qwen3.6-27B": { "input": "300000000", "output": "3200000000" },
+      "Qwen/Qwen3.6-35B-A3B": { "input": "200000000", "output": "1600000000" },
+      "stepfun-ai/Step-3.5-Flash": { "input": "100000000", "output": "300000000" },
+      "tencent/Hunyuan-A13B-Instruct": { "input": "140000000", "output": "570000000" },
+      "tencent/Hy3-preview": {
+        "input": "66000000",
+        "output": "260000000",
+        "cacheRead": "29000000"
+      },
+      "zai-org/GLM-4.5-Air": { "input": "140000000", "output": "860000000" },
+      "zai-org/GLM-5": { "input": "950000000", "output": "2550000000", "cacheRead": "200000000" },
+      "zai-org/GLM-5.1": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "0"
+      },
+      "zai-org/GLM-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "0"
+      },
+      "zai-org/GLM-5V-Turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000",
+        "cacheWrite": "0"
+      }
+    },
+    "siliconflow-cn": {
+      "baidu/ERNIE-4.5-300B-A47B": { "input": "280000000", "output": "1100000000" },
+      "ByteDance-Seed/Seed-OSS-36B-Instruct": { "input": "210000000", "output": "570000000" },
+      "deepseek-ai/DeepSeek-OCR": { "input": "0", "output": "0" },
+      "deepseek-ai/DeepSeek-R1": { "input": "500000000", "output": "2180000000" },
+      "deepseek-ai/DeepSeek-V3": { "input": "250000000", "output": "1000000000" },
+      "deepseek-ai/DeepSeek-V3.1-Terminus": { "input": "270000000", "output": "1000000000" },
+      "deepseek-ai/DeepSeek-V3.2": { "input": "270000000", "output": "420000000" },
+      "deepseek-ai/DeepSeek-V4-Flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "3000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "145000000"
+      },
+      "inclusionAI/Ling-flash-2.0": { "input": "140000000", "output": "570000000" },
+      "PaddlePaddle/PaddleOCR-VL-1.5": { "input": "0", "output": "0" },
+      "Pro/deepseek-ai/DeepSeek-R1": { "input": "500000000", "output": "2180000000" },
+      "Pro/deepseek-ai/DeepSeek-V3": { "input": "250000000", "output": "1000000000" },
+      "Pro/deepseek-ai/DeepSeek-V3.1-Terminus": { "input": "270000000", "output": "1000000000" },
+      "Pro/deepseek-ai/DeepSeek-V3.2": { "input": "270000000", "output": "420000000" },
+      "Pro/MiniMaxAI/MiniMax-M2.5": { "input": "300000000", "output": "1220000000" },
+      "Pro/moonshotai/Kimi-K2.5": {
+        "input": "450000000",
+        "output": "2250000000",
+        "cacheRead": "70000000"
+      },
+      "Pro/moonshotai/Kimi-K2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "Pro/zai-org/GLM-5": { "input": "1000000000", "output": "3200000000" },
+      "Pro/zai-org/GLM-5.1": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "0"
+      },
+      "Qwen/Qwen2.5-72B-Instruct": { "input": "590000000", "output": "590000000" },
+      "Qwen/Qwen2.5-7B-Instruct": { "input": "50000000", "output": "50000000" },
+      "Qwen/Qwen3-14B": { "input": "70000000", "output": "280000000" },
+      "Qwen/Qwen3-235B-A22B-Thinking-2507": { "input": "130000000", "output": "600000000" },
+      "Qwen/Qwen3-30B-A3B-Instruct-2507": { "input": "90000000", "output": "300000000" },
+      "Qwen/Qwen3-32B": { "input": "140000000", "output": "570000000" },
+      "Qwen/Qwen3-8B": { "input": "60000000", "output": "60000000" },
+      "Qwen/Qwen3-Coder-30B-A3B-Instruct": { "input": "70000000", "output": "280000000" },
+      "Qwen/Qwen3-Coder-480B-A35B-Instruct": { "input": "250000000", "output": "1000000000" },
+      "Qwen/Qwen3-VL-235B-A22B-Instruct": { "input": "300000000", "output": "1500000000" },
+      "Qwen/Qwen3-VL-235B-A22B-Thinking": { "input": "450000000", "output": "3500000000" },
+      "Qwen/Qwen3-VL-30B-A3B-Instruct": { "input": "290000000", "output": "1000000000" },
+      "Qwen/Qwen3-VL-30B-A3B-Thinking": { "input": "290000000", "output": "1000000000" },
+      "Qwen/Qwen3-VL-32B-Instruct": { "input": "200000000", "output": "600000000" },
+      "Qwen/Qwen3-VL-32B-Thinking": { "input": "200000000", "output": "1500000000" },
+      "Qwen/Qwen3-VL-8B-Instruct": { "input": "180000000", "output": "680000000" },
+      "Qwen/Qwen3.5-122B-A10B": { "input": "290000000", "output": "2320000000" },
+      "Qwen/Qwen3.5-27B": { "input": "260000000", "output": "2090000000" },
+      "Qwen/Qwen3.5-35B-A3B": { "input": "230000000", "output": "1860000000" },
+      "Qwen/Qwen3.5-397B-A17B": { "input": "290000000", "output": "1740000000" },
+      "Qwen/Qwen3.5-4B": { "input": "0", "output": "0" },
+      "Qwen/Qwen3.5-9B": { "input": "220000000", "output": "1740000000" },
+      "Qwen/Qwen3.6-35B-A3B": { "input": "230000000", "output": "1860000000" },
+      "stepfun-ai/Step-3.5-Flash": { "input": "100000000", "output": "300000000" },
+      "tencent/Hunyuan-A13B-Instruct": { "input": "140000000", "output": "570000000" },
+      "zai-org/GLM-4.5-Air": { "input": "140000000", "output": "860000000" },
+      "zai-org/GLM-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "0"
+      }
+    },
+    "stackit": {
+      "cortecs/Llama-3.3-70B-Instruct-FP8-Dynamic": { "input": "530000000", "output": "760000000" },
+      "google/gemma-3-27b-it": { "input": "530000000", "output": "760000000" },
+      "intfloat/e5-mistral-7b-instruct": { "input": "20000000", "output": "20000000" },
+      "openai/gpt-oss-120b": { "input": "530000000", "output": "760000000" },
+      "openai/gpt-oss-20b": { "input": "180000000", "output": "290000000" },
+      "Qwen/Qwen3-VL-235B-A22B-Instruct-FP8": { "input": "1760000000", "output": "2050000000" },
+      "Qwen/Qwen3-VL-Embedding-8B": { "input": "90000000", "output": "90000000" },
+      "Qwen/Qwen3.6-27B": { "input": "530000000", "output": "760000000" }
+    },
+    "standardcompute": { "standardcompute": { "input": "0", "output": "0" } },
+    "stepfun": {
+      "step-1-32k": { "input": "2050000000", "output": "9590000000", "cacheRead": "410000000" },
+      "step-2-16k": { "input": "5210000000", "output": "16440000000", "cacheRead": "1040000000" },
+      "step-3.5-flash": { "input": "100000000", "output": "300000000", "cacheRead": "20000000" },
+      "step-3.5-flash-2603": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "20000000"
+      },
+      "step-3.7-flash": { "input": "185000000", "output": "1110000000", "cacheRead": "37000000" }
+    },
+    "stepfun-ai": {
+      "step-1-32k": { "input": "2050000000", "output": "9590000000", "cacheRead": "410000000" },
+      "step-2-16k": { "input": "5210000000", "output": "16440000000", "cacheRead": "1040000000" },
+      "step-3.5-flash": { "input": "100000000", "output": "300000000", "cacheRead": "20000000" },
+      "step-3.5-flash-2603": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "20000000"
+      },
+      "step-3.7-flash": { "input": "185000000", "output": "1110000000", "cacheRead": "37000000" }
+    },
+    "subconscious": {
+      "subconscious/glm-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "subconscious/tim-qwen3.6-27b": {
+        "input": "300000000",
+        "output": "3000000000",
+        "cacheRead": "150000000"
+      }
+    },
+    "submodel": {
+      "deepseek-ai/DeepSeek-R1-0528": { "input": "500000000", "output": "2150000000" },
+      "deepseek-ai/DeepSeek-V3-0324": { "input": "200000000", "output": "800000000" },
+      "deepseek-ai/DeepSeek-V3.1": { "input": "200000000", "output": "800000000" },
+      "openai/gpt-oss-120b": { "input": "100000000", "output": "500000000" },
+      "Qwen/Qwen3-235B-A22B-Instruct-2507": { "input": "200000000", "output": "300000000" },
+      "Qwen/Qwen3-235B-A22B-Thinking-2507": { "input": "200000000", "output": "600000000" },
+      "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": { "input": "200000000", "output": "800000000" },
+      "zai-org/GLM-4.5-Air": { "input": "100000000", "output": "500000000" },
+      "zai-org/GLM-4.5-FP8": { "input": "200000000", "output": "800000000" }
+    },
+    "synthetic": {
+      "hf:MiniMaxAI/MiniMax-M3": {
+        "input": "600000000",
+        "output": "1200000000",
+        "cacheRead": "600000000"
+      },
+      "hf:moonshotai/Kimi-K2.7-Code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "950000000"
+      },
+      "hf:moonshotai/Kimi-K3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "450000000"
+      },
+      "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
+        "input": "300000000",
+        "output": "1000000000",
+        "cacheRead": "300000000"
+      },
+      "hf:openai/gpt-oss-120b": {
+        "input": "100000000",
+        "output": "100000000",
+        "cacheRead": "100000000"
+      },
+      "hf:Qwen/Qwen3.6-27B": {
+        "input": "450000000",
+        "output": "3600000000",
+        "cacheRead": "450000000"
+      },
+      "hf:zai-org/GLM-4.7-Flash": {
+        "input": "100000000",
+        "output": "500000000",
+        "cacheRead": "100000000"
+      },
+      "hf:zai-org/GLM-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "1400000000"
+      }
+    },
+    "tencent-coding-plan": {
+      "glm-5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "hunyuan-2.0-instruct": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "hunyuan-2.0-thinking": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "hunyuan-t1": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "hunyuan-turbos": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "kimi-k2.5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "minimax-m2.5": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "tc-code-latest": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" }
+    },
+    "tencent-token-plan": {
+      "hy3": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" }
+    },
+    "tencent-tokenhub": {
+      "hy3": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "hy3-preview": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" }
+    },
+    "tensorx": {
+      "deepseek/deepseek-chat-v3.1": {
+        "input": "200000000",
+        "output": "800000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "250000000"
+      },
+      "deepseek/deepseek-r1-0528": {
+        "input": "660000000",
+        "output": "2600000000",
+        "cacheRead": "165000000",
+        "cacheWrite": "825000000"
+      },
+      "deepseek/deepseek-v3.2": {
+        "input": "300000000",
+        "output": "500000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "375000000"
+      },
+      "deepseek/deepseek-v4-flash": {
+        "input": "150000000",
+        "output": "300000000",
+        "cacheRead": "37500000",
+        "cacheWrite": "187500000"
+      },
+      "deepseek/deepseek-v4-flash-0731": {
+        "input": "250000000",
+        "output": "300000000",
+        "cacheRead": "60000000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "1750000000",
+        "output": "3500000000",
+        "cacheRead": "437500000",
+        "cacheWrite": "2185000000"
+      },
+      "minimax/minimax-m2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m3": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "100000000"
+      },
+      "moonshotai/kimi-k2.5": {
+        "input": "500000000",
+        "output": "2800000000",
+        "cacheRead": "125000000",
+        "cacheWrite": "625000000"
+      },
+      "moonshotai/kimi-k2.6": {
+        "input": "1000000000",
+        "output": "4000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "1250000000"
+      },
+      "moonshotai/kimi-k2.7-code": {
+        "input": "1250000000",
+        "output": "4500000000",
+        "cacheRead": "312500000"
+      },
+      "moonshotai/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "750000000"
+      },
+      "nvidia/nemotron-3-super-120b-a12b": {
+        "input": "300000000",
+        "output": "900000000",
+        "cacheRead": "75000000",
+        "cacheWrite": "375000000"
+      },
+      "openai/gpt-oss-120b": {
+        "input": "40000000",
+        "output": "200000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "50000000"
+      },
+      "qwen/qwen3-235b-a22b-2507": {
+        "input": "72000000",
+        "output": "464000000",
+        "cacheRead": "18000000",
+        "cacheWrite": "90000000"
+      },
+      "qwen/qwen3-coder-30b-a3b-instruct": {
+        "input": "60000000",
+        "output": "250000000",
+        "cacheRead": "15000000",
+        "cacheWrite": "75000000"
+      },
+      "qwen/qwen3-vl-235b-a22b-instruct": {
+        "input": "210000000",
+        "output": "1900000000",
+        "cacheRead": "52500000",
+        "cacheWrite": "262500000"
+      },
+      "qwen/qwen3.5-122b-a10b": {
+        "input": "500000000",
+        "output": "3500000000",
+        "cacheRead": "125000000",
+        "cacheWrite": "625000000"
+      },
+      "qwen/qwen3.5-9b": {
+        "input": "150000000",
+        "output": "200000000",
+        "cacheRead": "37500000",
+        "cacheWrite": "187500000"
+      },
+      "z-ai/glm-4.7": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "150000000",
+        "cacheWrite": "750000000"
+      },
+      "z-ai/glm-5": {
+        "input": "1000000000",
+        "output": "3200000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "1250000000"
+      },
+      "z-ai/glm-5-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "1500000000"
+      },
+      "z-ai/glm-5.1": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "350000000",
+        "cacheWrite": "1750000000"
+      },
+      "z-ai/glm-5.2": { "input": "1500000000", "output": "4500000000", "cacheRead": "375000000" },
+      "z-ai/glm-5v-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "1500000000"
+      }
+    },
+    "thinkingmachines": {
+      "thinkingmachines/Inkling": {
+        "input": "1870000000",
+        "output": "4680000000",
+        "cacheRead": "374000000"
+      },
+      "thinkingmachines/Inkling:peft:262144": {
+        "input": "3740000000",
+        "output": "9360000000",
+        "cacheRead": "748000000"
+      }
+    },
+    "tinfoil": {
+      "deepseek-v4-flash": { "input": "300000000", "output": "700000000", "cacheRead": "60000000" },
+      "gemma4-31b": { "input": "400000000", "output": "1000000000" },
+      "glm-5-2": { "input": "1500000000", "output": "5250000000", "cacheRead": "375000000" },
+      "gpt-oss-120b": { "input": "150000000", "output": "600000000" },
+      "gpt-oss-safeguard-120b": { "input": "150000000", "output": "600000000" },
+      "kimi-k3": { "input": "4000000000", "output": "20000000000", "cacheRead": "800000000" },
+      "llama3-3-70b": { "input": "1750000000", "output": "2750000000" },
+      "nomic-embed-text": { "input": "50000000", "output": "0" }
+    },
+    "togetherai": {
+      "deepcogito/cogito-v2-1-671b": { "input": "1250000000", "output": "1250000000" },
+      "deepseek-ai/DeepSeek-R1": { "input": "3000000000", "output": "7000000000" },
+      "deepseek-ai/DeepSeek-V3": { "input": "1250000000", "output": "1250000000" },
+      "deepseek-ai/DeepSeek-V3-1": { "input": "600000000", "output": "1700000000" },
+      "deepseek-ai/DeepSeek-V4-Flash-0731": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "30000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "200000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro-0813": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "130000000"
+      },
+      "essentialai/Rnj-1-Instruct": { "input": "150000000", "output": "150000000" },
+      "google/gemma-3n-E4B-it": { "input": "60000000", "output": "120000000" },
+      "google/gemma-4-31B-it": { "input": "390000000", "output": "970000000" },
+      "LiquidAI/LFM2-24B-A2B": { "input": "30000000", "output": "120000000" },
+      "meta-llama/Llama-3.3-70B-Instruct-Turbo": { "input": "1040000000", "output": "1040000000" },
+      "meta-llama/Meta-Llama-3-8B-Instruct-Lite": { "input": "140000000", "output": "140000000" },
+      "MiniMaxAI/MiniMax-M2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "MiniMaxAI/MiniMax-M2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "MiniMaxAI/MiniMax-M3": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "moonshotai/Kimi-K2.5": { "input": "500000000", "output": "2800000000" },
+      "moonshotai/Kimi-K2.6": {
+        "input": "1200000000",
+        "output": "4500000000",
+        "cacheRead": "200000000"
+      },
+      "moonshotai/Kimi-K2.7-Code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "moonshotai/Kimi-K3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "nvidia/nemotron-3-ultra-550b-a55b": {
+        "input": "600000000",
+        "output": "3600000000",
+        "cacheRead": "200000000"
+      },
+      "openai/gpt-oss-120b": { "input": "150000000", "output": "600000000" },
+      "openai/gpt-oss-20b": { "input": "50000000", "output": "200000000" },
+      "pearl-ai/gemma-4-31b-it": { "input": "280000000", "output": "860000000" },
+      "Qwen/Qwen2.5-7B-Instruct-Turbo": { "input": "300000000", "output": "300000000" },
+      "Qwen/Qwen3-235B-A22B-Instruct-2507-tput": { "input": "200000000", "output": "600000000" },
+      "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": { "input": "2000000000", "output": "2000000000" },
+      "Qwen/Qwen3-Coder-Next-FP8": { "input": "500000000", "output": "1200000000" },
+      "Qwen/Qwen3.5-397B-A17B": {
+        "input": "600000000",
+        "output": "3600000000",
+        "cacheRead": "350000000"
+      },
+      "Qwen/Qwen3.5-9B": { "input": "170000000", "output": "250000000" },
+      "Qwen/Qwen3.6-Plus": { "input": "500000000", "output": "3000000000" },
+      "Qwen/Qwen3.7-Max": {
+        "input": "1250000000",
+        "output": "3750000000",
+        "cacheRead": "125000000"
+      },
+      "thinkingmachines/Inkling": {
+        "input": "1000000000",
+        "output": "4050000000",
+        "cacheRead": "170000000"
+      },
+      "zai-org/GLM-5": { "input": "1000000000", "output": "3200000000" },
+      "zai-org/GLM-5.1": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "zai-org/GLM-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" }
+    },
+    "umans-ai": {
+      "umans-coder": { "input": "950000000", "output": "4000000000", "cacheRead": "190000000" },
+      "umans-deepseek-v4-flash-0731": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "28000000"
+      },
+      "umans-deepseek-v4-pro-0813": {
+        "input": "1320000000",
+        "output": "3960000000",
+        "cacheRead": "44000000"
+      },
+      "umans-flash": { "input": "150000000", "output": "1000000000", "cacheRead": "50000000" },
+      "umans-glm-5.2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "umans-kimi-k2.7": { "input": "950000000", "output": "4000000000", "cacheRead": "190000000" },
+      "umans-kimi-k3": { "input": "3000000000", "output": "15000000000", "cacheRead": "300000000" }
+    },
+    "umans-ai-coding-plan": {
+      "umans-coder": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "umans-deepseek-v4-flash-0731": {
+        "input": "0",
+        "output": "0",
+        "cacheRead": "0",
+        "cacheWrite": "0"
+      },
+      "umans-deepseek-v4-pro-0813": {
+        "input": "0",
+        "output": "0",
+        "cacheRead": "0",
+        "cacheWrite": "0"
+      },
+      "umans-flash": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "umans-glm-5.2": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "umans-kimi-k2.7": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "umans-kimi-k3": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "umans-qwen3.6-35b-a3b": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" }
+    },
+    "unorouter": {
+      "claude-haiku-4-5-20251001": { "input": "1200000000", "output": "6000000000" },
+      "claude-opus-4-8": { "input": "425000000", "output": "2125000000" },
+      "claude-sonnet-5": { "input": "1440000000", "output": "7200000000" },
+      "deepseek-v4-flash": { "input": "62500000", "output": "125000000" },
+      "deepseek-v4-flash:free": { "input": "0", "output": "0" },
+      "deepseek-v4-pro": { "input": "899900000", "output": "1799900000" },
+      "deepseek-v4-pro:free": { "input": "0", "output": "0" },
+      "gemini-3.5-flash": { "input": "185700000", "output": "1114200000" },
+      "gemma-4-31b-it:free": { "input": "0", "output": "0" },
+      "glm-4.5-flash:free": { "input": "0", "output": "0" },
+      "glm-5.2": { "input": "1600100000", "output": "5028800000" },
+      "glm-5.2:free": { "input": "0", "output": "0" },
+      "gpt-5.2": { "input": "1050000000", "output": "8400000000" },
+      "gpt-5.4": { "input": "1800000000", "output": "10800000000" },
+      "gpt-5.4:free": { "input": "0", "output": "0" },
+      "gpt-5.5": { "input": "187500000", "output": "1125000000" },
+      "gpt-5.5:free": { "input": "0", "output": "0" },
+      "kimi-k2.6": { "input": "1267500000", "output": "5336800000" },
+      "minimax-m2.7": { "input": "819000000", "output": "3276000000" },
+      "minimax-m2.7:free": { "input": "0", "output": "0" },
+      "nemotron-3-ultra-550b-a55b:free": { "input": "0", "output": "0" },
+      "qwen3.5-397b-a17b:free": { "input": "0", "output": "0" },
+      "step-3.7-flash:free": { "input": "0", "output": "0" }
+    },
+    "upstage": {
+      "solar-mini": { "input": "150000000", "output": "150000000" },
+      "solar-pro2": { "input": "250000000", "output": "250000000" },
+      "solar-pro3": { "input": "250000000", "output": "250000000" },
+      "solar-pro4": { "input": "300000000", "output": "1200000000", "cacheRead": "60000000" }
+    },
+    "v0": {
+      "v0-1.0-md": { "input": "3000000000", "output": "15000000000" },
+      "v0-1.5-lg": { "input": "15000000000", "output": "75000000000" },
+      "v0-1.5-md": { "input": "3000000000", "output": "15000000000" }
+    },
+    "venice": {
+      "aion-labs-aion-3-0": {
+        "input": "3750000000",
+        "output": "7500000000",
+        "cacheRead": "937500000"
+      },
+      "aion-labs-aion-3-0-mini": {
+        "input": "875000000",
+        "output": "1750000000",
+        "cacheRead": "225000000"
+      },
+      "claude-fable-5": {
+        "input": "12000000000",
+        "output": "60000000000",
+        "cacheRead": "1200000000",
+        "cacheWrite": "15000000000"
+      },
+      "claude-opus-4-5": {
+        "input": "6000000000",
+        "output": "30000000000",
+        "cacheRead": "600000000",
+        "cacheWrite": "7500000000"
+      },
+      "claude-opus-4-6": {
+        "input": "6000000000",
+        "output": "30000000000",
+        "cacheRead": "600000000",
+        "cacheWrite": "7500000000"
+      },
+      "claude-opus-4-7": {
+        "input": "6000000000",
+        "output": "30000000000",
+        "cacheRead": "600000000",
+        "cacheWrite": "7500000000"
+      },
+      "claude-opus-4-8": {
+        "input": "6000000000",
+        "output": "30000000000",
+        "cacheRead": "600000000",
+        "cacheWrite": "7500000000"
+      },
+      "claude-opus-4-8-fast": {
+        "input": "12000000000",
+        "output": "60000000000",
+        "cacheRead": "1200000000",
+        "cacheWrite": "15000000000"
+      },
+      "claude-opus-5": {
+        "input": "6000000000",
+        "output": "30000000000",
+        "cacheRead": "600000000",
+        "cacheWrite": "7500000000"
+      },
+      "claude-opus-5-fast": {
+        "input": "12000000000",
+        "output": "60000000000",
+        "cacheRead": "1200000000",
+        "cacheWrite": "15000000000"
+      },
+      "claude-sonnet-4-5": {
+        "input": "3750000000",
+        "output": "18750000000",
+        "cacheRead": "375000000",
+        "cacheWrite": "4690000000"
+      },
+      "claude-sonnet-4-6": {
+        "input": "3600000000",
+        "output": "18000000000",
+        "cacheRead": "360000000",
+        "cacheWrite": "4500000000"
+      },
+      "claude-sonnet-5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "deepseek-v3.2": { "input": "330000000", "output": "480000000", "cacheRead": "160000000" },
+      "deepseek-v4-flash": { "input": "138000000", "output": "275000000", "cacheRead": "28000000" },
+      "deepseek-v4-flash-0731": {
+        "input": "175000000",
+        "output": "350000000",
+        "cacheRead": "35000000"
+      },
+      "deepseek-v4-flash-0731-fast": {
+        "input": "350000000",
+        "output": "700000000",
+        "cacheRead": "87500000"
+      },
+      "deepseek-v4-pro": {
+        "input": "1650000000",
+        "output": "3301000000",
+        "cacheRead": "330000000"
+      },
+      "deepseek-v4-pro-0813": {
+        "input": "1650000000",
+        "output": "4950000000",
+        "cacheRead": "165000000"
+      },
+      "gemini-3-1-pro-preview": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "500000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "cacheWrite": "500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3-5-flash": {
+        "input": "1550000000",
+        "output": "9450000000",
+        "cacheRead": "155000000",
+        "cacheWrite": "86000000"
+      },
+      "gemini-3-5-flash-lite": {
+        "input": "375000000",
+        "output": "3125000000",
+        "cacheRead": "37500000"
+      },
+      "gemini-3-6-flash": {
+        "input": "1875000000",
+        "output": "9375000000",
+        "cacheRead": "187500000"
+      },
+      "gemini-3-7-flash": {
+        "input": "1875000000",
+        "output": "9375000000",
+        "cacheRead": "187500000"
+      },
+      "gemini-3-flash-preview": {
+        "input": "700000000",
+        "output": "3750000000",
+        "cacheRead": "70000000"
+      },
+      "gemma-4-uncensored": { "input": "162500000", "output": "500000000" },
+      "google-gemma-3-27b-it": { "input": "120000000", "output": "200000000" },
+      "google-gemma-4-26b-a4b-it": {
+        "input": "130000000",
+        "output": "400000000",
+        "cacheRead": "50000000"
+      },
+      "google-gemma-4-31b-it": {
+        "input": "120000000",
+        "output": "360000000",
+        "cacheRead": "90000000"
+      },
+      "grok-4-20": {
+        "input": "1420000000",
+        "output": "2830000000",
+        "cacheRead": "230000000",
+        "tiers": [
+          {
+            "input": "2830000000",
+            "output": "5670000000",
+            "cacheRead": "450000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4-20-multi-agent": {
+        "input": "1420000000",
+        "output": "2830000000",
+        "cacheRead": "230000000",
+        "tiers": [
+          {
+            "input": "2830000000",
+            "output": "5670000000",
+            "cacheRead": "450000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4-3": {
+        "input": "1420000000",
+        "output": "2830000000",
+        "cacheRead": "230000000",
+        "tiers": [
+          {
+            "input": "2830000000",
+            "output": "5670000000",
+            "cacheRead": "450000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4-5": {
+        "input": "2270000000",
+        "output": "6800000000",
+        "cacheRead": "340000000",
+        "tiers": [
+          {
+            "input": "4530000000",
+            "output": "13600000000",
+            "cacheRead": "680000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4-6": {
+        "input": "2270000000",
+        "output": "6800000000",
+        "cacheRead": "570000000",
+        "tiers": [
+          {
+            "input": "4530000000",
+            "output": "13600000000",
+            "cacheRead": "1130000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-build-0-1": {
+        "input": "1000000000",
+        "output": "2000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "4000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "hermes-3-llama-3.1-405b": { "input": "1100000000", "output": "3000000000" },
+      "inkling": { "input": "1250000000", "output": "5062500000", "cacheRead": "212500000" },
+      "kimi-k2-5": { "input": "560000000", "output": "3500000000", "cacheRead": "220000000" },
+      "kimi-k2-6": { "input": "750000000", "output": "3500000000", "cacheRead": "160000000" },
+      "kimi-k2-7-code": { "input": "750000000", "output": "3500000000", "cacheRead": "160000000" },
+      "kimi-k3": { "input": "3750000000", "output": "18750000000", "cacheRead": "375000000" },
+      "kimi-k3-fast-api": {
+        "input": "4500000000",
+        "output": "22500000000",
+        "cacheRead": "450000000"
+      },
+      "llama-3.2-3b": { "input": "150000000", "output": "600000000" },
+      "llama-3.3-70b": { "input": "700000000", "output": "2800000000" },
+      "mercury-2": { "input": "312500000", "output": "937500000", "cacheRead": "31250000" },
+      "minimax-m25": { "input": "270000000", "output": "950000000", "cacheRead": "30000000" },
+      "minimax-m27": { "input": "375000000", "output": "1500000000", "cacheRead": "68750000" },
+      "minimax-m3-preview": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "mistral-small-2603": { "input": "187500000", "output": "750000000" },
+      "mistral-small-3-2-24b-instruct": { "input": "93750000", "output": "250000000" },
+      "nvidia-nemotron-3-nano-30b-a3b": { "input": "75000000", "output": "300000000" },
+      "nvidia-nemotron-3-ultra-550b-a55b": {
+        "input": "625000000",
+        "output": "3125000000",
+        "cacheRead": "187500000"
+      },
+      "olafangensan-glm-4.7-flash-heretic": {
+        "input": "70000000",
+        "output": "400000000",
+        "cacheRead": "35000000"
+      },
+      "openai-gpt-4o-2024-11-20": { "input": "3125000000", "output": "12500000000" },
+      "openai-gpt-4o-mini-2024-07-18": {
+        "input": "187500000",
+        "output": "750000000",
+        "cacheRead": "93750000"
+      },
+      "openai-gpt-52": { "input": "2190000000", "output": "17500000000", "cacheRead": "219000000" },
+      "openai-gpt-52-codex": {
+        "input": "2190000000",
+        "output": "17500000000",
+        "cacheRead": "219000000"
+      },
+      "openai-gpt-53-codex": {
+        "input": "2190000000",
+        "output": "17500000000",
+        "cacheRead": "219000000"
+      },
+      "openai-gpt-54": { "input": "3130000000", "output": "18800000000", "cacheRead": "313000000" },
+      "openai-gpt-54-mini": {
+        "input": "937500000",
+        "output": "5625000000",
+        "cacheRead": "93750000"
+      },
+      "openai-gpt-54-pro": {
+        "input": "37500000000",
+        "output": "225000000000",
+        "tiers": [
+          { "input": "75000000000", "output": "337500000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "openai-gpt-55": {
+        "input": "6250000000",
+        "output": "37500000000",
+        "cacheRead": "625000000",
+        "tiers": [
+          {
+            "input": "12500000000",
+            "output": "56250000000",
+            "cacheRead": "1250000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai-gpt-55-pro": { "input": "37500000000", "output": "225000000000" },
+      "openai-gpt-56-luna": {
+        "input": "266666670",
+        "output": "1600000000",
+        "cacheRead": "26666670",
+        "cacheWrite": "333333340"
+      },
+      "openai-gpt-56-luna-pro": {
+        "input": "1250000000",
+        "output": "7500000000",
+        "cacheRead": "125000000",
+        "cacheWrite": "1562500000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "11250000000",
+            "cacheRead": "250000000",
+            "cacheWrite": "3125000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai-gpt-56-sol": {
+        "input": "6250000000",
+        "output": "37500000000",
+        "cacheRead": "625000000",
+        "cacheWrite": "7812500000"
+      },
+      "openai-gpt-56-sol-pro": {
+        "input": "6250000000",
+        "output": "37500000000",
+        "cacheRead": "625000000",
+        "cacheWrite": "7812500000",
+        "tiers": [
+          {
+            "input": "12500000000",
+            "output": "56250000000",
+            "cacheRead": "1250000000",
+            "cacheWrite": "15625000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai-gpt-56-terra": {
+        "input": "3125000000",
+        "output": "18750000000",
+        "cacheRead": "312500000",
+        "cacheWrite": "3906250000"
+      },
+      "openai-gpt-56-terra-pro": {
+        "input": "3125000000",
+        "output": "18750000000",
+        "cacheRead": "312500000",
+        "cacheWrite": "3906250000",
+        "tiers": [
+          {
+            "input": "6250000000",
+            "output": "28125000000",
+            "cacheRead": "625000000",
+            "cacheWrite": "7812500000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai-gpt-oss-120b": { "input": "70000000", "output": "300000000" },
+      "qwen-3-6-plus": {
+        "input": "625000000",
+        "output": "3750000000",
+        "cacheRead": "62500000",
+        "cacheWrite": "780000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "7500000000",
+            "cacheRead": "62500000",
+            "cacheWrite": "780000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen-3-7-max": {
+        "input": "2700000000",
+        "output": "8050000000",
+        "cacheRead": "270000000",
+        "cacheWrite": "3350000000"
+      },
+      "qwen-3-7-plus": {
+        "input": "500000000",
+        "output": "2000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000",
+        "tiers": [
+          {
+            "input": "1500000000",
+            "output": "6000000000",
+            "cacheRead": "150000000",
+            "cacheWrite": "1875000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen-3-8-2-4t-a95b": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "312500000"
+      },
+      "qwen-3-8-27b": { "input": "450000000", "output": "3200000000" },
+      "qwen-3-8-max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "312500000",
+        "cacheWrite": "3125000000"
+      },
+      "qwen3-235b-a22b-instruct-2507": { "input": "150000000", "output": "750000000" },
+      "qwen3-235b-a22b-thinking-2507": { "input": "450000000", "output": "3500000000" },
+      "qwen3-5-35b-a3b": { "input": "312500000", "output": "1250000000", "cacheRead": "156250000" },
+      "qwen3-5-397b-a17b": { "input": "750000000", "output": "4500000000" },
+      "qwen3-5-9b": { "input": "100000000", "output": "150000000" },
+      "qwen3-6-27b": { "input": "325000000", "output": "3250000000" },
+      "qwen3-6-35b-a3b": { "input": "100000000", "output": "1000000000" },
+      "qwen3-coder-480b-a35b-instruct-turbo": {
+        "input": "350000000",
+        "output": "1500000000",
+        "cacheRead": "40000000"
+      },
+      "qwen3-next-80b": { "input": "350000000", "output": "1900000000" },
+      "qwen3-vl-235b-a22b": {
+        "input": "210000000",
+        "output": "1900000000",
+        "cacheRead": "100000000"
+      },
+      "seed-2-1-turbo": { "input": "625000000", "output": "3125000000", "cacheRead": "125000000" },
+      "stealth-ox-alpha": { "input": "0", "output": "0", "cacheRead": "0" },
+      "venice-uncensored-1-2": { "input": "200000000", "output": "900000000" },
+      "venice-uncensored-role-play": { "input": "500000000", "output": "2000000000" },
+      "xiaomi-mimo-v2-5": { "input": "400000000", "output": "2000000000", "cacheRead": "80000000" },
+      "z-ai-glm-5-3": { "input": "1750000000", "output": "5500000000", "cacheRead": "325000000" },
+      "z-ai-glm-5-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      },
+      "z-ai-glm-5v-turbo": {
+        "input": "1500000000",
+        "output": "5000000000",
+        "cacheRead": "300000000"
+      },
+      "zai-org-glm-4.6": { "input": "430000000", "output": "1750000000", "cacheRead": "80000000" },
+      "zai-org-glm-4.7": { "input": "550000000", "output": "2650000000", "cacheRead": "110000000" },
+      "zai-org-glm-4.7-flash": {
+        "input": "60000000",
+        "output": "400000000",
+        "cacheRead": "10000000"
+      },
+      "zai-org-glm-5": { "input": "1000000000", "output": "3200000000", "cacheRead": "200000000" },
+      "zai-org-glm-5-1": {
+        "input": "1540000000",
+        "output": "4840000000",
+        "cacheRead": "286000000"
+      },
+      "zai-org-glm-5-2": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" }
+    },
+    "vercel": {
+      "alibaba/qwen-3-14b": { "input": "120000000", "output": "240000000" },
+      "alibaba/qwen-3-235b": { "input": "220000000", "output": "880000000" },
+      "alibaba/qwen-3-30b": { "input": "120000000", "output": "500000000" },
+      "alibaba/qwen-3-32b": { "input": "160000000", "output": "640000000" },
+      "alibaba/qwen-3.6-max-preview": {
+        "input": "1300000000",
+        "output": "7800000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "1625000000"
+      },
+      "alibaba/qwen3-235b-a22b-thinking": { "input": "400000000", "output": "4000000000" },
+      "alibaba/qwen3-coder": {
+        "input": "1500000000",
+        "output": "7500000000",
+        "cacheRead": "300000000"
+      },
+      "alibaba/qwen3-coder-30b-a3b": { "input": "150000000", "output": "600000000" },
+      "alibaba/qwen3-coder-next": { "input": "500000000", "output": "1200000000" },
+      "alibaba/qwen3-coder-plus": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "200000000"
+      },
+      "alibaba/qwen3-max": {
+        "input": "1200000000",
+        "output": "6000000000",
+        "cacheRead": "240000000"
+      },
+      "alibaba/qwen3-max-preview": {
+        "input": "1200000000",
+        "output": "6000000000",
+        "cacheRead": "240000000"
+      },
+      "alibaba/qwen3-max-thinking": {
+        "input": "1200000000",
+        "output": "6000000000",
+        "cacheRead": "240000000"
+      },
+      "alibaba/qwen3-next-80b-a3b-instruct": { "input": "150000000", "output": "1200000000" },
+      "alibaba/qwen3-next-80b-a3b-thinking": { "input": "150000000", "output": "1200000000" },
+      "alibaba/qwen3-vl-235b-a22b-instruct": { "input": "400000000", "output": "1600000000" },
+      "alibaba/qwen3-vl-instruct": { "input": "400000000", "output": "1600000000" },
+      "alibaba/qwen3-vl-thinking": { "input": "400000000", "output": "4000000000" },
+      "alibaba/qwen3.5-flash": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "1000000",
+        "cacheWrite": "125000000"
+      },
+      "alibaba/qwen3.5-plus": {
+        "input": "400000000",
+        "output": "2400000000",
+        "cacheRead": "40000000",
+        "cacheWrite": "500000000"
+      },
+      "alibaba/qwen3.6-27b": { "input": "600000000", "output": "3600000000" },
+      "alibaba/qwen3.6-plus": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "625000000"
+      },
+      "alibaba/qwen3.7-flash": {
+        "input": "30000000",
+        "output": "130000000",
+        "cacheRead": "6000000",
+        "cacheWrite": "38000000"
+      },
+      "alibaba/qwen3.7-max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "3125000000"
+      },
+      "alibaba/qwen3.7-plus": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "500000000"
+      },
+      "alibaba/qwen3.8-2.4t-a95b": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "200000000"
+      },
+      "alibaba/qwen3.8-27b": {
+        "input": "550000000",
+        "output": "3300000000",
+        "cacheRead": "110000000"
+      },
+      "alibaba/qwen3.8-max": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "2500000000"
+      },
+      "amazon/nova-2-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "75000000"
+      },
+      "amazon/nova-lite": { "input": "60000000", "output": "240000000", "cacheRead": "15000000" },
+      "amazon/nova-micro": { "input": "35000000", "output": "140000000", "cacheRead": "8750000" },
+      "amazon/nova-pro": { "input": "800000000", "output": "3200000000", "cacheRead": "200000000" },
+      "anthropic/claude-3-haiku": {
+        "input": "250000000",
+        "output": "1250000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "300000000"
+      },
+      "anthropic/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-haiku-4.5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic/claude-opus-4": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic/claude-opus-4.5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.8-fast": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-opus-5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-5-fast": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-sonnet-4": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4.5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4.6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000",
+        "tiers": [
+          {
+            "input": "6000000000",
+            "output": "22500000000",
+            "cacheRead": "600000000",
+            "cacheWrite": "7500000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "arcee-ai/trinity-large-thinking": { "input": "250000000", "output": "900000000" },
+      "bytedance/seed-1.6": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "50000000"
+      },
+      "bytedance/seed-1.8": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "50000000"
+      },
+      "cohere/command-a": { "input": "2500000000", "output": "10000000000" },
+      "deepseek/deepseek-r1": { "input": "1350000000", "output": "5400000000" },
+      "deepseek/deepseek-v3": {
+        "input": "270000000",
+        "output": "1120000000",
+        "cacheRead": "135000000"
+      },
+      "deepseek/deepseek-v3.1": {
+        "input": "250000000",
+        "output": "950000000",
+        "cacheRead": "130000000"
+      },
+      "deepseek/deepseek-v3.1-terminus": {
+        "input": "270000000",
+        "output": "1000000000",
+        "cacheRead": "135000000"
+      },
+      "deepseek/deepseek-v3.2": {
+        "input": "280000000",
+        "output": "420000000",
+        "cacheRead": "28000000"
+      },
+      "deepseek/deepseek-v3.2-thinking": { "input": "620000000", "output": "1850000000" },
+      "deepseek/deepseek-v4-flash": {
+        "input": "130000000",
+        "output": "260000000",
+        "cacheRead": "28000000"
+      },
+      "deepseek/deepseek-v4-flash-0731": {
+        "input": "76000000",
+        "output": "153000000",
+        "cacheRead": "14000000"
+      },
+      "deepseek/deepseek-v4-flash-vision-exp": {
+        "input": "220000000",
+        "output": "660000000",
+        "cacheRead": "7000000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "1740000000",
+        "output": "3480000000",
+        "cacheRead": "140000000"
+      },
+      "deepseek/deepseek-v4-pro-0813": {
+        "input": "660000000",
+        "output": "1980000000",
+        "cacheRead": "66000000"
+      },
+      "google/gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000",
+        "inputAudio": "1000000000"
+      },
+      "google/gemini-2.5-flash-image": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "google/gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "10000000"
+      },
+      "google/gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "15000000000",
+            "cacheRead": "250000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "google/gemini-3-flash": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000"
+      },
+      "google/gemini-3-pro-image": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000"
+      },
+      "google/gemini-3.1-flash-image": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000"
+      },
+      "google/gemini-3.1-flash-image-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000"
+      },
+      "google/gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "30000000"
+      },
+      "google/gemini-3.1-flash-lite-image": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "30000000"
+      },
+      "google/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000"
+      },
+      "google/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000"
+      },
+      "google/gemini-3.5-flash-lite": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "30000000"
+      },
+      "google/gemini-3.6-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000"
+      },
+      "google/gemini-3.7-flash": {
+        "input": "750000000",
+        "output": "3750000000",
+        "cacheRead": "75000000"
+      },
+      "google/gemini-omni-flash-preview": { "input": "1500000000", "output": "9000000000" },
+      "google/gemma-4-26b-a4b-it": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "15000000"
+      },
+      "google/gemma-4-31b-it": { "input": "140000000", "output": "400000000" },
+      "inception/mercury-2": {
+        "input": "250000000",
+        "output": "750000000",
+        "cacheRead": "25000000"
+      },
+      "inception/mercury-coder-small": { "input": "250000000", "output": "1000000000" },
+      "inclusionai/ling-3.0-flash": {
+        "input": "60000000",
+        "output": "180000000",
+        "cacheRead": "12000000"
+      },
+      "interfaze/interfaze-beta": { "input": "1500000000", "output": "3500000000" },
+      "kwaipilot/kat-coder-air-v2.5": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "30000000"
+      },
+      "kwaipilot/kat-coder-pro-v1": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "kwaipilot/kat-coder-pro-v2": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "kwaipilot/kat-coder-pro-v2.5": {
+        "input": "740000000",
+        "output": "2960000000",
+        "cacheRead": "150000000"
+      },
+      "meta/llama-3.1-70b": { "input": "720000000", "output": "720000000" },
+      "meta/llama-3.1-8b": { "input": "220000000", "output": "220000000" },
+      "meta/llama-3.3-70b": { "input": "0", "output": "0" },
+      "meta/llama-4-maverick": { "input": "0", "output": "0" },
+      "meta/llama-4-scout": { "input": "0", "output": "0" },
+      "meta/muse-glimmer-30b": {
+        "input": "350000000",
+        "output": "1500000000",
+        "cacheRead": "40000000"
+      },
+      "meta/muse-spark-1.1": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "150000000"
+      },
+      "meta/muse-spark-1.2": {
+        "input": "1250000000",
+        "output": "4250000000",
+        "cacheRead": "150000000"
+      },
+      "meta/muse-spark-1.2-contributor": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "2000000"
+      },
+      "minimax/minimax-m2": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.1": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.1-lightning": {
+        "input": "300000000",
+        "output": "2400000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.5-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.7": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.7-free": { "input": "0", "output": "0" },
+      "minimax/minimax-m2.7-highspeed": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m3": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "minimax/minimax-m3-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "mistral/codestral": { "input": "300000000", "output": "900000000" },
+      "mistral/devstral-2": { "input": "400000000", "output": "2000000000" },
+      "mistral/devstral-small-2": { "input": "100000000", "output": "300000000" },
+      "mistral/ministral-14b": { "input": "200000000", "output": "200000000" },
+      "mistral/ministral-3b": { "input": "40000000", "output": "40000000" },
+      "mistral/ministral-8b": { "input": "100000000", "output": "100000000" },
+      "mistral/mistral-large-3": { "input": "500000000", "output": "1500000000" },
+      "mistral/mistral-medium": { "input": "400000000", "output": "2000000000" },
+      "mistral/mistral-medium-3.5": { "input": "1500000000", "output": "7500000000" },
+      "mistral/mistral-nemo": { "input": "150000000", "output": "150000000" },
+      "mistral/mistral-small": { "input": "100000000", "output": "300000000" },
+      "mistral/pixtral-12b": { "input": "150000000", "output": "150000000" },
+      "moonshotai/kimi-k2": { "input": "570000000", "output": "2300000000" },
+      "moonshotai/kimi-k2-thinking": {
+        "input": "470000000",
+        "output": "2000000000",
+        "cacheRead": "141000000"
+      },
+      "moonshotai/kimi-k2.5": {
+        "input": "600000000",
+        "output": "3000000000",
+        "cacheRead": "100000000"
+      },
+      "moonshotai/kimi-k2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "moonshotai/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "190000000"
+      },
+      "moonshotai/kimi-k2.7-code-highspeed": {
+        "input": "1900000000",
+        "output": "8000000000",
+        "cacheRead": "380000000"
+      },
+      "moonshotai/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "moonshotai/kimi-k3-fast": {
+        "input": "4500000000",
+        "output": "22500000000",
+        "cacheRead": "450000000"
+      },
+      "morph/morph-v3-fast": { "input": "800000000", "output": "1200000000" },
+      "morph/morph-v3-large": { "input": "900000000", "output": "1900000000" },
+      "nvidia/nemotron-3-nano-30b-a3b": { "input": "50000000", "output": "240000000" },
+      "nvidia/nemotron-3-super-120b-a12b": { "input": "150000000", "output": "650000000" },
+      "nvidia/nemotron-3-ultra-550b-a55b": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "120000000"
+      },
+      "nvidia/nemotron-3.5-lightning": {
+        "input": "50000000",
+        "output": "200000000",
+        "cacheRead": "10000000"
+      },
+      "nvidia/nemotron-nano-12b-v2-vl": { "input": "200000000", "output": "600000000" },
+      "nvidia/nemotron-nano-9b-v2": { "input": "60000000", "output": "230000000" },
+      "openai/gpt-3.5-turbo": { "input": "500000000", "output": "1500000000" },
+      "openai/gpt-4-turbo": { "input": "10000000000", "output": "30000000000" },
+      "openai/gpt-4.1": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/gpt-4.1-fast": {
+        "input": "3500000000",
+        "output": "14000000000",
+        "cacheRead": "875000000"
+      },
+      "openai/gpt-4.1-mini": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "100000000"
+      },
+      "openai/gpt-4.1-mini-fast": {
+        "input": "700000000",
+        "output": "2800000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-4.1-nano": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-4.1-nano-fast": {
+        "input": "200000000",
+        "output": "800000000",
+        "cacheRead": "50000000"
+      },
+      "openai/gpt-4o": {
+        "input": "2500000000",
+        "output": "10000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-4o-fast": {
+        "input": "4250000000",
+        "output": "17000000000",
+        "cacheRead": "2125000000"
+      },
+      "openai/gpt-4o-mini": {
+        "input": "150000000",
+        "output": "600000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-4o-mini-fast": {
+        "input": "250000000",
+        "output": "1000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-4o-mini-transcribe": { "input": "1250000000", "output": "5000000000" },
+      "openai/gpt-4o-transcribe": { "input": "2500000000", "output": "10000000000" },
+      "openai/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "openai/gpt-5-codex": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "130000000"
+      },
+      "openai/gpt-5-fast": {
+        "input": "2500000000",
+        "output": "20000000000",
+        "cacheRead": "250000000"
+      },
+      "openai/gpt-5-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "25000000"
+      },
+      "openai/gpt-5-mini-fast": {
+        "input": "450000000",
+        "output": "3600000000",
+        "cacheRead": "45000000"
+      },
+      "openai/gpt-5-nano": { "input": "50000000", "output": "400000000", "cacheRead": "5000000" },
+      "openai/gpt-5-pro": { "input": "15000000000", "output": "120000000000" },
+      "openai/gpt-5.1-codex": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "130000000"
+      },
+      "openai/gpt-5.1-codex-max": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "30000000"
+      },
+      "openai/gpt-5.1-thinking": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "openai/gpt-5.1-thinking-fast": {
+        "input": "2500000000",
+        "output": "20000000000",
+        "cacheRead": "250000000"
+      },
+      "openai/gpt-5.2": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.2-fast": {
+        "input": "3500000000",
+        "output": "28000000000",
+        "cacheRead": "350000000"
+      },
+      "openai/gpt-5.2-pro": { "input": "21000000000", "output": "168000000000" },
+      "openai/gpt-5.3-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "175000000"
+      },
+      "openai/gpt-5.3-codex-fast": {
+        "input": "3500000000",
+        "output": "28000000000",
+        "cacheRead": "350000000"
+      },
+      "openai/gpt-5.4": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000"
+      },
+      "openai/gpt-5.4-fast": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "openai/gpt-5.4-mini": {
+        "input": "750000000",
+        "output": "4500000000",
+        "cacheRead": "75000000"
+      },
+      "openai/gpt-5.4-mini-fast": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000"
+      },
+      "openai/gpt-5.4-nano": {
+        "input": "200000000",
+        "output": "1250000000",
+        "cacheRead": "20000000"
+      },
+      "openai/gpt-5.4-pro": { "input": "30000000000", "output": "180000000000" },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "openai/gpt-5.5-fast": {
+        "input": "12500000000",
+        "output": "75000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-5.5-pro": { "input": "30000000000", "output": "180000000000" },
+      "openai/gpt-5.6-luna": {
+        "input": "200000000",
+        "output": "1200000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "250000000"
+      },
+      "openai/gpt-5.6-luna-fast": {
+        "input": "400000000",
+        "output": "2400000000",
+        "cacheRead": "40000000",
+        "cacheWrite": "250000000"
+      },
+      "openai/gpt-5.6-sol": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "openai/gpt-5.6-sol-fast": {
+        "input": "4000000000",
+        "output": "20000000000",
+        "cacheRead": "400000000",
+        "cacheWrite": "2500000000"
+      },
+      "openai/gpt-5.6-terra": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "2500000000"
+      },
+      "openai/gpt-5.6-terra-fast": {
+        "input": "4000000000",
+        "output": "24000000000",
+        "cacheRead": "400000000",
+        "cacheWrite": "2500000000"
+      },
+      "openai/gpt-image-1": {
+        "input": "5000000000",
+        "output": "40000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-image-1-mini": {
+        "input": "2000000000",
+        "output": "8000000000",
+        "cacheRead": "200000000"
+      },
+      "openai/gpt-image-1.5": {
+        "input": "5000000000",
+        "output": "32000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-image-2": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "1250000000"
+      },
+      "openai/gpt-oss-120b": { "input": "100000000", "output": "500000000" },
+      "openai/gpt-oss-20b": { "input": "50000000", "output": "200000000" },
+      "openai/gpt-oss-safeguard-120b": { "input": "150000000", "output": "600000000" },
+      "openai/gpt-oss-safeguard-20b": { "input": "70000000", "output": "200000000" },
+      "openai/gpt-realtime-1.5": {
+        "input": "4000000000",
+        "output": "16000000000",
+        "cacheRead": "400000000"
+      },
+      "openai/gpt-realtime-2": {
+        "input": "4000000000",
+        "output": "24000000000",
+        "cacheRead": "400000000"
+      },
+      "openai/gpt-realtime-2.1": {
+        "input": "4000000000",
+        "output": "24000000000",
+        "cacheRead": "400000000"
+      },
+      "openai/gpt-realtime-mini": {
+        "input": "600000000",
+        "output": "2400000000",
+        "cacheRead": "60000000"
+      },
+      "openai/o1": { "input": "15000000000", "output": "60000000000", "cacheRead": "7500000000" },
+      "openai/o3": { "input": "2000000000", "output": "8000000000", "cacheRead": "500000000" },
+      "openai/o3-fast": {
+        "input": "3500000000",
+        "output": "14000000000",
+        "cacheRead": "875000000"
+      },
+      "openai/o3-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "550000000" },
+      "openai/o3-pro": { "input": "20000000000", "output": "80000000000" },
+      "openai/o4-mini": { "input": "1100000000", "output": "4400000000", "cacheRead": "275000000" },
+      "openai/o4-mini-fast": {
+        "input": "2000000000",
+        "output": "8000000000",
+        "cacheRead": "500000000"
+      },
+      "poolside/laguna-s-2.1": {
+        "input": "100000000",
+        "output": "200000000",
+        "cacheRead": "10000000"
+      },
+      "poolside/laguna-s-2.1-free": { "input": "0", "output": "0" },
+      "sakana/fugu-ultra": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "sakana/namazu": { "input": "950000000", "output": "4000000000", "cacheRead": "150000000" },
+      "spacexai/grok-4.1-fast-non-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "spacexai/grok-4.1-fast-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "spacexai/grok-4.20-multi-agent": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000"
+      },
+      "spacexai/grok-4.20-multi-agent-beta": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000"
+      },
+      "spacexai/grok-4.20-non-reasoning": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000"
+      },
+      "spacexai/grok-4.20-non-reasoning-beta": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "400000000"
+      },
+      "spacexai/grok-4.20-reasoning": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000"
+      },
+      "spacexai/grok-4.20-reasoning-beta": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000"
+      },
+      "spacexai/grok-4.3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000"
+      },
+      "spacexai/grok-4.5": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "300000000"
+      },
+      "spacexai/grok-4.6": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000"
+      },
+      "spacexai/grok-build-0.1": {
+        "input": "1000000000",
+        "output": "2000000000",
+        "cacheRead": "200000000"
+      },
+      "stepfun/step-3.5-flash": {
+        "input": "90000000",
+        "output": "300000000",
+        "cacheRead": "20000000"
+      },
+      "stepfun/step-3.7-flash": {
+        "input": "200000000",
+        "output": "1150000000",
+        "cacheRead": "40000000"
+      },
+      "tencent/hy-mt2-lite": { "input": "44000000", "output": "177000000" },
+      "tencent/hy-mt2-plus": { "input": "74000000", "output": "295000000" },
+      "tencent/hy-mt2-pro": { "input": "74000000", "output": "295000000" },
+      "tencent/hy3": { "input": "132000000", "output": "528000000", "cacheRead": "33000000" },
+      "thinkingmachines/inkling": {
+        "input": "1000000000",
+        "output": "4050000000",
+        "cacheRead": "170000000"
+      },
+      "thinkingmachines/inkling-small": {
+        "input": "500000000",
+        "output": "1200000000",
+        "cacheRead": "100000000"
+      },
+      "xiaomi/mimo-v2.5": { "input": "140000000", "output": "280000000", "cacheRead": "2800000" },
+      "xiaomi/mimo-v2.5-pro": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "3600000"
+      },
+      "zai/glm-4.5": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "zai/glm-4.5-air": { "input": "200000000", "output": "1100000000", "cacheRead": "30000000" },
+      "zai/glm-4.5v": { "input": "600000000", "output": "1800000000", "cacheRead": "110000000" },
+      "zai/glm-4.6": { "input": "600000000", "output": "2200000000", "cacheRead": "110000000" },
+      "zai/glm-4.7": { "input": "600000000", "output": "2200000000", "cacheRead": "120000000" },
+      "zai/glm-4.7-flash": { "input": "70000000", "output": "400000000" },
+      "zai/glm-4.7-flashx": { "input": "60000000", "output": "400000000", "cacheRead": "10000000" },
+      "zai/glm-5": { "input": "1000000000", "output": "3200000000" },
+      "zai/glm-5-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      },
+      "zai/glm-5.1": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "zai/glm-5.2": { "input": "800000000", "output": "2550000000", "cacheRead": "160000000" },
+      "zai/glm-5.2-fast": {
+        "input": "2100000000",
+        "output": "6600000000",
+        "cacheRead": "210000000"
+      },
+      "zai/glm-5.3": { "input": "1400000000", "output": "4400000000", "cacheRead": "260000000" },
+      "zai/glm-5v-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000"
+      }
+    },
+    "vivgrid": {
+      "deepseek-v3.2": { "input": "280000000", "output": "420000000" },
+      "deepseek-v4-flash": {
+        "input": "150000000",
+        "output": "300000000",
+        "cacheRead": "30000000",
+        "reasoning": "300000000"
+      },
+      "deepseek-v4-pro": { "input": "435000000", "output": "870000000", "cacheRead": "3625000" },
+      "gemini-3.1-flash-lite-preview": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000",
+        "cacheWrite": "1000000000"
+      },
+      "gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "18000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "gemini-3.7-flash": { "input": "750000000", "output": "3750000000", "cacheRead": "75000000" },
+      "glm-5.2": { "input": "1200000000", "output": "4200000000", "cacheRead": "300000000" },
+      "glm-5.3": { "input": "1200000000", "output": "4200000000", "cacheRead": "260000000" },
+      "gpt-5-mini": { "input": "250000000", "output": "2000000000", "cacheRead": "30000000" },
+      "gpt-5.1-codex": { "input": "1250000000", "output": "10000000000", "cacheRead": "125000000" },
+      "gpt-5.1-codex-max": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "125000000"
+      },
+      "gpt-5.2-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.3-codex": { "input": "1750000000", "output": "14000000000", "cacheRead": "175000000" },
+      "gpt-5.4": { "input": "2500000000", "output": "15000000000", "cacheRead": "250000000" },
+      "gpt-5.4-mini": { "input": "750000000", "output": "4500000000", "cacheRead": "75000000" },
+      "gpt-5.4-nano": { "input": "200000000", "output": "1250000000", "cacheRead": "20000000" },
+      "gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "gpt-5.6-luna": {
+        "input": "1000000000",
+        "output": "6000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "gpt-5.6-terra": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "3125000000"
+      },
+      "kimi-k3": { "input": "3000000000", "output": "15000000000", "cacheRead": "300000000" }
+    },
+    "vultr": {
+      "deepseek-ai/DeepSeek-V4-Flash": { "input": "300000000", "output": "1000000000" },
+      "MiniMaxAI/MiniMax-M2.7": { "input": "300000000", "output": "1200000000" },
+      "moonshotai/Kimi-K2.6": { "input": "300000000", "output": "1200000000" },
+      "nvidia/DeepSeek-V3.2-NVFP4": { "input": "550000000", "output": "1650000000" },
+      "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16": {
+        "input": "130000000",
+        "output": "380000000"
+      },
+      "nvidia/Nemotron-Cascade-2-30B-A3B": { "input": "150000000", "output": "600000000" },
+      "Qwen/Qwen3.5-397B-A17B": { "input": "300000000", "output": "2000000000" },
+      "Qwen/Qwen3.6-27B": { "input": "300000000", "output": "2000000000" },
+      "XiaomiMiMo/MiMo-V2.5-Pro": { "input": "550000000", "output": "1650000000" },
+      "zai-org/GLM-5.2-FP8": { "input": "850000000", "output": "3100000000" }
+    },
+    "wafer.ai": {
+      "GLM-5.1": {
+        "input": "1000000000",
+        "output": "3200000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "0"
+      },
+      "GLM-5.2": {
+        "input": "1200000000",
+        "output": "4100000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "0"
+      },
+      "glm5.2-fast": {
+        "input": "3000000000",
+        "output": "10250000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "0"
+      },
+      "Kimi-K2.6": {
+        "input": "1140000000",
+        "output": "4800000000",
+        "cacheRead": "190000000",
+        "cacheWrite": "0"
+      },
+      "MiniMax-M3": {
+        "input": "330000000",
+        "output": "1320000000",
+        "cacheRead": "70000000",
+        "cacheWrite": "0",
+        "tiers": [
+          {
+            "input": "660000000",
+            "output": "2640000000",
+            "cacheRead": "130000000",
+            "cacheWrite": "0",
+            "aboveInputTokens": "512000"
+          }
+        ]
+      }
+    },
+    "wandb": {
+      "deepseek-ai/DeepSeek-V3.1": {
+        "input": "550000000",
+        "output": "1650000000",
+        "cacheRead": "550000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "70000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Flash-0731": {
+        "input": "130000000",
+        "output": "280000000",
+        "cacheRead": "70000000"
+      },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "input": "1150000000",
+        "output": "2550000000",
+        "cacheRead": "200000000"
+      },
+      "google/gemma-4-31B-it": {
+        "input": "100000000",
+        "output": "340000000",
+        "cacheRead": "100000000"
+      },
+      "ibm-granite/granite-4.1-8b": {
+        "input": "50000000",
+        "output": "100000000",
+        "cacheRead": "50000000"
+      },
+      "ibm-granite/granite-4.2-8b": {
+        "input": "100000000",
+        "output": "150000000",
+        "cacheRead": "50000000"
+      },
+      "JetBrains/Mellum2-12B-A2.5B-Instruct": {
+        "input": "50000000",
+        "output": "100000000",
+        "cacheRead": "50000000"
+      },
+      "meta-llama/Llama-3.1-70B-Instruct": {
+        "input": "800000000",
+        "output": "800000000",
+        "cacheRead": "800000000"
+      },
+      "meta-llama/Llama-3.1-8B-Instruct": {
+        "input": "220000000",
+        "output": "220000000",
+        "cacheRead": "220000000"
+      },
+      "meta-llama/Llama-3.3-70B-Instruct": {
+        "input": "710000000",
+        "output": "710000000",
+        "cacheRead": "710000000"
+      },
+      "MiniMaxAI/MiniMax-M2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "300000000"
+      },
+      "MiniMaxAI/MiniMax-M3": {
+        "input": "230000000",
+        "output": "960000000",
+        "cacheRead": "50000000"
+      },
+      "moonshotai/Kimi-K2.6": {
+        "input": "650000000",
+        "output": "3410000000",
+        "cacheRead": "150000000"
+      },
+      "moonshotai/Kimi-K2.7-Code": {
+        "input": "710000000",
+        "output": "3500000000",
+        "cacheRead": "150000000"
+      },
+      "moonshotai/Kimi-K3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
+        "input": "200000000",
+        "output": "800000000",
+        "cacheRead": "200000000"
+      },
+      "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": {
+        "input": "750000000",
+        "output": "2750000000",
+        "cacheRead": "150000000"
+      },
+      "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B": {
+        "input": "100000000",
+        "output": "250000000",
+        "cacheRead": "50000000"
+      },
+      "openai/gpt-oss-120b": {
+        "input": "30000000",
+        "output": "170000000",
+        "cacheRead": "30000000"
+      },
+      "openai/gpt-oss-20b": { "input": "30000000", "output": "130000000", "cacheRead": "30000000" },
+      "OpenPipe/Qwen3-14B-Instruct": {
+        "input": "50000000",
+        "output": "220000000",
+        "cacheRead": "50000000"
+      },
+      "Qwen/Qwen3-30B-A3B-Instruct-2507": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "100000000"
+      },
+      "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
+        "input": "1000000000",
+        "output": "1500000000",
+        "cacheRead": "1000000000"
+      },
+      "Qwen/Qwen3.5-35B-A3B": {
+        "input": "250000000",
+        "output": "1250000000",
+        "cacheRead": "250000000"
+      },
+      "Qwen/Qwen3.6-27B": {
+        "input": "600000000",
+        "output": "3600000000",
+        "cacheRead": "120000000"
+      },
+      "Qwen/Qwen3.6-35B-A3B": {
+        "input": "250000000",
+        "output": "1250000000",
+        "cacheRead": "250000000"
+      },
+      "Qwen/Qwen3.8-27B": {
+        "input": "400000000",
+        "output": "3000000000",
+        "cacheRead": "150000000"
+      },
+      "zai-org/GLM-5.1": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000"
+      },
+      "zai-org/GLM-5.2": { "input": "760000000", "output": "2420000000", "cacheRead": "140000000" }
+    },
+    "watsonx": {
+      "ibm/granite-4-h-small": { "input": "63600000", "output": "265000000" },
+      "meta-llama/llama-3-3-70b-instruct": { "input": "752600000", "output": "752600000" },
+      "meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+        "input": "371000000",
+        "output": "1484000000"
+      },
+      "mistralai/mistral-small-3-1-24b-instruct-2503": {
+        "input": "106000000",
+        "output": "318000000"
+      },
+      "openai/gpt-oss-120b": { "input": "159000000", "output": "636000000" }
+    },
+    "xai": {
+      "grok-4.20-0309-non-reasoning": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4.20-0309-reasoning": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4.20-multi-agent-0309": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4.3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4.5": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "300000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "600000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-4.6": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "grok-build-0.1": {
+        "input": "1000000000",
+        "output": "2000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "4000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      }
+    },
+    "xiaomi": {
+      "mimo-v2-flash": { "input": "140000000", "output": "280000000", "cacheRead": "2800000" },
+      "mimo-v2-omni": { "input": "140000000", "output": "280000000", "cacheRead": "2800000" },
+      "mimo-v2-pro": { "input": "435000000", "output": "870000000", "cacheRead": "3600000" },
+      "mimo-v2.5": { "input": "140000000", "output": "280000000", "cacheRead": "2800000" },
+      "mimo-v2.5-pro": { "input": "435000000", "output": "870000000", "cacheRead": "3600000" },
+      "mimo-v2.5-pro-ultraspeed": {
+        "input": "1305000000",
+        "output": "2610000000",
+        "cacheRead": "10800000"
+      }
+    },
+    "xiaomi-token-plan-ams": {
+      "mimo-v2-pro": { "input": "0", "output": "0", "cacheRead": "0" },
+      "mimo-v2-tts": { "input": "0", "output": "0" },
+      "mimo-v2.5": { "input": "0", "output": "0", "cacheRead": "0" },
+      "mimo-v2.5-pro": { "input": "0", "output": "0", "cacheRead": "0" },
+      "mimo-v2.5-tts": { "input": "0", "output": "0" },
+      "mimo-v2.5-tts-voiceclone": { "input": "0", "output": "0" },
+      "mimo-v2.5-tts-voicedesign": { "input": "0", "output": "0" }
+    },
+    "xiaomi-token-plan-cn": {
+      "mimo-v2-pro": { "input": "0", "output": "0", "cacheRead": "0" },
+      "mimo-v2-tts": { "input": "0", "output": "0" },
+      "mimo-v2.5": { "input": "0", "output": "0", "cacheRead": "0" },
+      "mimo-v2.5-pro": { "input": "0", "output": "0", "cacheRead": "0" },
+      "mimo-v2.5-tts": { "input": "0", "output": "0" },
+      "mimo-v2.5-tts-voiceclone": { "input": "0", "output": "0" },
+      "mimo-v2.5-tts-voicedesign": { "input": "0", "output": "0" }
+    },
+    "xiaomi-token-plan-sgp": {
+      "mimo-v2-pro": { "input": "0", "output": "0", "cacheRead": "0" },
+      "mimo-v2-tts": { "input": "0", "output": "0" },
+      "mimo-v2.5": { "input": "0", "output": "0", "cacheRead": "0" },
+      "mimo-v2.5-pro": { "input": "0", "output": "0", "cacheRead": "0" },
+      "mimo-v2.5-tts": { "input": "0", "output": "0" },
+      "mimo-v2.5-tts-voiceclone": { "input": "0", "output": "0" },
+      "mimo-v2.5-tts-voicedesign": { "input": "0", "output": "0" }
+    },
+    "xpersona": {
+      "claude-fable-5": {
+        "input": "3000000000",
+        "output": "18500000000",
+        "cacheRead": "300000000",
+        "reasoning": "18500000000"
+      },
+      "claude-haiku-4-5": {
+        "input": "600000000",
+        "output": "3700000000",
+        "cacheRead": "60000000",
+        "reasoning": "3700000000"
+      },
+      "claude-opus-4-8": {
+        "input": "1500000000",
+        "output": "9250000000",
+        "cacheRead": "150000000",
+        "reasoning": "9250000000"
+      },
+      "claude-sonnet-4-6": {
+        "input": "900000000",
+        "output": "5550000000",
+        "cacheRead": "90000000",
+        "reasoning": "5550000000"
+      },
+      "gemini-3.5-flash": {
+        "input": "1550000000",
+        "output": "12200000000",
+        "cacheRead": "155000000",
+        "reasoning": "12200000000"
+      },
+      "gpt-5.4": {
+        "input": "750000000",
+        "output": "6000000000",
+        "cacheRead": "75000000",
+        "reasoning": "6000000000"
+      },
+      "gpt-5.4-mini": {
+        "input": "375000000",
+        "output": "4000000000",
+        "cacheRead": "37500000",
+        "reasoning": "4000000000"
+      },
+      "gpt-5.5": {
+        "input": "1500000000",
+        "output": "12000000000",
+        "cacheRead": "150000000",
+        "reasoning": "12000000000"
+      },
+      "gpt-5.6": {
+        "input": "1500000000",
+        "output": "12000000000",
+        "cacheRead": "150000000",
+        "reasoning": "12000000000"
+      },
+      "gpt-5.6-sol": {
+        "input": "1500000000",
+        "output": "12000000000",
+        "cacheRead": "150000000",
+        "reasoning": "12000000000"
+      },
+      "gpt-5.6-terra": {
+        "input": "1500000000",
+        "output": "2000000000",
+        "cacheRead": "150000000",
+        "reasoning": "2000000000"
+      },
+      "xpersona-frieren-coder": {
+        "input": "1500000000",
+        "output": "6000000000",
+        "cacheRead": "150000000",
+        "reasoning": "6000000000"
+      },
+      "xpersona-gpt-5.5": {
+        "input": "3000000000",
+        "output": "18000000000",
+        "cacheRead": "300000000",
+        "reasoning": "18000000000"
+      }
+    },
+    "zai": {
+      "glm-4.5": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "glm-4.5-air": {
+        "input": "200000000",
+        "output": "1100000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "0"
+      },
+      "glm-4.5-flash": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-4.5v": { "input": "600000000", "output": "1800000000" },
+      "glm-4.6": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "glm-4.6v": { "input": "300000000", "output": "900000000" },
+      "glm-4.7": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "glm-4.7-flash": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-4.7-flashx": {
+        "input": "70000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "0"
+      },
+      "glm-5": {
+        "input": "1000000000",
+        "output": "3200000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "0"
+      },
+      "glm-5-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000",
+        "cacheWrite": "0"
+      },
+      "glm-5.1": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "0"
+      },
+      "glm-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "0"
+      },
+      "glm-5.3": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "0"
+      },
+      "glm-5v-turbo": {
+        "input": "1200000000",
+        "output": "4000000000",
+        "cacheRead": "240000000",
+        "cacheWrite": "0"
+      }
+    },
+    "zai-coding-plan": {
+      "glm-4.7": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5-turbo": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5.2": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5.2-highspeed": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5.3": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" }
+    },
+    "zeldoc": { "zdev": { "input": "0", "output": "0" } },
+    "zenifra": { "alibaba/qwen3.6-35b-a3b": { "input": "190000000", "output": "480000000" } },
+    "zenmux": {
+      "anthropic/claude-3.5-haiku": {
+        "input": "800000000",
+        "output": "4000000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "1000000000"
+      },
+      "anthropic/claude-3.7-sonnet": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-fable-5": {
+        "input": "10000000000",
+        "output": "50000000000",
+        "cacheRead": "1000000000",
+        "cacheWrite": "12500000000"
+      },
+      "anthropic/claude-haiku-4.5": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "anthropic/claude-opus-4": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic/claude-opus-4.1": {
+        "input": "15000000000",
+        "output": "75000000000",
+        "cacheRead": "1500000000",
+        "cacheWrite": "18750000000"
+      },
+      "anthropic/claude-opus-4.5": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.6": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.7": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-opus-4.8": {
+        "input": "5000000000",
+        "output": "25000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000"
+      },
+      "anthropic/claude-sonnet-4": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4.5": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-4.6": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000",
+        "cacheWrite": "3750000000"
+      },
+      "anthropic/claude-sonnet-5": {
+        "input": "2000000000",
+        "output": "10000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "4000000000"
+      },
+      "anthropic/claude-sonnet-5-free": {
+        "input": "0",
+        "output": "0",
+        "cacheRead": "0",
+        "cacheWrite": "0"
+      },
+      "baidu/ernie-5.0-thinking-preview": { "input": "840000000", "output": "3370000000" },
+      "deepseek/deepseek-chat": {
+        "input": "280000000",
+        "output": "420000000",
+        "cacheRead": "30000000"
+      },
+      "deepseek/deepseek-v3.2": { "input": "280000000", "output": "430000000" },
+      "deepseek/deepseek-v3.2-exp": { "input": "220000000", "output": "330000000" },
+      "deepseek/deepseek-v4-flash": {
+        "input": "140000000",
+        "output": "280000000",
+        "cacheRead": "2800000"
+      },
+      "deepseek/deepseek-v4-pro": {
+        "input": "435000000",
+        "output": "870000000",
+        "cacheRead": "3625000"
+      },
+      "google/gemini-2.5-flash": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "70000000",
+        "cacheWrite": "1000000000"
+      },
+      "google/gemini-2.5-flash-lite": {
+        "input": "100000000",
+        "output": "400000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "1000000000"
+      },
+      "google/gemini-2.5-pro": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "310000000",
+        "cacheWrite": "4500000000"
+      },
+      "google/gemini-3-flash-preview": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "1000000000"
+      },
+      "google/gemini-3.1-flash-lite": {
+        "input": "250000000",
+        "output": "1500000000",
+        "cacheRead": "25000000"
+      },
+      "google/gemini-3.1-flash-lite-preview": { "input": "250000000", "output": "1500000000" },
+      "google/gemini-3.1-pro-preview": {
+        "input": "2000000000",
+        "output": "12000000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "4500000000"
+      },
+      "google/gemini-3.5-flash": {
+        "input": "1500000000",
+        "output": "9000000000",
+        "cacheRead": "150000000"
+      },
+      "inclusionai/ling-1t": {
+        "input": "560000000",
+        "output": "2240000000",
+        "cacheRead": "110000000"
+      },
+      "inclusionai/ring-1t": {
+        "input": "560000000",
+        "output": "2240000000",
+        "cacheRead": "110000000"
+      },
+      "inclusionai/ring-2.6-1t": {
+        "input": "300000000",
+        "output": "2500000000",
+        "cacheRead": "60000000"
+      },
+      "kuaishou/kat-coder-pro-v2": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "60000000"
+      },
+      "minimax/minimax-m2": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "380000000"
+      },
+      "minimax/minimax-m2.1": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "380000000"
+      },
+      "minimax/minimax-m2.5": {
+        "input": "300000000",
+        "output": "1200000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "375000000"
+      },
+      "minimax/minimax-m2.5-lightning": {
+        "input": "600000000",
+        "output": "4800000000",
+        "cacheRead": "60000000",
+        "cacheWrite": "750000000"
+      },
+      "minimax/minimax-m2.7": { "input": "305500000", "output": "1221900000" },
+      "minimax/minimax-m2.7-highspeed": { "input": "611000000", "output": "2443900000" },
+      "minimax/minimax-m3": { "input": "600000000", "output": "2400000000" },
+      "moonshotai/kimi-k2-0905": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "150000000"
+      },
+      "moonshotai/kimi-k2-thinking": {
+        "input": "600000000",
+        "output": "2500000000",
+        "cacheRead": "150000000"
+      },
+      "moonshotai/kimi-k2-thinking-turbo": {
+        "input": "1150000000",
+        "output": "8000000000",
+        "cacheRead": "150000000"
+      },
+      "moonshotai/kimi-k2.5": {
+        "input": "580000000",
+        "output": "3020000000",
+        "cacheRead": "100000000"
+      },
+      "moonshotai/kimi-k2.6": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "moonshotai/kimi-k2.7-code": {
+        "input": "950000000",
+        "output": "4000000000",
+        "cacheRead": "160000000"
+      },
+      "moonshotai/kimi-k2.7-code-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "moonshotai/kimi-k3": {
+        "input": "3000000000",
+        "output": "15000000000",
+        "cacheRead": "300000000"
+      },
+      "moonshotai/kimi-k3-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "openai/gpt-5": { "input": "1250000000", "output": "10000000000", "cacheRead": "120000000" },
+      "openai/gpt-5-codex": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "120000000"
+      },
+      "openai/gpt-5.1": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "120000000"
+      },
+      "openai/gpt-5.1-chat": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "120000000"
+      },
+      "openai/gpt-5.1-codex": {
+        "input": "1250000000",
+        "output": "10000000000",
+        "cacheRead": "120000000"
+      },
+      "openai/gpt-5.1-codex-mini": {
+        "input": "250000000",
+        "output": "2000000000",
+        "cacheRead": "30000000"
+      },
+      "openai/gpt-5.2": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "170000000"
+      },
+      "openai/gpt-5.2-codex": {
+        "input": "1750000000",
+        "output": "14000000000",
+        "cacheRead": "170000000"
+      },
+      "openai/gpt-5.2-pro": { "input": "21000000000", "output": "168000000000" },
+      "openai/gpt-5.3-chat": { "input": "1750000000", "output": "14000000000" },
+      "openai/gpt-5.3-codex": { "input": "1750000000", "output": "14000000000" },
+      "openai/gpt-5.4": { "input": "3750000000", "output": "18750000000" },
+      "openai/gpt-5.4-mini": { "input": "750000000", "output": "4500000000" },
+      "openai/gpt-5.4-nano": { "input": "200000000", "output": "1250000000" },
+      "openai/gpt-5.4-pro": { "input": "45000000000", "output": "225000000000" },
+      "openai/gpt-5.5": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "272000"
+          }
+        ],
+        "modes": {
+          "fast": { "input": "12500000000", "output": "75000000000", "cacheRead": "1250000000" }
+        }
+      },
+      "openai/gpt-5.5-instant": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000"
+      },
+      "openai/gpt-5.5-pro": {
+        "input": "30000000000",
+        "output": "180000000000",
+        "tiers": [
+          { "input": "60000000000", "output": "270000000000", "aboveInputTokens": "272000" }
+        ]
+      },
+      "openai/gpt-5.6-luna": {
+        "input": "1000000000",
+        "output": "6000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "9000000000",
+            "cacheRead": "200000000",
+            "cacheWrite": "2500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-sol": {
+        "input": "5000000000",
+        "output": "30000000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "6250000000",
+        "tiers": [
+          {
+            "input": "10000000000",
+            "output": "45000000000",
+            "cacheRead": "1000000000",
+            "cacheWrite": "12500000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "openai/gpt-5.6-terra": {
+        "input": "2500000000",
+        "output": "15000000000",
+        "cacheRead": "250000000",
+        "cacheWrite": "3125000000",
+        "tiers": [
+          {
+            "input": "5000000000",
+            "output": "22500000000",
+            "cacheRead": "500000000",
+            "cacheWrite": "6250000000",
+            "aboveInputTokens": "272000"
+          }
+        ]
+      },
+      "qwen/qwen3-coder-plus": {
+        "input": "1000000000",
+        "output": "5000000000",
+        "cacheRead": "100000000",
+        "cacheWrite": "1250000000"
+      },
+      "qwen/qwen3-max": { "input": "1200000000", "output": "6000000000" },
+      "qwen/qwen3.5-flash": { "input": "100000000", "output": "400000000" },
+      "qwen/qwen3.5-plus": { "input": "800000000", "output": "4800000000" },
+      "qwen/qwen3.6-plus": {
+        "input": "500000000",
+        "output": "3000000000",
+        "cacheRead": "50000000",
+        "cacheWrite": "625000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "200000000",
+            "cacheWrite": "2500000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "qwen/qwen3.7-max": {
+        "input": "2500000000",
+        "output": "7500000000",
+        "cacheRead": "500000000",
+        "cacheWrite": "3125000000"
+      },
+      "qwen/qwen3.7-plus": {
+        "input": "400000000",
+        "output": "1600000000",
+        "cacheRead": "80000000",
+        "cacheWrite": "500000000",
+        "tiers": [
+          {
+            "input": "1200000000",
+            "output": "4800000000",
+            "cacheRead": "240000000",
+            "cacheWrite": "1500000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "sapiens-ai/agnes-1.5-lite": { "input": "120000000", "output": "600000000" },
+      "sapiens-ai/agnes-1.5-pro": { "input": "160000000", "output": "800000000" },
+      "stepfun/step-3": { "input": "210000000", "output": "570000000" },
+      "stepfun/step-3.5-flash": { "input": "100000000", "output": "300000000" },
+      "stepfun/step-3.7-flash": { "input": "200000000", "output": "1150000000" },
+      "stepfun/step-3.7-flash-free": { "input": "0", "output": "0" },
+      "tencent/hy3-preview": {
+        "input": "172000000",
+        "output": "572000000",
+        "cacheRead": "58000000",
+        "cacheWrite": "0"
+      },
+      "volcengine/doubao-seed-1.8": {
+        "input": "110000000",
+        "output": "280000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "2400000"
+      },
+      "volcengine/doubao-seed-2.0-code": { "input": "900000000", "output": "4480000000" },
+      "volcengine/doubao-seed-2.0-lite": {
+        "input": "90000000",
+        "output": "510000000",
+        "cacheRead": "20000000",
+        "cacheWrite": "2400000"
+      },
+      "volcengine/doubao-seed-2.0-mini": {
+        "input": "30000000",
+        "output": "280000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "2400000"
+      },
+      "volcengine/doubao-seed-2.0-pro": {
+        "input": "450000000",
+        "output": "2240000000",
+        "cacheRead": "90000000",
+        "cacheWrite": "2400000"
+      },
+      "volcengine/doubao-seed-code": {
+        "input": "170000000",
+        "output": "1120000000",
+        "cacheRead": "30000000"
+      },
+      "x-ai/grok-4": { "input": "3000000000", "output": "15000000000", "cacheRead": "750000000" },
+      "x-ai/grok-4-fast": { "input": "200000000", "output": "500000000", "cacheRead": "50000000" },
+      "x-ai/grok-4.1-fast": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "x-ai/grok-4.1-fast-non-reasoning": {
+        "input": "200000000",
+        "output": "500000000",
+        "cacheRead": "50000000"
+      },
+      "x-ai/grok-4.2-fast": { "input": "3000000000", "output": "9000000000" },
+      "x-ai/grok-4.2-fast-non-reasoning": { "input": "3000000000", "output": "9000000000" },
+      "x-ai/grok-4.3": {
+        "input": "1250000000",
+        "output": "2500000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "0",
+        "tiers": [
+          {
+            "input": "2500000000",
+            "output": "5000000000",
+            "cacheRead": "400000000",
+            "cacheWrite": "0",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "x-ai/grok-4.5": {
+        "input": "2000000000",
+        "output": "6000000000",
+        "cacheRead": "500000000",
+        "tiers": [
+          {
+            "input": "4000000000",
+            "output": "12000000000",
+            "cacheRead": "1000000000",
+            "aboveInputTokens": "200000"
+          }
+        ]
+      },
+      "x-ai/grok-build-0.1": {
+        "input": "1000000000",
+        "output": "2000000000",
+        "cacheRead": "200000000"
+      },
+      "x-ai/grok-code-fast-1": {
+        "input": "200000000",
+        "output": "1500000000",
+        "cacheRead": "20000000"
+      },
+      "xiaomi/mimo-v2-flash": {
+        "input": "100000000",
+        "output": "300000000",
+        "cacheRead": "10000000"
+      },
+      "xiaomi/mimo-v2-omni": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "80000000"
+      },
+      "xiaomi/mimo-v2-pro": {
+        "input": "1000000000",
+        "output": "3000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "xiaomi/mimo-v2.5": {
+        "input": "400000000",
+        "output": "2000000000",
+        "cacheRead": "80000000",
+        "tiers": [
+          {
+            "input": "800000000",
+            "output": "4000000000",
+            "cacheRead": "160000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "xiaomi/mimo-v2.5-pro": {
+        "input": "1000000000",
+        "output": "3000000000",
+        "cacheRead": "200000000",
+        "tiers": [
+          {
+            "input": "2000000000",
+            "output": "6000000000",
+            "cacheRead": "400000000",
+            "aboveInputTokens": "256000"
+          }
+        ]
+      },
+      "z-ai/glm-4.5": { "input": "350000000", "output": "1540000000", "cacheRead": "70000000" },
+      "z-ai/glm-4.5-air": { "input": "110000000", "output": "560000000", "cacheRead": "20000000" },
+      "z-ai/glm-4.6": { "input": "350000000", "output": "1540000000", "cacheRead": "70000000" },
+      "z-ai/glm-4.6v": { "input": "140000000", "output": "420000000", "cacheRead": "30000000" },
+      "z-ai/glm-4.6v-flash": { "input": "20000000", "output": "210000000", "cacheRead": "4300000" },
+      "z-ai/glm-4.6v-flash-free": { "input": "0", "output": "0" },
+      "z-ai/glm-4.7": { "input": "280000000", "output": "1140000000", "cacheRead": "60000000" },
+      "z-ai/glm-4.7-flash-free": { "input": "0", "output": "0" },
+      "z-ai/glm-4.7-flashx": {
+        "input": "70000000",
+        "output": "420000000",
+        "cacheRead": "10000000"
+      },
+      "z-ai/glm-5": { "input": "580000000", "output": "2600000000", "cacheRead": "140000000" },
+      "z-ai/glm-5-turbo": { "input": "880000000", "output": "3480000000" },
+      "z-ai/glm-5.1": { "input": "878100000", "output": "3512600000", "cacheRead": "190300000" },
+      "z-ai/glm-5.2": { "input": "1400000000", "output": "4500000000", "cacheRead": "260000000" },
+      "z-ai/glm-5.2-free": { "input": "0", "output": "0", "cacheRead": "0" },
+      "z-ai/glm-5v-turbo": {
+        "input": "726000000",
+        "output": "3194600000",
+        "cacheRead": "174300000"
+      }
+    },
+    "zhipuai": {
+      "glm-4.5": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "glm-4.5-air": {
+        "input": "200000000",
+        "output": "1100000000",
+        "cacheRead": "30000000",
+        "cacheWrite": "0"
+      },
+      "glm-4.5-flash": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-4.5v": { "input": "600000000", "output": "1800000000" },
+      "glm-4.6": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "glm-4.6v": { "input": "300000000", "output": "900000000" },
+      "glm-4.7": {
+        "input": "600000000",
+        "output": "2200000000",
+        "cacheRead": "110000000",
+        "cacheWrite": "0"
+      },
+      "glm-4.7-flash": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-4.7-flashx": {
+        "input": "70000000",
+        "output": "400000000",
+        "cacheRead": "10000000",
+        "cacheWrite": "0"
+      },
+      "glm-5": {
+        "input": "1000000000",
+        "output": "3200000000",
+        "cacheRead": "200000000",
+        "cacheWrite": "0"
+      },
+      "glm-5.1": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "0"
+      },
+      "glm-5.2": {
+        "input": "1400000000",
+        "output": "4400000000",
+        "cacheRead": "260000000",
+        "cacheWrite": "0"
+      },
+      "glm-5v-turbo": {
+        "input": "5000000000",
+        "output": "22000000000",
+        "cacheRead": "1200000000",
+        "cacheWrite": "0"
+      }
+    },
+    "zhipuai-coding-plan": {
+      "glm-4.6v": { "input": "300000000", "output": "900000000" },
+      "glm-4.7": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5-turbo": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5.1": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5.2": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5.2-highspeed": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5.3": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" },
+      "glm-5v-turbo": { "input": "0", "output": "0", "cacheRead": "0", "cacheWrite": "0" }
+    }
+  }
+}

--- a/packages/agent-worker/src/ai-pricing/models-dev.ts
+++ b/packages/agent-worker/src/ai-pricing/models-dev.ts
@@ -1,0 +1,472 @@
+import {
+  normalizeAiModelCallCostRecord,
+  normalizeAiPricingContext,
+} from "@sixb/core/internal/ai-cost-storage-provider"
+import type {
+  AiBillableMeter,
+  AiBillingIdentity,
+  AiCostComponent,
+  AiModelCallCostRecord,
+  AiModelCallUsage,
+  AiModelCallUsageRecord,
+  AiPriceSource,
+  AiPricingContext,
+  AiUnpriceableReason,
+} from "@sixb/core/storage"
+import { normalizeAiModelCallUsage } from "@sixb/core/storage"
+import catalogJson from "./models-dev-pricing.json"
+
+const SIGNED_INT64_MAX = 9_223_372_036_854_775_807n
+const TOKENS_PER_MILLION = 1_000_000n
+const HALF_MILLION = TOKENS_PER_MILLION / 2n
+const MAX_NUMERIC_TEXT_LENGTH = 128
+
+interface RateAiModelCallInput {
+  readonly usage: AiModelCallUsageRecord
+  readonly pricingContext?: AiPricingContext
+  readonly ratedAt: Date
+}
+
+interface CatalogRateSet {
+  readonly input: string
+  readonly output: string
+  readonly cacheRead?: string
+  readonly cacheWrite?: string
+  readonly reasoning?: string
+  readonly inputAudio?: string
+  readonly outputAudio?: string
+}
+
+interface CatalogTier extends CatalogRateSet {
+  readonly aboveInputTokens: string
+}
+
+interface CatalogPrice extends CatalogRateSet {
+  readonly tiers?: readonly CatalogTier[]
+  readonly modes?: Readonly<Record<string, Omit<CatalogPrice, "modes">>>
+}
+
+interface ModelsDevCatalog {
+  readonly source: {
+    readonly id: string
+    readonly version: string
+    readonly url: string
+    readonly observedAt: string
+  }
+  readonly providers: Readonly<Record<string, Readonly<Record<string, CatalogPrice>>>>
+}
+
+const catalog = catalogJson as ModelsDevCatalog
+
+/** Reviewed AI SDK namespaces whose provider key differs from Models.dev. */
+const SDK_PROVIDER_BINDINGS: Readonly<Record<string, string>> = {
+  "anthropic.messages": "anthropic",
+  "openai.responses": "openai",
+  "openai.chat": "openai",
+  "google.generative-ai": "google",
+  "amazon-bedrock.converse": "amazon-bedrock",
+  gateway: "vercel",
+  "gateway.language-model": "vercel",
+  bedrock: "amazon-bedrock",
+  "google.vertex": "google-vertex",
+  "google.vertex.anthropic": "google-vertex",
+  vertex: "google-vertex",
+  "groq.chat": "groq",
+  "wafer.ai.chat": "wafer.ai",
+}
+
+/** Metadata for the immutable Models.dev snapshot shipped with this agent worker. */
+export const MODELS_DEV_CATALOG_SOURCE = Object.freeze({
+  sourceId: catalog.source.id,
+  sourceVersion: catalog.source.version,
+  sourceUrl: catalog.source.url,
+  observedAt: new Date(catalog.source.observedAt),
+})
+
+/** Rate one immutable usage record against this worker's pinned Models.dev snapshot. */
+export function rateAiModelCall(input: RateAiModelCallInput): AiModelCallCostRecord {
+  const usageRecord = input.usage
+  assertNonBlank(usageRecord.id, "usage record id")
+  assertNonBlank(usageRecord.projectId, "usage projectId")
+  const ratedAt = cloneDate(input.ratedAt, "record ratedAt")
+  const pricingContext = normalizeAiPricingContext(input.pricingContext ?? {})
+  const source = priceSource("unresolved")
+  const billingIdentity = resolveModelsDevBillingIdentity(usageRecord)
+
+  if (!billingIdentity) {
+    return unpriceable(input, ratedAt, pricingContext, source, "missingBillingIdentity")
+  }
+
+  const entry = catalog.providers[billingIdentity.providerId]?.[billingIdentity.modelId]
+  let resolvedSource = priceSource(`${billingIdentity.providerId}/${billingIdentity.modelId}`)
+  if (!entry) {
+    return unpriceable(
+      input,
+      ratedAt,
+      pricingContext,
+      resolvedSource,
+      "missingCatalogEntry",
+      billingIdentity
+    )
+  }
+
+  if (
+    pricingContext.batch === true ||
+    !isBaseServiceTier(pricingContext.serviceTier) ||
+    (pricingContext.cacheWriteTtlSeconds !== undefined &&
+      pricingContext.cacheWriteTtlSeconds !== 300) ||
+    hasUnsupportedRoutingContext(pricingContext)
+  ) {
+    return unpriceable(
+      input,
+      ratedAt,
+      pricingContext,
+      resolvedSource,
+      "unsupportedPricingDimension",
+      billingIdentity
+    )
+  }
+
+  const mode = pricingContext.mode
+  let rates: CatalogRateSet = entry
+  let tiers = entry.tiers
+  if (mode !== undefined) {
+    const modeRates = entry.modes?.[mode]
+    if (!modeRates) {
+      return unpriceable(
+        input,
+        ratedAt,
+        pricingContext,
+        resolvedSource,
+        "unsupportedPricingDimension",
+        billingIdentity
+      )
+    }
+    rates = modeRates
+    tiers = modeRates.tiers
+    resolvedSource = priceSource(
+      `${billingIdentity.providerId}/${billingIdentity.modelId}#mode=${mode}`
+    )
+  }
+
+  const usage = normalizeAiModelCallUsage(usageRecord.usage)
+  if (tiers?.length) {
+    if (usage.inputTokens === undefined) {
+      return unpriceable(
+        input,
+        ratedAt,
+        pricingContext,
+        resolvedSource,
+        "missingUsageMeter",
+        billingIdentity,
+        ["tokens.input.total"]
+      )
+    }
+    rates = selectTier(tiers, usage.inputTokens) ?? rates
+  }
+
+  if (
+    (rates.inputAudio !== undefined || rates.outputAudio !== undefined) &&
+    rawUsageContainsAudioTokens(usageRecord)
+  ) {
+    return unpriceable(
+      input,
+      ratedAt,
+      pricingContext,
+      resolvedSource,
+      "unsupportedPricingDimension",
+      billingIdentity
+    )
+  }
+
+  const components = componentsForUsage(usage, rates)
+  if (components.status === "unpriceable") {
+    return unpriceable(
+      input,
+      ratedAt,
+      pricingContext,
+      resolvedSource,
+      components.reason,
+      billingIdentity,
+      components.missingMeters
+    )
+  }
+
+  return normalizeAiModelCallCostRecord({
+    projectId: usageRecord.projectId,
+    usageRecordId: usageRecord.id,
+    status: "rated",
+    billingIdentity,
+    pricingContext,
+    priceSource: resolvedSource,
+    money: { currency: "USD", amountNanos: sumComponents(components.components) },
+    components: components.components,
+    ratedAt,
+  })
+}
+
+/** Resolve only exact catalog identities or reviewed AI SDK namespace bindings. */
+export function resolveModelsDevBillingIdentity(
+  usage: Pick<
+    AiModelCallUsageRecord,
+    "providerId" | "requestedModelId" | "responseModelId" | "rawUsage"
+  >
+): AiBillingIdentity | undefined {
+  const providerId =
+    SDK_PROVIDER_BINDINGS[usage.providerId] ??
+    (Object.hasOwn(catalog.providers, usage.providerId) ? usage.providerId : undefined)
+  if (providerId === undefined) return undefined
+
+  // Models.dev's `vercel` catalog can key a Gateway route by either its requested name or its
+  // canonical routed name. Prefer the exact requested catalog entry, then the exact canonical
+  // entry. The response model identifies the underlying serving model and is not a Gateway SKU.
+  if (providerId === "vercel" && isGatewayProvider(usage.providerId)) {
+    const canonicalSlug = gatewayCanonicalSlug(usage.rawUsage)
+    const models = catalog.providers[providerId]!
+    const modelId = [usage.requestedModelId, canonicalSlug].find(
+      (candidate): candidate is string =>
+        candidate !== undefined && Object.hasOwn(models, candidate)
+    )
+    return { providerId, modelId: modelId ?? usage.requestedModelId }
+  }
+
+  // A response model identifies the serving SKU when a direct provider reports one. Preserve it
+  // even when this catalog does not know it so valuation fails closed instead of silently applying
+  // the requested model's price to a different model.
+  const modelId = usage.responseModelId ?? usage.requestedModelId
+  return { providerId, modelId }
+}
+
+type ComponentResult =
+  | { readonly status: "rated"; readonly components: readonly AiCostComponent[] }
+  | {
+      readonly status: "unpriceable"
+      readonly reason: Extract<AiUnpriceableReason, "missingUsageMeter" | "invalidUsageForFormula">
+      readonly missingMeters?: readonly AiBillableMeter[]
+    }
+
+function componentsForUsage(usage: AiModelCallUsage, rates: CatalogRateSet): ComponentResult {
+  const components: AiCostComponent[] = []
+  const missing: AiBillableMeter[] = []
+
+  if (usage.inputTokens === undefined) missing.push("tokens.input.total")
+  if (usage.outputTokens === undefined) missing.push("tokens.output.total")
+
+  const usesCachePartition = rates.cacheRead !== undefined || rates.cacheWrite !== undefined
+  if (usesCachePartition) {
+    if (usage.uncachedInputTokens === undefined) missing.push("tokens.input.uncached")
+    if (rates.cacheRead !== undefined && usage.cacheReadInputTokens === undefined) {
+      missing.push("tokens.input.cacheRead")
+    }
+    if (rates.cacheWrite !== undefined && usage.cacheWriteInputTokens === undefined) {
+      missing.push("tokens.input.cacheWrite")
+    }
+  }
+
+  if (rates.reasoning !== undefined) {
+    if (usage.textOutputTokens === undefined) missing.push("tokens.output.text")
+    if (usage.reasoningOutputTokens === undefined) missing.push("tokens.output.reasoning")
+  }
+  if (missing.length > 0) {
+    return { status: "unpriceable", reason: "missingUsageMeter", missingMeters: missing }
+  }
+
+  if (usesCachePartition) {
+    const uncached = usage.uncachedInputTokens!
+    const cacheRead = usage.cacheReadInputTokens ?? 0
+    const cacheWrite = usage.cacheWriteInputTokens ?? 0
+    if (BigInt(uncached) + BigInt(cacheRead) + BigInt(cacheWrite) !== BigInt(usage.inputTokens!)) {
+      return { status: "unpriceable", reason: "invalidUsageForFormula" }
+    }
+    if (rates.cacheRead === undefined && cacheRead !== 0) {
+      return { status: "unpriceable", reason: "invalidUsageForFormula" }
+    }
+    if (rates.cacheWrite === undefined && cacheWrite !== 0) {
+      return { status: "unpriceable", reason: "invalidUsageForFormula" }
+    }
+    components.push(calculateComponent("tokens.input.uncached", uncached, rates.input))
+    if (rates.cacheRead !== undefined) {
+      components.push(calculateComponent("tokens.input.cacheRead", cacheRead, rates.cacheRead))
+    }
+    if (rates.cacheWrite !== undefined) {
+      components.push(calculateComponent("tokens.input.cacheWrite", cacheWrite, rates.cacheWrite))
+    }
+  } else {
+    components.push(calculateComponent("tokens.input.total", usage.inputTokens!, rates.input))
+  }
+
+  if (rates.reasoning !== undefined) {
+    const text = usage.textOutputTokens!
+    const reasoning = usage.reasoningOutputTokens!
+    if (BigInt(text) + BigInt(reasoning) !== BigInt(usage.outputTokens!)) {
+      return { status: "unpriceable", reason: "invalidUsageForFormula" }
+    }
+    components.push(calculateComponent("tokens.output.text", text, rates.output))
+    components.push(calculateComponent("tokens.output.reasoning", reasoning, rates.reasoning))
+  } else {
+    components.push(calculateComponent("tokens.output.total", usage.outputTokens!, rates.output))
+  }
+
+  return { status: "rated", components }
+}
+
+function selectTier(tiers: readonly CatalogTier[], inputTokens: number): CatalogTier | undefined {
+  return [...tiers]
+    .sort((left, right) =>
+      BigInt(right.aboveInputTokens) > BigInt(left.aboveInputTokens) ? 1 : -1
+    )
+    .find((tier) => BigInt(inputTokens) > BigInt(tier.aboveInputTokens))
+}
+
+function calculateComponent(
+  meter: AiBillableMeter,
+  quantity: number | string,
+  rateAmountNanosPerMillion: string
+): AiCostComponent {
+  const normalizedQuantity = parseQuantity(quantity, `${meter} quantity`)
+  const rate = parseNonnegativeInt64(rateAmountNanosPerMillion, `${meter} rate`)
+  const charge = (normalizedQuantity * rate + HALF_MILLION) / TOKENS_PER_MILLION
+  assertSignedInt64(charge, `${meter} charge`)
+  return {
+    meter,
+    quantity: normalizedQuantity.toString(),
+    rateAmountNanosPerMillion: rate.toString(),
+    chargeAmountNanos: charge.toString(),
+  }
+}
+
+function unpriceable(
+  input: RateAiModelCallInput,
+  ratedAt: Date,
+  pricingContext: AiPricingContext,
+  source: AiPriceSource,
+  reason: AiUnpriceableReason,
+  billingIdentity?: AiBillingIdentity,
+  missingMeters?: readonly AiBillableMeter[]
+): AiModelCallCostRecord {
+  return normalizeAiModelCallCostRecord({
+    projectId: input.usage.projectId,
+    usageRecordId: input.usage.id,
+    status: "unpriceable",
+    ...(billingIdentity ? { billingIdentity } : {}),
+    pricingContext,
+    priceSource: source,
+    reason,
+    ...(missingMeters ? { missingMeters } : {}),
+    ratedAt,
+  })
+}
+
+function priceSource(sourceEntryId: string): AiPriceSource {
+  return {
+    sourceId: catalog.source.id,
+    sourceEntryId,
+    sourceVersion: catalog.source.version,
+    sourceUrl: catalog.source.url,
+    observedAt: new Date(catalog.source.observedAt),
+  }
+}
+
+function sumComponents(components: readonly AiCostComponent[]): string {
+  let total = 0n
+  for (const component of components) {
+    total += parseNonnegativeInt64(component.chargeAmountNanos, "component charge")
+    assertSignedInt64(total, "cost total")
+  }
+  return total.toString()
+}
+
+function parseQuantity(value: number | string, field: string): bigint {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new TypeError(`[SixbAgentWorker] AI ${field} must be a non-negative safe integer.`)
+    }
+    return BigInt(value)
+  }
+  return parseNonnegativeInt64(value, field)
+}
+
+function parseNonnegativeInt64(value: string, field: string): bigint {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_NUMERIC_TEXT_LENGTH ||
+    !/^\d+$/.test(value)
+  ) {
+    throw new TypeError(`[SixbAgentWorker] AI ${field} must be a non-negative integer string.`)
+  }
+  const parsed = BigInt(value)
+  assertSignedInt64(parsed, field)
+  return parsed
+}
+
+function isGatewayProvider(providerId: string): boolean {
+  return providerId === "gateway" || providerId === "gateway.language-model"
+}
+
+function gatewayCanonicalSlug(rawUsage: AiModelCallUsageRecord["rawUsage"]): string | undefined {
+  const providerMetadata = jsonObjectProperty(rawUsage, "providerMetadata")
+  const gateway = jsonObjectProperty(providerMetadata, "gateway")
+  const routing = jsonObjectProperty(gateway, "routing")
+  const canonicalSlug = routing?.canonicalSlug
+  return typeof canonicalSlug === "string" && canonicalSlug.trim().length > 0
+    ? canonicalSlug
+    : undefined
+}
+
+function jsonObjectProperty(value: unknown, property: string): Record<string, unknown> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined
+  const child = (value as Record<string, unknown>)[property]
+  return typeof child === "object" && child !== null && !Array.isArray(child)
+    ? (child as Record<string, unknown>)
+    : undefined
+}
+
+function rawUsageContainsAudioTokens(usage: AiModelCallUsageRecord): boolean {
+  if (!usage.rawUsage) return false
+  const stack: unknown[] = [usage.rawUsage]
+  while (stack.length > 0) {
+    const value = stack.pop()
+    if (!value || typeof value !== "object") continue
+    for (const [key, child] of Object.entries(value)) {
+      if (/audio.*tokens|tokens.*audio/i.test(key) && typeof child === "number" && child > 0) {
+        return true
+      }
+      if (typeof child === "object") stack.push(child)
+    }
+  }
+  return false
+}
+
+function isBaseServiceTier(value: string | undefined): boolean {
+  return value === undefined || value === "standard" || value === "default" || value === "auto"
+}
+
+function hasUnsupportedRoutingContext(context: AiPricingContext): boolean {
+  return (
+    context.region !== undefined ||
+    (context.inferenceGeo !== undefined && context.inferenceGeo !== "global") ||
+    context.routedProviderId !== undefined ||
+    context.deploymentId !== undefined ||
+    context.inferenceProfileId !== undefined
+  )
+}
+
+function assertSignedInt64(value: bigint, field: string): void {
+  if (value < 0n || value > SIGNED_INT64_MAX) {
+    throw new TypeError(`[SixbAgentWorker] AI ${field} exceeds the signed 64-bit range.`)
+  }
+}
+
+function assertNonBlank(value: string, field: string): void {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TypeError(`[SixbAgentWorker] AI ${field} must be nonblank.`)
+  }
+}
+
+function cloneDate(value: Date, field: string): Date {
+  if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+    throw new TypeError(`[SixbAgentWorker] AI ${field} must be a valid Date.`)
+  }
+  return new Date(value)
+}

--- a/packages/agent-worker/src/ai-sdk-adapters.ts
+++ b/packages/agent-worker/src/ai-sdk-adapters.ts
@@ -17,8 +17,15 @@ import {
 } from "@sixb/core/internal/agents"
 import { createSixbError } from "@sixb/core/internal/errors"
 import { schemaRecordToJsonSchema } from "@sixb/core/internal/ontology"
-import type { AiModelCallUsageInput } from "@sixb/core/storage"
-import { jsonSchema, type LanguageModelUsage, type Tool, type ToolSet, tool } from "ai"
+import type { AiModelCallUsageInput, AiPricingContext } from "@sixb/core/storage"
+import {
+  jsonSchema,
+  type LanguageModelCallStartEvent,
+  type LanguageModelUsage,
+  type Tool,
+  type ToolSet,
+  tool,
+} from "ai"
 import { NEVER_ABORTED_SIGNAL } from "./abort"
 import { AgentToolExecutionError, AgentToolOutputError } from "./errors"
 import type { AgentToolModelOutput } from "./tool-result-output"
@@ -323,6 +330,65 @@ export function agentToolErrorText(error: unknown): string {
   return error instanceof AgentToolPublicError ? error.message : "An error occurred."
 }
 
+/** Snapshot only explicitly allowlisted billing dimensions from request-side provider options. */
+export function aiPricingContextFromAiSdkCallStart(
+  event: Pick<LanguageModelCallStartEvent, "provider">,
+  providerOptions: unknown
+): AiPricingContext {
+  if (!isUnknownRecord(providerOptions)) return {}
+  const options = providerOptions[providerOptionsKey(event.provider)]
+  if (!isUnknownRecord(options)) return {}
+  const serviceTier = nonBlankString(options.serviceTier)
+  const region = nonBlankString(options.region)
+  const inferenceGeo = nonBlankString(options.inferenceGeo)
+  const routedProviderId = nonBlankString(options.routedProviderId)
+  const deploymentId = nonBlankString(options.deploymentId)
+  const inferenceProfileId = nonBlankString(options.inferenceProfileId)
+  const mode = nonBlankString(options.mode) ?? nonBlankString(options.speed)
+  return {
+    ...(serviceTier === undefined ? {} : { serviceTier }),
+    ...(typeof options.batch === "boolean" ? { batch: options.batch } : {}),
+    ...(region === undefined ? {} : { region }),
+    ...(inferenceGeo === undefined ? {} : { inferenceGeo }),
+    ...(routedProviderId === undefined ? {} : { routedProviderId }),
+    ...(deploymentId === undefined ? {} : { deploymentId }),
+    ...(inferenceProfileId === undefined ? {} : { inferenceProfileId }),
+    ...(mode === undefined ? {} : { mode }),
+    ...(Number.isSafeInteger(options.cacheWriteTtlSeconds) &&
+    (options.cacheWriteTtlSeconds as number) > 0
+      ? { cacheWriteTtlSeconds: options.cacheWriteTtlSeconds as number }
+      : {}),
+  }
+}
+
+/** Merge allowlisted provider-returned billing dimensions over the request snapshot. */
+export function aiPricingContextFromAiSdkUsage(
+  request: AiPricingContext,
+  rawUsage: unknown
+): AiPricingContext {
+  if (!isUnknownRecord(rawUsage)) return { ...request }
+  const serviceTier = findBillingString(rawUsage, ["service_tier", "serviceTier"])
+  const inferenceGeo = findBillingString(rawUsage, ["inference_geo", "inferenceGeo"])
+  const routedProviderId = findBillingString(rawUsage, ["routed_provider_id", "routedProviderId"])
+  const mode = findBillingString(rawUsage, ["mode", "speed"])
+  const oneHourCacheWriteTokens = findBillingNumber(rawUsage, ["ephemeral_1h_input_tokens"])
+  const fiveMinuteCacheWriteTokens = findBillingNumber(rawUsage, ["ephemeral_5m_input_tokens"])
+  const cacheWriteTtlSeconds =
+    oneHourCacheWriteTokens !== undefined && oneHourCacheWriteTokens > 0
+      ? 3_600
+      : fiveMinuteCacheWriteTokens !== undefined && fiveMinuteCacheWriteTokens > 0
+        ? 300
+        : undefined
+  return {
+    ...request,
+    ...(serviceTier === undefined ? {} : { serviceTier }),
+    ...(inferenceGeo === undefined ? {} : { inferenceGeo }),
+    ...(routedProviderId === undefined ? {} : { routedProviderId }),
+    ...(mode === undefined ? {} : { mode }),
+    ...(cacheWriteTtlSeconds === undefined ? {} : { cacheWriteTtlSeconds }),
+  }
+}
+
 /** Preserve every provider-neutral count from one AI SDK model call without inventing zeroes. */
 export function aiModelCallUsageFromAiSdk(usage: LanguageModelUsage): AiModelCallUsageInput {
   return {
@@ -344,4 +410,60 @@ export function aiModelCallUsageFromAiSdk(usage: LanguageModelUsage): AiModelCal
       ? {}
       : { reasoningOutputTokens: usage.outputTokenDetails.reasoningTokens }),
   }
+}
+
+function providerOptionsKey(provider: string): string {
+  const knownNamespaces: Readonly<Record<string, string>> = {
+    "openai.responses": "openai",
+    "openai.chat": "openai",
+    "anthropic.messages": "anthropic",
+    "google.generative-ai": "google",
+    "amazon-bedrock.converse": "bedrock",
+    "gateway.language-model": "gateway",
+  }
+  return knownNamespaces[provider] ?? provider
+}
+
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function nonBlankString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined
+}
+
+function findBillingString(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+  depth = 0
+): string | undefined {
+  for (const key of keys) {
+    const match = nonBlankString(value[key])
+    if (match !== undefined) return match
+  }
+  if (depth >= 3) return undefined
+  for (const child of Object.values(value)) {
+    if (!isUnknownRecord(child)) continue
+    const match = findBillingString(child, keys, depth + 1)
+    if (match !== undefined) return match
+  }
+  return undefined
+}
+
+function findBillingNumber(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+  depth = 0
+): number | undefined {
+  for (const key of keys) {
+    const match = value[key]
+    if (typeof match === "number" && Number.isFinite(match) && match >= 0) return match
+  }
+  if (depth >= 3) return undefined
+  for (const child of Object.values(value)) {
+    if (!isUnknownRecord(child)) continue
+    const match = findBillingNumber(child, keys, depth + 1)
+    if (match !== undefined) return match
+  }
+  return undefined
 }

--- a/packages/agent-worker/src/model-call-recorder.ts
+++ b/packages/agent-worker/src/model-call-recorder.ts
@@ -1,21 +1,35 @@
 import { randomUUID } from "node:crypto"
 import { omitUndefinedObjectProperties } from "@sixb/core/internal/agents"
-import type { AiUsageStorage, ReadonlyJsonObject, RecordAiModelCallInput } from "@sixb/core/storage"
+import type {
+  AiPricingContext,
+  ReadonlyJsonObject,
+  RecordAiModelCallInput,
+} from "@sixb/core/storage"
 import { normalizeAiModelCallRecord } from "@sixb/core/storage"
-import type { LanguageModelCallEndEvent } from "ai"
-import { aiModelCallUsageFromAiSdk } from "./ai-sdk-adapters"
+import {
+  type LanguageModelCallEndEvent,
+  type LanguageModelCallStartEvent,
+  wrapLanguageModel,
+} from "ai"
+import { recordAiModelCallAccounting } from "./ai-pricing/accounting"
+import {
+  aiModelCallUsageFromAiSdk,
+  aiPricingContextFromAiSdkCallStart,
+  aiPricingContextFromAiSdkUsage,
+} from "./ai-sdk-adapters"
 import { AgentUsageRecordingError } from "./errors"
 import { isPermanentAiUsageRecoveryError } from "./model-call-recovery"
-import type { RecoverAiModelCall } from "./types"
+import type { AgentWorkerStorage, RecoverAiModelCall, RecoverAiModelCallInput } from "./types"
 
 const STORAGE_RETRY_DELAYS_MS = [50, 200, 600] as const
 
 export interface AiModelCallRecorderInput {
-  readonly storage: AiUsageStorage
+  readonly storage: AgentWorkerStorage
   readonly projectId: string
   readonly executionId: string
   readonly attempt: number
   readonly requesterGroupIds: readonly string[]
+  readonly providerOptions?: unknown
   readonly recoverAiModelCall: RecoverAiModelCall
   /** Run identity used only in terminal recorder diagnostics. */
   readonly errorRunId: string
@@ -26,20 +40,34 @@ interface AiModelCallRecorderInternals {
   readonly now?: () => Date
   readonly retryDelaysMs?: readonly number[]
   readonly sleep?: (ms: number) => Promise<void>
+  readonly recordAccounting?: (input: RecoverAiModelCallInput) => Promise<void>
+}
+
+interface ModelCallStartSnapshot {
+  readonly pricingContext: AiPricingContext
+}
+
+interface ModelCallResponseSnapshot {
+  readonly modelId?: string
+  readonly providerMetadata?: ReadonlyJsonObject
+  readonly pricingContext?: AiPricingContext
 }
 
 /**
- * Persist every completed AI SDK provider call before the tool loop can begin another model step.
+ * Persist every completed provider call before the tool loop can begin another model step.
  *
- * AI SDK deliberately swallows lifecycle callback errors. This recorder therefore hands a failed
- * append to durable recovery and retains the failure for `prepareStep` to surface before another
- * provider call. Recovery can then continue independently without allowing unaccounted spend.
+ * Current storage records usage, allowlisted request billing context, and strict local valuation in
+ * one transaction. AI SDK swallows lifecycle callback errors, so persistent failures still move to
+ * durable recovery and are surfaced by `prepareStep` before another provider call.
  */
 export class AiModelCallRecorder {
   private readonly generateId: () => string
   private readonly now: () => Date
   private readonly retryDelaysMs: readonly number[]
   private readonly sleep: (ms: number) => Promise<void>
+  private readonly recordAccounting: (input: RecoverAiModelCallInput) => Promise<void>
+  private readonly starts = new Map<string, ModelCallStartSnapshot>()
+  private readonly responses = new Map<string, ModelCallResponseSnapshot>()
   private recordingError: AgentUsageRecordingError | undefined
 
   constructor(
@@ -50,18 +78,43 @@ export class AiModelCallRecorder {
     this.now = internals.now ?? (() => new Date())
     this.retryDelaysMs = internals.retryDelaysMs ?? STORAGE_RETRY_DELAYS_MS
     this.sleep = internals.sleep ?? sleep
+    this.recordAccounting =
+      internals.recordAccounting ??
+      (async (input) => {
+        await recordAiModelCallAccounting({ storage: this.input.storage, ...input })
+      })
+  }
+
+  readonly onLanguageModelCallStart = async (event: LanguageModelCallStartEvent): Promise<void> => {
+    if (this.recordingError) return
+    this.starts.set(event.callId, {
+      pricingContext: aiPricingContextFromAiSdkCallStart(event, this.input.providerOptions),
+    })
   }
 
   readonly onLanguageModelCallEnd = async (event: LanguageModelCallEndEvent): Promise<void> => {
     if (this.recordingError) return
 
     try {
-      // AI SDK's JSONObject permits optional object properties with `undefined`; omission is the
-      // canonical JSON representation of those properties. Storage still validates the result.
-      const rawUsage =
+      const response = this.responses.get(event.responseId)
+      this.responses.delete(event.responseId)
+      const normalizedRawUsage =
         event.usage.raw === undefined
           ? undefined
           : (omitUndefinedObjectProperties(event.usage.raw) as ReadonlyJsonObject)
+      const rawUsage =
+        normalizedRawUsage === undefined && response?.providerMetadata === undefined
+          ? undefined
+          : {
+              ...(normalizedRawUsage ?? {}),
+              ...(response?.providerMetadata === undefined
+                ? {}
+                : { providerMetadata: response.providerMetadata }),
+            }
+      const occurredAt = this.now()
+      const start = this.starts.get(event.callId)
+      this.starts.delete(event.callId)
+      const responseModelId = response?.modelId
       const record: RecordAiModelCallInput = {
         id: this.generateId(),
         projectId: this.input.projectId,
@@ -71,18 +124,25 @@ export class AiModelCallRecorder {
         requesterGroupIds: this.input.requesterGroupIds,
         providerId: event.provider,
         requestedModelId: event.modelId,
+        ...(responseModelId === undefined ? {} : { responseModelId }),
         responseId: event.responseId,
         usage: aiModelCallUsageFromAiSdk(event.usage),
         ...(rawUsage === undefined ? {} : { rawUsage }),
-        occurredAt: this.now(),
+        occurredAt,
       }
-      // Reject malformed SDK/provider data before retrying storage or handing a poison record to
-      // the durable queue. The storage boundary repeats this validation defensively.
       normalizeAiModelCallRecord(record)
+      const recoveryInput: RecoverAiModelCallInput = {
+        usage: record,
+        pricingContext: aiPricingContextFromAiSdkUsage(
+          { ...(start?.pricingContext ?? {}), ...(response?.pricingContext ?? {}) },
+          rawUsage
+        ),
+        ratedAt: new Date(occurredAt),
+      }
 
       try {
         await retryOperation(
-          () => this.input.storage.recordModelCall(record),
+          () => this.recordAccounting(recoveryInput),
           this.retryDelaysMs,
           this.sleep,
           (error) => !isPermanentAiUsageRecoveryError(error)
@@ -92,7 +152,7 @@ export class AiModelCallRecorder {
 
         try {
           await retryOperation(
-            () => this.input.recoverAiModelCall(record),
+            () => this.input.recoverAiModelCall(recoveryInput),
             this.retryDelaysMs,
             this.sleep,
             (error) => !isPermanentAiUsageRecoveryError(error)
@@ -100,7 +160,7 @@ export class AiModelCallRecorder {
         } catch (recoveryError) {
           throw new AggregateError(
             [storageError, recoveryError],
-            "Direct AI usage recording and durable recovery both failed."
+            "Direct AI accounting and durable recovery both failed."
           )
         }
         throw new AgentUsageRecordingError(this.input.errorRunId, event.callId, true, {
@@ -117,6 +177,46 @@ export class AiModelCallRecorder {
     }
   }
 
+  /** Capture response model identities that AI SDK lifecycle callbacks do not expose. */
+  wrapModel(
+    model: Parameters<typeof wrapLanguageModel>[0]["model"]
+  ): ReturnType<typeof wrapLanguageModel> {
+    return wrapLanguageModel({
+      model,
+      middleware: {
+        specificationVersion: "v4",
+        wrapGenerate: async ({ doGenerate, model, params }) => {
+          const result = await doGenerate()
+          this.rememberResponse(
+            result.response,
+            result.providerMetadata,
+            aiPricingContextFromAiSdkCallStart(model, params.providerOptions)
+          )
+          return result
+        },
+        wrapStream: async ({ doStream, model, params }) => {
+          const result = await doStream()
+          const pricingContext = aiPricingContextFromAiSdkCallStart(model, params.providerOptions)
+          let response: { readonly id?: string; readonly modelId?: string } | undefined
+          return {
+            ...result,
+            stream: result.stream.pipeThrough(
+              new TransformStream({
+                transform: (part, controller) => {
+                  if (part.type === "response-metadata") response = part
+                  if (part.type === "finish") {
+                    this.rememberResponse(response, part.providerMetadata, pricingContext)
+                  }
+                  controller.enqueue(part)
+                },
+              })
+            ),
+          }
+        },
+      },
+    })
+  }
+
   /** AI SDK invokes this before every step; a prior append failure prevents the next provider call. */
   readonly prepareStep = (): undefined => {
     this.assertHealthy()
@@ -125,6 +225,32 @@ export class AiModelCallRecorder {
 
   assertHealthy(): void {
     if (this.recordingError) throw this.recordingError
+  }
+
+  private rememberResponse(
+    response: { readonly id?: string; readonly modelId?: string } | undefined,
+    providerMetadata: unknown,
+    pricingContext: AiPricingContext
+  ): void {
+    if (!response?.id) return
+    const normalizedProviderMetadata =
+      providerMetadata === undefined
+        ? undefined
+        : (omitUndefinedObjectProperties(providerMetadata) as ReadonlyJsonObject)
+    if (
+      response.modelId === undefined &&
+      normalizedProviderMetadata === undefined &&
+      Object.keys(pricingContext).length === 0
+    ) {
+      return
+    }
+    this.responses.set(response.id, {
+      ...(response.modelId === undefined ? {} : { modelId: response.modelId }),
+      ...(normalizedProviderMetadata === undefined
+        ? {}
+        : { providerMetadata: normalizedProviderMetadata }),
+      ...(Object.keys(pricingContext).length === 0 ? {} : { pricingContext }),
+    })
   }
 }
 

--- a/packages/agent-worker/src/model-call-recovery.ts
+++ b/packages/agent-worker/src/model-call-recovery.ts
@@ -1,5 +1,6 @@
 import { createSixbError } from "@sixb/core/internal/errors"
 import type {
+  AgentAiUsageAccountingPayload,
   AgentAiUsageRecordPayload,
   AgentAiUsageRecordRequestedQueueJob,
   AgentQueueJob,
@@ -7,11 +8,16 @@ import type {
 } from "@sixb/core/queues"
 import type {
   AiModelCallUsageInput,
-  AiUsageStorage,
   RecordAiModelCallInput,
   RecordAiModelCallResult,
 } from "@sixb/core/storage"
-import { AiUsageStorageError, normalizeAiModelCallRecord } from "@sixb/core/storage"
+import {
+  AiCostStorageError,
+  AiUsageStorageError,
+  normalizeAiModelCallRecord,
+} from "@sixb/core/storage"
+import { recordAiModelCallAccounting } from "./ai-pricing/accounting"
+import type { AgentWorkerStorage, RecoverAiModelCallInput } from "./types"
 
 const AGENT_AI_USAGE_RECOVERY_JOB_PREFIX = "agt_usage_job_"
 
@@ -28,11 +34,14 @@ export function agentAiUsageRecoveryJobId(recordId: string): string {
   return `${AGENT_AI_USAGE_RECOVERY_JOB_PREFIX}${recordId}`
 }
 
-/** Hand one failed ledger append to the durable agent lane without serializing Date objects. */
+/** Hand one failed accounting transaction to the durable lane using only JSON-safe values. */
 export async function enqueueAiModelCallRecovery(
   queue: Pick<Queue<AgentQueueJob>, "enqueue">,
-  record: RecordAiModelCallInput
+  input: RecoverAiModelCallInput | RecordAiModelCallInput
 ): Promise<void> {
+  const recovery = isRecoveryInput(input) ? input : undefined
+  const record: RecordAiModelCallInput =
+    recovery === undefined ? (input as RecordAiModelCallInput) : recovery.usage
   normalizeAiModelCallRecord(record)
   const jobId = agentAiUsageRecoveryJobId(record.id)
   const [job] = await queue.enqueue({
@@ -41,7 +50,10 @@ export async function enqueueAiModelCallRecovery(
       {
         id: jobId,
         type: "agent.ai-usage.record.requested",
-        payload: { record: toQueuePayload(record) },
+        payload: {
+          record: toQueuePayload(record),
+          ...(recovery === undefined ? {} : { accounting: toAccountingPayload(recovery) }),
+        },
       },
     ],
   })
@@ -55,12 +67,14 @@ export async function enqueueAiModelCallRecovery(
   }
 }
 
-/** Replay one durable handoff through the idempotent model-call ledger boundary. */
+/** Replay one durable handoff through the idempotent atomic accounting boundary. */
 export async function recordRecoveredAiModelCall(
-  storage: AiUsageStorage,
+  storage: AgentWorkerStorage,
   job: AgentAiUsageRecordRequestedQueueJob
 ): Promise<RecordAiModelCallResult> {
-  return storage.recordModelCall(fromQueuePayload(job))
+  const usage = fromQueuePayload(job)
+  const accounting = accountingFromQueuePayload(job, usage)
+  return recordAiModelCallAccounting({ storage, usage, ...accounting })
 }
 
 /** Validation and referential-integrity failures cannot become valid through queue redelivery. */
@@ -69,7 +83,9 @@ export function isPermanentAiUsageRecoveryError(error: unknown): boolean {
     error instanceof InvalidAiUsageRecoveryJobError ||
     error instanceof TypeError ||
     (error instanceof AiUsageStorageError &&
-      (error.code === "duplicate_id" || error.code === "missing_execution"))
+      (error.code === "duplicate_id" || error.code === "missing_execution")) ||
+    (error instanceof AiCostStorageError &&
+      (error.code === "missing_usage" || error.code === "cost_mismatch"))
   )
 }
 
@@ -87,6 +103,13 @@ function toQueuePayload(record: RecordAiModelCallInput): AgentAiUsageRecordPaylo
     usage: toQueueUsage(record.usage),
     ...(record.rawUsage === undefined ? {} : { rawUsage: structuredClone(record.rawUsage) }),
     occurredAt: record.occurredAt.toISOString(),
+  }
+}
+
+function toAccountingPayload(input: RecoverAiModelCallInput): AgentAiUsageAccountingPayload {
+  return {
+    pricingContext: { ...input.pricingContext },
+    ratedAt: input.ratedAt.toISOString(),
   }
 }
 
@@ -111,16 +134,39 @@ function toQueueUsage(usage: AiModelCallUsageInput): AgentAiUsageRecordPayload["
 }
 
 function fromQueuePayload(job: AgentAiUsageRecordRequestedQueueJob): RecordAiModelCallInput {
-  const occurredAt = new Date(job.payload.record.occurredAt)
-  if (!Number.isFinite(occurredAt.getTime())) {
+  const occurredAt = parseDate(job.payload.record.occurredAt, job.id, "occurredAt")
+  return { ...job.payload.record, projectId: job.projectId, occurredAt }
+}
+
+function accountingFromQueuePayload(
+  job: AgentAiUsageRecordRequestedQueueJob,
+  usage: RecordAiModelCallInput
+): Omit<RecoverAiModelCallInput, "usage"> {
+  const accounting = job.payload.accounting
+  if (!accounting) {
+    return {
+      pricingContext: {},
+      ratedAt: new Date(usage.occurredAt),
+    }
+  }
+  return {
+    pricingContext: { ...accounting.pricingContext },
+    ratedAt: parseDate(accounting.ratedAt, job.id, "ratedAt"),
+  }
+}
+
+function parseDate(value: string, jobId: string, field: string): Date {
+  const date = new Date(value)
+  if (!Number.isFinite(date.getTime())) {
     throw new InvalidAiUsageRecoveryJobError(
-      `AI usage recovery job '${job.id}' has an invalid occurredAt timestamp.`
+      `AI usage recovery job '${jobId}' has an invalid ${field} timestamp.`
     )
   }
+  return date
+}
 
-  return {
-    ...job.payload.record,
-    projectId: job.projectId,
-    occurredAt,
-  }
+function isRecoveryInput(
+  input: RecoverAiModelCallInput | RecordAiModelCallInput
+): input is RecoverAiModelCallInput {
+  return !("id" in input)
 }

--- a/packages/agent-worker/src/run-agent-loop.ts
+++ b/packages/agent-worker/src/run-agent-loop.ts
@@ -42,7 +42,7 @@ export function runAgentLoop(
   input: RunAgentLoopInput
 ): StreamTextResult<ToolSet, Record<string, unknown>, ReturnType<typeof Output.text>> {
   return streamText({
-    model: input.agent.model,
+    model: input.usageRecorder.wrapModel(input.agent.model),
     ...(input.agent.reasoning === undefined ? {} : { reasoning: input.agent.reasoning }),
     ...(input.agent.providerOptions === undefined
       ? {}
@@ -68,6 +68,7 @@ export function runAgentLoop(
         ],
       }
     },
+    onLanguageModelCallStart: input.usageRecorder.onLanguageModelCallStart,
     onLanguageModelCallEnd: input.usageRecorder.onLanguageModelCallEnd,
     ...(input.onError === undefined ? {} : { onError: input.onError }),
     ...(input.onStepEnd === undefined ? {} : { onStepEnd: input.onStepEnd }),

--- a/packages/agent-worker/src/run-agent-turn.ts
+++ b/packages/agent-worker/src/run-agent-turn.ts
@@ -93,11 +93,12 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
 
   const maxSteps = agent.loop?.stopWhen?.maxSteps ?? defaultMaxSteps
   const usageRecorder = new AiModelCallRecorder({
-    storage: storage.aiUsage,
+    storage,
     projectId,
     executionId: run.executionId,
     attempt: run.attempt,
     requesterGroupIds: run.requesterGroupIds,
+    providerOptions: agent.providerOptions,
     recoverAiModelCall: context.recoverAiModelCall,
     errorRunId: runId,
   })

--- a/packages/agent-worker/src/run-workflow-agent-node.ts
+++ b/packages/agent-worker/src/run-workflow-agent-node.ts
@@ -161,7 +161,7 @@ export async function runWorkflowAgentNode(
     for (let attempt = 1; attempt <= WORKFLOW_OUTPUT_FINALIZATION_ATTEMPTS; attempt += 1) {
       try {
         const finalization = await generateText({
-          model: input.agent.model,
+          model: input.usageRecorder.wrapModel(input.agent.model),
           ...(input.agent.providerOptions === undefined
             ? {}
             : { providerOptions: input.agent.providerOptions }),
@@ -171,6 +171,7 @@ export async function runWorkflowAgentNode(
           messages: finalizerMessages,
           output: Output.object({ schema, name: input.agentStep.id }),
           prepareStep: input.usageRecorder.prepareStep,
+          onLanguageModelCallStart: input.usageRecorder.onLanguageModelCallStart,
           onLanguageModelCallEnd: input.usageRecorder.onLanguageModelCallEnd,
           abortSignal,
         })

--- a/packages/agent-worker/src/types.ts
+++ b/packages/agent-worker/src/types.ts
@@ -14,6 +14,8 @@ import type { AgentExecutionHost } from "@sixb/core/internal/agent-execution"
 import type { LoggingService } from "@sixb/core/internal/logging"
 import type {
   AgentStorage,
+  AiCostStorage,
+  AiPricingContext,
   AiUsageStorage,
   AuthStorage,
   RecordAiModelCallInput,
@@ -28,10 +30,17 @@ import type { StreamSink } from "./stream-sink"
 export type AgentWorkerStorage = Storage & {
   readonly agents: AgentStorage
   readonly aiUsage: AiUsageStorage
+  readonly aiCosts: AiCostStorage
   readonly auth: AuthStorage
 }
 
-export type RecoverAiModelCall = (record: RecordAiModelCallInput) => Promise<void>
+export interface RecoverAiModelCallInput {
+  readonly usage: RecordAiModelCallInput
+  readonly pricingContext: AiPricingContext
+  readonly ratedAt: Date
+}
+
+export type RecoverAiModelCall = (input: RecoverAiModelCallInput) => Promise<void>
 
 /**
  * The host surface the agent worker is constructed with. `SixbHost` satisfies it structurally, so

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -150,7 +150,7 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
     const context = this.requireContext()
     const { job } = claimed
     if (job.type === "agent.ai-usage.record.requested") {
-      await recordRecoveredAiModelCall(context.storage.aiUsage, job)
+      await recordRecoveredAiModelCall(context.storage, job)
       return
     }
     if (job.type === "agent.workflow-node.requested") {
@@ -698,7 +698,7 @@ function buildAgentContext(
         host.broker
       )
     ),
-    recoverAiModelCall: (record) => enqueueAiModelCallRecovery(host.queues.agents, record),
+    recoverAiModelCall: (input) => enqueueAiModelCallRecovery(host.queues.agents, input),
     agentSkills,
     defaultMaxSteps: options.defaultMaxSteps ?? DEFAULT_MAX_STEPS,
     turnTimeoutMs,
@@ -724,6 +724,12 @@ function assertAgentWorkerStorage(
     throw createSixbError(
       "internal.unexpected",
       "[SixbAgentWorker] Agent workers require storage.aiUsage support."
+    )
+  }
+  if (!storage.aiCosts) {
+    throw createSixbError(
+      "internal.unexpected",
+      "[SixbAgentWorker] Agent workers require storage.aiCosts support."
     )
   }
 }

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -126,11 +126,12 @@ export async function executeWorkflowAgentNode(
     )
   }
   const usageRecorder = new AiModelCallRecorder({
-    storage: context.storage.aiUsage,
+    storage: context.storage,
     projectId: context.id,
     executionId: executionRecord.executionId,
     attempt: reserved.attempt,
     requesterGroupIds: workflowRun.requesterGroupIds,
+    providerOptions: agent.providerOptions,
     recoverAiModelCall: context.recoverAiModelCall,
     errorRunId: nodeRun.id,
   })

--- a/packages/agent-worker/tests/ai-sdk-adapters.test.ts
+++ b/packages/agent-worker/tests/ai-sdk-adapters.test.ts
@@ -16,6 +16,8 @@ import {
   agentToolErrorText,
   agentTraceFromAiSdkSteps,
   aiModelCallUsageFromAiSdk,
+  aiPricingContextFromAiSdkCallStart,
+  aiPricingContextFromAiSdkUsage,
 } from "../src/ai-sdk-adapters"
 
 const unusedArtifacts: AgentToolArtifacts = {
@@ -507,6 +509,63 @@ describe("AI SDK agent adapters", () => {
         },
       ])
     ).toThrow("tool output must be a JSON value")
+  })
+
+  test("captures only allowlisted request-side pricing context", () => {
+    expect(
+      aiPricingContextFromAiSdkCallStart(
+        { provider: "openai.responses" },
+        {
+          openai: {
+            serviceTier: "priority",
+            batch: false,
+            region: "us-east-1",
+            inferenceGeo: "us",
+            routedProviderId: "openai",
+            deploymentId: "prod",
+            inferenceProfileId: "profile-1",
+            cacheWriteTtlSeconds: 300,
+            apiKey: "must-not-persist",
+            headers: { authorization: "must-not-persist" },
+          },
+          anthropic: { serviceTier: "irrelevant" },
+        }
+      )
+    ).toEqual({
+      serviceTier: "priority",
+      batch: false,
+      region: "us-east-1",
+      inferenceGeo: "us",
+      routedProviderId: "openai",
+      deploymentId: "prod",
+      inferenceProfileId: "profile-1",
+      cacheWriteTtlSeconds: 300,
+    })
+    expect(
+      aiPricingContextFromAiSdkCallStart(
+        { provider: "unknown" },
+        { openai: { serviceTier: "priority" } }
+      )
+    ).toEqual({})
+  })
+
+  test("merges provider-returned billing context over request context", () => {
+    expect(
+      aiPricingContextFromAiSdkUsage(
+        { serviceTier: "auto", inferenceGeo: "us" },
+        {
+          service_tier: "standard",
+          inference_geo: "global",
+          speed: "fast",
+          cache_creation: { ephemeral_1h_input_tokens: 2 },
+        }
+      )
+    ).toEqual({
+      serviceTier: "standard",
+      inferenceGeo: "global",
+      mode: "fast",
+      cacheWriteTtlSeconds: 3_600,
+    })
   })
 
   test("preserves every provider-neutral model-call usage field", () => {

--- a/packages/agent-worker/tests/model-call-recorder.test.ts
+++ b/packages/agent-worker/tests/model-call-recorder.test.ts
@@ -1,27 +1,19 @@
 import { describe, expect, test } from "bun:test"
-import type {
-  AiUsageExecutionSummary,
-  AiUsageStorage,
-  RecordAiModelCallInput,
-} from "@sixb/core/storage"
+import type { RecordAiModelCallInput } from "@sixb/core/storage"
 import {
   AiUsageStorageError,
-  InMemoryAiUsageStorage,
   InMemoryStorage,
   normalizeAiModelCallRecord,
 } from "@sixb/core/storage"
 import { createTestAgentExecution } from "@sixb/core/testing"
-import type { LanguageModelCallEndEvent } from "ai"
+import { generateText, type LanguageModelCallEndEvent, type LanguageModelCallStartEvent } from "ai"
+import { MockLanguageModelV4 } from "ai/test"
 import { AgentUsageRecordingError } from "../src/errors"
 import { AiModelCallRecorder } from "../src/model-call-recorder"
+import type { RecoverAiModelCall } from "../src/types"
 
 const occurredAt = new Date("2026-07-01T12:00:00.000Z")
 const executionId = "test_agent_execution:run_1"
-const emptySummary: AiUsageExecutionSummary = {
-  modelCallCount: 0,
-  usage: { reportingStatus: "unavailable" },
-}
-
 function callEndEvent(): LanguageModelCallEndEvent {
   return {
     callId: "call_1",
@@ -33,7 +25,7 @@ function callEndEvent(): LanguageModelCallEndEvent {
       inputTokenDetails: {
         noCacheTokens: 9,
         cacheReadTokens: 3,
-        cacheWriteTokens: 1,
+        cacheWriteTokens: 0,
       },
       outputTokens: 8,
       outputTokenDetails: {
@@ -62,9 +54,9 @@ function callEndEvent(): LanguageModelCallEndEvent {
 }
 
 function recorder(
-  storage: AiUsageStorage,
+  storage: InMemoryStorage,
   internals: ConstructorParameters<typeof AiModelCallRecorder>[1] = {},
-  recoverAiModelCall: (record: RecordAiModelCallInput) => Promise<void> = async () => {
+  recoverAiModelCall: RecoverAiModelCall = async () => {
     throw new Error("Unexpected AI usage recovery handoff.")
   }
 ): AiModelCallRecorder {
@@ -82,7 +74,7 @@ function recorder(
   )
 }
 
-async function createInMemoryUsageStorage(): Promise<InMemoryAiUsageStorage> {
+async function createInMemoryStorage(): Promise<InMemoryStorage> {
   const bundle = new InMemoryStorage()
   await createTestAgentExecution(bundle, {
     projectId: "project_1",
@@ -90,34 +82,81 @@ async function createInMemoryUsageStorage(): Promise<InMemoryAiUsageStorage> {
     runId: "run_1",
     executionId,
   })
-  return new InMemoryAiUsageStorage(bundle.executions)
+  return bundle
+}
+
+async function recordedCall(storage: InMemoryStorage, usageRecordId: string) {
+  const result = await storage.aiCosts.listModelCalls({
+    projectId: "project_1",
+    from: new Date("2026-07-01T00:00:00.000Z"),
+    to: new Date("2026-07-02T00:00:00.000Z"),
+  })
+  return result.items.find((item) => item.usage.id === usageRecordId)
+}
+
+async function recordedUsage(storage: InMemoryStorage, usageRecordId: string) {
+  return (await recordedCall(storage, usageRecordId))?.usage
 }
 
 describe("AiModelCallRecorder", () => {
+  test("captures the provider response model identity through middleware", async () => {
+    const storage = await createInMemoryStorage()
+    const usage = recorder(storage, {
+      generateId: () => "usage_response_model",
+      now: () => occurredAt,
+    })
+    const model = new MockLanguageModelV4({
+      provider: "anthropic.messages",
+      modelId: "claude-opus-4-8",
+      doGenerate: {
+        content: [{ type: "text", text: "done" }],
+        finishReason: { unified: "stop", raw: "stop" },
+        usage: {
+          inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 1, text: 1, reasoning: 0 },
+        },
+        response: {
+          id: "response_served",
+          modelId: "claude-opus-4-8-20260801",
+        },
+        providerMetadata: { anthropic: { serviceTier: "standard" } },
+        warnings: [],
+      },
+    })
+
+    await generateText({
+      model: usage.wrapModel(model),
+      prompt: "hello",
+      onLanguageModelCallStart: usage.onLanguageModelCallStart,
+      onLanguageModelCallEnd: usage.onLanguageModelCallEnd,
+    })
+
+    const record = await recordedUsage(storage, "usage_response_model")
+    expect(record).toMatchObject({
+      requestedModelId: "claude-opus-4-8",
+      responseModelId: "claude-opus-4-8-20260801",
+      responseId: "response_served",
+      rawUsage: { providerMetadata: { anthropic: { serviceTier: "standard" } } },
+    })
+  })
+
   test("retries and records one complete provider call with stable identity", async () => {
     const inputs: RecordAiModelCallInput[] = []
     const delays: number[] = []
     let attempts = 0
-    const storage: AiUsageStorage = {
-      async recordModelCall(input) {
-        attempts += 1
-        inputs.push(structuredClone(input))
-        if (attempts < 3) throw new Error("temporary storage failure")
-        return { record: normalizeAiModelCallRecord(input), created: true }
-      },
-      async summarizeExecution(): Promise<AiUsageExecutionSummary> {
-        return emptySummary
-      },
-      async summarizeExecutions() {
-        return []
-      },
-    }
+    const storage = await createInMemoryStorage()
     const usage = recorder(storage, {
       generateId: () => "usage_1",
       now: () => occurredAt,
       retryDelaysMs: [10, 20],
       sleep: async (ms) => {
         delays.push(ms)
+      },
+      recordAccounting: async (input) => {
+        attempts += 1
+        inputs.push(structuredClone(input.usage))
+        if (attempts < 3) throw new Error("temporary storage failure")
+        normalizeAiModelCallRecord(input.usage)
       },
     })
 
@@ -140,7 +179,7 @@ describe("AiModelCallRecorder", () => {
         outputTokens: 8,
         uncachedInputTokens: 9,
         cacheReadInputTokens: 3,
-        cacheWriteInputTokens: 1,
+        cacheWriteInputTokens: 0,
         textOutputTokens: 6,
         reasoningOutputTokens: 2,
       },
@@ -152,10 +191,103 @@ describe("AiModelCallRecorder", () => {
     expect(usage.prepareStep()).toBeUndefined()
   })
 
+  test("atomically records request context and a Models.dev valuation", async () => {
+    const bundle = new InMemoryStorage()
+    await createTestAgentExecution(bundle, {
+      projectId: "project_1",
+      agentId: "assistant",
+      runId: "run_1",
+      executionId,
+    })
+    const times = [new Date("2026-07-01T11:59:59.000Z"), occurredAt]
+    const usage = new AiModelCallRecorder(
+      {
+        storage: bundle,
+        projectId: "project_1",
+        executionId,
+        attempt: 2,
+        requesterGroupIds: [],
+        providerOptions: {
+          gateway: { serviceTier: "standard", batch: false, apiKey: "must-not-persist" },
+        },
+        recoverAiModelCall: async () => {
+          throw new Error("Unexpected recovery")
+        },
+        errorRunId: "run_1",
+      },
+      {
+        generateId: () => "usage_atomic",
+        now: () => times.shift() ?? occurredAt,
+      }
+    )
+
+    await usage.onLanguageModelCallStart({
+      callId: "call_1",
+      provider: "gateway",
+    } as LanguageModelCallStartEvent)
+    await usage.onLanguageModelCallEnd(callEndEvent())
+    usage.assertHealthy()
+
+    await expect(recordedCall(bundle, "usage_atomic")).resolves.toMatchObject({
+      cost: {
+        status: "rated",
+        pricingContext: { serviceTier: "standard", batch: false },
+        priceSource: { sourceId: "models.dev", sourceEntryId: "vercel/openai/gpt-5" },
+        money: { currency: "USD", amountNanos: "91625" },
+      },
+    })
+  })
+
+  test("records unsupported deployment context as unpriceable without losing usage", async () => {
+    const bundle = new InMemoryStorage()
+    await createTestAgentExecution(bundle, {
+      projectId: "project_1",
+      agentId: "assistant",
+      runId: "run_1",
+      executionId,
+    })
+    const usage = new AiModelCallRecorder(
+      {
+        storage: bundle,
+        projectId: "project_1",
+        executionId,
+        attempt: 1,
+        requesterGroupIds: [],
+        providerOptions: { gateway: { deploymentId: "production" } },
+        recoverAiModelCall: async () => {
+          throw new Error("Unexpected recovery")
+        },
+        errorRunId: "run_1",
+      },
+      {
+        generateId: () => "usage_deployment",
+        now: () => occurredAt,
+      }
+    )
+
+    await usage.onLanguageModelCallStart({
+      callId: "call_1",
+      provider: "gateway",
+    } as LanguageModelCallStartEvent)
+    await usage.onLanguageModelCallEnd(callEndEvent())
+    usage.assertHealthy()
+
+    await expect(recordedCall(bundle, "usage_deployment")).resolves.toMatchObject({
+      cost: {
+        status: "unpriceable",
+        reason: "unsupportedPricingDimension",
+        pricingContext: { deploymentId: "production" },
+      },
+    })
+    await expect(
+      bundle.aiUsage.summarizeExecution({ projectId: "project_1", executionId })
+    ).resolves.toMatchObject({ modelCallCount: 1 })
+  })
+
   test("deduplicates a repeated lifecycle callback without double-counting usage", async () => {
     // The recorder deliberately generates a fresh row ID for each callback. Removing the storage
     // idempotency lookup makes this exact callback replay produce two records and double the total.
-    const storage = await createInMemoryUsageStorage()
+    const storage = await createInMemoryStorage()
     let nextId = 0
     const usage = recorder(storage, {
       generateId: () => `usage_${++nextId}`,
@@ -167,9 +299,8 @@ describe("AiModelCallRecorder", () => {
     await usage.onLanguageModelCallEnd(event)
 
     expect(nextId).toBe(2)
-    expect(storage.snapshot().records.size).toBe(1)
     await expect(
-      storage.summarizeExecution({
+      storage.aiUsage.summarizeExecution({
         projectId: "project_1",
         executionId,
       })
@@ -181,7 +312,7 @@ describe("AiModelCallRecorder", () => {
 
   test("preserves entirely missing callback usage without inventing zeroes", async () => {
     // Default any omitted SDK count to zero in the adapter and both assertions below fail.
-    const storage = await createInMemoryUsageStorage()
+    const storage = await createInMemoryStorage()
     const usage = recorder(storage, {
       generateId: () => "usage_missing",
       now: () => occurredAt,
@@ -207,11 +338,11 @@ describe("AiModelCallRecorder", () => {
 
     await usage.onLanguageModelCallEnd(event)
 
-    const [record] = storage.snapshot().records.values()
+    const record = await recordedUsage(storage, "usage_missing")
     expect(record?.usage).toEqual({ reportingStatus: "unavailable" })
     expect(record?.rawUsage).toBeUndefined()
     await expect(
-      storage.summarizeExecution({
+      storage.aiUsage.summarizeExecution({
         projectId: "project_1",
         executionId,
       })
@@ -224,26 +355,19 @@ describe("AiModelCallRecorder", () => {
   test("hands a persistent storage failure to durable recovery and blocks the next step", async () => {
     let attempts = 0
     const recovered: RecordAiModelCallInput[] = []
-    const storage: AiUsageStorage = {
-      async recordModelCall() {
-        attempts += 1
-        throw new Error("storage unavailable")
-      },
-      async summarizeExecution(): Promise<AiUsageExecutionSummary> {
-        return emptySummary
-      },
-      async summarizeExecutions() {
-        return []
-      },
-    }
+    const storage = await createInMemoryStorage()
     const usage = recorder(
       storage,
       {
         retryDelaysMs: [10, 20],
         sleep: async () => undefined,
+        recordAccounting: async () => {
+          attempts += 1
+          throw new Error("storage unavailable")
+        },
       },
-      async (record) => {
-        recovered.push(structuredClone(record))
+      async (input) => {
+        recovered.push(structuredClone(input.usage))
       }
     )
 
@@ -264,23 +388,16 @@ describe("AiModelCallRecorder", () => {
   test("blocks the next model step when storage and durable recovery both fail", async () => {
     let storageAttempts = 0
     let recoveryAttempts = 0
-    const storage: AiUsageStorage = {
-      async recordModelCall() {
-        storageAttempts += 1
-        throw new Error("storage unavailable")
-      },
-      async summarizeExecution(): Promise<AiUsageExecutionSummary> {
-        return emptySummary
-      },
-      async summarizeExecutions() {
-        return []
-      },
-    }
+    const storage = await createInMemoryStorage()
     const usage = recorder(
       storage,
       {
         retryDelaysMs: [10, 20],
         sleep: async () => undefined,
+        recordAccounting: async () => {
+          storageAttempts += 1
+          throw new Error("storage unavailable")
+        },
       },
       async () => {
         recoveryAttempts += 1
@@ -304,21 +421,17 @@ describe("AiModelCallRecorder", () => {
   test("does not retry or enqueue a permanently invalid ledger append", async () => {
     let storageAttempts = 0
     let recoveryAttempts = 0
-    const storage: AiUsageStorage = {
-      async recordModelCall() {
-        storageAttempts += 1
-        throw new AiUsageStorageError("missing_execution", "missing execution")
-      },
-      async summarizeExecution(): Promise<AiUsageExecutionSummary> {
-        return emptySummary
-      },
-      async summarizeExecutions() {
-        return []
-      },
-    }
+    const storage = await createInMemoryStorage()
     const usage = recorder(
       storage,
-      { retryDelaysMs: [10, 20], sleep: async () => undefined },
+      {
+        retryDelaysMs: [10, 20],
+        sleep: async () => undefined,
+        recordAccounting: async () => {
+          storageAttempts += 1
+          throw new AiUsageStorageError("missing_execution", "missing execution")
+        },
+      },
       async () => {
         recoveryAttempts += 1
       }
@@ -339,21 +452,13 @@ describe("AiModelCallRecorder", () => {
 
   test("retains failures raised while constructing the callback record", async () => {
     let records = 0
-    const storage: AiUsageStorage = {
-      async recordModelCall(input) {
-        records += 1
-        return { record: normalizeAiModelCallRecord(input), created: true }
-      },
-      async summarizeExecution(): Promise<AiUsageExecutionSummary> {
-        return emptySummary
-      },
-      async summarizeExecutions() {
-        return []
-      },
-    }
+    const storage = await createInMemoryStorage()
     const usage = recorder(storage, {
       generateId: () => {
         throw new Error("ID generation unavailable")
+      },
+      recordAccounting: async () => {
+        records += 1
       },
     })
 

--- a/packages/agent-worker/tests/model-call-recovery.test.ts
+++ b/packages/agent-worker/tests/model-call-recovery.test.ts
@@ -24,7 +24,12 @@ function modelCall(): RecordAiModelCallInput {
     providerId: "gateway",
     requestedModelId: "openai/gpt-5",
     responseId: "response_1",
-    usage: { inputTokens: 12, outputTokens: 8, cacheReadInputTokens: undefined },
+    usage: {
+      inputTokens: 12,
+      outputTokens: 8,
+      uncachedInputTokens: 12,
+      cacheReadInputTokens: 0,
+    },
     rawUsage: { input_tokens: 12, output_tokens: 8 },
     occurredAt: new Date("2026-07-01T12:00:00.000Z"),
     recordedAt: new Date("2026-07-01T12:00:01.000Z"),
@@ -65,12 +70,12 @@ describe("AI usage recovery", () => {
     })
     expect(claimed.job.payload.record).not.toHaveProperty("projectId")
     expect(claimed.job.payload.record).not.toHaveProperty("recordedAt")
-    expect(claimed.job.payload.record.usage).not.toHaveProperty("cacheReadInputTokens")
+    expect(claimed.job.payload.record.usage).toMatchObject({ cacheReadInputTokens: 0 })
 
-    await expect(recordRecoveredAiModelCall(storage.aiUsage, claimed.job)).resolves.toMatchObject({
+    await expect(recordRecoveredAiModelCall(storage, claimed.job)).resolves.toMatchObject({
       created: true,
     })
-    await expect(recordRecoveredAiModelCall(storage.aiUsage, claimed.job)).resolves.toMatchObject({
+    await expect(recordRecoveredAiModelCall(storage, claimed.job)).resolves.toMatchObject({
       created: false,
     })
     await expect(
@@ -78,6 +83,55 @@ describe("AI usage recovery", () => {
     ).resolves.toMatchObject({
       modelCallCount: 1,
       usage: { inputTokens: 12, outputTokens: 8, totalTokens: 20 },
+    })
+  })
+
+  test("recovers pricing context and local valuation atomically for current jobs", async () => {
+    const queues = new InMemoryQueues()
+    const storage = new InMemoryStorage()
+    await createTestAgentExecution(storage, {
+      projectId,
+      agentId: "assistant",
+      runId: "run_1",
+      executionId,
+    })
+    await enqueueAiModelCallRecovery(queues.agents, {
+      usage: modelCall(),
+      pricingContext: { serviceTier: "standard" },
+      ratedAt: new Date("2026-07-01T12:00:01.000Z"),
+    })
+    const [claimed] = await queues.agents.claim({
+      projectId,
+      workerId: "test-worker",
+      limit: 1,
+    })
+    if (claimed?.job.type !== "agent.ai-usage.record.requested") {
+      throw new Error("Expected an AI usage recovery job.")
+    }
+    expect(claimed.job.payload.accounting).toEqual({
+      pricingContext: { serviceTier: "standard" },
+      ratedAt: "2026-07-01T12:00:01.000Z",
+    })
+
+    await expect(recordRecoveredAiModelCall(storage, claimed.job)).resolves.toMatchObject({
+      created: true,
+    })
+    await expect(
+      storage.aiCosts.listModelCalls({
+        projectId,
+        from: new Date("2026-07-01T00:00:00.000Z"),
+        to: new Date("2026-07-02T00:00:00.000Z"),
+      })
+    ).resolves.toMatchObject({
+      items: [
+        {
+          cost: {
+            status: "rated",
+            billingIdentity: { providerId: "vercel", modelId: "openai/gpt-5" },
+            pricingContext: { serviceTier: "standard" },
+          },
+        },
+      ],
     })
   })
 
@@ -99,7 +153,7 @@ describe("AI usage recovery", () => {
     }
 
     const storage = new InMemoryStorage()
-    const invalidJobError = await recordRecoveredAiModelCall(storage.aiUsage, job).catch(
+    const invalidJobError = await recordRecoveredAiModelCall(storage, job).catch(
       (error: unknown) => error
     )
     expect(invalidJobError).toMatchObject({

--- a/packages/agent-worker/tests/models-dev-pricing.test.ts
+++ b/packages/agent-worker/tests/models-dev-pricing.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeAiModelCallCostRecord } from "@sixb/core/internal/ai-cost-storage-provider"
+import type { AiModelCallUsageRecord } from "@sixb/core/storage"
+import {
+  MODELS_DEV_CATALOG_SOURCE,
+  rateAiModelCall,
+  resolveModelsDevBillingIdentity,
+} from "../src/ai-pricing/models-dev"
+
+function usage(overrides: Partial<AiModelCallUsageRecord> = {}): AiModelCallUsageRecord {
+  return {
+    id: "usage_1",
+    projectId: "project_1",
+    executionId: "execution_1",
+    attempt: 1,
+    callId: "call_1",
+    requesterGroupIds: [],
+    providerId: "anthropic.messages",
+    requestedModelId: "claude-opus-4-8",
+    responseId: "response_1",
+    usage: {
+      inputTokens: 1_913,
+      outputTokens: 247,
+      uncachedInputTokens: 1_913,
+      cacheReadInputTokens: 0,
+      cacheWriteInputTokens: 0,
+      reportingStatus: "complete",
+      totalTokens: 2_160,
+    },
+    occurredAt: new Date("2026-08-25T00:00:00.000Z"),
+    recordedAt: new Date("2026-08-25T00:00:00.100Z"),
+    ...overrides,
+  }
+}
+
+function rate(
+  record = usage(),
+  input: Parameters<typeof rateAiModelCall>[0] = {
+    usage: record,
+    ratedAt: new Date("2026-08-25T00:00:01.000Z"),
+  }
+) {
+  return rateAiModelCall({ ...input, usage: record })
+}
+
+describe("Models.dev AI cost rating", () => {
+  test("rates the exact direct Anthropic AI SDK model identity", () => {
+    const result = rate()
+    expect(result).toMatchObject({
+      status: "rated",
+      billingIdentity: { providerId: "anthropic", modelId: "claude-opus-4-8" },
+      money: { currency: "USD", amountNanos: "15740000" },
+      priceSource: {
+        sourceId: "models.dev",
+        sourceEntryId: "anthropic/claude-opus-4-8",
+        sourceVersion: MODELS_DEV_CATALOG_SOURCE.sourceVersion,
+      },
+    })
+    if (result.status !== "rated") throw new Error("Expected a rated result")
+    expect(result.components).toEqual([
+      {
+        meter: "tokens.input.uncached",
+        quantity: "1913",
+        rateAmountNanosPerMillion: "5000000000",
+        chargeAmountNanos: "9565000",
+      },
+      {
+        meter: "tokens.input.cacheRead",
+        quantity: "0",
+        rateAmountNanosPerMillion: "500000000",
+        chargeAmountNanos: "0",
+      },
+      {
+        meter: "tokens.input.cacheWrite",
+        quantity: "0",
+        rateAmountNanosPerMillion: "6250000000",
+        chargeAmountNanos: "0",
+      },
+      {
+        meter: "tokens.output.total",
+        quantity: "247",
+        rateAmountNanosPerMillion: "25000000000",
+        chargeAmountNanos: "6175000",
+      },
+    ])
+  })
+
+  test("keeps Gateway and direct-provider identities separate", () => {
+    const gatewayUsage = usage({
+      providerId: "gateway",
+      requestedModelId: "anthropic/claude-opus-4.8",
+    })
+    expect(resolveModelsDevBillingIdentity(gatewayUsage)).toEqual({
+      providerId: "vercel",
+      modelId: "anthropic/claude-opus-4.8",
+    })
+    expect(rate(gatewayUsage)).toMatchObject({
+      status: "rated",
+      billingIdentity: {
+        providerId: "vercel",
+        modelId: "anthropic/claude-opus-4.8",
+      },
+    })
+  })
+
+  test("prices a requested Gateway route instead of its underlying response model", () => {
+    const gatewayUsage = usage({
+      providerId: "gateway",
+      requestedModelId: "poolside/laguna-s-2.1-free",
+      responseModelId: "poolside/laguna-s-2.1",
+      usage: {
+        inputTokens: 1_044,
+        outputTokens: 40,
+        uncachedInputTokens: 1_044,
+        cacheReadInputTokens: 0,
+        reportingStatus: "complete",
+        totalTokens: 1_084,
+      },
+      rawUsage: {
+        providerMetadata: {
+          gateway: {
+            routing: { canonicalSlug: "poolside/laguna-s-2.1-free" },
+            cost: "0",
+          },
+        },
+      },
+    })
+
+    expect(resolveModelsDevBillingIdentity(gatewayUsage)).toEqual({
+      providerId: "vercel",
+      modelId: "poolside/laguna-s-2.1-free",
+    })
+    expect(rate(gatewayUsage)).toMatchObject({
+      status: "rated",
+      billingIdentity: {
+        providerId: "vercel",
+        modelId: "poolside/laguna-s-2.1-free",
+      },
+      money: { currency: "USD", amountNanos: "0" },
+      priceSource: {
+        sourceEntryId: "vercel/poolside/laguna-s-2.1-free",
+      },
+    })
+  })
+
+  test("prefers an exact requested Gateway entry over a differently named canonical route", () => {
+    const gatewayUsage = usage({
+      providerId: "gateway",
+      requestedModelId: "spacexai/grok-4.6",
+      responseModelId: "grok-4.6",
+      usage: {
+        inputTokens: 1_726,
+        outputTokens: 401,
+        uncachedInputTokens: 1_598,
+        cacheReadInputTokens: 128,
+        reportingStatus: "complete",
+        totalTokens: 2_127,
+      },
+      rawUsage: {
+        providerMetadata: {
+          gateway: {
+            routing: { canonicalSlug: "xai/grok-4.6", finalProvider: "xai" },
+          },
+        },
+      },
+    })
+
+    expect(resolveModelsDevBillingIdentity(gatewayUsage)).toEqual({
+      providerId: "vercel",
+      modelId: "spacexai/grok-4.6",
+    })
+    expect(rate(gatewayUsage)).toMatchObject({
+      status: "rated",
+      billingIdentity: { providerId: "vercel", modelId: "spacexai/grok-4.6" },
+      money: { currency: "USD", amountNanos: "5666000" },
+      priceSource: { sourceEntryId: "vercel/spacexai/grok-4.6" },
+    })
+  })
+
+  test("uses an exact canonical Gateway entry when the requested route is absent", () => {
+    expect(
+      resolveModelsDevBillingIdentity({
+        providerId: "gateway",
+        requestedModelId: "legacy/laguna-free",
+        responseModelId: "poolside/laguna-s-2.1",
+        rawUsage: {
+          providerMetadata: {
+            gateway: {
+              routing: { canonicalSlug: "poolside/laguna-s-2.1-free" },
+            },
+          },
+        },
+      })
+    ).toEqual({ providerId: "vercel", modelId: "poolside/laguna-s-2.1-free" })
+  })
+
+  test("uses the requested Gateway route when canonical routing metadata is unavailable", () => {
+    expect(
+      resolveModelsDevBillingIdentity({
+        providerId: "gateway",
+        requestedModelId: "poolside/laguna-s-2.1-free",
+        responseModelId: "poolside/laguna-s-2.1",
+      })
+    ).toEqual({ providerId: "vercel", modelId: "poolside/laguna-s-2.1-free" })
+  })
+
+  test("maps exact catalog providers and reviewed AI SDK namespaces", () => {
+    expect(
+      resolveModelsDevBillingIdentity({ providerId: "groq", requestedModelId: "model" })
+    ).toEqual({ providerId: "groq", modelId: "model" })
+    expect(
+      resolveModelsDevBillingIdentity({ providerId: "groq.chat", requestedModelId: "model" })
+    ).toEqual({ providerId: "groq", modelId: "model" })
+    expect(
+      resolveModelsDevBillingIdentity({ providerId: "wafer.ai.chat", requestedModelId: "model" })
+    ).toEqual({ providerId: "wafer.ai", modelId: "model" })
+  })
+
+  test("uses an exact cataloged response model when a provider resolves an alias", () => {
+    expect(
+      resolveModelsDevBillingIdentity({
+        providerId: "anthropic.messages",
+        requestedModelId: "claude-sonnet-4-5",
+        responseModelId: "claude-sonnet-4-5-20250929",
+      })
+    ).toEqual({ providerId: "anthropic", modelId: "claude-sonnet-4-5-20250929" })
+  })
+
+  test("fails closed when a direct provider reports an unknown response model", () => {
+    const record = usage({ responseModelId: "claude-opus-private-v2" })
+    expect(resolveModelsDevBillingIdentity(record)).toEqual({
+      providerId: "anthropic",
+      modelId: "claude-opus-private-v2",
+    })
+    expect(rate(record)).toMatchObject({
+      status: "unpriceable",
+      reason: "missingCatalogEntry",
+      billingIdentity: {
+        providerId: "anthropic",
+        modelId: "claude-opus-private-v2",
+      },
+    })
+  })
+
+  test("does not coerce custom provider prefixes into catalog identities", () => {
+    expect(
+      resolveModelsDevBillingIdentity({
+        providerId: "openai.private-proxy",
+        requestedModelId: "gpt-5",
+      })
+    ).toBeUndefined()
+    expect(
+      rate(usage({ providerId: "openai.private-proxy", requestedModelId: "gpt-5" }))
+    ).toMatchObject({ status: "unpriceable", reason: "missingBillingIdentity" })
+  })
+
+  test("selects named catalog modes from observed pricing context", () => {
+    const result = rate(usage(), {
+      usage: usage(),
+      pricingContext: { mode: "fast" },
+      ratedAt: new Date("2026-08-25T00:00:01.000Z"),
+    })
+    expect(result).toMatchObject({
+      status: "rated",
+      money: { amountNanos: "31480000" },
+    })
+  })
+
+  test("selects Models.dev long-context tiers without a generic schedule DSL", () => {
+    const longContext = usage({
+      providerId: "google.generative-ai",
+      requestedModelId: "gemini-2.5-computer-use-preview-10-2025",
+      usage: {
+        inputTokens: 200_001,
+        outputTokens: 1,
+        reportingStatus: "complete",
+        totalTokens: 200_002,
+      },
+    })
+    expect(rate(longContext)).toMatchObject({
+      status: "rated",
+      money: { currency: "USD", amountNanos: "500017500" },
+      components: [
+        { meter: "tokens.input.total", rateAmountNanosPerMillion: "2500000000" },
+        { meter: "tokens.output.total", rateAmountNanosPerMillion: "15000000000" },
+      ],
+    })
+  })
+
+  test("fails closed for unknown identities and entries", () => {
+    expect(rate(usage({ providerId: "custom", requestedModelId: "model" }))).toMatchObject({
+      status: "unpriceable",
+      reason: "missingBillingIdentity",
+    })
+    expect(rate(usage({ requestedModelId: "claude-opus-nearest-ish" }))).toMatchObject({
+      status: "unpriceable",
+      reason: "missingCatalogEntry",
+      billingIdentity: { providerId: "anthropic", modelId: "claude-opus-nearest-ish" },
+    })
+  })
+
+  test("fails closed when required cache usage is missing or inconsistent", () => {
+    const missing = usage({
+      usage: {
+        inputTokens: 10,
+        outputTokens: 1,
+        reportingStatus: "complete",
+        totalTokens: 11,
+      },
+    })
+    expect(rate(missing)).toMatchObject({
+      status: "unpriceable",
+      reason: "missingUsageMeter",
+      missingMeters: ["tokens.input.uncached", "tokens.input.cacheRead", "tokens.input.cacheWrite"],
+    })
+
+    const inconsistent = usage({
+      usage: {
+        inputTokens: 10,
+        outputTokens: 1,
+        uncachedInputTokens: 8,
+        cacheReadInputTokens: 1,
+        cacheWriteInputTokens: 0,
+        reportingStatus: "complete",
+        totalTokens: 11,
+      },
+    })
+    expect(rate(inconsistent)).toMatchObject({
+      status: "unpriceable",
+      reason: "invalidUsageForFormula",
+    })
+  })
+
+  test("rejects unsupported pricing dimensions instead of applying base rates", () => {
+    for (const pricingContext of [
+      { batch: true },
+      { routedProviderId: "alternate-provider" },
+      { deploymentId: "production" },
+      { deploymentId: "production", mode: "fast" },
+    ]) {
+      expect(
+        rateAiModelCall({
+          usage: usage(),
+          pricingContext,
+          ratedAt: new Date("2026-08-25T00:00:01.000Z"),
+        })
+      ).toMatchObject({ status: "unpriceable", reason: "unsupportedPricingDimension" })
+    }
+  })
+
+  test("validates persisted component arithmetic", () => {
+    const result = rate()
+    if (result.status !== "rated") throw new Error("Expected rated fixture")
+    expect(() =>
+      normalizeAiModelCallCostRecord({
+        ...result,
+        money: { ...result.money, amountNanos: "1" },
+      })
+    ).toThrow("total does not equal")
+  })
+})

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1329,6 +1329,38 @@ function withStorage(sixb: TestSixb, storage: Storage): TestSixb {
   })
 }
 
+function interceptAiUsageTransactions(
+  storage: Storage,
+  handler: (
+    input: RecordAiModelCallInput,
+    next: AiUsageStorage["recordModelCall"]
+  ) => ReturnType<AiUsageStorage["recordModelCall"]>
+): void {
+  const transaction = storage.transaction.bind(storage)
+  storage.transaction = <T>(
+    run: (tx: Storage) => Promise<T> | T,
+    options?: Parameters<Storage["transaction"]>[1]
+  ): Promise<T> =>
+    transaction((tx) => {
+      if (!tx.aiUsage) return run(tx)
+      const next = tx.aiUsage.recordModelCall.bind(tx.aiUsage)
+      const aiUsage = new Proxy(tx.aiUsage, {
+        get(target, property, receiver) {
+          return property === "recordModelCall"
+            ? (input: RecordAiModelCallInput) => handler(input, next)
+            : Reflect.get(target, property, receiver)
+        },
+      })
+      return run(
+        new Proxy(tx, {
+          get(target, property, receiver) {
+            return property === "aiUsage" ? aiUsage : Reflect.get(target, property, receiver)
+          },
+        })
+      )
+    }, options)
+}
+
 function aiUsageStorageOf(sixb: TestSixb): AiUsageStorage {
   const storage = sixb.storage.aiUsage
   if (!storage) {
@@ -1826,11 +1858,10 @@ describe("AgentWorker", () => {
     })
     const recordedUsage: RecordAiModelCallInput[] = []
     const aiUsage = aiUsageStorageOf(sixb)
-    const recordModelCall = aiUsage.recordModelCall.bind(aiUsage)
-    aiUsage.recordModelCall = async (usage) => {
+    interceptAiUsageTransactions(sixb.storage, async (usage, next) => {
       recordedUsage.push(structuredClone(usage))
-      return recordModelCall(usage)
-    }
+      return next(usage)
+    })
 
     const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
     await worker.start()
@@ -2144,17 +2175,16 @@ describe("AgentWorker", () => {
       runId: "workflow-accounting-failure",
     })
     const aiUsage = aiUsageStorageOf(sixb)
-    const recordModelCall = aiUsage.recordModelCall.bind(aiUsage)
     const queue = sixb.queues.agents
     const enqueue = queue.enqueue.bind(queue)
     let storageAvailable = false
     let appendAttempts = 0
     let recoveryJobs = 0
-    aiUsage.recordModelCall = async (input) => {
-      if (storageAvailable) return recordModelCall(input)
+    interceptAiUsageTransactions(sixb.storage, async (input, next) => {
+      if (storageAvailable) return next(input)
       appendAttempts += 1
       throw new Error("usage storage unavailable")
-    }
+    })
     queue.enqueue = async (params) => {
       const jobs = await enqueue(params)
       const handedOff = params.jobs.filter(
@@ -2255,15 +2285,14 @@ describe("AgentWorker", () => {
       model,
       runId: "workflow-final-callback-failure",
     })
-    const aiUsage = aiUsageStorageOf(sixb)
     const queue = sixb.queues.agents
     const enqueue = queue.enqueue.bind(queue)
     let appendAttempts = 0
     let recoveryAttempts = 0
-    aiUsage.recordModelCall = async () => {
+    interceptAiUsageTransactions(sixb.storage, async () => {
       appendAttempts += 1
       throw new Error("usage storage unavailable")
-    }
+    })
     queue.enqueue = async (params) => {
       if (params.jobs.some((job) => job.type === "agent.ai-usage.record.requested")) {
         recoveryAttempts += 1
@@ -4178,17 +4207,16 @@ describe("AgentWorker", () => {
     const sixb = buildSixbWithEchoTool(model)
     const storage = agentStorageOf(sixb)
     const aiUsage = aiUsageStorageOf(sixb)
-    const recordModelCall = aiUsage.recordModelCall.bind(aiUsage)
     const queue = sixb.queues.agents
     const enqueue = queue.enqueue.bind(queue)
     let storageAvailable = false
     let appendAttempts = 0
     let recoveryJobs = 0
-    aiUsage.recordModelCall = async (input) => {
-      if (storageAvailable) return recordModelCall(input)
+    interceptAiUsageTransactions(sixb.storage, async (input, next) => {
+      if (storageAvailable) return next(input)
       appendAttempts += 1
       throw new Error("usage storage unavailable")
-    }
+    })
     queue.enqueue = async (params) => {
       const jobs = await enqueue(params)
       const handedOff = params.jobs.filter(
@@ -4254,13 +4282,12 @@ describe("AgentWorker", () => {
       runId: "usage-recovery",
     })
     const aiUsage = aiUsageStorageOf(sixb)
-    const recordModelCall = aiUsage.recordModelCall.bind(aiUsage)
     let appendAttempts = 0
-    aiUsage.recordModelCall = async (input) => {
+    interceptAiUsageTransactions(sixb.storage, async (input, next) => {
       appendAttempts += 1
       if (appendAttempts === 1) throw new Error("temporary usage storage failure")
-      return recordModelCall(input)
-    }
+      return next(input)
+    })
 
     const queue = sixb.queues.agents
     const retry = queue.retry.bind(queue)
@@ -4330,15 +4357,14 @@ describe("AgentWorker", () => {
     })
     const sixb = buildSixbWithEchoTool(model)
     const storage = agentStorageOf(sixb)
-    const aiUsage = aiUsageStorageOf(sixb)
     const queue = sixb.queues.agents
     const enqueue = queue.enqueue.bind(queue)
     let appendAttempts = 0
     let recoveryAttempts = 0
-    aiUsage.recordModelCall = async () => {
+    interceptAiUsageTransactions(sixb.storage, async () => {
       appendAttempts += 1
       throw new Error("usage storage unavailable")
-    }
+    })
     queue.enqueue = async (params) => {
       if (params.jobs.some((job) => job.type === "agent.ai-usage.record.requested")) {
         recoveryAttempts += 1
@@ -5589,12 +5615,10 @@ describe("AgentWorker", () => {
     // Regression guard: hard-code the recorder attempt to 1 instead of using the reclaimed durable
     // run and this captures [1, 1], even though the terminal run correctly reports attempt 2.
     const recordedAttempts: number[] = []
-    const aiUsage = aiUsageStorageOf(sixb)
-    const recordModelCall = aiUsage.recordModelCall.bind(aiUsage)
-    aiUsage.recordModelCall = async (input) => {
+    interceptAiUsageTransactions(sixb.storage, async (input, next) => {
       recordedAttempts.push(input.attempt)
-      return recordModelCall(input)
-    }
+      return next(input)
+    })
 
     const worker = new AgentWorker(sixb, workerOptions())
     await worker.start()

--- a/packages/agent-worker/tsconfig.build.json
+++ b/packages/agent-worker/tsconfig.build.json
@@ -9,7 +9,7 @@
     "rootDir": "./src",
     "tsBuildInfoFile": "./.tsbuild/tsconfig.build.tsbuildinfo"
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "src/ai-pricing/models-dev-pricing.json"],
   "references": [
     {
       "path": "../core/tsconfig.build.json"

--- a/packages/core/src/queues/index.ts
+++ b/packages/core/src/queues/index.ts
@@ -4,6 +4,7 @@ export { InMemoryQueues } from "./in-memory"
 export type {
   ActionQueueJobFailureCode,
   ActionRunRequestedQueueJob,
+  AgentAiUsageAccountingPayload,
   AgentAiUsageRecordPayload,
   AgentAiUsageRecordRequestedQueueJob,
   AgentQueueJob,

--- a/packages/core/src/queues/types.ts
+++ b/packages/core/src/queues/types.ts
@@ -4,6 +4,7 @@ import type { ProjectionRunFailureCode } from "../projections/types"
 import type { ProviderScope } from "../provider-scope"
 import type { ActionRunFailureCode } from "../storage/action-runs/types"
 import type { AgentRunFailureCode } from "../storage/agents/types"
+import type { AiPricingContext } from "../storage/ai-cost/types"
 import type { RecordAiModelCallInput } from "../storage/ai-usage"
 import type { PipelineRunFailureCode } from "../storage/pipeline-runs/types"
 import type { SyncRunFailureCode } from "../storage/sync-runs/types"
@@ -209,11 +210,18 @@ export type AgentAiUsageRecordPayload = Omit<
   readonly occurredAt: string
 }
 
+export interface AgentAiUsageAccountingPayload {
+  readonly pricingContext: AiPricingContext
+  readonly ratedAt: string
+}
+
 export interface AgentAiUsageRecordRequestedQueueJob
   extends QueueJob<
     "agent.ai-usage.record.requested",
     {
       readonly record: AgentAiUsageRecordPayload
+      /** Absent on Phase 1 jobs; recovery then uses an empty pricing context. */
+      readonly accounting?: AgentAiUsageAccountingPayload
     }
   > {}
 

--- a/scripts/generate-models-dev-pricing.ts
+++ b/scripts/generate-models-dev-pricing.ts
@@ -1,0 +1,173 @@
+import { createHash } from "node:crypto"
+import { mkdir } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+
+const SOURCE_URL = "https://models.dev/api.json"
+const OUTPUT_PATH = resolve(
+  import.meta.dir,
+  "../packages/agent-worker/src/ai-pricing/models-dev-pricing.json"
+)
+interface ModelsDevCost {
+  readonly input: number
+  readonly output: number
+  readonly cache_read?: number
+  readonly cache_write?: number
+  readonly reasoning?: number
+  readonly input_audio?: number
+  readonly output_audio?: number
+  readonly tiers?: readonly (ModelsDevCost & {
+    readonly tier: { readonly type: string; readonly size: number }
+  })[]
+}
+
+interface ModelsDevMode {
+  readonly cost?: ModelsDevCost
+}
+
+interface ModelsDevModel {
+  readonly cost?: ModelsDevCost
+  readonly experimental?: {
+    readonly modes?: Readonly<Record<string, ModelsDevMode>>
+  }
+}
+
+interface ModelsDevProvider {
+  readonly models: Readonly<Record<string, ModelsDevModel>>
+}
+
+interface GeneratedRateSet {
+  readonly input: string
+  readonly output: string
+  readonly cacheRead?: string
+  readonly cacheWrite?: string
+  readonly reasoning?: string
+  readonly inputAudio?: string
+  readonly outputAudio?: string
+}
+
+interface GeneratedPrice extends GeneratedRateSet {
+  readonly tiers?: readonly (GeneratedRateSet & { readonly aboveInputTokens: string })[]
+  readonly modes?: Readonly<Record<string, Omit<GeneratedPrice, "modes">>>
+}
+
+const response = await fetch(SOURCE_URL)
+if (!response.ok) {
+  throw new Error(`[SixbPricing] Models.dev returned HTTP ${response.status}.`)
+}
+const sourceText = await response.text()
+const source = JSON.parse(sourceText) as Readonly<Record<string, ModelsDevProvider>>
+const providers: Record<string, Record<string, GeneratedPrice>> = {}
+
+for (const [providerId, provider] of Object.entries(source).sort(compareEntries)) {
+  const models: Record<string, GeneratedPrice> = {}
+  for (const [modelId, model] of Object.entries(provider.models).sort(compareEntries)) {
+    if (!model.cost) continue
+    const modes = Object.fromEntries(
+      Object.entries(model.experimental?.modes ?? {})
+        .sort(compareEntries)
+        .flatMap(([mode, value]) => (value.cost ? [[mode, generatedPrice(value.cost)]] : []))
+    )
+    models[modelId] = {
+      ...generatedPrice(model.cost),
+      ...(Object.keys(modes).length ? { modes } : {}),
+    }
+  }
+  if (Object.keys(models).length > 0) providers[providerId] = models
+}
+
+const output = {
+  source: {
+    id: "models.dev",
+    version: `sha256:${createHash("sha256").update(sourceText).digest("hex")}`,
+    url: SOURCE_URL,
+    observedAt: new Date().toISOString(),
+  },
+  providers,
+}
+
+await mkdir(dirname(OUTPUT_PATH), { recursive: true })
+await Bun.write(OUTPUT_PATH, `${JSON.stringify(output)}\n`)
+console.log(
+  `[SixbPricing] Wrote ${Object.keys(providers).length} providers to ${OUTPUT_PATH} (${output.source.version}).`
+)
+
+function generatedPrice(cost: ModelsDevCost): Omit<GeneratedPrice, "modes"> {
+  const tiers = cost.tiers?.map((tier) => {
+    if (tier.tier.type !== "context") {
+      throw new Error(`[SixbPricing] Unsupported Models.dev tier '${tier.tier.type}'.`)
+    }
+    return {
+      ...rateSet(tier),
+      aboveInputTokens: integerString(tier.tier.size, "tier size"),
+    }
+  })
+  return { ...rateSet(cost), ...(tiers?.length ? { tiers } : {}) }
+}
+
+function rateSet(cost: ModelsDevCost): GeneratedRateSet {
+  return {
+    input: dollarsPerMillionToNanos(cost.input),
+    output: dollarsPerMillionToNanos(cost.output),
+    ...(cost.cache_read === undefined
+      ? {}
+      : { cacheRead: dollarsPerMillionToNanos(cost.cache_read) }),
+    ...(cost.cache_write === undefined
+      ? {}
+      : { cacheWrite: dollarsPerMillionToNanos(cost.cache_write) }),
+    ...(cost.reasoning === undefined
+      ? {}
+      : { reasoning: dollarsPerMillionToNanos(cost.reasoning) }),
+    ...(cost.input_audio === undefined
+      ? {}
+      : { inputAudio: dollarsPerMillionToNanos(cost.input_audio) }),
+    ...(cost.output_audio === undefined
+      ? {}
+      : { outputAudio: dollarsPerMillionToNanos(cost.output_audio) }),
+  }
+}
+
+/**
+ * Models.dev publishes JSON numbers. Its generated feed occasionally contains binary-float tails
+ * such as 0.049999999999999996, so catalog compilation rounds the textual value to the nearest
+ * currency nanounit per million tokens. Runtime money arithmetic never uses floating point.
+ */
+function dollarsPerMillionToNanos(value: number): string {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`[SixbPricing] Invalid Models.dev price '${String(value)}'.`)
+  }
+  const decimal = value.toString()
+  const match = /^(\d+)(?:\.(\d+))?(?:e([+-]?\d+))?$/.exec(decimal)
+  if (!match) throw new Error(`[SixbPricing] Invalid Models.dev decimal '${decimal}'.`)
+
+  const whole = match[1]!
+  const fraction = match[2] ?? ""
+  const exponent = Number(match[3] ?? "0")
+  const digits = `${whole}${fraction}`
+  const decimalPlaces = fraction.length - exponent
+  let scaled: bigint
+  if (decimalPlaces <= 9) {
+    scaled = BigInt(digits) * 10n ** BigInt(9 - decimalPlaces)
+  } else {
+    const divisor = 10n ** BigInt(decimalPlaces - 9)
+    const coefficient = BigInt(digits)
+    scaled = (coefficient + divisor / 2n) / divisor
+  }
+  if (scaled < 0n || scaled > 9_223_372_036_854_775_807n) {
+    throw new Error(`[SixbPricing] Models.dev price '${decimal}' exceeds signed 64-bit nanounits.`)
+  }
+  return scaled.toString()
+}
+
+function integerString(value: number, field: string): string {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`[SixbPricing] Models.dev ${field} must be a non-negative safe integer.`)
+  }
+  return value.toString()
+}
+
+function compareEntries(
+  left: readonly [string, unknown],
+  right: readonly [string, unknown]
+): number {
+  return left[0].localeCompare(right[0])
+}


### PR DESCRIPTION
## Why

The previous layers define and persist valuations. This PR creates valuations at the point where the Agent worker observes a completed provider call.

A cost estimate is only useful if its model identity, usage meters, pricing dimensions, and source version are auditable. The worker therefore rates calls against a pinned catalog and fails closed whenever it cannot prove that the selected price applies.

## Accounting flow

```text
AI SDK provider call
  → normalized usage + allowlisted pricing context
  → exact provider/model identity resolution
  → pinned Models.dev catalog rating
  → one storage transaction: usage + valuation
  → durable recovery queue if the transaction cannot be recorded
```

## What changed

- adds a generated, versioned Models.dev pricing snapshot to the Agent worker
- adds integer-only rating for input, output, cache, reasoning, mode, and context tiers
- captures request pricing dimensions, response model identity, and provider metadata
- records usage and valuation atomically
- extends durable recovery jobs with pricing context and rating time
- requires `storage.aiCosts` when starting an Agent worker
- documents the accounting and failure behavior

## Pricing rules

- Only exact catalog identities and explicitly reviewed AI SDK provider mappings are accepted.
- Direct providers prefer the response model identity when one is reported.
- Gateway routes use the exact requested or canonical catalog route, not the underlying serving model.
- Unknown identities, missing meters, unsupported deployment dimensions, and inconsistent formulas become explicit `unpriceable` records.
- Money and token calculations use integer arithmetic; no runtime floating point is used.
- The catalog source version and selected entry are stored with every valuation.

## Generated catalog

[`models-dev-pricing.json`](https://github.com/sixb-ai/sixb/blob/feature/ai-cost-03-rating/packages/agent-worker/src/ai-pricing/models-dev-pricing.json) is generated and intentionally shipped with the worker. Review the generator and rater rather than the generated JSON:

```text
bun run generate:ai-pricing
```

- [Catalog generator](https://github.com/sixb-ai/sixb/blob/feature/ai-cost-03-rating/scripts/generate-models-dev-pricing.ts)
- [Models.dev rater](https://github.com/sixb-ai/sixb/blob/feature/ai-cost-03-rating/packages/agent-worker/src/ai-pricing/models-dev.ts)
- [Atomic accounting transaction](https://github.com/sixb-ai/sixb/blob/feature/ai-cost-03-rating/packages/agent-worker/src/ai-pricing/accounting.ts)
- [Recorder and AI SDK middleware](https://github.com/sixb-ai/sixb/blob/feature/ai-cost-03-rating/packages/agent-worker/src/model-call-recorder.ts)
- [Durable recovery](https://github.com/sixb-ai/sixb/blob/feature/ai-cost-03-rating/packages/agent-worker/src/model-call-recovery.ts)

## Stack

> Layer 3 of native GitHub stack **#448**. This PR depends on #443 and #444.

1. #443 — core vocabulary and in-memory contract
2. #444 — SQLite and PostgreSQL persistence
3. **#445 — Models.dev rating and worker recording**
4. #446 — HTTP API and generated client
5. #447 — Atlas analytics experience

## Verification

```text
bun run typecheck
bun run check
bun test packages/agent-worker/tests/models-dev-pricing.test.ts \
  packages/agent-worker/tests/ai-sdk-adapters.test.ts \
  packages/agent-worker/tests/model-call-recorder.test.ts \
  packages/agent-worker/tests/model-call-recovery.test.ts \
  packages/agent-worker/tests/worker.test.ts
```
