### PR TITLE
atlas: add AI usage analytics

### DIFF
--- a/packages/agent-worker/src/ai-pricing/models-dev.ts
+++ b/packages/agent-worker/src/ai-pricing/models-dev.ts
@@ -165,6 +165,24 @@ export function rateAiModelCall(input: RateAiModelCallInput): AiModelCallCostRec
     rates = selectTier(tiers, usage.inputTokens) ?? rates
   }
 
+  // The compact catalog's cache-write rate is the five-minute price. A nonzero write without an
+  // observed TTL is ambiguous because providers may also charge a different one-hour rate.
+  if (
+    rates.cacheWrite !== undefined &&
+    usage.cacheWriteInputTokens !== undefined &&
+    usage.cacheWriteInputTokens > 0 &&
+    pricingContext.cacheWriteTtlSeconds === undefined
+  ) {
+    return unpriceable(
+      input,
+      ratedAt,
+      pricingContext,
+      resolvedSource,
+      "unsupportedPricingDimension",
+      billingIdentity
+    )
+  }
+
   if (
     (rates.inputAudio !== undefined || rates.outputAudio !== undefined) &&
     rawUsageContainsAudioTokens(usageRecord)

--- a/packages/agent-worker/tests/models-dev-pricing.test.ts
+++ b/packages/agent-worker/tests/models-dev-pricing.test.ts
@@ -331,6 +331,32 @@ describe("Models.dev AI cost rating", () => {
     })
   })
 
