### PR TITLE
app: add custom magic-link login experiences

### DIFF
--- a/auth/magic-link/src/strategy.ts
+++ b/auth/magic-link/src/strategy.ts
@@ -120,6 +120,7 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
     })
 
     const link = this.createCallbackUrl({
+      audience: input.audience,
       magicLinkId,
       requestOrigin: input.requestOrigin,
       token: credential.token,
@@ -281,6 +282,7 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
   }
 
   private createCallbackUrl(input: {
+    readonly audience: MagicLinkRequestInput["audience"]
     readonly magicLinkId: string
     readonly requestOrigin: string
     readonly token: string
@@ -288,6 +290,9 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
   }): string {
     const origin = this.publicOrigin ?? normalizePublicOrigin(input.requestOrigin)
     const url = new URL("/auth/callback", origin)
+    // This non-secret hint only selects the pre-auth presentation. Completion
+    // still uses the audience and returnTo stored with the magic link.
+    url.searchParams.set("audience", input.audience)
     url.searchParams.set("magicLinkId", input.magicLinkId)
     url.searchParams.set("token", input.token)
     if (input.requesterHash) {

--- a/docs/apps/overview.md
+++ b/docs/apps/overview.md
@@ -230,6 +230,36 @@ bun add tailwindcss @tailwindcss/cli
 
 Bringing your own UI? Keep `globals.css` plain CSS and skip the install.
 
+## Custom login experience
+
+Add `app/auth.tsx` to give the app audience an organization-specific magic-link experience. The
+component renders before a session exists and receives safe states and actions from Sixb:
+
+```tsx
+import type { AuthExperienceProps } from "@sixb/app/auth"
+
+export default function AuthExperience({ state, actions }: AuthExperienceProps) {
+  if (state.kind === "checkEmail") {
+    return <p>Check your inbox for a secure sign-in link.</p>
+  }
+
+  if (state.kind !== "signIn") {
+    return <button onClick={actions.restartSignIn}>Request a new link</button>
+  }
+
+  return <SignInForm onSubmit={actions.requestMagicLink} />
+}
+```
+
+The available states are `signIn`, `checkEmail`, `confirm`, `invalidLink`, and `error`. The auth
+entry automatically includes `app/globals.css` and uses the app metadata for its document title and
+theme. It is not wrapped in `app/layout.tsx`, because layouts may assume an authenticated session.
+
+Sixb builds this as a separate bundle and serves it from the API's existing `/auth/*` routes. The
+component controls presentation only: the API retains tokens, cookies, callback completion,
+audience checks, neutral email responses, and safe return redirects. Without `app/auth.tsx`, the
+generic server login remains unchanged. Atlas also continues to use the generic login.
+
 ## Running
 
 During development, `bun sixb dev` starts the app alongside the API whenever `app/`

--- a/docs/auth/authentication.md
+++ b/docs/auth/authentication.md
@@ -337,6 +337,11 @@ When you serve the runtime, these endpoints are registered for you:
 | `POST /api/auth/service-accounts/:serviceAccountId/access-tokens/:tokenId/revoke` | Revoke a service-account token |
 | `GET /api/auth/access-management-options` | Groups and capabilities for the tokens/service-accounts UI |
 
+Custom apps can replace the app-audience presentation for the magic-link pages with
+`app/auth.tsx`. The API still owns these routes and all credential handling; the custom component
+only renders the organization-specific states and invokes framework actions. See
+[Building Apps](../apps/overview.md#custom-login-experience).
+
 See [Server](../server/overview.md) for how routes are mounted.
 
 ## Development and production

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -62,6 +62,15 @@ Try the complete flow:
 The custom app is intentionally small: it proves the selected invitation destination, audience
 cookie, application grant, group membership, and scoped `Note` read in one screen.
 
+It also exports `app/auth.tsx`, so app-audience magic-link requests use the branded Acme login,
+check-email, confirmation, and expired-link states. Atlas intentionally keeps the generic Sixb
+login to demonstrate the audience-specific fallback.
+
+The magic-link email is branded too. `sixb.config.ts` sets the Acme subject and passes the
+framework-generated `message.url` to `lib/magic-link-email.ts`, which owns the organization-specific
+plain-text and HTML presentation. Link generation, expiry, and single-use behavior remain owned by
+the magic-link strategy.
+
 ## Use OIDC instead (Google Workspace)
 
 ```bash

--- a/examples/auth/app/auth.tsx
+++ b/examples/auth/app/auth.tsx
@@ -1,0 +1,110 @@
+import type { AuthExperienceProps } from "@sixb/app/auth"
+import { type FormEvent, useState } from "react"
+
+export default function AuthExperience({ state, actions }: AuthExperienceProps) {
+  const [email, setEmail] = useState("")
+  const [pending, setPending] = useState(false)
+
+  function requestLink(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (pending) return
+    setPending(true)
+    actions.requestMagicLink(email)
+  }
+
+  function confirmSignIn() {
+    if (pending) return
+    setPending(true)
+    actions.confirmSignIn()
+  }
+
+  return (
+    <main className="auth-login-shell">
+      <section className="auth-login-story" aria-label="Acme Operations">
+        <p className="auth-login-mark">A</p>
+        <div>
+          <p className="auth-login-eyebrow">Acme Operations</p>
+          <h1>Clear access to the work that matters.</h1>
+          <p>
+            One secure link connects your team to live operations, approvals, and shared context.
+          </p>
+        </div>
+      </section>
+
+      <section className="auth-login-panel">
+        <div className="auth-login-card">
+          {state.kind === "signIn" ? (
+            <>
+              <p className="auth-login-step">Welcome back</p>
+              <h2>Sign in to Acme</h2>
+              <p className="auth-login-copy">Use your work email. No password required.</p>
+              <form onSubmit={requestLink}>
+                <label htmlFor="auth-email">Work email</label>
+                <input
+                  id="auth-email"
+                  type="email"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  autoComplete="email"
+                  placeholder="you@acme.com"
+                  required
+                  autoFocus
+                />
+                <button type="submit" disabled={pending}>
+                  {pending ? "Sending…" : "Email me a sign-in link"}
+                </button>
+              </form>
+            </>
+          ) : state.kind === "checkEmail" ? (
+            <>
+              <p className="auth-login-icon" aria-hidden="true">
+                ✦
+              </p>
+              <p className="auth-login-step">Almost there</p>
+              <h2>Check your inbox</h2>
+              <p className="auth-login-copy">
+                If your email can sign in, a secure link is on its way. It expires soon and works
+                once.
+              </p>
+              <button
+                type="button"
+                className="auth-login-secondary"
+                onClick={actions.restartSignIn}
+              >
+                Use a different email
+              </button>
+            </>
+          ) : state.kind === "confirm" ? (
+            <>
+              <p className="auth-login-step">Secure sign-in</p>
+              <h2>Continue to Acme</h2>
+              <p className="auth-login-copy">
+                {state.email
+                  ? `Confirm sign-in as ${state.email}.`
+                  : "Confirm this sign-in request."}
+              </p>
+              <button type="button" onClick={confirmSignIn} disabled={pending}>
+                {pending ? "Signing in…" : "Continue"}
+              </button>
+            </>
+          ) : (
+            <>
+              <p className="auth-login-step">Start again</p>
+              <h2>
+                {state.kind === "invalidLink" ? "This link has expired" : "Sign-in unavailable"}
+              </h2>
+              <p className="auth-login-copy">
+                Request a fresh link to continue. If the problem persists, contact your Acme
+                administrator.
+              </p>
+              <button type="button" onClick={actions.restartSignIn}>
+                Request a new link
+              </button>
+            </>
+          )}
+        </div>
+        <p className="auth-login-footnote">Protected by Sixb passwordless authentication</p>
+      </section>
+    </main>
+  )
+}

--- a/examples/auth/app/globals.css
+++ b/examples/auth/app/globals.css
@@ -16,6 +16,192 @@ input {
   font: inherit;
 }
 
+.auth-login-shell {
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(420px, 0.85fr);
+  background: #eef2ed;
+  color: #15211c;
+}
+
+.auth-login-story {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: clamp(32px, 5vw, 72px);
+  background:
+    radial-gradient(circle at 72% 24%, rgb(149 202 174 / 35%), transparent 28%),
+    linear-gradient(145deg, #173127, #0c1b15);
+  color: #f4f7f2;
+}
+
+.auth-login-mark {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  margin: 0;
+  border: 1px solid rgb(255 255 255 / 24%);
+  border-radius: 12px;
+  background: rgb(255 255 255 / 10%);
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.auth-login-story h1 {
+  max-width: 680px;
+  margin: 12px 0 20px;
+  font-size: clamp(2.8rem, 7vw, 6.5rem);
+  line-height: 0.94;
+  letter-spacing: -0.065em;
+}
+
+.auth-login-story > div > p:last-child {
+  max-width: 540px;
+  margin: 0;
+  color: #b9c9c0;
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.auth-login-eyebrow,
+.auth-login-step {
+  margin: 0;
+  color: #789085;
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.auth-login-story .auth-login-eyebrow {
+  color: #9eb8aa;
+}
+
+.auth-login-panel {
+  min-height: 100%;
+  display: grid;
+  align-content: center;
+  padding: clamp(28px, 6vw, 80px);
+  background: #f8faf7;
+}
+
+.auth-login-card {
+  width: 100%;
+  max-width: 420px;
+  margin: 0 auto;
+}
+
+.auth-login-card h2 {
+  margin: 10px 0 0;
+  color: #132019;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  line-height: 1.05;
+  letter-spacing: -0.045em;
+}
+
+.auth-login-copy {
+  margin: 14px 0 30px;
+  color: #69766f;
+  line-height: 1.6;
+}
+
+.auth-login-card form {
+  display: grid;
+  gap: 10px;
+}
+
+.auth-login-card label {
+  color: #35473e;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.auth-login-card input {
+  width: 100%;
+  height: 52px;
+  border: 1px solid #cfd8d2;
+  border-radius: 12px;
+  background: #fff;
+  padding: 0 15px;
+  color: #132019;
+  outline: none;
+}
+
+.auth-login-card input:focus {
+  border-color: #2f6d50;
+  box-shadow: 0 0 0 4px rgb(47 109 80 / 12%);
+}
+
+.auth-login-card button {
+  width: 100%;
+  min-height: 52px;
+  margin-top: 4px;
+  border: 0;
+  border-radius: 12px;
+  background: #173b2b;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.auth-login-card button:hover:not(:disabled) {
+  background: #20513b;
+}
+
+.auth-login-card button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.auth-login-card .auth-login-secondary {
+  border: 1px solid #cfd8d2;
+  background: transparent;
+  color: #294437;
+}
+
+.auth-login-icon {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  margin: 0 0 28px;
+  border-radius: 50%;
+  background: #dcebe1;
+  color: #24573d;
+  font-size: 1.2rem;
+}
+
+.auth-login-footnote {
+  max-width: 420px;
+  margin: 28px auto 0;
+  color: #8a948f;
+  font-size: 0.72rem;
+  text-align: center;
+}
+
+@media (max-width: 820px) {
+  .auth-login-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-login-story {
+    min-height: 300px;
+    gap: 64px;
+  }
+
+  .auth-login-story h1 {
+    max-width: 560px;
+    font-size: clamp(2.5rem, 12vw, 4.5rem);
+  }
+
+  .auth-login-panel {
+    min-height: 560px;
+  }
+}
+
 .auth-app-shell {
   width: min(960px, calc(100% - 32px));
   margin: 0 auto;

--- a/examples/auth/app/layout.tsx
+++ b/examples/auth/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { AppMetadata } from "@sixb/app"
+import type { PropsWithChildren } from "react"
+
+export const metadata = {
+  title: "Acme Operations",
+  description: "Secure access to Acme operations.",
+  themeColor: "#13271f",
+  backgroundColor: "#eef2ed",
+} satisfies AppMetadata
+
+export default function RootLayout({ children }: PropsWithChildren) {
+  return <>{children}</>
+}

--- a/examples/auth/lib/magic-link-email.ts
+++ b/examples/auth/lib/magic-link-email.ts
@@ -1,0 +1,73 @@
+export interface AcmeMagicLinkEmailInput {
+  readonly subject: string
+  readonly url: string
+}
+
+export interface AcmeMagicLinkEmail {
+  readonly subject: string
+  readonly text: string
+  readonly html: string
+}
+
+const EMAIL_FONT = "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif"
+
+/** Organization-owned presentation around the framework-owned sign-in URL. */
+export function renderAcmeMagicLinkEmail(input: AcmeMagicLinkEmailInput): AcmeMagicLinkEmail {
+  const safeSubject = escapeHtml(input.subject)
+  const safeUrl = escapeHtml(input.url)
+
+  return {
+    subject: input.subject,
+    text: [
+      input.subject,
+      "",
+      "A secure sign-in was requested for your Acme Operations account.",
+      "Open the link below to continue:",
+      "",
+      input.url,
+      "",
+      "This link expires soon and works once. If you did not request it, you can ignore this email.",
+    ].join("\n"),
+    html: [
+      "<!doctype html>",
+      '<html lang="en">',
+      "<head>",
+      '<meta charset="utf-8">',
+      '<meta name="viewport" content="width=device-width,initial-scale=1">',
+      `<title>${safeSubject}</title>`,
+      "</head>",
+      '<body style="margin:0;background:#eef2ed;color:#15211c;">',
+      '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#eef2ed;">',
+      '<tr><td align="center" style="padding:56px 20px;">',
+      '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:520px;background:#ffffff;border-radius:20px;overflow:hidden;">',
+      '<tr><td style="height:8px;background:#173b2b;font-size:0;line-height:0;">&nbsp;</td></tr>',
+      `<tr><td style="padding:40px;font-family:${EMAIL_FONT};">`,
+      '<div style="display:inline-block;padding:9px 13px;border-radius:10px;background:#173b2b;color:#ffffff;font-size:16px;font-weight:800;">A</div>',
+      '<p style="margin:28px 0 8px;color:#789085;font-size:12px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;">Acme Operations</p>',
+      '<h1 style="margin:0;color:#132019;font-size:32px;line-height:1.15;letter-spacing:-.03em;">Your secure sign-in link</h1>',
+      '<p style="margin:18px 0 30px;color:#69766f;font-size:16px;line-height:1.6;">Continue to live operations, approvals, and shared team context. This link expires soon and works once.</p>',
+      '<table role="presentation" cellpadding="0" cellspacing="0" border="0"><tr>',
+      '<td bgcolor="#173b2b" style="border-radius:12px;">',
+      `<a href="${safeUrl}" style="display:inline-block;padding:15px 24px;font-family:${EMAIL_FONT};color:#ffffff;font-size:15px;font-weight:700;text-decoration:none;">Sign in to Acme</a>`,
+      "</td>",
+      "</tr></table>",
+      '<p style="margin:30px 0 8px;color:#8a948f;font-size:12px;line-height:1.5;">If the button does not work, copy this link:</p>',
+      `<p style="margin:0;word-break:break-all;font-size:12px;line-height:1.5;"><a href="${safeUrl}" style="color:#2f6d50;">${safeUrl}</a></p>`,
+      '<p style="margin:32px 0 0;padding-top:24px;border-top:1px solid #e3e9e5;color:#8a948f;font-size:12px;line-height:1.5;">If you did not request this email, you can safely ignore it.</p>',
+      "</td></tr>",
+      "</table>",
+      "</td></tr>",
+      "</table>",
+      "</body>",
+      "</html>",
+    ].join(""),
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+}

--- a/examples/auth/sixb.config.ts
+++ b/examples/auth/sixb.config.ts
@@ -8,6 +8,7 @@ import {
   InMemoryQueues,
 } from "@sixb/core"
 import { migrateSqliteStorage, SqliteStorage } from "@sixb/sqlite"
+import { renderAcmeMagicLinkEmail } from "./lib/magic-link-email"
 import { securityAdmins } from "./security/groups/security-admins"
 
 // Switch the auth strategy with SIXB_AUTH_MODE:
@@ -51,12 +52,18 @@ async function createAuthExampleSixb() {
             bootstrapUsers,
             bootstrapGroups: [securityAdmins],
             from: fromEmail,
+            subject: "Sign in to Acme Operations",
             sendMagicLink: sendMagicLinkEmail,
           }),
   })
 }
 
 async function sendMagicLinkEmail(message: SendMagicLinkInput): Promise<void> {
+  const email = renderAcmeMagicLinkEmail({
+    subject: message.subject,
+    url: message.url,
+  })
+
   // Print the link so you can sign in even without an email provider configured.
   console.log(`\n[auth] Magic sign-in link for ${message.email}:\n${message.url}\n`)
 
@@ -67,9 +74,9 @@ async function sendMagicLinkEmail(message: SendMagicLinkInput): Promise<void> {
   await sendResendEmail({
     from: message.from,
     to: message.email,
-    subject: message.subject,
-    text: message.text,
-    html: message.html,
+    subject: email.subject,
+    text: email.text,
+    html: email.html,
   })
 }
 

--- a/examples/auth/tests/magic-link-email.test.ts
+++ b/examples/auth/tests/magic-link-email.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { renderAcmeMagicLinkEmail } from "../lib/magic-link-email"
+
+describe("auth example magic-link email", () => {
+  test("renders branded text and escaped email-safe HTML around the supplied URL", () => {
+    const url = "https://auth.example.com/auth/callback?token=one&audience=app"
+    const email = renderAcmeMagicLinkEmail({
+      subject: "Sign in to Acme <Operations>",
+      url,
+    })
+
+    expect(email.subject).toBe("Sign in to Acme <Operations>")
+    expect(email.text).toContain(url)
+    expect(email.html).toContain("Acme Operations")
+    expect(email.html).toContain("Sign in to Acme &lt;Operations&gt;")
+    expect(email.html).toContain(
+      'href="https://auth.example.com/auth/callback?token=one&amp;audience=app"'
+    )
+  })
+})

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -34,6 +34,8 @@ The generated entry also intercepts plain same-origin `<a href="/...">` clicks a
 
 If `app/layout.tsx` exists, it is used as a root layout wrapper. It can also export a `metadata` object (`title`, `description`, `favicon`, `themeColor`, and `backgroundColor`). Metadata is loaded during generation and written into the static HTML and manifest, so it is available before auth and client startup. The layout module must therefore be import-safe in Bun: do not access `window` or `document` at module scope. An `app/globals.css` file is imported automatically when present.
 
+Add an optional `app/auth.tsx` default export to customize the app audience's magic-link pages. It receives `AuthExperienceProps` from `@sixb/app/auth` with `signIn`, `checkEmail`, `confirm`, `invalidLink`, and `error` states plus framework-owned actions. Sixb builds it separately, includes `app/globals.css`, and serves it from the API's existing `/auth/*` routes. It is not wrapped by `app/layout.tsx`, and it never owns tokens, cookies, callbacks, audience validation, or return redirects. When the file is absent, the generic server login remains the fallback.
+
 ### Built-in Agent Routes
 
 Custom apps automatically receive the shared Sixb agent chat UI at:
@@ -186,5 +188,6 @@ A file at `app/public/app.webmanifest` is ignored because the generated manifest
 | --- | --- |
 | `createCustomApp(options)` | High-level custom app toolkit for dev/build/start |
 | `AppMetadata` | Metadata shape exported by `app/layout.tsx` |
+| `@sixb/app/auth` | Custom auth experience states, actions, and component props |
 | `createTailwindCssCompiler(options)` | Shared Tailwind v4 build pipeline (also used by Atlas) |
 | `@sixb/app/agents` | Full-page agent route plus `AgentPanel`, context provider/hooks, and helpers |

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -33,6 +33,12 @@
       "bun": "./src/agents.ts",
       "import": "./dist/agents.js",
       "default": "./dist/agents.js"
+    },
+    "./auth": {
+      "types": "./dist/auth.d.ts",
+      "bun": "./src/auth.ts",
+      "import": "./dist/auth.js",
+      "default": "./dist/auth.js"
     }
   },
   "scripts": {

--- a/packages/app/src/auth.ts
+++ b/packages/app/src/auth.ts
@@ -1,0 +1,17 @@
+export type AuthExperienceState =
+  | { readonly kind: "signIn" }
+  | { readonly kind: "checkEmail" }
+  | { readonly kind: "confirm"; readonly email?: string }
+  | { readonly kind: "invalidLink" }
+  | { readonly kind: "error" }
+
+export interface AuthExperienceActions {
+  requestMagicLink(email: string): void
+  confirmSignIn(): void
+  restartSignIn(): void
+}
+
+export interface AuthExperienceProps {
+  readonly state: AuthExperienceState
+  readonly actions: AuthExperienceActions
+}

--- a/packages/app/src/build.ts
+++ b/packages/app/src/build.ts
@@ -30,6 +30,15 @@ export interface BuildAppResult {
   logs?: string[]
 }
 
+export interface BuildAuthExperienceOptions {
+  /** Generated HTML shell containing the auth bootstrap placeholder. */
+  entryPath: string
+  /** Browser TypeScript entry generated alongside `entryPath`. */
+  scriptEntryPath: string
+  /** Directory written for the API server to mount under `/auth`. */
+  outdir: string
+}
+
 /**
  * Builds the generated browser entry and writes a production-ready static shell and bundle.
  */
@@ -105,6 +114,74 @@ export async function buildApp(options: BuildAppOptions): Promise<BuildAppResult
   if (options.manifestPath) {
     await copyFile(options.manifestPath, join(outdir, "app.webmanifest"))
   }
+  await precompressBuildAssets(result.outputs)
+
+  return { success: true, outdir }
+}
+
+/** Builds the optional custom auth entry as API-served static assets. */
+export async function buildAuthExperience(
+  options: BuildAuthExperienceOptions
+): Promise<BuildAppResult> {
+  const outdir = resolve(options.outdir)
+  const assetsDir = join(outdir, "assets")
+  await rm(outdir, { recursive: true, force: true })
+  await mkdir(assetsDir, { recursive: true })
+
+  const result = await Bun.build({
+    entrypoints: [options.scriptEntryPath],
+    outdir: assetsDir,
+    target: "browser",
+    conditions: ["bun"],
+    publicPath: "/auth/assets/",
+    minify: true,
+    splitting: true,
+    naming: {
+      entry: "auth-[hash].[ext]",
+      chunk: "chunk-[name]-[hash].[ext]",
+      asset: "asset-[name]-[hash].[ext]",
+    },
+    plugins: [extensionlessSourceImportPlugin],
+    define: { "process.env.NODE_ENV": '"production"' },
+    sourcemap: "external",
+  })
+
+  if (!result.success) {
+    return {
+      success: false,
+      outdir,
+      logs: result.logs.map(String),
+    }
+  }
+
+  const script = result.outputs.find(
+    (output) => output.kind === "entry-point" && output.type.startsWith("text/javascript")
+  )
+  const stylesheets = result.outputs.filter((output) => output.type.startsWith("text/css"))
+  if (!script || stylesheets.length > 1) {
+    throw new Error(
+      `[SixbCustomApp] Expected one auth entry and at most one stylesheet, found ${script ? 1 : 0} entries and ${stylesheets.length} stylesheets.`
+    )
+  }
+
+  const sourceHtml = await readFile(options.entryPath, "utf-8")
+  const sourceEntryPattern =
+    /\s*<script\s+type=["']module["']\s+src=["']\.\/auth-main\.tsx["']><\/script>/
+  if (!sourceEntryPattern.test(sourceHtml)) {
+    throw new Error("[SixbCustomApp] Generated auth shell is missing its ./auth-main.tsx entry.")
+  }
+
+  const assetTags = [
+    ...stylesheets.map(
+      (stylesheet) =>
+        `<link rel="stylesheet" crossorigin href="/auth/assets/${basename(stylesheet.path)}">`
+    ),
+    `<script type="module" crossorigin src="/auth/assets/${basename(script.path)}"></script>`,
+  ].join("")
+  const html = sourceHtml
+    .replace(sourceEntryPattern, "")
+    .replace("</head>", `  ${assetTags}</head>`)
+  await writeFile(join(outdir, "index.html"), html, "utf-8")
   await precompressBuildAssets(result.outputs)
 
   return { success: true, outdir }

--- a/packages/app/src/codegen.ts
+++ b/packages/app/src/codegen.ts
@@ -16,6 +16,8 @@ export interface GenerateRouteManifestOptions {
   readonly builtInRoutes?: readonly BuiltInRouteManifestEntry[]
 }
 
+export const AUTH_EXPERIENCE_BOOTSTRAP_PLACEHOLDER = "__SIXB_AUTH_BOOTSTRAP__"
+
 /**
  * Generates `.sixb/generated/routes.ts` with static route imports. Pages are
  * eager on purpose: project-specific apps bundle small, and a single bundle
@@ -67,6 +69,143 @@ ${routeEntries}
   const outPath = join(generatedDir, "routes.ts")
   await writeFileIfChanged(outPath, content)
   return outPath
+}
+
+/** Generates the optional browser entry served by the API for `/auth/*`. */
+export async function generateAuthExperienceEntry(
+  projectRoot: string,
+  generatedDir: string,
+  options: {
+    readonly appDir?: string
+    readonly publicDir?: string
+    readonly stylesheetPath?: string | null
+  } = {}
+): Promise<{ readonly htmlPath: string; readonly mainPath: string } | null> {
+  await mkdir(generatedDir, { recursive: true })
+
+  const appDir = options.appDir ? resolve(projectRoot, options.appDir) : join(projectRoot, "app")
+  const authPath = join(appDir, "auth.tsx")
+  if (!(await fileExists(authPath))) {
+    return null
+  }
+
+  const publicDir = options.publicDir
+    ? resolve(projectRoot, options.publicDir)
+    : join(appDir, "public")
+  const layoutPath = join(appDir, "layout.tsx")
+  const globalsCssPath = join(appDir, "globals.css")
+  const metadata = await resolveAppMetadata({ layoutPath, publicDir })
+  const stylesheetPath =
+    options.stylesheetPath !== undefined
+      ? options.stylesheetPath
+      : (await fileExists(globalsCssPath))
+        ? globalsCssPath
+        : null
+  const stylesheetImport = stylesheetPath
+    ? `import ${JSON.stringify(relativeTo(generatedDir, stylesheetPath))}`
+    : ""
+  const authRel = relativeTo(generatedDir, authPath)
+
+  const mainContent = `import React from "react"
+import { createRoot } from "react-dom/client"
+import type {
+  AuthExperienceActions,
+  AuthExperienceState,
+} from "@sixb/app/auth"
+import AuthExperience from ${JSON.stringify(authRel)}
+${stylesheetImport}
+
+interface AuthExperienceBootstrap {
+  readonly state: AuthExperienceState
+  readonly signInUrl: string
+  readonly submission?: {
+    readonly kind: "requestMagicLink" | "confirmSignIn"
+    readonly action: string
+    readonly fields: Readonly<Record<string, string>>
+  }
+}
+
+const root = document.getElementById("root")
+if (!root) {
+  throw new Error("[SixbApp] Could not find the auth experience root element.")
+}
+
+const encodedBootstrap = root.dataset.sixbAuth
+if (!encodedBootstrap) {
+  throw new Error("[SixbApp] Auth experience bootstrap is missing.")
+}
+
+const bootstrap = decodeBootstrap(encodedBootstrap)
+const actions: AuthExperienceActions = {
+  requestMagicLink(email) {
+    submit("requestMagicLink", { email })
+  },
+  confirmSignIn() {
+    submit("confirmSignIn")
+  },
+  restartSignIn() {
+    window.location.assign(bootstrap.signInUrl)
+  },
+}
+
+function submit(
+  kind: NonNullable<AuthExperienceBootstrap["submission"]>["kind"],
+  additionalFields: Readonly<Record<string, string>> = {}
+): void {
+  const submission = bootstrap.submission
+  if (!submission || submission.kind !== kind) {
+    throw new Error("[SixbApp] Auth action '" + kind + "' is not available in this state.")
+  }
+
+  const form = document.createElement("form")
+  form.method = "post"
+  form.action = submission.action
+  form.hidden = true
+  for (const [name, value] of Object.entries({ ...submission.fields, ...additionalFields })) {
+    const input = document.createElement("input")
+    input.type = "hidden"
+    input.name = name
+    input.value = value
+    form.append(input)
+  }
+  document.body.append(form)
+  form.submit()
+}
+
+function decodeBootstrap(value: string): AuthExperienceBootstrap {
+  const base64 = value.replaceAll("-", "+").replaceAll("_", "/")
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=")
+  const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0))
+  return JSON.parse(new TextDecoder().decode(bytes)) as AuthExperienceBootstrap
+}
+
+createRoot(root).render(<AuthExperience state={bootstrap.state} actions={actions} />)
+`
+
+  const mainPath = join(generatedDir, "auth-main.tsx")
+  await writeFileIfChanged(mainPath, mainContent)
+
+  const htmlContent = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+${renderAuthMetadataHead(metadata)}
+    <style>
+      * { box-sizing: border-box; }
+      html, body, #root { margin: 0; min-height: 100%; }
+      body, #root { min-height: 100vh; min-height: 100dvh; }
+    </style>
+  </head>
+  <body>
+    <div id="root" data-sixb-auth="${AUTH_EXPERIENCE_BOOTSTRAP_PLACEHOLDER}"></div>
+    <script type="module" src="./auth-main.tsx"></script>
+  </body>
+</html>
+`
+  const htmlPath = join(generatedDir, "auth-index.html")
+  await writeFileIfChanged(htmlPath, htmlContent)
+  return { htmlPath, mainPath }
 }
 
 /**
@@ -535,6 +674,20 @@ function renderMetadataHead(metadata: Awaited<ReturnType<typeof resolveAppMetada
       : []),
     ...(metadata.appleTouchIcon
       ? [`    <link rel="apple-touch-icon" href="${metadata.appleTouchIcon}" />`]
+      : []),
+  ]
+  return tags.join("\n")
+}
+
+function renderAuthMetadataHead(metadata: Awaited<ReturnType<typeof resolveAppMetadata>>): string {
+  const tags = [
+    `    <title>${escapeHtmlText(metadata.title)}</title>`,
+    ...(metadata.description
+      ? [`    <meta name="description" content="${escapeHtmlAttribute(metadata.description)}" />`]
+      : []),
+    `    <meta name="theme-color" content="${escapeHtmlAttribute(metadata.themeColor)}" />`,
+    ...(metadata.favicon && /^(?:https?:|data:)/.test(metadata.favicon)
+      ? [`    <link rel="icon" href="${escapeHtmlAttribute(metadata.favicon)}" />`]
       : []),
   ]
   return tags.join("\n")

--- a/packages/app/src/createCustomApp.ts
+++ b/packages/app/src/createCustomApp.ts
@@ -1,15 +1,21 @@
 import { watch } from "node:fs"
-import { access, cp, mkdir, readFile, writeFile } from "node:fs/promises"
+import { access, cp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { dirname, isAbsolute, join, normalize, relative, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 import type { AuthSessionAudience } from "@sixb/core"
 import {
   type BuildAppResult,
   buildApp,
+  buildAuthExperience,
   prepareAppHtmlBundleEntry,
   restoreAppStaticUrls,
 } from "./build"
-import { type BuiltInRouteManifestEntry, generateAppEntry, generateRouteManifest } from "./codegen"
+import {
+  type BuiltInRouteManifestEntry,
+  generateAppEntry,
+  generateAuthExperienceEntry,
+  generateRouteManifest,
+} from "./codegen"
 import { renderCustomAppRuntimeScript } from "./runtime"
 import { type PageRoute, scanPages } from "./scanner"
 import { type CustomAppStylesheet, resolveCustomAppStylesheet } from "./styles"
@@ -35,6 +41,14 @@ export interface CustomAppBuildOptions {
   outdir?: string
 }
 
+export interface CustomAuthExperienceBuildOptions {
+  outdir?: string
+}
+
+export interface CustomAuthExperienceBuildResult {
+  readonly outdir: string
+}
+
 export interface CustomAppStartOptions {
   host?: string
   port?: number
@@ -54,6 +68,9 @@ export interface CustomAppDevServer {
 export interface CustomAppInstance {
   scanRoutes(): Promise<PageRoute[]>
   hasRoutes(): Promise<boolean>
+  prepareAuthExperience(
+    options?: CustomAuthExperienceBuildOptions
+  ): Promise<CustomAuthExperienceBuildResult | null>
   dev(options?: CustomAppDevOptions): Promise<CustomAppDevServer>
   build(options?: CustomAppBuildOptions): Promise<BuildAppResult>
   start(options?: CustomAppStartOptions): Promise<CustomAppDevServer>
@@ -90,6 +107,7 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
 
   let tailwindCompiler: TailwindCssCompiler | null = null
   let tailwindCompilerKey: string | null = null
+  let authTailwindCompiler: TailwindCssCompiler | null = null
   let builtInAgentCssCompiler: TailwindCssCompiler | null = null
 
   // `app/globals.css` is source. When it uses Tailwind, compile it to
@@ -238,6 +256,58 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
     return { htmlPath, mainPath, manifestPath, routes }
   }
 
+  async function prepareAuthExperience(
+    authOptions: CustomAuthExperienceBuildOptions = {}
+  ): Promise<CustomAuthExperienceBuildResult | null> {
+    const outdir = authOptions.outdir
+      ? resolve(rootDir, authOptions.outdir)
+      : join(generatedDir, "auth")
+    if (!(await pathExists(join(appDir, "auth.tsx")))) {
+      await rm(outdir, { recursive: true, force: true })
+      return null
+    }
+
+    const stylesheet = await resolveCustomAppStylesheet({ appDir, generatedDir, rootDir })
+    let stylesheetPath: string | null
+    if (stylesheet.kind === "none") {
+      stylesheetPath = null
+    } else if (stylesheet.kind === "static") {
+      stylesheetPath = stylesheet.path
+    } else {
+      const outputPath = join(generatedDir, "auth.css")
+      authTailwindCompiler ??= createTailwindCssCompiler({
+        inputPath: stylesheet.sourcePath,
+        outputPath,
+        cwd: appDir,
+        resolveFrom: rootDir,
+        label: "[SixbCustomApp]",
+      })
+      await authTailwindCompiler.compile()
+      stylesheetPath = outputPath
+    }
+
+    const entry = await generateAuthExperienceEntry(rootDir, generatedDir, {
+      appDir,
+      publicDir,
+      stylesheetPath,
+    })
+    if (!entry) {
+      return null
+    }
+
+    const result = await buildAuthExperience({
+      entryPath: entry.htmlPath,
+      scriptEntryPath: entry.mainPath,
+      outdir,
+    })
+    if (!result.success) {
+      throw new Error(
+        `[SixbCustomApp] Failed to build the auth experience: ${(result.logs ?? []).join("\n")}`
+      )
+    }
+    return { outdir: result.outdir }
+  }
+
   return {
     async scanRoutes() {
       return await scanRoutes()
@@ -248,10 +318,15 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
       return routes.length > 0
     },
 
+    async prepareAuthExperience(options) {
+      return await prepareAuthExperience(options)
+    },
+
     async dev(devOptions: CustomAppDevOptions = {}) {
       const host = devOptions.host ?? "0.0.0.0"
       const port = devOptions.port ?? 3001
       const { htmlPath, manifestPath } = await prepareGeneratedApp()
+      await prepareAuthExperience()
       let htmlImportVersion = 0
       let htmlBundle = await importHtmlBundle(htmlPath, htmlImportVersion)
       const publicRoutes = (await pathExists(publicDir)) ? await createPublicRoutes(publicDir) : {}
@@ -282,6 +357,7 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
         rebuildChain = rebuildChain
           .then(async () => {
             const { htmlPath: nextHtmlPath } = await prepareGeneratedApp()
+            await prepareAuthExperience()
             htmlImportVersion++
             htmlBundle = await importHtmlBundle(nextHtmlPath, htmlImportVersion)
             server.reload(serveOptions(htmlBundle))
@@ -331,6 +407,7 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
           watcher.close()
           await rebuildChain
           await tailwindCompiler?.stop()
+          await authTailwindCompiler?.stop()
           await builtInAgentCssCompiler?.stop()
           server.stop(true)
         },
@@ -347,11 +424,21 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
         outdir,
       })
 
+      if (result.success) {
+        await prepareAuthExperience({ outdir: join(outdir, "auth") })
+      }
+
       if (result.success && (await pathExists(publicDir))) {
         await cp(publicDir, outdir, {
           recursive: true,
           force: true,
-          filter: (source) => resolve(source) !== join(publicDir, "app.webmanifest"),
+          filter: (source) => {
+            const resolvedSource = resolve(source)
+            return (
+              resolvedSource !== join(publicDir, "app.webmanifest") &&
+              resolvedSource !== join(publicDir, "auth")
+            )
+          },
         })
       }
 

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -5,6 +5,8 @@ export {
   type CustomAppDevServer,
   type CustomAppInstance,
   type CustomAppStartOptions,
+  type CustomAuthExperienceBuildOptions,
+  type CustomAuthExperienceBuildResult,
   createCustomApp,
 } from "./createCustomApp"
 export type { AppMetadata } from "./metadata"

--- a/packages/app/tests/createCustomApp.test.ts
+++ b/packages/app/tests/createCustomApp.test.ts
@@ -4,7 +4,11 @@ import { createServer } from "node:net"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { brotliCompressSync, gzipSync } from "node:zlib"
-import { generateAppEntry, generateRouteManifest } from "../src/codegen"
+import {
+  generateAppEntry,
+  generateAuthExperienceEntry,
+  generateRouteManifest,
+} from "../src/codegen"
 import { createCustomApp } from "../src/createCustomApp"
 
 async function linkDependencies(projectRoot: string, packages: readonly string[]): Promise<void> {
@@ -374,6 +378,30 @@ describe("createCustomApp.dev", () => {
     expect(main).toContain("data.queryClient ??= createQueryClient()")
     expect(main).toContain("getRoot().render(<App />)")
     expect(main).not.toContain('createRoot(document.getElementById("root")!).render')
+  })
+
+  test("generates a separate pre-auth entry when app/auth.tsx exists", async () => {
+    await writeFile(
+      join(tempRoot, "app", "auth.tsx"),
+      [
+        'import type { AuthExperienceProps } from "@sixb/app/auth"',
+        "export default function AuthExperience(_props: AuthExperienceProps) { return null }",
+        "",
+      ].join("\n")
+    )
+    const generatedDir = join(tempRoot, ".sixb", "generated")
+    const entry = await generateAuthExperienceEntry(tempRoot, generatedDir)
+    if (!entry) throw new Error("Expected an auth experience entry")
+
+    const main = await readFile(entry.mainPath, "utf-8")
+    const html = await readFile(entry.htmlPath, "utf-8")
+    expect(main).toContain('import AuthExperience from "../../app/auth.tsx"')
+    expect(main).toContain("requestMagicLink(email)")
+    expect(main).toContain("confirmSignIn()")
+    expect(main).toContain("form.submit()")
+    expect(html).toContain('data-sixb-auth="__SIXB_AUTH_BOOTSTRAP__"')
+    expect(html).toContain('src="./auth-main.tsx"')
+    expect(main).not.toContain("RootLayout")
   })
 
   test("renders an access-denied view without starting the application", async () => {

--- a/packages/cli/src/commands/api.tsx
+++ b/packages/cli/src/commands/api.tsx
@@ -52,6 +52,10 @@ export async function runApi(options: ApiOptions = {}) {
     const hasBuiltCustomApp = await stat(resolve(appOutdir, "index.html"))
       .then(() => true)
       .catch(() => false)
+    const authExperienceOutdir = resolve(appOutdir, "auth")
+    const hasAuthExperience = await stat(resolve(authExperienceOutdir, "index.html"))
+      .then(() => true)
+      .catch(() => false)
     const topology = resolveBrowserTopology({
       role: "api",
       host: options.host,
@@ -73,6 +77,7 @@ export async function runApi(options: ApiOptions = {}) {
         publicOrigin: topology.apiPublicOrigin,
         allowedOrigins: topology.allowedBrowserOrigins,
       },
+      ...(hasAuthExperience ? { authExperience: { outdir: authExperienceOutdir } } : {}),
     })
     await server.start()
 

--- a/packages/cli/src/commands/dev.tsx
+++ b/packages/cli/src/commands/dev.tsx
@@ -59,6 +59,17 @@ export async function runDev(options: DevOptions = {}) {
       appPublicOrigin: options.appPublicOrigin,
       hasCustomApp,
     })
+    const customApp = await createCustomApp({
+      rootDir: projectRoot,
+      apiBaseUrl: topology.apiPublicOrigin,
+      audience: "app",
+      authEnabled: host.auth.isEnabled(),
+    })
+    const authExperience = hasCustomApp
+      ? ((await customApp.prepareAuthExperience()) ?? {
+          outdir: resolve(projectRoot, ".sixb", "generated", "auth"),
+        })
+      : null
 
     runtime = await startSixbRuntime(host, {
       cohostWorkers: true,
@@ -79,6 +90,7 @@ export async function runDev(options: DevOptions = {}) {
         publicOrigin: topology.apiPublicOrigin,
         allowedOrigins: topology.allowedBrowserOrigins,
       },
+      ...(authExperience ? { authExperience } : {}),
     })
     await server.start()
 
@@ -91,13 +103,6 @@ export async function runDev(options: DevOptions = {}) {
       host: topology.host,
       port: topology.atlasPort,
       development: true,
-    })
-
-    const customApp = await createCustomApp({
-      rootDir: projectRoot,
-      apiBaseUrl: topology.apiPublicOrigin,
-      audience: "app",
-      authEnabled,
     })
 
     let appUrl: string | null = null

--- a/packages/server/src/auth/experience.ts
+++ b/packages/server/src/auth/experience.ts
@@ -1,0 +1,190 @@
+import { resolve } from "node:path"
+import type { AuthSessionAudience } from "@sixb/core"
+
+const AUTH_BOOTSTRAP_PLACEHOLDER = "__SIXB_AUTH_BOOTSTRAP__"
+const AUTH_ASSET_PREFIX = "/auth/assets/"
+
+export interface SixbAuthExperienceOptions {
+  readonly outdir: string
+  readonly audience?: AuthSessionAudience
+}
+
+export type AuthExperiencePageState =
+  | { readonly kind: "signIn" }
+  | { readonly kind: "checkEmail" }
+  | { readonly kind: "confirm"; readonly email?: string }
+  | { readonly kind: "invalidLink" }
+  | { readonly kind: "error" }
+
+export interface AuthExperienceSubmission {
+  readonly kind: "requestMagicLink" | "confirmSignIn"
+  readonly action: string
+  readonly fields: Readonly<Record<string, string>>
+}
+
+export async function customAuthExperienceResponse(
+  options: SixbAuthExperienceOptions | undefined,
+  input: {
+    readonly audience: AuthSessionAudience
+    readonly state: AuthExperiencePageState
+    readonly signInUrl: string
+    readonly submission?: AuthExperienceSubmission
+    readonly status?: number
+    readonly referrerPolicy?: "no-referrer" | "same-origin"
+    readonly formActionOrigins?: readonly string[]
+  }
+): Promise<Response | null> {
+  if (!options || input.audience !== (options.audience ?? "app")) {
+    return null
+  }
+
+  const template = Bun.file(resolve(options.outdir, "index.html"))
+  if (!(await template.exists())) {
+    return null
+  }
+
+  const html = await template.text()
+  if (!html.includes(AUTH_BOOTSTRAP_PLACEHOLDER)) {
+    console.warn(
+      `[SixbServer] Custom auth experience in ${options.outdir} is missing its bootstrap placeholder. Using the generic page.`
+    )
+    return null
+  }
+
+  const bootstrap = Buffer.from(
+    JSON.stringify({
+      state: input.state,
+      signInUrl: input.signInUrl,
+      ...(input.submission ? { submission: input.submission } : {}),
+    })
+  ).toString("base64url")
+  const formAction = ["'self'", ...(input.formActionOrigins ?? []).map(normalizeCspOrigin)].join(
+    " "
+  )
+
+  return new Response(html.replace(AUTH_BOOTSTRAP_PLACEHOLDER, bootstrap), {
+    status: input.status ?? 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+      "content-security-policy": [
+        "default-src 'none'",
+        "script-src 'self'",
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data:",
+        "font-src 'self'",
+        "base-uri 'none'",
+        `form-action ${formAction}`,
+        "frame-ancestors 'none'",
+      ].join("; "),
+      "referrer-policy": input.referrerPolicy ?? "no-referrer",
+      "x-content-type-options": "nosniff",
+    },
+  })
+}
+
+function normalizeCspOrigin(value: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`[SixbServer] Invalid custom auth form-action origin: '${value}'.`)
+  }
+
+  if ((url.protocol !== "http:" && url.protocol !== "https:") || url.origin !== value) {
+    throw new Error(`[SixbServer] Invalid custom auth form-action origin: '${value}'.`)
+  }
+  return url.origin
+}
+
+export async function customAuthExperienceAssetResponse(
+  options: SixbAuthExperienceOptions | undefined,
+  request: Request
+): Promise<Response> {
+  const method = request.method.toUpperCase()
+  if (!options || (method !== "GET" && method !== "HEAD")) {
+    return notFoundResponse()
+  }
+
+  const url = new URL(request.url)
+  if (!url.pathname.startsWith(AUTH_ASSET_PREFIX)) {
+    return notFoundResponse()
+  }
+
+  let fileName: string
+  try {
+    fileName = decodeURIComponent(url.pathname.slice(AUTH_ASSET_PREFIX.length))
+  } catch {
+    return notFoundResponse()
+  }
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(fileName)) {
+    return notFoundResponse()
+  }
+
+  const path = resolve(options.outdir, "assets", fileName)
+  const source = Bun.file(path)
+  if (!(await source.exists())) {
+    return notFoundResponse()
+  }
+
+  const encoding = await resolvePrecompressedAsset(request, path)
+  const body = encoding ? Bun.file(`${path}.${encoding === "br" ? "br" : "gz"}`) : source
+  const headers = new Headers({
+    "content-type": source.type || "application/octet-stream",
+    "cache-control": "public, max-age=31536000, immutable",
+    "x-content-type-options": "nosniff",
+  })
+  if (encoding) {
+    headers.set("content-encoding", encoding)
+    headers.set("vary", "Accept-Encoding")
+  }
+  return new Response(method === "HEAD" ? null : body, { headers })
+}
+
+async function resolvePrecompressedAsset(
+  request: Request,
+  sourcePath: string
+): Promise<"br" | "gzip" | null> {
+  for (const encoding of acceptedPrecompressedEncodings(request)) {
+    const suffix = encoding === "br" ? "br" : "gz"
+    if (await Bun.file(`${sourcePath}.${suffix}`).exists()) {
+      return encoding
+    }
+  }
+  return null
+}
+
+function acceptedPrecompressedEncodings(request: Request): ("br" | "gzip")[] {
+  const header = request.headers.get("accept-encoding")
+  if (!header) return []
+
+  const qualities = new Map<string, number>()
+  for (const item of header.split(",")) {
+    const [rawName, ...parameters] = item.trim().split(";")
+    const name = rawName.toLowerCase()
+    let quality = 1
+    for (const parameter of parameters) {
+      const match = parameter.trim().match(/^q=(0(?:\.\d+)?|1(?:\.0+)?)$/)
+      if (match) quality = Number(match[1])
+    }
+    qualities.set(name, quality)
+  }
+
+  const wildcard = qualities.get("*") ?? 0
+  return (["br", "gzip"] as const)
+    .map((encoding, preference) => ({
+      encoding,
+      preference,
+      quality: qualities.get(encoding) ?? wildcard,
+    }))
+    .filter((candidate) => candidate.quality > 0)
+    .sort((left, right) => right.quality - left.quality || left.preference - right.preference)
+    .map((candidate) => candidate.encoding)
+}
+
+function notFoundResponse(): Response {
+  return new Response("Not Found", {
+    status: 404,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  })
+}

--- a/packages/server/src/auth/public-routes.ts
+++ b/packages/server/src/auth/public-routes.ts
@@ -72,6 +72,13 @@ export function isPublicRoute(pathname: string, method: string): boolean {
     return true
   }
 
+  if (
+    pathname.startsWith("/auth/assets/") &&
+    (normalizedMethod === "GET" || normalizedMethod === "HEAD")
+  ) {
+    return true
+  }
+
   if (pathname === "/auth/sign-in" && (normalizedMethod === "GET" || normalizedMethod === "POST")) {
     return true
   }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,2 +1,3 @@
 export type { SixbApiBrowserPolicy, SixbBrowserOrigin } from "./auth/browser-origin"
+export type { SixbAuthExperienceOptions } from "./auth/experience"
 export { createSixbServer, SixbServer, type SixbServerOptions } from "./server"

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -39,6 +39,11 @@ import {
   type ResolveRequestAuthContext,
 } from "../auth/browser-origin"
 import { CSRF_TOKEN_RESPONSE_HEADER_NAME } from "../auth/csrf"
+import {
+  customAuthExperienceAssetResponse,
+  customAuthExperienceResponse,
+  type SixbAuthExperienceOptions,
+} from "../auth/experience"
 import { hasForegroundSessionActivity } from "../auth/session-activity"
 import { createSessionRenewalCookieHeaders } from "../auth/session-cookies"
 import { SIXB_CSRF_SECURITY_REQUIREMENT } from "../openapi/security"
@@ -115,10 +120,21 @@ export interface AuthRoutesOptions {
     request: Request,
     input: AuthInvitationRedirectInput
   ) => AuthInvitationRedirectContext
+  readonly authExperience?: SixbAuthExperienceOptions
 }
 
 export function registerAuthRoutes(app: Elysia, host: SixbHostView, options: AuthRoutesOptions) {
   return app
+    .get(
+      "/auth/assets/*",
+      async ({ request }) => customAuthExperienceAssetResponse(options.authExperience, request),
+      { detail: { hide: true } }
+    )
+    .head(
+      "/auth/assets/*",
+      async ({ request }) => customAuthExperienceAssetResponse(options.authExperience, request),
+      { detail: { hide: true } }
+    )
     .get(
       "/api/auth/session",
       async ({ request }) => {
@@ -1241,11 +1257,7 @@ export function registerAuthRoutes(app: Elysia, host: SixbHostView, options: Aut
             requesterHash: pending.hash,
           })
 
-          const response = htmlMessageResponse(
-            "If this email can sign in, we sent a link. Check your inbox to continue.",
-            200,
-            "Check your email"
-          )
+          const response = await magicLinkRequestedResponse(options, authRedirect)
           // Same-device fast path: this browser keeps the preimage of the
           // `requester` hash embedded in the emailed callback URL, so opening
           // the link here signs in without the confirmation click. Always
@@ -1304,7 +1316,7 @@ export function registerAuthRoutes(app: Elysia, host: SixbHostView, options: Aut
         }
 
         if (isMagicLinkAuthStrategy(strategy)) {
-          return signInFormResponse(authRedirect)
+          return await signInFormResponse(options, authRedirect)
         }
 
         if (isOidcAuthStrategy(strategy)) {
@@ -1331,9 +1343,14 @@ export function registerAuthRoutes(app: Elysia, host: SixbHostView, options: Aut
           const url = new URL(request.url)
           const magicLinkId = url.searchParams.get("magicLinkId")?.trim()
           const token = url.searchParams.get("token")?.trim()
+          const authRedirectHint = resolveAuthExperienceRedirectHint(
+            options,
+            request,
+            url.searchParams.get("audience")
+          )
 
           if (!magicLinkId || !token) {
-            return htmlMessageResponse("This sign-in link is invalid or expired.", 400)
+            return await invalidMagicLinkResponse(options, authRedirectHint)
           }
 
           // Read-only peek so the page can greet the user by email and dead
@@ -1353,11 +1370,12 @@ export function registerAuthRoutes(app: Elysia, host: SixbHostView, options: Aut
                 token,
               })
               if (!peeked) {
-                return htmlMessageResponse("This sign-in link is invalid or expired.", 400)
+                return await invalidMagicLinkResponse(options, authRedirectHint)
               }
               email = peeked.email
-            } catch {
-              return htmlMessageResponse("This sign-in link is invalid or expired.", 400)
+            } catch (error) {
+              logAuthCallbackError("Magic-link", error)
+              return await authExperienceErrorResponse(options, authRedirectHint)
             }
           }
 
@@ -1380,10 +1398,16 @@ export function registerAuthRoutes(app: Elysia, host: SixbHostView, options: Aut
               magicLinkId,
               token,
               clearPendingCookie: true,
+              authRedirectHint,
             })
           }
 
-          return magicLinkConfirmResponse({ magicLinkId, token, email })
+          return await magicLinkConfirmResponse(options, {
+            magicLinkId,
+            token,
+            email,
+            authRedirect: authRedirectHint,
+          })
         }
 
         if (isOidcAuthStrategy(strategy)) {
@@ -1438,16 +1462,26 @@ export function registerAuthRoutes(app: Elysia, host: SixbHostView, options: Aut
 
         const magicLinkId = body.magicLinkId?.trim()
         const token = body.token?.trim()
+        const authRedirectHint = resolveAuthExperienceRedirectHint(options, request, body.audience)
         if (!magicLinkId || !token) {
-          return htmlMessageResponse("This sign-in link is invalid or expired.", 400)
+          return await invalidMagicLinkResponse(options, authRedirectHint)
         }
 
-        return completeMagicLinkCallback({ host, strategy, options, request, magicLinkId, token })
+        return completeMagicLinkCallback({
+          host,
+          strategy,
+          options,
+          request,
+          magicLinkId,
+          token,
+          authRedirectHint,
+        })
       },
       {
         body: t.Object({
           magicLinkId: t.Optional(t.String()),
           token: t.Optional(t.String()),
+          audience: t.Optional(t.String()),
         }),
         parse: "urlencoded",
         detail: { hide: true },
@@ -1520,6 +1554,7 @@ async function completeMagicLinkCallback(input: {
   readonly magicLinkId: string
   readonly token: string
   readonly clearPendingCookie?: boolean
+  readonly authRedirectHint?: AuthRedirectContext
 }): Promise<Response> {
   const authOptions = resolveAuthOptions(input.options, input.request)
   const now = new Date()
@@ -1564,7 +1599,7 @@ async function completeMagicLinkCallback(input: {
     }
     return response
   } catch {
-    return htmlMessageResponse("This sign-in link is invalid or expired.", 400)
+    return await invalidMagicLinkResponse(input.options, input.authRedirectHint)
   }
 }
 
@@ -1925,19 +1960,108 @@ function authPageResponse(body: string, status = 200): Response {
   })
 }
 
-function signInFormResponse(context: AuthRedirectContext): Response {
-  return authPageResponse(
-    [
-      "<h1>Sign in</h1>",
-      "<p>We'll email you a sign-in link.</p>",
-      '<form method="post" action="/auth/sign-in">',
-      `<input type="hidden" name="audience" value="${escapeHtml(context.audience)}">`,
-      `<input type="hidden" name="returnTo" value="${escapeHtml(context.returnTo)}">`,
-      '<input name="email" type="email" autocomplete="email" placeholder="you@example.com" aria-label="Email address" required autofocus>',
-      '<button type="submit">Send sign-in link</button>',
-      "</form>",
-    ].join("")
+async function signInFormResponse(
+  options: AuthRoutesOptions,
+  context: AuthRedirectContext
+): Promise<Response> {
+  return (
+    (await customAuthExperienceResponse(options.authExperience, {
+      audience: context.audience,
+      state: { kind: "signIn" },
+      signInUrl: authExperienceSignInUrl(context),
+      submission: {
+        kind: "requestMagicLink",
+        action: "/auth/sign-in",
+        fields: { audience: context.audience, returnTo: context.returnTo },
+      },
+      // Native POST forms inherit the document's referrer policy when
+      // constructing their Origin header. `no-referrer` produces
+      // `Origin: null`, which the API origin guard correctly rejects.
+      referrerPolicy: "same-origin",
+    })) ??
+    authPageResponse(
+      [
+        "<h1>Sign in</h1>",
+        "<p>We'll email you a sign-in link.</p>",
+        '<form method="post" action="/auth/sign-in">',
+        `<input type="hidden" name="audience" value="${escapeHtml(context.audience)}">`,
+        `<input type="hidden" name="returnTo" value="${escapeHtml(context.returnTo)}">`,
+        '<input name="email" type="email" autocomplete="email" placeholder="you@example.com" aria-label="Email address" required autofocus>',
+        '<button type="submit">Send sign-in link</button>',
+        "</form>",
+      ].join("")
+    )
   )
+}
+
+async function magicLinkRequestedResponse(
+  options: AuthRoutesOptions,
+  context: AuthRedirectContext
+): Promise<Response> {
+  return (
+    (await customAuthExperienceResponse(options.authExperience, {
+      audience: context.audience,
+      state: { kind: "checkEmail" },
+      signInUrl: authExperienceSignInUrl(context),
+    })) ??
+    htmlMessageResponse(
+      "If this email can sign in, we sent a link. Check your inbox to continue.",
+      200,
+      "Check your email"
+    )
+  )
+}
+
+async function invalidMagicLinkResponse(
+  options: AuthRoutesOptions,
+  context: AuthRedirectContext | undefined
+): Promise<Response> {
+  if (context) {
+    const custom = await customAuthExperienceResponse(options.authExperience, {
+      audience: context.audience,
+      state: { kind: "invalidLink" },
+      signInUrl: authExperienceSignInUrl(context),
+      status: 400,
+    })
+    if (custom) return custom
+  }
+
+  return htmlMessageResponse("This sign-in link is invalid or expired.", 400)
+}
+
+async function authExperienceErrorResponse(
+  options: AuthRoutesOptions,
+  context: AuthRedirectContext | undefined
+): Promise<Response> {
+  if (context) {
+    const custom = await customAuthExperienceResponse(options.authExperience, {
+      audience: context.audience,
+      state: { kind: "error" },
+      signInUrl: authExperienceSignInUrl(context),
+      status: 500,
+    })
+    if (custom) return custom
+  }
+
+  return await invalidMagicLinkResponse(options, undefined)
+}
+
+function authExperienceSignInUrl(context: AuthRedirectContext): string {
+  const params = new URLSearchParams({ audience: context.audience, returnTo: context.returnTo })
+  return `/auth/sign-in?${params.toString()}`
+}
+
+function resolveAuthExperienceRedirectHint(
+  options: AuthRoutesOptions,
+  request: Request,
+  audience: string | null | undefined
+): AuthRedirectContext | undefined {
+  if (audience !== "app" && audience !== "atlas") {
+    return undefined
+  }
+
+  const context = resolveInvitationDeliveryContext(options, request, { destinationId: audience })
+  return context instanceof Response ? undefined : context
 }
 
 // Deliberately a plain form with no auto-submit: link scanners that execute
@@ -1948,12 +2072,39 @@ function signInFormResponse(context: AuthRedirectContext): Response {
 // a disabled spinner. The form POST is a normal navigation, so this page stays
 // visible (spinner and all) until the server responds; the pageshow handler
 // resets the button when the page is restored from the back/forward cache.
-function magicLinkConfirmResponse(input: {
-  readonly magicLinkId: string
-  readonly token: string
-  // Absent when the strategy doesn't support the read-only peek.
-  readonly email?: string
-}): Response {
+async function magicLinkConfirmResponse(
+  options: AuthRoutesOptions,
+  input: {
+    readonly magicLinkId: string
+    readonly token: string
+    // Absent when the strategy doesn't support the read-only peek.
+    readonly email?: string
+    readonly authRedirect?: AuthRedirectContext
+  }
+): Promise<Response> {
+  if (input.authRedirect) {
+    const custom = await customAuthExperienceResponse(options.authExperience, {
+      audience: input.authRedirect.audience,
+      state: { kind: "confirm", ...(input.email ? { email: input.email } : {}) },
+      signInUrl: authExperienceSignInUrl(input.authRedirect),
+      submission: {
+        kind: "confirmSignIn",
+        action: "/auth/callback",
+        fields: {
+          magicLinkId: input.magicLinkId,
+          token: input.token,
+          audience: input.authRedirect.audience,
+        },
+      },
+      referrerPolicy: "same-origin",
+      // The callback POST is same-origin, but its successful 303 continues to
+      // the validated custom-app origin. CSP applies form-action across that
+      // redirect chain, so permit that exact origin for this state only.
+      formActionOrigins: [new URL(input.authRedirect.returnTo).origin],
+    })
+    if (custom) return custom
+  }
+
   const response = authPageResponse(
     [
       "<h1>Sign in</h1>",
@@ -1963,6 +2114,11 @@ function magicLinkConfirmResponse(input: {
       '<form method="post" action="/auth/callback" id="confirm">',
       `<input type="hidden" name="magicLinkId" value="${escapeHtml(input.magicLinkId)}">`,
       `<input type="hidden" name="token" value="${escapeHtml(input.token)}">`,
+      ...(input.authRedirect
+        ? [
+            `<input type="hidden" name="audience" value="${escapeHtml(input.authRedirect.audience)}">`,
+          ]
+        : []),
       '<button type="submit" id="confirm-button">Continue</button>',
       "</form>",
       "<script>",

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -25,6 +25,7 @@ import {
   type SixbApiBrowserPolicy,
 } from "./auth/browser-origin"
 import { CSRF_TOKEN_RESPONSE_HEADER_NAME } from "./auth/csrf"
+import type { SixbAuthExperienceOptions } from "./auth/experience"
 import { ServerAuthGuard } from "./auth/guard"
 import { consumeInternalRequestAuthState } from "./auth/scope"
 import { SESSION_ACTIVITY_HEADER_NAME } from "./auth/session-activity"
@@ -49,6 +50,8 @@ export interface SixbServerOptions {
   hostname?: string
   quiet?: boolean
   browser: SixbApiBrowserPolicy
+  /** Optional custom-app auth bundle mounted under the API's `/auth` routes. */
+  authExperience?: SixbAuthExperienceOptions
 }
 
 export function createSixbServer(options: SixbServerOptions): SixbServer {
@@ -63,6 +66,7 @@ export class SixbServer {
   private readonly apiBrowserPolicy: ResolvedSixbApiBrowserPolicy
   private readonly authContextResolver: ResolveRequestAuthContext
   private readonly authRedirectContextResolver: ResolveAuthRedirectContext
+  private readonly authExperience?: SixbAuthExperienceOptions
   private app: SixbApp | null = null
   private bunServer: ReturnType<typeof Bun.serve> | null = null
   private maintenance: OntologyMaintenanceHandle | null = null
@@ -77,6 +81,7 @@ export class SixbServer {
     this.authRedirectContextResolver = createApiBrowserAuthRedirectContextResolver(
       this.apiBrowserPolicy
     )
+    this.authExperience = options.authExperience
   }
 
   getHost(): SixbHostView {
@@ -115,6 +120,10 @@ export class SixbServer {
 
   getApiBrowserPolicy(): ResolvedSixbApiBrowserPolicy {
     return this.apiBrowserPolicy
+  }
+
+  getAuthExperience(): SixbAuthExperienceOptions | undefined {
+    return this.authExperience
   }
 
   async start(): Promise<void> {
@@ -304,6 +313,7 @@ export function createSixbApi(server: SixbServer) {
       server.resolveAuthRedirectContext(request, input),
     getInvitationDestinationOptions: (request) => server.getInvitationDestinationOptions(request),
     resolveAuthRequestOrigin: (request) => server.resolveAuthRequestOrigin(request),
+    authExperience: server.getAuthExperience(),
     resolveInvitationRedirectContext: (request, input) =>
       server.resolveInvitationRedirectContext(request, input),
   })

--- a/packages/server/tests/helpers.ts
+++ b/packages/server/tests/helpers.ts
@@ -24,10 +24,16 @@ export async function confirmCallback(app: TestApp, link: URL): Promise<Response
   const body = new URLSearchParams()
   for (const name of ["magicLinkId", "token"]) {
     const match = html.match(new RegExp(`name="${name}" value="([^"]+)"`))
-    if (!match) {
+    const value = match?.[1] ?? link.searchParams.get(name)
+    if (!value) {
       throw new Error(`Confirmation form is missing the ${name} field`)
     }
-    body.set(name, match[1])
+    body.set(name, value)
+  }
+  const audience =
+    html.match(/name="audience" value="([^"]+)"/)?.[1] ?? link.searchParams.get("audience")
+  if (audience) {
+    body.set("audience", audience)
   }
   return app.fetch(
     new Request(new URL("/auth/callback", link).toString(), {

--- a/packages/server/tests/magic-link-auth-routes.test.ts
+++ b/packages/server/tests/magic-link-auth-routes.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { brotliCompressSync, gzipSync } from "node:zlib"
 import { magicLink, type SendMagicLinkInput } from "@sixb/auth-magic-link"
 import {
   type AuthSessionOptions,
@@ -13,7 +17,7 @@ import {
   prop,
   SixbHost,
 } from "@sixb/core"
-import { createSixbApi, SixbServer } from "../src/server"
+import { createSixbApi, SixbServer, type SixbServerOptions } from "../src/server"
 import { confirmCallback, createTestBrowserPolicy, linkFromLatestMessage } from "./helpers"
 
 const projectId = "test-project"
@@ -44,6 +48,7 @@ function createRuntime(
     readonly bootstrapGroups?: readonly [typeof securityAdmins]
     readonly rateLimit?: false | { readonly perMinute?: number; readonly perHour?: number }
     readonly session?: AuthSessionOptions
+    readonly authExperience?: SixbServerOptions["authExperience"]
   } = {}
 ) {
   const storage = new InMemoryStorage()
@@ -73,11 +78,49 @@ function createRuntime(
         host: sixb,
         quiet: true,
         browser: createTestBrowserPolicy(),
+        ...(options.authExperience ? { authExperience: options.authExperience } : {}),
       })
     ),
     messages,
     sixb,
     storage,
+  }
+}
+
+function customAuthBootstrap(html: string): {
+  readonly state: { readonly kind: string; readonly email?: string }
+  readonly signInUrl: string
+  readonly submission?: {
+    readonly kind: string
+    readonly action: string
+    readonly fields: Readonly<Record<string, string>>
+  }
+} {
+  const encoded = html.match(/data-sixb-auth="([^"]+)"/)?.[1]
+  if (!encoded) throw new Error("Expected a custom auth bootstrap")
+  return JSON.parse(Buffer.from(encoded, "base64url").toString("utf-8"))
+}
+
+async function createCustomAuthFixture(): Promise<{
+  readonly outdir: string
+  cleanup(): Promise<void>
+}> {
+  const outdir = await mkdtemp(join(tmpdir(), "sixb-custom-auth-"))
+  await mkdir(join(outdir, "assets"), { recursive: true })
+  await writeFile(
+    join(outdir, "index.html"),
+    '<!doctype html><html><body><div id="root" data-sixb-auth="__SIXB_AUTH_BOOTSTRAP__">Acme auth</div><script src="/auth/assets/auth-fixture.js"></script></body></html>'
+  )
+  const scriptPath = join(outdir, "assets", "auth-fixture.js")
+  const script = "export {}\n"
+  await writeFile(scriptPath, script)
+  await writeFile(`${scriptPath}.br`, brotliCompressSync(script))
+  await writeFile(`${scriptPath}.gz`, gzipSync(script))
+  return {
+    outdir,
+    async cleanup() {
+      await rm(outdir, { recursive: true, force: true })
+    },
   }
 }
 
@@ -148,6 +191,155 @@ async function founderUserId(storage: InMemoryStorage): Promise<string> {
 }
 
 describe("magic-link auth routes", () => {
+  test("renders a custom app auth experience while retaining the Atlas fallback", async () => {
+    const fixture = await createCustomAuthFixture()
+    try {
+      const { app } = createRuntime({ authExperience: { outdir: fixture.outdir } })
+
+      const custom = await app.fetch(
+        new Request(
+          "http://api.localhost/auth/sign-in?audience=app&returnTo=http%3A%2F%2Fapp.localhost%2Fnotes"
+        )
+      )
+      const customHtml = await custom.text()
+      const bootstrap = customAuthBootstrap(customHtml)
+
+      expect(custom.status).toBe(200)
+      expect(customHtml).toContain("Acme auth")
+      expect(custom.headers.get("referrer-policy")).toBe("same-origin")
+      expect(custom.headers.get("content-security-policy")).toContain(
+        "form-action 'self'; frame-ancestors 'none'"
+      )
+      expect(bootstrap).toMatchObject({
+        state: { kind: "signIn" },
+        submission: {
+          kind: "requestMagicLink",
+          action: "/auth/sign-in",
+          fields: { audience: "app", returnTo: "http://app.localhost/notes" },
+        },
+      })
+
+      const atlas = await app.fetch(
+        new Request(
+          "http://api.localhost/auth/sign-in?audience=atlas&returnTo=http%3A%2F%2Fatlas.localhost%2F"
+        )
+      )
+      expect(await atlas.text()).toContain('name="audience" value="atlas"')
+
+      const asset = await app.fetch(new Request("http://api.localhost/auth/assets/auth-fixture.js"))
+      expect(asset.status).toBe(200)
+      expect(asset.headers.get("cache-control")).toContain("immutable")
+
+      const head = await app.fetch(
+        new Request("http://api.localhost/auth/assets/auth-fixture.js", { method: "HEAD" })
+      )
+      expect(head.status).toBe(200)
+      expect(head.headers.get("content-type")).toBe(asset.headers.get("content-type"))
+      expect(await head.text()).toBe("")
+
+      const gzip = await app.fetch(
+        new Request("http://api.localhost/auth/assets/auth-fixture.js", {
+          headers: { "accept-encoding": "br;q=0, gzip;q=1" },
+        })
+      )
+      expect(gzip.headers.get("content-encoding")).toBe("gzip")
+
+      const identity = await app.fetch(
+        new Request("http://api.localhost/auth/assets/auth-fixture.js", {
+          headers: { "accept-encoding": "br;q=0, gzip;q=0" },
+        })
+      )
+      expect(identity.headers.get("content-encoding")).toBeNull()
+    } finally {
+      await fixture.cleanup()
+    }
+  })
+
+  test("custom app magic-link states preserve neutral delivery and scanner-safe confirmation", async () => {
+    const fixture = await createCustomAuthFixture()
+    try {
+      const { app, messages } = createRuntime({
+        authExperience: { outdir: fixture.outdir },
+        bootstrapUsers: ["founder@acme.com"],
+      })
+
+      const requested = await postSignIn(app, {
+        audience: "app",
+        email: "founder@acme.com",
+        returnTo: "http://app.localhost/notes",
+      })
+      expect(customAuthBootstrap(await requested.text()).state).toEqual({ kind: "checkEmail" })
+
+      const link = linkFromLatestMessage(messages)
+      expect(link.searchParams.get("audience")).toBe("app")
+      expect(link.searchParams.get("returnTo")).toBeNull()
+
+      const invalidLink = new URL(link)
+      invalidLink.searchParams.set("token", "invalid")
+      const invalid = await app.fetch(new Request(invalidLink, { redirect: "manual" }))
+      const invalidBootstrap = customAuthBootstrap(await invalid.text())
+      expect(invalid.status).toBe(400)
+      expect(invalidBootstrap.state).toEqual({ kind: "invalidLink" })
+      expect(invalidBootstrap.signInUrl).toBe(
+        "/auth/sign-in?audience=app&returnTo=http%3A%2F%2Fapp.localhost%2F"
+      )
+
+      for (let i = 0; i < 2; i++) {
+        const confirmation = await app.fetch(new Request(link.toString(), { redirect: "manual" }))
+        const bootstrap = customAuthBootstrap(await confirmation.text())
+        expect(confirmation.headers.get("content-security-policy")).toContain(
+          "form-action 'self' http://app.localhost"
+        )
+        expect(bootstrap.state).toEqual({ kind: "confirm", email: "founder@acme.com" })
+        expect(bootstrap.submission).toMatchObject({
+          kind: "confirmSignIn",
+          fields: {
+            audience: "app",
+            magicLinkId: link.searchParams.get("magicLinkId"),
+            token: link.searchParams.get("token"),
+          },
+        })
+        expect(bootstrap.signInUrl).toBe(
+          "/auth/sign-in?audience=app&returnTo=http%3A%2F%2Fapp.localhost%2F"
+        )
+      }
+
+      const completed = await confirmCallback(app, link)
+      expect(completed.status).toBe(303)
+      expect(completed.headers.get("location")).toBe("http://app.localhost/notes")
+      expect(completed.headers.get("set-cookie")).toContain("sixb_session_app=")
+    } finally {
+      await fixture.cleanup()
+    }
+  })
+
+  test("renders a safe custom error when callback validation is unavailable", async () => {
+    const fixture = await createCustomAuthFixture()
+    try {
+      const { app, messages, storage } = createRuntime({
+        authExperience: { outdir: fixture.outdir },
+        bootstrapUsers: ["founder@acme.com"],
+      })
+      await postSignIn(app, {
+        audience: "app",
+        email: "founder@acme.com",
+        returnTo: "http://app.localhost/notes",
+      })
+
+      storage.auth.magicLinks.getById = async () => {
+        throw new Error("Storage unavailable")
+      }
+      const response = await app.fetch(
+        new Request(linkFromLatestMessage(messages), { redirect: "manual" })
+      )
+
+      expect(response.status).toBe(500)
+      expect(customAuthBootstrap(await response.text()).state).toEqual({ kind: "error" })
+    } finally {
+      await fixture.cleanup()
+    }
+  })
+
   test("renders the magic-link sign-in form for the magic-link strategy", async () => {
     const { app } = createRuntime()
 

--- a/packages/server/tests/route-classifier.test.ts
+++ b/packages/server/tests/route-classifier.test.ts
@@ -20,6 +20,8 @@ const PUBLIC: ReadonlyArray<readonly [string, string, string]> = [
   ["POST", "/api/webhooks/github/events", "third-party callers sign their payloads"],
   ["GET", "/api/auth/session", "answers whether a session exists"],
   ["POST", "/api/auth/sign-out", "must work with an expired session"],
+  ["GET", "/auth/assets/auth-example.js", "custom auth experience asset"],
+  ["HEAD", "/auth/assets/auth-example.js", "custom auth experience asset metadata"],
   ["GET", "/auth/sign-in", "the page that creates a session"],
   ["POST", "/auth/sign-in", "the page that creates a session"],
   ["GET", "/auth/callback", "the emailed token IS the credential"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
       "@sixb/agent-worker": ["./packages/agent-worker/src/index.ts"],
       "@sixb/app": ["./packages/app/src/index.ts"],
       "@sixb/app/agents": ["./packages/app/src/agents.ts"],
+      "@sixb/app/auth": ["./packages/app/src/auth.ts"],
       "@sixb/atlas": ["./packages/atlas/src/index.ts"],
       "@sixb/auth-magic-link": ["./auth/magic-link/src/index.ts"],
       "@sixb/auth-oidc": ["./auth/oidc/src/index.ts"],


### PR DESCRIPTION
## Context

Custom apps using magic-link auth currently hand users off to the same generic Sixb sign-in page. That makes the first interaction feel disconnected from the organization-specific app.

This change separates auth **presentation** from auth **execution**:

```text
app/auth.tsx                         Sixb API + magic-link strategy
branding, copy, layout, states  ->  tokens, cookies, sessions, redirects
```

The custom app controls the experience; the framework keeps every security-sensitive decision.

## What changed

Custom apps can now opt into a branded auth experience with the `app/auth.tsx` convention:

```tsx
import type { AuthExperienceProps } from "@sixb/app/auth"

export default function AuthExperience({ state, actions }: AuthExperienceProps) {
  if (state.kind === "signIn") {
    return <SignIn onSubmit={actions.requestMagicLink} />
  }

  if (state.kind === "confirm") {
    return <button onClick={actions.confirmSignIn}>Continue</button>
  }

  return <button onClick={actions.restartSignIn}>Start again</button>
}
```

The public contract exposes five presentation states:

```text
signIn -> checkEmail -> confirm -> authenticated app
                       \-> invalidLink | error
```

- Builds `app/auth.tsx` as a separate pre-auth bundle, outside the authenticated app layout.
- Serves custom app auth pages and immutable, precompressed assets through the existing `/auth/*` routes.
- Keeps Atlas, API-only flows, and apps without `app/auth.tsx` on the generic fallback.
- Wires the bundle through both CLI development and production builds.
- Adds a branded Acme auth screen to `examples/auth`.
- Demonstrates the existing custom email hook with organization-specific subject, text, and HTML:

```ts
magicLink({
  subject: "Sign in to Acme Operations",
  sendMagicLink: sendMagicLinkEmail,
})
```

## Auth and security behavior

- The server remains authoritative for token validation and consumption, audience, allowed return targets, sessions, and cookies.
- The callback URL adds only a non-secret audience hint for selecting the presentation. The stored magic-link record remains authoritative, and `returnTo` is not included in the emailed URL.
- Link-scanner-safe GET behavior and the same-device fast path are preserved.
- Cross-device confirmation permits only the already-validated custom app origin in CSP `form-action`, allowing the successful POST redirect without broadening allowed destinations.
- Auth HTML is `no-store`; hashed assets are immutable; CSP, referrer policy, safe asset names, GET/HEAD handling, and `Accept-Encoding` quality values are covered.

## Reviewer map

- Public app contract and build: `packages/app`
- Runtime serving and auth states: `packages/server`
- Dev/production wiring: `packages/cli`
- Strategy callback hint: `auth/magic-link`
- Branded UI and email example: `examples/auth`

## Screenshots

<img width="1906" height="1321" alt="Screenshot 2026-08-26 at 3 12 33 PM" src="https://github.com/user-attachments/assets/df720ef5-08d8-431e-a17f-49a8e4a9a4fb" />