+  test("requires an observed five-minute TTL before pricing cache writes", () => {
+    const cacheWriteUsage = usage({
+      usage: {
+        inputTokens: 10,
+        outputTokens: 1,
+        uncachedInputTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheWriteInputTokens: 10,
+        reportingStatus: "complete",
+        totalTokens: 11,
+      },
+    })
+
+    expect(rate(cacheWriteUsage)).toMatchObject({
+      status: "unpriceable",
+      reason: "unsupportedPricingDimension",
+    })
+    expect(
+      rateAiModelCall({
+        usage: cacheWriteUsage,
+        pricingContext: { cacheWriteTtlSeconds: 300 },
+        ratedAt: new Date("2026-08-25T00:00:01.000Z"),
+      })
+    ).toMatchObject({ status: "rated" })
+  })
+
   test("rejects unsupported pricing dimensions instead of applying base rates", () => {
     for (const pricingContext of [
       { batch: true },

--- a/packages/atlas/src/components/AiUsageCharts.tsx
+++ b/packages/atlas/src/components/AiUsageCharts.tsx
@@ -1,0 +1,348 @@
+import { Card, CardContent, CardHeader, CardTitle, MiniSparkline } from "@sixb/ui/components"
+import { cn } from "@sixb/ui/lib/utils"
+import type { ReactNode } from "react"
+import { useId } from "react"
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts/lib/index.js"
+
+const DEFAULT_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+] as const
+
+interface AiUsageMetricCardProps {
+  readonly label: string
+  readonly value: ReactNode
+  readonly description?: ReactNode
+  readonly icon?: ReactNode
+  readonly sparkline?: readonly { readonly value: number; readonly timestamp: string }[]
+  readonly className?: string
+}
+
+export function AiUsageMetricCard({
+  label,
+  value,
+  description,
+  icon,
+  sparkline,
+  className,
+}: AiUsageMetricCardProps) {
+  return (
+    <Card className={cn("min-w-0 gap-3 py-4", className)}>
+      <CardHeader className="flex flex-row items-center justify-between gap-3 px-4">
+        <CardTitle className="truncate text-xs font-medium text-muted-foreground">
+          {label}
+        </CardTitle>
+        {icon ? <span className="shrink-0 text-muted-foreground">{icon}</span> : null}
+      </CardHeader>
+      <CardContent className="px-4">
+        <div className="flex min-w-0 items-end justify-between gap-3">
+          <div className="min-w-0">
+            <div className="truncate text-2xl font-semibold tracking-tight tabular-nums">
+              {value}
+            </div>
+            {description ? (
+              <p className="mt-1 truncate text-xs text-muted-foreground">{description}</p>
+            ) : null}
+          </div>
+          {sparkline && sparkline.length > 1 ? (
+            <MiniSparkline data={[...sparkline]} width={72} height={30} className="shrink-0" />
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+interface AiUsageBreakdownDatum {
+  readonly key: string
+  readonly label: string
+  readonly value: number
+  readonly color?: string
+}
+
+interface AiUsageBreakdownProps {
+  readonly data: readonly AiUsageBreakdownDatum[]
+  readonly valueLabel: string
+  readonly height?: number
+  readonly className?: string
+  readonly valueFormatter?: (value: number) => string
+  readonly emptyLabel?: string
+  readonly ariaLabel: string
+}
+
+export function AiUsageBreakdown({
+  data,
+  valueLabel,
+  height,
+  className,
+  valueFormatter,
+  emptyLabel = "No data available",
+  ariaLabel,
+}: AiUsageBreakdownProps) {
+  if (data.length === 0) {
+    return (
+      <div
+        className={cn(
+          "flex min-h-32 items-center justify-center rounded-lg border border-dashed text-sm text-muted-foreground",
+          className
+        )}
+        style={height === undefined ? undefined : { minHeight: height }}
+      >
+        {emptyLabel}
+      </div>
+    )
+  }
+
+  const maximum = Math.max(...data.map((item) => item.value), 0)
+
+  return (
+    <div
+      className={cn("space-y-4", className)}
+      style={height === undefined ? undefined : { minHeight: height }}
+      role="img"
+      aria-label={ariaLabel}
+    >
+      {data.map((item) => {
+        const formattedValue = valueFormatter
+          ? valueFormatter(item.value)
+          : item.value.toLocaleString()
+        const percentage = maximum === 0 ? 0 : (item.value / maximum) * 100
+
+        return (
+          <div key={item.key} aria-label={`${item.label}: ${formattedValue}`}>
+            <div className="mb-1.5 flex items-start justify-between gap-4 text-sm">
+              <span className="min-w-0 break-words text-muted-foreground" title={item.label}>
+                {item.label}
+              </span>
+              <span className="shrink-0 font-mono font-medium tabular-nums" title={valueLabel}>
+                {formattedValue}
+              </span>
+            </div>
+            <div className="h-2.5 overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full transition-[width]"
+                style={{
+                  backgroundColor: item.color ?? "var(--chart-2)",
+                  width: item.value > 0 ? `${Math.max(percentage, 0.75)}%` : 0,
+                }}
+              />
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+interface AiUsageTimeSeriesDatum {
+  readonly [key: string]: number | string | null | undefined
+}
+
+interface AiUsageTimeSeriesSeries {
+  readonly key: string
+  readonly label: string
+  readonly color?: string
+  readonly stackId?: string
+}
+
+interface AiUsageTimeSeriesProps {
+  readonly data: readonly AiUsageTimeSeriesDatum[]
+  readonly xKey: string
+  readonly series: readonly AiUsageTimeSeriesSeries[]
+  readonly variant?: "line" | "area" | "bar"
+  readonly height?: number
+  readonly yAxisWidth?: number
+  readonly showLegend?: boolean
+  readonly className?: string
+  readonly xFormatter?: (value: string) => string
+  readonly valueFormatter?: (value: number, seriesKey: string) => string
+  readonly emptyLabel?: string
+  readonly ariaLabel: string
+}
+
+export function AiUsageTimeSeries({
+  data,
+  xKey,
+  series,
+  variant = "line",
+  height = 280,
+  yAxisWidth = 54,
+  showLegend = true,
+  className,
+  xFormatter,
+  valueFormatter,
+  emptyLabel = "No data available",
+  ariaLabel,
+}: AiUsageTimeSeriesProps) {
+  const id = useId().replace(/:/g, "")
+  if (data.length === 0 || series.length === 0) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center rounded-lg border border-dashed text-sm text-muted-foreground",
+          className
+        )}
+        style={{ height }}
+      >
+        {emptyLabel}
+      </div>
+    )
+  }
+
+  const configuredSeries = series.map((item, index) => ({
+    ...item,
+    color: item.color ?? DEFAULT_COLORS[index % DEFAULT_COLORS.length]!,
+  }))
+  const isolatedSeries = new Set(
+    configuredSeries
+      .filter((item) => data.filter((datum) => datum[item.key] != null).length === 1)
+      .map((item) => item.key)
+  )
+  // Recharts 2 only discovers chart controls among direct children. Keep these as a flattened
+  // array rather than a Fragment so axes, tooltips, and legends are registered by every variant.
+  const common = [
+    <CartesianGrid key="grid" vertical={false} stroke="var(--border)" strokeDasharray="3 3" />,
+    <XAxis
+      key="x-axis"
+      dataKey={xKey}
+      tickLine={false}
+      axisLine={false}
+      minTickGap={28}
+      tickMargin={10}
+      tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+      tickFormatter={(value) => (xFormatter ? xFormatter(String(value)) : String(value))}
+    />,
+    <YAxis
+      key="y-axis"
+      tickLine={false}
+      axisLine={false}
+      width={yAxisWidth}
+      tickMargin={8}
+      tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+      tickFormatter={(value) =>
+        valueFormatter ? valueFormatter(Number(value), series[0]?.key ?? "value") : String(value)
+      }
+    />,
+    <Tooltip
+      key="tooltip"
+      cursor={
+        variant === "bar" ? { fill: "var(--muted)", opacity: 0.35 } : { stroke: "var(--border)" }
+      }
+      contentStyle={{
+        background: "var(--popover)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-md)",
+        color: "var(--popover-foreground)",
+        boxShadow: "0 6px 16px -4px rgb(0 0 0 / 0.3)",
+        fontSize: 12,
+      }}
+      labelStyle={{ color: "var(--muted-foreground)", marginBottom: 4 }}
+      wrapperStyle={{ zIndex: 20, outline: "none" }}
+      labelFormatter={(label) =>
+        xFormatter && typeof label === "string" ? xFormatter(label) : label
+      }
+      formatter={(value, name) => {
+        const key = String(name)
+        const seriesItem = configuredSeries.find((item) => item.key === key)
+        const formattedValue = valueFormatter
+          ? valueFormatter(Number(value), key)
+          : Number(value).toLocaleString()
+        return [formattedValue, seriesItem?.label ?? key]
+      }}
+    />,
+    showLegend ? (
+      <Legend
+        key="legend"
+        iconSize={8}
+        iconType="circle"
+        height={28}
+        wrapperStyle={{ color: "var(--muted-foreground)", fontSize: 12, paddingTop: 8 }}
+        formatter={(value) =>
+          configuredSeries.find((item) => item.key === String(value))?.label ?? String(value)
+        }
+      />
+    ) : null,
+  ]
+
+  return (
+    <div className={cn("w-full", className)} style={{ height }} role="img" aria-label={ariaLabel}>
+      <ResponsiveContainer width="100%" height="100%">
+        {variant === "area" ? (
+          <AreaChart data={[...data]} margin={{ top: 8, right: 12, bottom: 4, left: 0 }}>
+            <defs>
+              {configuredSeries.map((item) => (
+                <linearGradient key={item.key} id={`${id}-${item.key}`} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={item.color} stopOpacity={0.45} />
+                  <stop offset="95%" stopColor={item.color} stopOpacity={0.04} />
+                </linearGradient>
+              ))}
+            </defs>
+            {common}
+            {configuredSeries.map((item) => (
+              <Area
+                key={item.key}
+                type="monotone"
+                dataKey={item.key}
+                stackId={item.stackId}
+                stroke={item.color}
+                fill={`url(#${id}-${item.key})`}
+                strokeWidth={2}
+                dot={isolatedSeries.has(item.key) ? { r: 3 } : false}
+                connectNulls={false}
+                isAnimationActive={false}
+              />
+            ))}
+          </AreaChart>
+        ) : variant === "bar" ? (
+          <BarChart data={[...data]} margin={{ top: 8, right: 12, bottom: 4, left: 0 }}>
+            {common}
+            {configuredSeries.map((item) => (
+              <Bar
+                key={item.key}
+                dataKey={item.key}
+                stackId={item.stackId}
+                fill={item.color}
+                radius={[3, 3, 0, 0]}
+                maxBarSize={36}
+                isAnimationActive={false}
+              />
+            ))}
+          </BarChart>
+        ) : (
+          <LineChart data={[...data]} margin={{ top: 8, right: 12, bottom: 4, left: 0 }}>
+            {common}
+            {configuredSeries.map((item) => (
+              <Line
+                key={item.key}
+                type="monotone"
+                dataKey={item.key}
+                stroke={item.color}
+                strokeWidth={2}
+                dot={isolatedSeries.has(item.key) ? { r: 3 } : false}
+                activeDot={{ r: 4 }}
+                connectNulls={false}
+                isAnimationActive={false}
+              />
+            ))}
+          </LineChart>
+        )}
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/packages/atlas/src/components/AiUsageDateRangeControl.tsx
+++ b/packages/atlas/src/components/AiUsageDateRangeControl.tsx
@@ -1,0 +1,95 @@
+import { Button, Calendar, Popover, PopoverContent, PopoverTrigger } from "@sixb/ui/components"
+import { CalendarRange } from "lucide-react"
+import { useState } from "react"
+
+interface AiUsageDateRangeControlProps {
+  readonly from: Date
+  readonly through: Date
+  readonly label: string
+  readonly active: boolean
+  readonly onApply: (from: Date, through: Date) => void
+}
+
+interface SelectedDateRange {
+  readonly from: Date | undefined
+  readonly to?: Date
+}
+
+export function AiUsageDateRangeControl({
+  from,
+  through,
+  label,
+  active,
+  onApply,
+}: AiUsageDateRangeControlProps) {
+  const [open, setOpen] = useState(false)
+  const [selected, setSelected] = useState<SelectedDateRange>(() => selectedRange(from, through))
+  const today = localDayStart(new Date())
+  const invalid =
+    selected.from === undefined ||
+    selected.to === undefined ||
+    selected.from.getTime() > selected.to.getTime() ||
+    selected.to.getTime() > today.getTime()
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) setSelected(selectedRange(from, through))
+        setOpen(nextOpen)
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant={active ? "secondary" : "outline"}
+          size="sm"
+          className="max-w-full justify-start gap-2 bg-card px-2.5 font-normal"
+        >
+          <CalendarRange className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="truncate">{label}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-auto max-w-[calc(100vw-2rem)] p-0">
+        <div className="border-b px-4 py-3">
+          <p className="text-sm font-medium">Custom date range</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Select the first and last UTC day to include in the report.
+          </p>
+        </div>
+        <Calendar
+          mode="range"
+          selected={selected}
+          defaultMonth={selected.from ?? through}
+          disabled={{ after: today }}
+          onSelect={(range) => setSelected(range ?? { from: undefined })}
+        />
+        <div className="flex justify-end gap-2 border-t px-4 py-3">
+          <Button type="button" variant="ghost" size="sm" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            disabled={invalid}
+            onClick={() => {
+              if (!selected.from || !selected.to || invalid) return
+              onApply(selected.from, selected.to)
+              setOpen(false)
+            }}
+          >
+            Apply range
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function selectedRange(from: Date, through: Date): SelectedDateRange {
+  return { from: localDayStart(from), to: localDayStart(through) }
+}
+
+function localDayStart(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}

--- a/packages/atlas/src/components/layout/Sidebar.tsx
+++ b/packages/atlas/src/components/layout/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
   Bot,
   Box,
   Cable,
+  ChartNoAxesCombined,
   Database,
   GitBranch,
   Layers,
@@ -34,6 +35,7 @@ import {
 
 export type ViewMode =
   | "home"
+  | "ai-usage"
   | "datasets"
   | "connectors"
   | "syncs"
@@ -64,6 +66,7 @@ const projectNavItems: NavItem[] = [
   { id: "actions", label: "Actions", Icon: Bolt },
   { id: "workflows", label: "Workflows", Icon: GitBranch },
   { id: "agents", label: "Agents", Icon: Bot },
+  { id: "ai-usage", label: "AI usage", Icon: ChartNoAxesCombined },
   { id: "logs", label: "Logs", Icon: ScrollText },
   { id: "rules", label: "Rules", Icon: ListChecks },
   { id: "settings", label: "Settings", Icon: Settings },

--- a/packages/atlas/src/components/layout/viewMode.ts
+++ b/packages/atlas/src/components/layout/viewMode.ts
@@ -2,6 +2,7 @@ import type { ViewMode } from "./Sidebar"
 
 export const KNOWN_VIEWS = new Set([
   "home",
+  "ai-usage",
   "datasets",
   "connectors",
   "syncs",

--- a/packages/atlas/src/features/workflows/components/runs/AgentExecutionPanel.tsx
+++ b/packages/atlas/src/features/workflows/components/runs/AgentExecutionPanel.tsx
@@ -66,7 +66,7 @@ export function AgentExecutionPanel({
           )}
           {data.cost ? (
             <>
-              <span>{formatAiCostAmounts(data.cost.amounts)} rated cost</span>
+              <span>{formatAiCostAmounts(data.cost.amounts)} catalog-estimated cost</span>
               <span>{formatAiCostCoverage(data.cost)}</span>
             </>
           ) : null}

--- a/packages/atlas/src/features/workflows/components/runs/AgentExecutionPanel.tsx
+++ b/packages/atlas/src/features/workflows/components/runs/AgentExecutionPanel.tsx
@@ -64,6 +64,12 @@ export function AgentExecutionPanel({
           {data.usage?.totalTokens === undefined ? null : (
             <span>{formatTokenCount(data.usage.totalTokens)} tokens</span>
           )}
+          {data.cost ? (
+            <>
+              <span>{formatAiCostAmounts(data.cost.amounts)} rated cost</span>
+              <span>{formatAiCostCoverage(data.cost)}</span>
+            </>
+          ) : null}
           {execution ? (
             <>
               <span>{pluralCount(stepCount, "model step")}</span>
@@ -305,6 +311,32 @@ function finalAgentAnswer(
 
 function formatTokenCount(value: number | undefined): string {
   return value === undefined ? "—" : new Intl.NumberFormat().format(value)
+}
+
+function formatAiCostAmounts(
+  amounts: readonly { currency: string; amountNanos: string }[]
+): string {
+  if (amounts.length === 0) return "—"
+  return amounts
+    .map((amount) => {
+      const nanos = BigInt(amount.amountNanos)
+      const whole = nanos / 1_000_000_000n
+      const fraction = (nanos % 1_000_000_000n).toString().padStart(9, "0").replace(/0+$/, "")
+      return `${amount.currency} ${whole.toLocaleString("en-US")}${fraction ? `.${fraction.padEnd(2, "0")}` : ".00"}`
+    })
+    .join(" · ")
+}
+
+function formatAiCostCoverage(cost: {
+  ratedCallCount: number
+  unpriceableCallCount: number
+  unvaluedCallCount: number
+}): string {
+  const valued = cost.ratedCallCount
+  const missing = cost.unpriceableCallCount + cost.unvaluedCallCount
+  if (valued === 0 && missing === 0) return "No model calls"
+  if (missing === 0) return `${valued} valued`
+  return `${valued} valued · ${missing} missing`
 }
 
 function pluralCount(value: number, singular: string): string {

--- a/packages/atlas/src/lib/aiUsageDateRange.ts
+++ b/packages/atlas/src/lib/aiUsageDateRange.ts
@@ -1,0 +1,18 @@
+/** Map calendar labels selected in the browser to the UTC buckets used by accounting storage. */
+export function utcAccountingRangeForCalendarDays(
+  from: Date,
+  through: Date
+): { readonly from: string; readonly to: string } {
+  return {
+    from: utcCalendarDayStart(from).toISOString(),
+    to: nextUtcCalendarDayStart(through).toISOString(),
+  }
+}
+
+function utcCalendarDayStart(date: Date): Date {
+  return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
+}
+
+function nextUtcCalendarDayStart(date: Date): Date {
+  return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate() + 1))
+}

--- a/packages/atlas/src/pages/AiUsagePage.tsx
+++ b/packages/atlas/src/pages/AiUsagePage.tsx
@@ -1,0 +1,1030 @@
+import type { GetAiAccountingOverviewResponse, ListAiModelCallsResponse } from "@sixb/client"
+import { getAiAccountingOverviewOptions, listAiModelCallsOptions } from "@sixb/client/hooks"
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  EmptyState,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@sixb/ui/components"
+import { useQuery } from "@tanstack/react-query"
+import {
+  Bot,
+  CircleDollarSign,
+  Coins,
+  Cpu,
+  DatabaseZap,
+  RefreshCw,
+  TriangleAlert,
+} from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { Link } from "react-router-dom"
+import { AiUsageBreakdown, AiUsageMetricCard, AiUsageTimeSeries } from "../components/AiUsageCharts"
+import { AiUsageDateRangeControl } from "../components/AiUsageDateRangeControl"
+import { utcAccountingRangeForCalendarDays } from "../lib/aiUsageDateRange"
+
+const PAGE_SIZE = 25
+const ALL = "__all__"
+
+type Overview = GetAiAccountingOverviewResponse
+type ModelCall = ListAiModelCallsResponse["items"][number]
+type RangePreset = "24h" | "7d" | "30d" | "1y"
+type RangeSelection =
+  | { readonly kind: "preset"; readonly preset: RangePreset; readonly end: Date }
+  | { readonly kind: "custom"; readonly from: Date; readonly through: Date }
+type ValuationStatus = ModelCall["valuationStatus"]
+
+const DAY_MILLISECONDS = 24 * 60 * 60 * 1000
+const RANGE_OPTIONS: readonly { value: RangePreset; label: string; milliseconds: number }[] = [
+  { value: "24h", label: "24h", milliseconds: DAY_MILLISECONDS },
+  { value: "7d", label: "7d", milliseconds: 7 * DAY_MILLISECONDS },
+  { value: "30d", label: "30d", milliseconds: 30 * DAY_MILLISECONDS },
+  { value: "1y", label: "1y", milliseconds: 365 * DAY_MILLISECONDS },
+]
+
+export function AiUsagePage() {
+  const [rangeSelection, setRangeSelection] = useState<RangeSelection>(() => ({
+    kind: "preset",
+    preset: "7d",
+    end: new Date(),
+  }))
+  const [providerId, setProviderId] = useState<string>()
+  const [modelId, setModelId] = useState<string>()
+  const [currency, setCurrency] = useState<string>()
+  const [valuationStatus, setValuationStatus] = useState<ValuationStatus>()
+  const [offset, setOffset] = useState(0)
+  const range = useMemo(() => accountingRange(rangeSelection), [rangeSelection])
+  const displayedRange = useMemo(() => accountingDisplayRange(rangeSelection), [rangeSelection])
+  const bucket = accountingBucket(range)
+
+  const unfilteredQuery = useQuery(getAiAccountingOverviewOptions({ query: { ...range, bucket } }))
+  const hasFilters = providerId !== undefined || modelId !== undefined
+  const overviewQuery = useQuery({
+    ...getAiAccountingOverviewOptions({
+      query: { ...range, bucket, providerId, modelId },
+    }),
+    enabled: hasFilters,
+  })
+  const overview = (hasFilters ? overviewQuery.data : unfilteredQuery.data) as Overview | undefined
+  const filterSource = unfilteredQuery.data as Overview | undefined
+  const callsQuery = useQuery(
+    listAiModelCallsOptions({
+      query: {
+        ...range,
+        providerId,
+        modelId,
+        valuationStatus,
+        limit: String(PAGE_SIZE),
+        offset: String(offset),
+      },
+    })
+  )
+
+  const currencies = useMemo(() => accountingCurrencies(overview), [overview])
+  useEffect(() => {
+    if (currency && currencies.includes(currency)) return
+    setCurrency(currencies.includes("USD") ? "USD" : currencies[0])
+  }, [currencies, currency])
+
+  const refresh = () => {
+    if (rangeSelection.kind === "preset") {
+      setRangeSelection({ ...rangeSelection, end: new Date() })
+      return
+    }
+    void unfilteredQuery.refetch()
+    if (hasFilters) void overviewQuery.refetch()
+    void callsQuery.refetch()
+  }
+  const loading = unfilteredQuery.isLoading || (hasFilters && overviewQuery.isLoading)
+  const error = unfilteredQuery.error ?? overviewQuery.error
+
+  if (loading) return <AiUsageLoading />
+  if (error || !overview) {
+    return (
+      <EmptyState
+        icon={<TriangleAlert />}
+        title="AI accounting is unavailable"
+        description="Atlas could not load project token usage and pricing analytics. Check that AI accounting storage is configured and migrated."
+        action={<Button onClick={refresh}>Retry</Button>}
+      />
+    )
+  }
+
+  const totals = overview.totals
+  const valuedCalls = totals.costs.ratedCallCount
+  const coverage = totals.modelCallCount === 0 ? 0 : (valuedCalls / totals.modelCallCount) * 100
+  const selectedAmount = amountForCurrency(totals.costs.amounts, currency)
+  const tokenSeries = overview.series.map((period) => ({
+    at: period.start,
+    input: bucketTokenValue(period, "inputTokens"),
+    output: bucketTokenValue(period, "outputTokens"),
+  }))
+  const spendSeries = overview.series.map((period) => ({
+    at: period.start,
+    spend: nanosToChartValue(amountForCurrency(period.costs.amounts, currency)?.amountNanos),
+  }))
+  const modelSpend = overview.models
+    .flatMap((model) => {
+      const amount = amountForCurrency(model.costs.amounts, currency)
+      return amount
+        ? [
+            {
+              key: `${model.providerId}/${model.modelId}`,
+              label: model.modelId,
+              value: nanosToChartValue(amount.amountNanos),
+            },
+          ]
+        : []
+    })
+    .sort((left, right) => right.value - left.value)
+    .slice(0, 8)
+  const agentSpend = overview.agents
+    .flatMap((agent) => {
+      const amount = amountForCurrency(agent.costs.amounts, currency)
+      return amount
+        ? [
+            {
+              key: agent.agentId,
+              label: agent.agentId,
+              value: nanosToChartValue(amount.amountNanos),
+            },
+          ]
+        : []
+    })
+    .sort((left, right) => right.value - left.value)
+    .slice(0, 8)
+  const workflowSpend = overview.workflows
+    .flatMap((workflow) => {
+      const amount = amountForCurrency(workflow.costs.amounts, currency)
+      return amount
+        ? [
+            {
+              key: workflow.workflowId,
+              label: workflow.workflowId,
+              value: nanosToChartValue(amount.amountNanos),
+            },
+          ]
+        : []
+    })
+    .sort((left, right) => right.value - left.value)
+    .slice(0, 8)
+  const valuationBreakdown = [
+    { key: "rated", label: "Catalog rated", value: totals.costs.ratedCallCount },
+    { key: "unpriceable", label: "Unpriceable", value: totals.costs.unpriceableCallCount },
+    { key: "unvalued", label: "Unvalued", value: totals.costs.unvaluedCallCount },
+  ].filter((item) => item.value > 0)
+
+  return (
+    <div className="space-y-5">
+      <header className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <h1 className="text-3xl font-semibold tracking-tight">AI usage</h1>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex rounded-md border bg-card p-0.5">
+            {RANGE_OPTIONS.map((option) => (
+              <Button
+                key={option.value}
+                variant={
+                  rangeSelection.kind === "preset" && rangeSelection.preset === option.value
+                    ? "secondary"
+                    : "ghost"
+                }
+                size="sm"
+                className="h-7 px-2.5"
+                onClick={() => {
+                  setRangeSelection({ kind: "preset", preset: option.value, end: new Date() })
+                  setOffset(0)
+                }}
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+          <AiUsageDateRangeControl
+            from={displayedRange.from}
+            through={displayedRange.through}
+            label={formatDateRange(displayedRange.from, displayedRange.through)}
+            active={rangeSelection.kind === "custom"}
+            onApply={(from, through) => {
+              setRangeSelection({ kind: "custom", from, through })
+              setOffset(0)
+            }}
+          />
+          <Button
+            variant="outline"
+            size="icon-sm"
+            className="bg-card"
+            onClick={refresh}
+            aria-label="Refresh usage"
+          >
+            <RefreshCw className="size-4" />
+          </Button>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap gap-2">
+        <AccountingSelect
+          label="All providers"
+          value={providerId}
+          options={[...new Set((filterSource?.models ?? []).map((model) => model.providerId))]}
+          onChange={(value) => {
+            setProviderId(value)
+            setOffset(0)
+            if (
+              modelId &&
+              !filterSource?.models.some(
+                (model) => model.modelId === modelId && (!value || model.providerId === value)
+              )
+            ) {
+              setModelId(undefined)
+            }
+          }}
+        />
+        <AccountingSelect
+          label="All models"
+          value={modelId}
+          options={(filterSource?.models ?? [])
+            .filter((model) => !providerId || model.providerId === providerId)
+            .map((model) => model.modelId)}
+          onChange={(value) => {
+            setModelId(value)
+            setOffset(0)
+          }}
+        />
+        {currencies.length > 1 ? (
+          <AccountingSelect
+            label="Currency"
+            value={currency}
+            allowAll={false}
+            options={currencies}
+            onChange={setCurrency}
+          />
+        ) : null}
+      </div>
+
+      {totals.modelCallCount === 0 ? (
+        <EmptyState
+          icon={<Bot />}
+          title="No model calls in this range"
+          description="Token and pricing charts will appear after an agent or workflow completes a model call."
+        />
+      ) : (
+        <>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <AiUsageMetricCard
+              label="Rated spend"
+              value={
+                selectedAmount
+                  ? formatChartMoney(nanosToChartValue(selectedAmount.amountNanos), currency)
+                  : "—"
+              }
+              description={currency ? `Rated values in ${currency}` : "No valued calls"}
+              icon={<CircleDollarSign className="size-4" />}
+              sparkline={spendSeries.map((point) => ({
+                timestamp: point.at,
+                value: point.spend,
+              }))}
+            />
+            <AiUsageMetricCard
+              label="Total tokens"
+              value={formatOptionalTokens(totals.usage.totalTokens)}
+              description={reportingDescription(totals.usage.reportingStatus)}
+              icon={<DatabaseZap className="size-4" />}
+              sparkline={overview.series.map((period) => ({
+                timestamp: period.start,
+                value: period.usage.totalTokens ?? 0,
+              }))}
+            />
+            <AiUsageMetricCard
+              label="Model calls"
+              value={totals.modelCallCount.toLocaleString()}
+              description={`${overview.models.length.toLocaleString()} ${overview.models.length === 1 ? "model" : "models"} · ${new Set(overview.models.map((model) => model.providerId)).size.toLocaleString()} providers`}
+              icon={<Cpu className="size-4" />}
+            />
+            <AiUsageMetricCard
+              label="Pricing coverage"
+              value={`${coverage.toFixed(coverage >= 99.95 ? 0 : 1)}%`}
+              description={`${valuedCalls.toLocaleString()} of ${totals.modelCallCount.toLocaleString()} calls valued`}
+              icon={<Coins className="size-4" />}
+            />
+          </div>
+
+          {(totals.usage.reportingStatus !== "complete" || coverage < 100) && (
+            <AccountingQualityNotice
+              overview={overview}
+              coverage={coverage}
+              onReview={(status) => {
+                setValuationStatus(status)
+                setOffset(0)
+                document
+                  .getElementById("ai-model-calls")
+                  ?.scrollIntoView({ behavior: "smooth", block: "start" })
+              }}
+            />
+          )}
+
+          <div className="grid items-start gap-4 xl:grid-cols-3">
+            <ChartCard
+              className="xl:col-span-2"
+              title="Daily spend"
+              description={
+                currency
+                  ? `Rated model-call values in ${currency}`
+                  : "No rated monetary values in this range"
+              }
+            >
+              <AiUsageTimeSeries
+                data={selectedAmount ? spendSeries : []}
+                xKey="at"
+                variant="bar"
+                yAxisWidth={68}
+                showLegend={false}
+                series={[
+                  {
+                    key: "spend",
+                    label: currency ? `Spend (${currency})` : "Spend",
+                    color: "var(--chart-1)",
+                  },
+                ]}
+                xFormatter={(value) => formatBucketLabel(value, bucket)}
+                valueFormatter={(value) => formatChartMoney(value, currency)}
+                emptyLabel="No valued spend in this range"
+                ariaLabel="Daily rated AI spend"
+              />
+            </ChartCard>
+            <ChartCard
+              className="h-full"
+              title="Spend by model"
+              description="Highest rated cost for the selected currency"
+            >
+              <AiUsageBreakdown
+                data={modelSpend}
+                valueLabel="Spend"
+                valueFormatter={(value) => formatChartMoney(value, currency)}
+                emptyLabel="No valued model costs in this range"
+                ariaLabel="AI spend by model"
+              />
+            </ChartCard>
+            <ChartCard
+              className="xl:col-span-2"
+              title="Token usage"
+              description="Input and output tokens reported by providers"
+            >
+              <AiUsageTimeSeries
+                data={tokenSeries}
+                xKey="at"
+                variant="bar"
+                series={[
+                  {
+                    key: "input",
+                    label: "Input",
+                    stackId: "tokens",
+                    color: "var(--chart-1)",
+                  },
+                  {
+                    key: "output",
+                    label: "Output",
+                    stackId: "tokens",
+                    color: "var(--chart-3)",
+                  },
+                ]}
+                xFormatter={(value) => formatBucketLabel(value, bucket)}
+                valueFormatter={(value) => formatCompactNumber(value)}
+                ariaLabel="Input and output token usage by period"
+              />
+            </ChartCard>
+            <AccountingInsights
+              overview={overview}
+              coverage={coverage}
+              valuationBreakdown={valuationBreakdown}
+            />
+          </div>
+
+          {agentSpend.length > 1 || workflowSpend.length > 1 ? (
+            <div className="grid gap-4 xl:grid-cols-2">
+              {agentSpend.length > 1 ? (
+                <ChartCard title="Spend by agent" description="Highest-cost agents in this range">
+                  <AiUsageBreakdown
+                    data={agentSpend}
+                    valueLabel="Spend"
+                    valueFormatter={(value) => formatChartMoney(value, currency)}
+                    ariaLabel="AI spend by agent"
+                  />
+                </ChartCard>
+              ) : null}
+              {workflowSpend.length > 1 ? (
+                <ChartCard
+                  title="Spend by workflow"
+                  description="Highest-cost workflow agent nodes in this range"
+                >
+                  <AiUsageBreakdown
+                    data={workflowSpend}
+                    valueLabel="Spend"
+                    valueFormatter={(value) => formatChartMoney(value, currency)}
+                    ariaLabel="AI spend by workflow"
+                  />
+                </ChartCard>
+              ) : null}
+            </div>
+          ) : null}
+        </>
+      )}
+
+      <ModelCallsTable
+        calls={(callsQuery.data as ListAiModelCallsResponse | undefined)?.items ?? []}
+        total={(callsQuery.data as ListAiModelCallsResponse | undefined)?.total ?? 0}
+        loading={callsQuery.isLoading}
+        error={callsQuery.isError}
+        offset={offset}
+        hasMore={(callsQuery.data as ListAiModelCallsResponse | undefined)?.hasMore ?? false}
+        valuationStatus={valuationStatus}
+        onValuationStatusChange={(value) => {
+          setValuationStatus(value)
+          setOffset(0)
+        }}
+        onPrevious={() => setOffset((value) => Math.max(0, value - PAGE_SIZE))}
+        onNext={() => setOffset((value) => value + PAGE_SIZE)}
+        onRetry={() => void callsQuery.refetch()}
+      />
+    </div>
+  )
+}
+
+function ModelCallsTable({
+  calls,
+  total,
+  loading,
+  error,
+  offset,
+  hasMore,
+  valuationStatus,
+  onValuationStatusChange,
+  onPrevious,
+  onNext,
+  onRetry,
+}: {
+  calls: readonly ModelCall[]
+  total: number
+  loading: boolean
+  error: boolean
+  offset: number
+  hasMore: boolean
+  valuationStatus?: ValuationStatus
+  onValuationStatusChange: (value: ValuationStatus | undefined) => void
+  onPrevious: () => void
+  onNext: () => void
+  onRetry: () => void
+}) {
+  return (
+    <Card id="ai-model-calls" className="scroll-mt-4">
+      <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <CardTitle>Model calls</CardTitle>
+          <CardDescription>Immutable usage and valuation drilldown</CardDescription>
+        </div>
+        <AccountingSelect
+          label="All valuations"
+          value={valuationStatus}
+          options={["rated", "unpriceable", "unvalued"]}
+          formatOption={(value) => valuationStatusLabel(value as ValuationStatus)}
+          onChange={(value) => onValuationStatusChange(value as ValuationStatus | undefined)}
+        />
+      </CardHeader>
+      <CardContent className="px-0">
+        <div className="[&_[data-slot=table-container]]:max-h-[70vh] [&_[data-slot=table-container]]:overflow-auto">
+          <Table>
+            <TableHeader className="sticky top-0 z-10">
+              <TableRow>
+                <TableHead className="pl-6">Time</TableHead>
+                <TableHead>Provider / model</TableHead>
+                <TableHead className="text-right">Tokens</TableHead>
+                <TableHead className="text-right">Rated cost</TableHead>
+                <TableHead>Valuation</TableHead>
+                <TableHead className="pr-6">Source</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {loading ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-24 text-center text-muted-foreground">
+                    Loading model calls…
+                  </TableCell>
+                </TableRow>
+              ) : error ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-28 text-center">
+                    <div className="flex flex-col items-center gap-3">
+                      <p className="text-sm text-muted-foreground">
+                        Atlas could not load model-call accounting records.
+                      </p>
+                      <Button variant="outline" size="sm" onClick={onRetry}>
+                        Retry
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ) : calls.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-24 text-center text-muted-foreground">
+                    No model calls match these filters.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                calls.map((call) => (
+                  <TableRow key={call.usage.id}>
+                    <TableCell className="whitespace-nowrap pl-6 text-xs text-muted-foreground">
+                      {formatCallTime(call.usage.occurredAt)}
+                    </TableCell>
+                    <TableCell>
+                      <p className="font-medium">{call.usage.requestedModelId}</p>
+                      <p className="text-xs text-muted-foreground">{call.usage.providerId}</p>
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-xs tabular-nums">
+                      {formatOptionalTokens(call.usage.usage.totalTokens)}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-right font-mono text-xs tabular-nums">
+                      {call.cost?.status === "rated" ? formatMoney(call.cost.money) : "—"}
+                    </TableCell>
+                    <TableCell>
+                      <ValuationBadge call={call} />
+                    </TableCell>
+                    <TableCell className="max-w-48 pr-6 text-xs">
+                      <AccountingSource call={call} />
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+        <div className="flex items-center justify-between border-t px-6 py-3">
+          <p className="text-xs text-muted-foreground">
+            {total === 0
+              ? "0 calls"
+              : `${(offset + 1).toLocaleString()}–${Math.min(offset + calls.length, total).toLocaleString()} of ${total.toLocaleString()}`}
+          </p>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" disabled={offset === 0} onClick={onPrevious}>
+              Previous
+            </Button>
+            <Button variant="outline" size="sm" disabled={!hasMore} onClick={onNext}>
+              Next
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function AccountingSource({ call }: { call: ModelCall }) {
+  if (call.attribution?.kind === "agent") {
+    return (
+      <Link
+        to={`/agents/${encodeURIComponent(call.attribution.threadId)}`}
+        className="block truncate font-medium text-foreground hover:underline"
+      >
+        Agent · {call.attribution.agentId}
+      </Link>
+    )
+  }
+  if (call.attribution?.kind === "workflowAgent") {
+    return (
+      <Link
+        to={`/workflows/${encodeURIComponent(call.attribution.workflowId)}?run=${encodeURIComponent(call.attribution.workflowRunId)}`}
+        className="block truncate font-medium text-foreground hover:underline"
+      >
+        Workflow · {call.attribution.workflowId}
+      </Link>
+    )
+  }
+  return (
+    <span className="block truncate font-mono text-muted-foreground">{call.usage.executionId}</span>
+  )
+}
+
+function ValuationBadge({ call }: { call: ModelCall }) {
+  const title =
+    call.cost?.status === "unpriceable"
+      ? unpriceableReasonLabel(call.cost.reason)
+      : valuationStatusLabel(call.valuationStatus)
+  return (
+    <Badge
+      variant="outline"
+      title={title}
+      className={
+        call.valuationStatus === "rated"
+          ? "border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300"
+          : "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+      }
+    >
+      {title}
+    </Badge>
+  )
+}
+
+function AccountingQualityNotice({
+  overview,
+  coverage,
+  onReview,
+}: {
+  overview: Overview
+  coverage: number
+  onReview: (status: Extract<ValuationStatus, "unpriceable" | "unvalued">) => void
+}) {
+  const messages: string[] = []
+  if (overview.totals.usage.reportingStatus !== "complete") {
+    messages.push("Some providers did not report a complete token partition")
+  }
+  if (coverage < 100) {
+    messages.push(
+      `${overview.totals.costs.unpriceableCallCount + overview.totals.costs.unvaluedCallCount} calls do not have a rated cost`
+    )
+  }
+  const reviewStatus = overview.totals.costs.unpriceableCallCount > 0 ? "unpriceable" : "unvalued"
+  const reviewCount =
+    reviewStatus === "unpriceable"
+      ? overview.totals.costs.unpriceableCallCount
+      : overview.totals.costs.unvaluedCallCount
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-amber-500/25 bg-amber-500/5 px-4 py-3 text-sm sm:flex-row sm:items-center">
+      <div className="flex min-w-0 flex-1 items-start gap-3">
+        <TriangleAlert className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+        <div>
+          <p className="font-medium">Accounting coverage is partial</p>
+          <p className="mt-0.5 text-muted-foreground">{messages.join(". ")}.</p>
+        </div>
+      </div>
+      {reviewCount > 0 ? (
+        <Button
+          variant="outline"
+          size="sm"
+          className="shrink-0 bg-background"
+          onClick={() => onReview(reviewStatus)}
+        >
+          Review {reviewCount.toLocaleString()} {reviewCount === 1 ? "call" : "calls"}
+        </Button>
+      ) : null}
+    </div>
+  )
+}
+
+function AccountingInsights({
+  overview,
+  coverage,
+  valuationBreakdown,
+}: {
+  overview: Overview
+  coverage: number
+  valuationBreakdown: readonly { key: string; label: string; value: number }[]
+}) {
+  const usage = overview.totals.usage
+  const cacheHitRate = percentageOf(usage.cacheReadInputTokens, usage.inputTokens)
+  const reasoningShare = percentageOf(usage.reasoningOutputTokens, usage.outputTokens)
+  const totalCalls = overview.totals.modelCallCount
+
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle>Efficiency and coverage</CardTitle>
+        <CardDescription>Token composition and confidence in rated spend</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+          <InsightMetric label="Cache hit rate" value={formatOptionalPercentage(cacheHitRate)} />
+          <InsightMetric
+            label="Cached input"
+            value={formatOptionalTokens(usage.cacheReadInputTokens)}
+          />
+          <InsightMetric label="Reasoning share" value={formatOptionalPercentage(reasoningShare)} />
+          <InsightMetric
+            label="Reasoning tokens"
+            value={formatOptionalTokens(usage.reasoningOutputTokens)}
+          />
+        </div>
+
+        <div className="border-t pt-5">
+          <div className="mb-2 flex items-baseline justify-between gap-4">
+            <p className="text-sm font-medium">Valuation coverage</p>
+            <p className="font-mono text-sm font-medium tabular-nums">
+              {coverage.toFixed(coverage >= 99.95 ? 0 : 1)}%
+            </p>
+          </div>
+          <div
+            className="flex h-2.5 overflow-hidden rounded-full bg-muted"
+            role="img"
+            aria-label={`${coverage.toFixed(1)}% of calls have a rated cost`}
+          >
+            {valuationBreakdown.map((item) => (
+              <div
+                key={item.key}
+                className={valuationSegmentClass(item.key)}
+                style={{ width: `${totalCalls === 0 ? 0 : (item.value / totalCalls) * 100}%` }}
+              />
+            ))}
+          </div>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            {valuationBreakdown.map((item) => (
+              <div key={item.key} className="flex items-center justify-between gap-3 text-xs">
+                <span className="flex min-w-0 items-center gap-2 text-muted-foreground">
+                  <span className={`size-2 shrink-0 rounded-full ${valuationDotClass(item.key)}`} />
+                  <span className="truncate">{item.label}</span>
+                </span>
+                <span className="font-mono tabular-nums">{item.value.toLocaleString()}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function InsightMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 text-lg font-semibold tracking-tight tabular-nums">{value}</p>
+    </div>
+  )
+}
+
+function valuationSegmentClass(key: string): string {
+  if (key === "rated") return "bg-foreground"
+  if (key === "unpriceable") return "bg-amber-500"
+  return "bg-muted-foreground/40"
+}
+
+function valuationDotClass(key: string): string {
+  if (key === "rated") return "bg-foreground"
+  if (key === "unpriceable") return "bg-amber-500"
+  return "bg-muted-foreground/40"
+}
+
+function ChartCard({
+  title,
+  description,
+  children,
+  className,
+}: {
+  title: string
+  description: string
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  )
+}
+
+function AccountingSelect({
+  label,
+  value,
+  options,
+  allowAll = true,
+  formatOption = (option) => option,
+  onChange,
+}: {
+  label: string
+  value?: string
+  options: readonly string[]
+  allowAll?: boolean
+  formatOption?: (option: string) => string
+  onChange: (value: string | undefined) => void
+}) {
+  const unique = [...new Set(options)]
+  return (
+    <Select
+      value={value ?? ALL}
+      onValueChange={(next) => onChange(next === ALL ? undefined : next)}
+    >
+      <SelectTrigger size="sm" className="min-w-36 bg-card">
+        <SelectValue placeholder={label} />
+      </SelectTrigger>
+      <SelectContent>
+        {allowAll ? <SelectItem value={ALL}>{label}</SelectItem> : null}
+        {unique.map((option) => (
+          <SelectItem key={option} value={option}>
+            {formatOption(option)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function AiUsageLoading() {
+  return (
+    <div className="space-y-5 animate-pulse">
+      <div className="h-16 rounded-lg bg-muted" />
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {[0, 1, 2, 3].map((key) => (
+          <div key={key} className="h-32 rounded-xl border bg-muted/50" />
+        ))}
+      </div>
+      <div className="grid gap-4 xl:grid-cols-2">
+        <div className="h-96 rounded-xl border bg-muted/40" />
+        <div className="h-96 rounded-xl border bg-muted/40" />
+      </div>
+    </div>
+  )
+}
+
+function accountingRange(selection: RangeSelection): { from: string; to: string } {
+  if (selection.kind === "custom") {
+    return utcAccountingRangeForCalendarDays(selection.from, selection.through)
+  }
+  const option =
+    RANGE_OPTIONS.find((candidate) => candidate.value === selection.preset) ?? RANGE_OPTIONS[1]!
+  return {
+    from: new Date(selection.end.getTime() - option.milliseconds).toISOString(),
+    to: selection.end.toISOString(),
+  }
+}
+
+function accountingDisplayRange(selection: RangeSelection): { from: Date; through: Date } {
+  if (selection.kind === "custom") {
+    return { from: selection.from, through: selection.through }
+  }
+  const option =
+    RANGE_OPTIONS.find((candidate) => candidate.value === selection.preset) ?? RANGE_OPTIONS[1]!
+  return {
+    from: new Date(selection.end.getTime() - option.milliseconds),
+    through: selection.end,
+  }
+}
+
+function accountingBucket(range: { from: string; to: string }): Overview["bucket"] {
+  const duration = new Date(range.to).getTime() - new Date(range.from).getTime()
+  if (duration <= 2 * DAY_MILLISECONDS) return "hour"
+  if (duration > 180 * DAY_MILLISECONDS) return "week"
+  return "day"
+}
+
+function accountingCurrencies(overview: Overview | undefined): string[] {
+  if (!overview) return []
+  const values = new Set<string>()
+  for (const aggregate of [overview.totals, ...overview.series, ...overview.models]) {
+    for (const amount of aggregate.costs.amounts) values.add(amount.currency)
+  }
+  return [...values].sort()
+}
+
+function amountForCurrency(
+  amounts: readonly { currency: string; amountNanos: string }[],
+  currency: string | undefined
+) {
+  return currency ? amounts.find((amount) => amount.currency === currency) : undefined
+}
+
+function bucketTokenValue(
+  period: Overview["series"][number],
+  key:
+    | "inputTokens"
+    | "outputTokens"
+    | "cacheReadInputTokens"
+    | "cacheWriteInputTokens"
+    | "reasoningOutputTokens"
+): number | undefined {
+  // Empty buckets are known zeroes. Preserve undefined only when calls exist but the provider did
+  // not report that meter, so the chart does not imply complete reporting.
+  return period.modelCallCount === 0 ? 0 : period.usage[key]
+}
+
+function percentageOf(numerator: number | undefined, denominator: number | undefined) {
+  if (numerator === undefined || denominator === undefined || denominator === 0) return undefined
+  return (numerator / denominator) * 100
+}
+
+function formatOptionalPercentage(value: number | undefined): string {
+  return value === undefined ? "—" : `${value.toFixed(value >= 99.95 ? 0 : 1)}%`
+}
+
+function nanosToChartValue(amountNanos: string | undefined): number {
+  return amountNanos === undefined ? 0 : Number(amountNanos) / 1_000_000_000
+}
+
+function formatMoney(money: { currency: string; amountNanos: string }): string {
+  const nanos = BigInt(money.amountNanos)
+  const whole = nanos / 1_000_000_000n
+  const fraction = (nanos % 1_000_000_000n).toString().padStart(9, "0").replace(/0+$/, "")
+  return `${money.currency} ${whole.toLocaleString("en-US")}${fraction ? `.${fraction.padEnd(2, "0")}` : ".00"}`
+}
+
+function formatChartMoney(value: number, currency: string | undefined): string {
+  if (!currency) return value.toLocaleString(undefined, { maximumFractionDigits: 4 })
+  const maximumFractionDigits = value === 0 ? 2 : value < 0.01 ? 6 : value < 1 ? 4 : 2
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+    maximumFractionDigits,
+  }).format(value)
+}
+
+function formatOptionalTokens(value: number | undefined): string {
+  return value === undefined ? "—" : formatCompactNumber(value)
+}
+
+function formatCompactNumber(value: number): string {
+  return new Intl.NumberFormat(undefined, { notation: "compact", maximumFractionDigits: 1 }).format(
+    value
+  )
+}
+
+function reportingDescription(status: Overview["totals"]["usage"]["reportingStatus"]): string {
+  if (status === "complete") return "Complete provider reporting"
+  if (status === "partial") return "Partial provider reporting"
+  return "Token counts unavailable"
+}
+
+function formatBucketLabel(value: string, bucket: Overview["bucket"]): string {
+  const date = new Date(value)
+  return bucket === "hour"
+    ? date.toLocaleTimeString([], { hour: "numeric" })
+    : date.toLocaleDateString([], { month: "short", day: "numeric", timeZone: "UTC" })
+}
+
+function formatDateRange(from: Date, through: Date): string {
+  if (
+    from.getFullYear() === through.getFullYear() &&
+    from.getMonth() === through.getMonth() &&
+    from.getDate() === through.getDate()
+  ) {
+    return from.toLocaleDateString([], { month: "short", day: "numeric", year: "numeric" })
+  }
+  if (from.getFullYear() === through.getFullYear()) {
+    const start = from.toLocaleDateString([], { month: "short", day: "numeric" })
+    const end = through.toLocaleDateString([], {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    })
+    return `${start} – ${end}`
+  }
+  const options: Intl.DateTimeFormatOptions = {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }
+  return `${from.toLocaleDateString([], options)} – ${through.toLocaleDateString([], options)}`
+}
+
+function formatCallTime(value: string): string {
+  return new Date(value).toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })
+}
+
+function valuationStatusLabel(status: ValuationStatus): string {
+  switch (status) {
+    case "rated":
+      return "Catalog rated"
+    case "unpriceable":
+      return "Unpriceable"
+    case "unvalued":
+      return "Unvalued"
+  }
+}
+
+function unpriceableReasonLabel(
+  reason: NonNullable<ModelCall["cost"]> extends infer Cost
+    ? Cost extends { status: "unpriceable"; reason: infer Reason }
+      ? Reason
+      : never
+    : never
+): string {
+  switch (reason) {
+    case "missingBillingIdentity":
+      return "Missing billing identity"
+    case "missingCatalogEntry":
+      return "Missing Models.dev entry"
+    case "missingUsageMeter":
+      return "Missing usage meter"
+    case "unsupportedPricingDimension":
+      return "Unsupported pricing"
+    case "invalidUsageForFormula":
+      return "Invalid usage formula"
+  }
+}

--- a/packages/atlas/src/pages/AiUsagePage.tsx
+++ b/packages/atlas/src/pages/AiUsagePage.tsx
@@ -125,19 +125,20 @@ export function AiUsagePage() {
   }
 
   const totals = overview.totals
-  const valuedCalls = totals.costs.ratedCallCount
-  const coverage = totals.modelCallCount === 0 ? 0 : (valuedCalls / totals.modelCallCount) * 100
+  const catalogValuedCalls = totals.costs.ratedCallCount
+  const coverage =
+    totals.modelCallCount === 0 ? 0 : (catalogValuedCalls / totals.modelCallCount) * 100
   const selectedAmount = amountForCurrency(totals.costs.amounts, currency)
   const tokenSeries = overview.series.map((period) => ({
     at: period.start,
     input: bucketTokenValue(period, "inputTokens"),
     output: bucketTokenValue(period, "outputTokens"),
   }))
-  const spendSeries = overview.series.map((period) => ({
+  const costSeries = overview.series.map((period) => ({
     at: period.start,
-    spend: nanosToChartValue(amountForCurrency(period.costs.amounts, currency)?.amountNanos),
+    cost: nanosToChartValue(amountForCurrency(period.costs.amounts, currency)?.amountNanos),
   }))
-  const modelSpend = overview.models
+  const modelCosts = overview.models
     .flatMap((model) => {
       const amount = amountForCurrency(model.costs.amounts, currency)
       return amount
@@ -152,7 +153,7 @@ export function AiUsagePage() {
     })
     .sort((left, right) => right.value - left.value)
     .slice(0, 8)
-  const agentSpend = overview.agents
+  const agentCosts = overview.agents
     .flatMap((agent) => {
       const amount = amountForCurrency(agent.costs.amounts, currency)
       return amount
@@ -167,7 +168,7 @@ export function AiUsagePage() {
     })
     .sort((left, right) => right.value - left.value)
     .slice(0, 8)
-  const workflowSpend = overview.workflows
+  const workflowCosts = overview.workflows
     .flatMap((workflow) => {
       const amount = amountForCurrency(workflow.costs.amounts, currency)
       return amount
@@ -183,7 +184,7 @@ export function AiUsagePage() {
     .sort((left, right) => right.value - left.value)
     .slice(0, 8)
   const valuationBreakdown = [
-    { key: "rated", label: "Catalog rated", value: totals.costs.ratedCallCount },
+    { key: "rated", label: "Catalog-valued", value: totals.costs.ratedCallCount },
     { key: "unpriceable", label: "Unpriceable", value: totals.costs.unpriceableCallCount },
     { key: "unvalued", label: "Unvalued", value: totals.costs.unvaluedCallCount },
   ].filter((item) => item.value > 0)
@@ -285,17 +286,15 @@ export function AiUsagePage() {
         <>
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
             <AiUsageMetricCard
-              label="Rated spend"
-              value={
-                selectedAmount
-                  ? formatChartMoney(nanosToChartValue(selectedAmount.amountNanos), currency)
-                  : "—"
+              label="Catalog-estimated cost"
+              value={selectedAmount ? formatMoney(selectedAmount) : "—"}
+              description={
+                currency ? `Catalog-valued calls in ${currency}` : "No catalog-valued calls"
               }
-              description={currency ? `Rated values in ${currency}` : "No valued calls"}
               icon={<CircleDollarSign className="size-4" />}
-              sparkline={spendSeries.map((point) => ({
+              sparkline={costSeries.map((point) => ({
                 timestamp: point.at,
-                value: point.spend,
+                value: point.cost,
               }))}
             />
             <AiUsageMetricCard
@@ -317,7 +316,7 @@ export function AiUsagePage() {
             <AiUsageMetricCard
               label="Pricing coverage"
               value={`${coverage.toFixed(coverage >= 99.95 ? 0 : 1)}%`}
-              description={`${valuedCalls.toLocaleString()} of ${totals.modelCallCount.toLocaleString()} calls valued`}
+              description={`${catalogValuedCalls.toLocaleString()} of ${totals.modelCallCount.toLocaleString()} calls catalog-valued`}
               icon={<Coins className="size-4" />}
             />
           </div>
@@ -339,43 +338,43 @@ export function AiUsagePage() {
           <div className="grid items-start gap-4 xl:grid-cols-3">
             <ChartCard
               className="xl:col-span-2"
-              title="Daily spend"
+              title="Estimated cost over time"
               description={
                 currency
-                  ? `Rated model-call values in ${currency}`
-                  : "No rated monetary values in this range"
+                  ? `Catalog-valued model calls in ${currency}`
+                  : "No catalog-valued calls in this range"
               }
             >
               <AiUsageTimeSeries
-                data={selectedAmount ? spendSeries : []}
+                data={selectedAmount ? costSeries : []}
                 xKey="at"
                 variant="bar"
                 yAxisWidth={68}
                 showLegend={false}
                 series={[
                   {
-                    key: "spend",
-                    label: currency ? `Spend (${currency})` : "Spend",
+                    key: "cost",
+                    label: currency ? `Estimated cost (${currency})` : "Estimated cost",
                     color: "var(--chart-1)",
                   },
                 ]}
                 xFormatter={(value) => formatBucketLabel(value, bucket)}
                 valueFormatter={(value) => formatChartMoney(value, currency)}
-                emptyLabel="No valued spend in this range"
-                ariaLabel="Daily rated AI spend"
+                emptyLabel="No catalog-estimated cost in this range"
+                ariaLabel="Catalog-estimated AI cost over time"
               />
             </ChartCard>
             <ChartCard
               className="h-full"
-              title="Spend by model"
-              description="Highest rated cost for the selected currency"
+              title="Estimated cost by requested model"
+              description="Highest catalog-estimated cost for the selected currency"
             >
               <AiUsageBreakdown
-                data={modelSpend}
-                valueLabel="Spend"
+                data={modelCosts}
+                valueLabel="Estimated cost"
                 valueFormatter={(value) => formatChartMoney(value, currency)}
-                emptyLabel="No valued model costs in this range"
-                ariaLabel="AI spend by model"
+                emptyLabel="No catalog-estimated model cost in this range"
+                ariaLabel="Catalog-estimated AI cost by requested model"
               />
             </ChartCard>
             <ChartCard
@@ -413,28 +412,31 @@ export function AiUsagePage() {
             />
           </div>
 
-          {agentSpend.length > 1 || workflowSpend.length > 1 ? (
+          {agentCosts.length > 1 || workflowCosts.length > 1 ? (
             <div className="grid gap-4 xl:grid-cols-2">
-              {agentSpend.length > 1 ? (
-                <ChartCard title="Spend by agent" description="Highest-cost agents in this range">
+              {agentCosts.length > 1 ? (
+                <ChartCard
+                  title="Estimated cost by agent"
+                  description="Highest catalog-estimated cost in this range"
+                >
                   <AiUsageBreakdown
-                    data={agentSpend}
-                    valueLabel="Spend"
+                    data={agentCosts}
+                    valueLabel="Estimated cost"
                     valueFormatter={(value) => formatChartMoney(value, currency)}
-                    ariaLabel="AI spend by agent"
+                    ariaLabel="Catalog-estimated AI cost by agent"
                   />
                 </ChartCard>
               ) : null}
-              {workflowSpend.length > 1 ? (
+              {workflowCosts.length > 1 ? (
                 <ChartCard
-                  title="Spend by workflow"
-                  description="Highest-cost workflow agent nodes in this range"
+                  title="Estimated cost by workflow"
+                  description="Highest catalog-estimated workflow Agent nodes in this range"
                 >
                   <AiUsageBreakdown
-                    data={workflowSpend}
-                    valueLabel="Spend"
+                    data={workflowCosts}
+                    valueLabel="Estimated cost"
                     valueFormatter={(value) => formatChartMoney(value, currency)}
-                    ariaLabel="AI spend by workflow"
+                    ariaLabel="Catalog-estimated AI cost by workflow"
                   />
                 </ChartCard>
               ) : null}
@@ -511,7 +513,7 @@ function ModelCallsTable({
                 <TableHead className="pl-6">Time</TableHead>
                 <TableHead>Provider / model</TableHead>
                 <TableHead className="text-right">Tokens</TableHead>
-                <TableHead className="text-right">Rated cost</TableHead>
+                <TableHead className="text-right">Catalog-estimated cost</TableHead>
                 <TableHead>Valuation</TableHead>
                 <TableHead className="pr-6">Source</TableHead>
               </TableRow>
@@ -651,7 +653,7 @@ function AccountingQualityNotice({
   }
   if (coverage < 100) {
     messages.push(
-      `${overview.totals.costs.unpriceableCallCount + overview.totals.costs.unvaluedCallCount} calls do not have a rated cost`
+      `${overview.totals.costs.unpriceableCallCount + overview.totals.costs.unvaluedCallCount} calls do not have a catalog-estimated cost`
     )
   }
   const reviewStatus = overview.totals.costs.unpriceableCallCount > 0 ? "unpriceable" : "unvalued"
@@ -700,7 +702,9 @@ function AccountingInsights({
     <Card className="h-full">
       <CardHeader>
         <CardTitle>Efficiency and coverage</CardTitle>
-        <CardDescription>Token composition and confidence in rated spend</CardDescription>
+        <CardDescription>
+          Token composition and confidence in catalog-estimated cost
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
         <div className="grid grid-cols-2 gap-x-6 gap-y-4">
@@ -726,7 +730,7 @@ function AccountingInsights({
           <div
             className="flex h-2.5 overflow-hidden rounded-full bg-muted"
             role="img"
-            aria-label={`${coverage.toFixed(1)}% of calls have a rated cost`}
+            aria-label={`${coverage.toFixed(1)}% of calls have a catalog-estimated cost`}
           >
             {valuationBreakdown.map((item) => (
               <div
@@ -1000,7 +1004,7 @@ function formatCallTime(value: string): string {
 function valuationStatusLabel(status: ValuationStatus): string {
   switch (status) {
     case "rated":
-      return "Catalog rated"
+      return "Catalog-valued"
     case "unpriceable":
       return "Unpriceable"
     case "unvalued":

--- a/packages/atlas/src/pages/ProjectWorkspace.tsx
+++ b/packages/atlas/src/pages/ProjectWorkspace.tsx
@@ -49,6 +49,7 @@ import { ObjectsWorkbench, type ObjectTypePreviewSection } from "./ObjectsWorkbe
 import {
   ActionRunDetailPage,
   ActionsPage,
+  AiUsagePage,
   ConnectorDetailPage,
   ConnectorsPage,
   DatasetDetailPage,
@@ -440,6 +441,7 @@ export function ProjectWorkspace() {
               />
               <Route path="home" element={<Navigate to="/" replace />} />
               <Route path="objects" element={<Navigate to="/" replace />} />
+              <Route path="ai-usage" element={<AiUsagePage />} />
               <Route path="datasets" element={<DatasetsPage />} />
               <Route path="connectors" element={<ConnectorsPage />} />
               <Route path="connectors/:connectorId" element={<ConnectorDetailPage />} />

--- a/packages/atlas/src/pages/workspaceRoutes.ts
+++ b/packages/atlas/src/pages/workspaceRoutes.ts
@@ -5,6 +5,7 @@ import { KNOWN_VIEWS } from "../components/layout/viewMode"
 const loadActionRunDetailPage = () => import("./ActionRunDetailPage")
 const loadActionsPage = () => import("./ActionsPage")
 const loadAgentsPage = () => import("./AgentsPage")
+const loadAiUsagePage = () => import("./AiUsagePage")
 const loadConnectorsPage = () => import("./ConnectorsPage")
 const loadDatasetsPage = () => import("./DatasetsPage")
 const loadLogsPage = () => import("./LogsPage")
@@ -30,6 +31,9 @@ export const ActionsPage = lazy(() =>
 )
 export const AgentsPage = lazy(() =>
   loadAgentsPage().then((module) => ({ default: module.AgentsPage }))
+)
+export const AiUsagePage = lazy(() =>
+  loadAiUsagePage().then((module) => ({ default: module.AiUsagePage }))
 )
 export const ConnectorDetailPage = lazy(() =>
   loadConnectorsPage().then((module) => ({ default: module.ConnectorDetailPage }))
@@ -103,6 +107,7 @@ type WorkspaceRouteLoader = () => Promise<unknown>
 const workspaceViewLoaders: Partial<Record<ViewMode, WorkspaceRouteLoader>> = {
   actions: loadActionsPage,
   agents: loadAgentsPage,
+  "ai-usage": loadAiUsagePage,
   connectors: loadConnectorsPage,
   datasets: loadDatasetsPage,
   logs: loadLogsPage,

--- a/packages/atlas/tests/aiUsageDateRange.test.ts
+++ b/packages/atlas/tests/aiUsageDateRange.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { utcAccountingRangeForCalendarDays } from "../src/lib/aiUsageDateRange"
+
+describe("AI usage calendar ranges", () => {
+  test("maps browser calendar days to whole UTC accounting buckets", () => {
+    expect(utcAccountingRangeForCalendarDays(new Date(2026, 8, 10), new Date(2026, 8, 10))).toEqual(
+      {
+        from: "2026-09-10T00:00:00.000Z",
+        to: "2026-09-11T00:00:00.000Z",
+      }
+    )
+
+    expect(utcAccountingRangeForCalendarDays(new Date(2026, 8, 10), new Date(2026, 8, 12))).toEqual(
+      {
+        from: "2026-09-10T00:00:00.000Z",
+        to: "2026-09-13T00:00:00.000Z",
+      }
+    )
+  })
+})


### PR DESCRIPTION
## Why

This final layer makes the accounting data useful inside Atlas. It adds a project-level workspace for understanding token usage, rated spend, pricing coverage, and the individual calls behind those totals.

## What changed

- adds an **AI usage** destination to project navigation at `/ai-usage`
- adds token and rated-spend time series
- adds breakdowns by model, Agent, workflow, and valuation status
- adds rolling presets and custom calendar date ranges
- adds provider, model, currency, and valuation-status filters
- adds paginated model-call details with pricing diagnostics
- shows cost and valuation coverage on workflow Agent executions
- integrates the page with Atlas's intent-preloaded lazy workspace routes

## Honest accounting behavior

- Spend charts include only rated calls.
- Unpriceable and unvalued calls remain visible in the coverage totals.
- Missing cost is not displayed as `$0`.
- Currencies are kept separate and selected explicitly.
- Custom calendar ranges are converted to complete UTC accounting buckets.

## Screenshot

<img width="919" height="997" alt="Screenshot 2026-08-26 at 12 54 43 PM" src="https://github.com/user-attachments/assets/ce844e4d-bf8d-402c-bb48-081c0f8b6102" />

## Review guide

1. [AI usage workspace](https://github.com/sixb-ai/sixb/blob/feature/ai-cost-05-atlas/packages/atlas/src/pages/AiUsagePage.tsx)
2. [Charts and metric cards](https://github.com/sixb-ai/sixb/blob/feature/ai-cost-05-atlas/packages/atlas/src/components/AiUsageCharts.tsx)
3. [Date-range control](https://github.com/sixb-ai/sixb/blob/feature/ai-cost-05-atlas/packages/atlas/src/components/AiUsageDateRangeControl.tsx)
4. [Calendar-to-accounting range conversion](https://github.com/sixb-ai/sixb/blob/feature/ai-cost-05-atlas/packages/atlas/src/lib/aiUsageDateRange.ts)

## Stack

> Layer 5 of native GitHub stack **#448**. This is the top of the stack and depends on #443–#446.

1. #443 — core vocabulary and in-memory contract
2. #444 — SQLite and PostgreSQL persistence
3. #445 — Models.dev rating and worker recording
4. #446 — HTTP API and generated client
5. **#447 — Atlas analytics experience**

## Verification

```text
bun run typecheck
bun run check
bun --filter @sixb/atlas build
bun test packages/atlas/tests/aiUsageDateRange.test.ts
```
