### PR TITLE
storage: persist managed connector connections

### DIFF
--- a/docs/data/connectors.md
+++ b/docs/data/connectors.md
@@ -184,7 +184,8 @@ in the Sync definition. See [OAuth connector fan-out](./syncs.md#oauth-connector
 ## Protect OAuth credentials
 
 When at least one OAuth connector uses durable connector storage, Sixb encrypts its tokens at rest.
-Provide the canonical base64url encoding of 32 random bytes through `createSixb()`:
+`SqliteStorage` and `PostgresStorage` provide that durable storage automatically. Provide the
+canonical base64url encoding of 32 random bytes through `createSixb()`:
 
 ```ts
 const connectorEncryptionKey = process.env.SIXB_CONNECTOR_ENCRYPTION_KEY
@@ -194,12 +195,13 @@ if (!connectorEncryptionKey) {
 }
 
 export const sixb = createSixb({
-  // ...providers
-  connectorConnections: {
-    encryptionKey: connectorEncryptionKey,
-  },
+  storage: new PostgresStorage({ connectionString: process.env.DATABASE_URL }),
+  connectorConnections: { encryptionKey: connectorEncryptionKey },
 })
 ```
+
+The storage provider owns persistence; `connectorConnections` only configures credential
+protection. Static connectors still require neither.
 
 Generate the value once, then store it in the deployment's secret manager:
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -155,6 +155,12 @@
       "import": "./dist/connectors/connections/internal.js",
       "default": "./dist/connectors/connections/internal.js"
     },
+    "./internal/connector-connection-storage-provider": {
+      "types": "./dist/storage/connector-connections/provider.d.ts",
+      "bun": "./src/storage/connector-connections/provider.ts",
+      "import": "./dist/storage/connector-connections/provider.js",
+      "default": "./dist/storage/connector-connections/provider.js"
+    },
     "./internal/edits": {
       "types": "./dist/edits/index.d.ts",
       "bun": "./src/edits/index.ts",

--- a/packages/core/src/connectors/connections/runs.ts
+++ b/packages/core/src/connectors/connections/runs.ts
@@ -142,7 +142,6 @@ export class ConnectorConnectionRunService {
             owner: prepared.attempt.owner,
             slot: prepared.attempt.slot,
             initiatedByExecutionId: command.execution.id,
-            authorizationAttemptId: prepared.attempt.id,
             ttlMs: prepared.attempt.ttlMs,
           })
           const attempt = await connections.createAuthorizationAttempt({

--- a/packages/core/src/storage/connector-connections/in-memory.ts
+++ b/packages/core/src/storage/connector-connections/in-memory.ts
@@ -119,6 +119,25 @@ export class InMemoryConnectorConnectionStorage implements ConnectorConnectionSt
         "[Sixb] Connector authorization attempt already exists."
       )
     }
+    if (input.connectionRunId !== undefined) {
+      const run = this.connectionRuns.get(input.connectionRunId)
+      const existingAttempt = this.findAuthorizationAttemptByConnectionRunId(input.connectionRunId)
+      if (
+        !run ||
+        existingAttempt ||
+        run.projectId !== input.projectId ||
+        run.connectorId !== input.connectorId ||
+        run.status !== "waiting" ||
+        run.waitingFor !== "provider_authorization" ||
+        run.slot !== input.slot ||
+        run.initiatedByExecutionId !== input.initiatedByExecutionId
+      ) {
+        throw new ConnectorConnectionStorageError(
+          "attempt_conflict",
+          "[Sixb] Connector authorization attempt does not match its connection run."
+        )
+      }
+    }
     const now = this.now()
     const record: ConnectorAuthorizationAttemptRecord = {
       id: input.id,
@@ -194,7 +213,6 @@ export class InMemoryConnectorConnectionStorage implements ConnectorConnectionSt
       initiatedByExecutionId: input.initiatedByExecutionId,
       status: "waiting",
       waitingFor: "provider_authorization",
-      authorizationAttemptId: input.authorizationAttemptId,
       createdAt: now,
       updatedAt: now,
       expiresAt: new Date(now.getTime() + input.ttlMs),
@@ -266,7 +284,7 @@ export class InMemoryConnectorConnectionStorage implements ConnectorConnectionSt
       run.connectorId !== attempt.connectorId ||
       run.status !== "waiting" ||
       run.waitingFor !== "provider_authorization" ||
-      run.authorizationAttemptId !== attempt.id ||
+      run.slot !== attempt.slot ||
       run.initiatedByExecutionId !== attempt.initiatedByExecutionId
     ) {
       return null
@@ -1062,7 +1080,8 @@ export class InMemoryConnectorConnectionStorage implements ConnectorConnectionSt
     if (run.expiresAt.getTime() > now.getTime()) return run
 
     if (run.status === "waiting" && run.waitingFor === "provider_authorization") {
-      this.attempts.delete(run.authorizationAttemptId)
+      const attempt = this.findAuthorizationAttemptByConnectionRunId(run.id)
+      if (attempt) this.attempts.delete(attempt.id)
     }
     if (run.status === "waiting") {
       if (run.kind === "connect" && run.waitingFor === "account_selection") {
@@ -1093,6 +1112,15 @@ export class InMemoryConnectorConnectionStorage implements ConnectorConnectionSt
       ) {
         return connection
       }
+    }
+    return undefined
+  }
+
+  private findAuthorizationAttemptByConnectionRunId(
+    connectionRunId: string
+  ): ConnectorAuthorizationAttemptRecord | undefined {
+    for (const attempt of this.attempts.values()) {
+      if (attempt.connectionRunId === connectionRunId) return attempt
     }
     return undefined
   }

--- a/packages/core/src/storage/connector-connections/provider.ts
+++ b/packages/core/src/storage/connector-connections/provider.ts
@@ -1,0 +1,219 @@
+import { DurableConnectorAuthorizations } from "./provider/authorizations"
+import { DurableConnectorConnections } from "./provider/connections"
+import { DurableConnectorConnectionRuns } from "./provider/runs"
+import type { ConnectorConnectionPersistenceBackend } from "./provider/shared"
+import type { ConnectorConnectionStorage } from "./types"
+
+export type {
+  ConnectorConnectionPersistence,
+  ConnectorConnectionPersistenceBackend,
+  ConnectorConnectionPersistenceScope,
+} from "./provider/shared"
+
+/**
+ * Shared durable implementation of the Connector connection lifecycle.
+ *
+ * Concrete providers own SQL, transactions, database time and per-connector serialization. The
+ * focused services below own protocol runs, authorization mutations and stable connections so
+ * SQLite and PostgreSQL cannot drift semantically.
+ */
+export class DurableConnectorConnectionStorage implements ConnectorConnectionStorage {
+  readonly durability = "durable" as const
+  private readonly runs: DurableConnectorConnectionRuns
+  private readonly authorizations: DurableConnectorAuthorizations
+  private readonly connections: DurableConnectorConnections
+
+  constructor(backend: ConnectorConnectionPersistenceBackend) {
+    this.runs = new DurableConnectorConnectionRuns(backend)
+    this.authorizations = new DurableConnectorAuthorizations(backend)
+    this.connections = new DurableConnectorConnections(backend)
+  }
+
+  async createAuthorizationAttempt(
+    ...args: Parameters<ConnectorConnectionStorage["createAuthorizationAttempt"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["createAuthorizationAttempt"]>>> {
+    return this.runs.createAuthorizationAttempt(...args)
+  }
+
+  async consumeAuthorizationAttempt(
+    ...args: Parameters<ConnectorConnectionStorage["consumeAuthorizationAttempt"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["consumeAuthorizationAttempt"]>>> {
+    return this.runs.consumeAuthorizationAttempt(...args)
+  }
+
+  async createConnectionRun(
+    ...args: Parameters<ConnectorConnectionStorage["createConnectionRun"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["createConnectionRun"]>>> {
+    return this.runs.createConnectionRun(...args)
+  }
+
+  async createConnectionSelectionRun(
+    ...args: Parameters<ConnectorConnectionStorage["createConnectionSelectionRun"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["createConnectionSelectionRun"]>>> {
+    return this.runs.createConnectionSelectionRun(...args)
+  }
+
+  async claimConnectionRunCallback(
+    ...args: Parameters<ConnectorConnectionStorage["claimConnectionRunCallback"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["claimConnectionRunCallback"]>>> {
+    return this.runs.claimConnectionRunCallback(...args)
+  }
+
+  async attachConnectionRunAuthorization(
+    ...args: Parameters<ConnectorConnectionStorage["attachConnectionRunAuthorization"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["attachConnectionRunAuthorization"]>>> {
+    return this.runs.attachConnectionRunAuthorization(...args)
+  }
+
+  async waitForConnectionRunSelection(
+    ...args: Parameters<ConnectorConnectionStorage["waitForConnectionRunSelection"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["waitForConnectionRunSelection"]>>> {
+    return this.runs.waitForConnectionRunSelection(...args)
+  }
+
+  async finishConnectionRun(
+    ...args: Parameters<ConnectorConnectionStorage["finishConnectionRun"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["finishConnectionRun"]>>> {
+    return this.runs.finishConnectionRun(...args)
+  }
+
+  async getConnectionRun(
+    ...args: Parameters<ConnectorConnectionStorage["getConnectionRun"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["getConnectionRun"]>>> {
+    return this.runs.getConnectionRun(...args)
+  }
+
+  async createAuthorization(
+    ...args: Parameters<ConnectorConnectionStorage["createAuthorization"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["createAuthorization"]>>> {
+    return this.authorizations.createAuthorization(...args)
+  }
+
+  async initializeAuthorizationAccounts(
+    ...args: Parameters<ConnectorConnectionStorage["initializeAuthorizationAccounts"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["initializeAuthorizationAccounts"]>>> {
+    return this.authorizations.initializeAuthorizationAccounts(...args)
+  }
+
+  async getAuthorization(
+    ...args: Parameters<ConnectorConnectionStorage["getAuthorization"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["getAuthorization"]>>> {
+    return this.authorizations.getAuthorization(...args)
+  }
+
+  async getAuthorizationByConnectionId(
+    ...args: Parameters<ConnectorConnectionStorage["getAuthorizationByConnectionId"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["getAuthorizationByConnectionId"]>>> {
+    return this.authorizations.getAuthorizationByConnectionId(...args)
+  }
+
+  async claimCredentialMutation(
+    ...args: Parameters<ConnectorConnectionStorage["claimCredentialMutation"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["claimCredentialMutation"]>>> {
+    return this.authorizations.claimCredentialMutation(...args)
+  }
+
+  async markCredentialMutationExecuting(
+    ...args: Parameters<ConnectorConnectionStorage["markCredentialMutationExecuting"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["markCredentialMutationExecuting"]>>> {
+    return this.authorizations.markCredentialMutationExecuting(...args)
+  }
+
+  async renewCredentialMutation(
+    ...args: Parameters<ConnectorConnectionStorage["renewCredentialMutation"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["renewCredentialMutation"]>>> {
+    return this.authorizations.renewCredentialMutation(...args)
+  }
+
+  async stageCredentialMutationCredentials(
+    ...args: Parameters<ConnectorConnectionStorage["stageCredentialMutationCredentials"]>
+  ): Promise<
+    Awaited<ReturnType<ConnectorConnectionStorage["stageCredentialMutationCredentials"]>>
+  > {
+    return this.authorizations.stageCredentialMutationCredentials(...args)
+  }
+
+  async stageCredentialMutationRevocation(
+    ...args: Parameters<ConnectorConnectionStorage["stageCredentialMutationRevocation"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["stageCredentialMutationRevocation"]>>> {
+    return this.authorizations.stageCredentialMutationRevocation(...args)
+  }
+
+  async releaseCredentialMutation(
+    ...args: Parameters<ConnectorConnectionStorage["releaseCredentialMutation"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["releaseCredentialMutation"]>>> {
+    return this.authorizations.releaseCredentialMutation(...args)
+  }
+
+  async recoverExpiredCredentialMutation(
+    ...args: Parameters<ConnectorConnectionStorage["recoverExpiredCredentialMutation"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["recoverExpiredCredentialMutation"]>>> {
+    return this.authorizations.recoverExpiredCredentialMutation(...args)
+  }
+
+  async markNeedsReauthorization(
+    ...args: Parameters<ConnectorConnectionStorage["markNeedsReauthorization"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["markNeedsReauthorization"]>>> {
+    return this.authorizations.markNeedsReauthorization(...args)
+  }
+
+  async finalizeRefresh(
+    ...args: Parameters<ConnectorConnectionStorage["finalizeRefresh"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["finalizeRefresh"]>>> {
+    return this.authorizations.finalizeRefresh(...args)
+  }
+
+  async finalizeReauthorization(
+    ...args: Parameters<ConnectorConnectionStorage["finalizeReauthorization"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["finalizeReauthorization"]>>> {
+    return this.authorizations.finalizeReauthorization(...args)
+  }
+
+  async finalizeRevocation(
+    ...args: Parameters<ConnectorConnectionStorage["finalizeRevocation"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["finalizeRevocation"]>>> {
+    return this.authorizations.finalizeRevocation(...args)
+  }
+
+  async putConnection(
+    ...args: Parameters<ConnectorConnectionStorage["putConnection"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["putConnection"]>>> {
+    return this.connections.putConnection(...args)
+  }
+
+  async putConnectionFromRun(
+    ...args: Parameters<ConnectorConnectionStorage["putConnectionFromRun"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["putConnectionFromRun"]>>> {
+    return this.connections.putConnectionFromRun(...args)
+  }
+
+  async getConnection(
+    ...args: Parameters<ConnectorConnectionStorage["getConnection"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["getConnection"]>>> {
+    return this.connections.getConnection(...args)
+  }
+
+  async getConnectionById(
+    ...args: Parameters<ConnectorConnectionStorage["getConnectionById"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["getConnectionById"]>>> {
+    return this.connections.getConnectionById(...args)
+  }
+
+  async listConnections(
+    ...args: Parameters<ConnectorConnectionStorage["listConnections"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["listConnections"]>>> {
+    return this.connections.listConnections(...args)
+  }
+
+  async listConnectionsByAuthorization(
+    ...args: Parameters<ConnectorConnectionStorage["listConnectionsByAuthorization"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["listConnectionsByAuthorization"]>>> {
+    return this.connections.listConnectionsByAuthorization(...args)
+  }
+
+  async disconnectConnection(
+    ...args: Parameters<ConnectorConnectionStorage["disconnectConnection"]>
+  ): Promise<Awaited<ReturnType<ConnectorConnectionStorage["disconnectConnection"]>>> {
+    return this.connections.disconnectConnection(...args)
+  }
+}

--- a/packages/core/src/storage/connector-connections/provider/authorizations.ts
+++ b/packages/core/src/storage/connector-connections/provider/authorizations.ts
@@ -1,0 +1,446 @@
+import { ConnectorConnectionStorageError } from "../errors"
+import type {
+  ClaimConnectorCredentialMutationInput,
+  ClaimConnectorCredentialMutationResult,
+  ConnectorAuthorizationKey,
+  ConnectorAuthorizationRecord,
+  ConnectorConnectionKey,
+  ConnectorConnectionRecord,
+  ConnectorCredentialMutationFence,
+  CreateConnectorAuthorizationInput,
+  FinalizeConnectorReauthorizationInput,
+  InitializeConnectorAuthorizationAccountsInput,
+  MarkConnectorAuthorizationNeedsReauthorizationInput,
+  MarkConnectorCredentialMutationExecutingInput,
+  RecoverExpiredConnectorCredentialMutationInput,
+  ReleaseConnectorCredentialMutationInput,
+  RenewConnectorCredentialMutationInput,
+  StageConnectorCredentialMutationCredentialsInput,
+  StageConnectorCredentialMutationRevocationInput,
+} from "../types"
+import {
+  applyStagedCredentials,
+  assertPositiveDuration,
+  ConnectorConnectionOperations,
+  canClaimMutation,
+  disconnectConnectionRecord,
+  leaseExpiry,
+  matchesMutation,
+  mutationExpired,
+  sameIds,
+  stagedCredentials,
+} from "./shared"
+
+export class DurableConnectorAuthorizations extends ConnectorConnectionOperations {
+  createAuthorization(
+    input: CreateConnectorAuthorizationInput
+  ): Promise<ConnectorAuthorizationRecord> {
+    assertPositiveDuration(input.selectionTtlMs, "account selection TTL")
+    return this.write(input, async (persistence) => {
+      const now = await persistence.now()
+      const record: ConnectorAuthorizationRecord = {
+        id: input.id,
+        projectId: input.projectId,
+        connectorId: input.connectorId,
+        authorizedBy: structuredClone(input.authorizedBy),
+        credentials: structuredClone(input.credentials),
+        ...(input.credentialExpiresAt === undefined
+          ? {}
+          : { credentialExpiresAt: new Date(input.credentialExpiresAt) }),
+        scopes: [...input.scopes],
+        accounts: structuredClone(input.accounts),
+        status: "pending_selection",
+        selectionExpiresAt: new Date(now.getTime() + input.selectionTtlMs),
+        revision: 0,
+        createdAt: now,
+        updatedAt: now,
+      }
+      if (!(await persistence.insertAuthorization(record))) {
+        throw authorizationConflict("[Sixb] Connector authorization already exists.")
+      }
+      return structuredClone(record)
+    })
+  }
+
+  initializeAuthorizationAccounts(
+    input: InitializeConnectorAuthorizationAccountsInput
+  ): Promise<ConnectorAuthorizationRecord | null> {
+    return this.write(input, async (persistence) => {
+      const record = await persistence.getAuthorization(input.authorizationId)
+      if (
+        !record ||
+        record.revision !== input.expectedRevision ||
+        record.status !== "pending_selection" ||
+        record.credentialMutation
+      ) {
+        return null
+      }
+      const updated: ConnectorAuthorizationRecord = {
+        ...record,
+        accounts: structuredClone(input.accounts),
+        revision: record.revision + 1,
+        updatedAt: await persistence.now(),
+      }
+      await persistence.updateAuthorization(updated)
+      return structuredClone(updated)
+    })
+  }
+
+  getAuthorization(input: ConnectorAuthorizationKey): Promise<ConnectorAuthorizationRecord | null> {
+    return this.read(input, async (persistence) => {
+      const authorization = await persistence.getAuthorization(input.authorizationId)
+      return authorization ? structuredClone(authorization) : null
+    })
+  }
+
+  getAuthorizationByConnectionId(
+    input: ConnectorConnectionKey
+  ): Promise<ConnectorAuthorizationRecord | null> {
+    return this.read(input, async (persistence) => {
+      const connection = await persistence.getConnectionById(input.connectionId)
+      if (!connection) return null
+      const authorization = await persistence.getAuthorization(connection.authorizationId)
+      return authorization ? structuredClone(authorization) : null
+    })
+  }
+
+  claimCredentialMutation(
+    input: ClaimConnectorCredentialMutationInput
+  ): Promise<ClaimConnectorCredentialMutationResult | null> {
+    assertPositiveDuration(input.leaseDurationMs, "credential mutation lease duration")
+    assertPositiveDuration(input.operationTimeoutMs, "credential mutation timeout")
+    return this.write(input, async (persistence) => {
+      const now = await persistence.now()
+      const record = await persistence.getAuthorization(input.authorizationId)
+      if (
+        !record ||
+        record.revision !== input.expectedRevision ||
+        !canClaimMutation(record.status, input.mutation.kind)
+      ) {
+        return null
+      }
+
+      if (record.credentialMutation) {
+        const canReplacePrepared =
+          record.credentialMutation.phase === "prepared" &&
+          record.credentialMutation.expiresAt.getTime() <= now.getTime()
+        if (!canReplacePrepared) return null
+      }
+
+      const attached = await persistence.listConnectionsByAuthorization(record.id, {
+        connectedOnly: true,
+      })
+      if (
+        input.mutation.kind === "reauthorization" &&
+        !sameIds(
+          attached.map((connection) => connection.id),
+          input.expectedConnectionIds ?? []
+        )
+      ) {
+        return null
+      }
+
+      const deadlineAt = new Date(now.getTime() + input.operationTimeoutMs)
+      const mutation = {
+        ...structuredClone(input.mutation),
+        phase: "prepared" as const,
+        expiresAt: leaseExpiry(now, input.leaseDurationMs, deadlineAt),
+        deadlineAt,
+        ...(input.mutation.kind === "reauthorization"
+          ? { expectedConnectionIds: [...(input.expectedConnectionIds ?? [])] }
+          : {}),
+      }
+      const startsRevocation =
+        input.mutation.kind === "revocation" && record.status !== "revocation_pending"
+      const updated: ConnectorAuthorizationRecord = {
+        ...record,
+        status: input.mutation.kind === "revocation" ? "revocation_pending" : record.status,
+        selectionExpiresAt:
+          input.mutation.kind === "revocation" ? undefined : record.selectionExpiresAt,
+        revision: startsRevocation ? record.revision + 1 : record.revision,
+        credentialMutation: mutation,
+        updatedAt: now,
+      }
+      await persistence.updateAuthorization(updated)
+
+      const disconnected: ConnectorConnectionRecord[] = []
+      if (input.mutation.kind === "revocation") {
+        for (const connection of attached) {
+          const updatedConnection = disconnectConnectionRecord(connection, now)
+          await persistence.updateConnection(updatedConnection)
+          disconnected.push(structuredClone(updatedConnection))
+        }
+      }
+      return { authorization: structuredClone(updated), disconnected }
+    })
+  }
+
+  markCredentialMutationExecuting(
+    input: MarkConnectorCredentialMutationExecutingInput
+  ): Promise<ConnectorAuthorizationRecord | null> {
+    return this.write(input, async (persistence) => {
+      const now = await persistence.now()
+      const record = await persistence.getAuthorization(input.authorizationId)
+      if (
+        !matchesMutation(record, input, input.holderId) ||
+        record.credentialMutation.phase !== "prepared" ||
+        mutationExpired(record, now)
+      ) {
+        return null
+      }
+      const updated: ConnectorAuthorizationRecord = {
+        ...record,
+        credentialMutation: { ...record.credentialMutation, phase: "executing" },
+        updatedAt: now,
+      }
+      await persistence.updateAuthorization(updated)
+      return structuredClone(updated)
+    })
+  }
+
+  renewCredentialMutation(
+    input: RenewConnectorCredentialMutationInput
+  ): Promise<ConnectorAuthorizationRecord | null> {
+    assertPositiveDuration(input.leaseDurationMs, "credential mutation lease duration")
+    return this.write(input, async (persistence) => {
+      const now = await persistence.now()
+      const record = await persistence.getAuthorization(input.authorizationId)
+      if (
+        !matchesMutation(record, input, input.holderId) ||
+        record.credentialMutation.phase === "result_staged" ||
+        mutationExpired(record, now)
+      ) {
+        return null
+      }
+      const updated: ConnectorAuthorizationRecord = {
+        ...record,
+        credentialMutation: {
+          ...record.credentialMutation,
+          expiresAt: leaseExpiry(now, input.leaseDurationMs, record.credentialMutation.deadlineAt),
+        },
+      }
+      await persistence.updateAuthorization(updated)
+      return structuredClone(updated)
+    })
+  }
+
+  stageCredentialMutationCredentials(
+    input: StageConnectorCredentialMutationCredentialsInput
+  ): Promise<ConnectorAuthorizationRecord | null> {
+    return this.write(input, async (persistence) => {
+      const now = await persistence.now()
+      const record = await persistence.getAuthorization(input.authorizationId)
+      if (
+        !matchesMutation(record, input, input.holderId) ||
+        record.credentialMutation.phase !== "executing" ||
+        mutationExpired(record, now) ||
+        record.credentialMutation.kind === "revocation"
+      ) {
+        return null
+      }
+      const updated: ConnectorAuthorizationRecord = {
+        ...record,
+        credentialMutation: {
+          ...record.credentialMutation,
+          phase: "result_staged",
+          stagedCredentials: {
+            credentials: structuredClone(input.credentials),
+            ...(input.credentialExpiresAt === undefined
+              ? {}
+              : { credentialExpiresAt: new Date(input.credentialExpiresAt) }),
+            scopes: [...input.scopes],
+          },
+        },
+        updatedAt: now,
+      }
+      await persistence.updateAuthorization(updated)
+      return structuredClone(updated)
+    })
+  }
+
+  stageCredentialMutationRevocation(
+    input: StageConnectorCredentialMutationRevocationInput
+  ): Promise<ConnectorAuthorizationRecord | null> {
+    return this.write(input, async (persistence) => {
+      const now = await persistence.now()
+      const record = await persistence.getAuthorization(input.authorizationId)
+      if (
+        !matchesMutation(record, input, input.holderId) ||
+        record.credentialMutation.phase !== "executing" ||
+        record.credentialMutation.kind !== "revocation" ||
+        mutationExpired(record, now)
+      ) {
+        return null
+      }
+      const updated: ConnectorAuthorizationRecord = {
+        ...record,
+        credentialMutation: { ...record.credentialMutation, phase: "result_staged" },
+        updatedAt: now,
+      }
+      await persistence.updateAuthorization(updated)
+      return structuredClone(updated)
+    })
+  }
+
+  releaseCredentialMutation(input: ReleaseConnectorCredentialMutationInput): Promise<boolean> {
+    return this.write(input, async (persistence) => {
+      const record = await persistence.getAuthorization(input.authorizationId)
+      if (
+        !matchesMutation(record, input, input.holderId) ||
+        record.credentialMutation.phase === "result_staged"
+      ) {
+        return false
+      }
+      await persistence.updateAuthorization({
+        ...record,
+        credentialMutation: undefined,
+        updatedAt: await persistence.now(),
+      })
+      return true
+    })
+  }
+
+  recoverExpiredCredentialMutation(
+    input: RecoverExpiredConnectorCredentialMutationInput
+  ): Promise<ConnectorAuthorizationRecord | null> {
+    return this.write(input, async (persistence) => {
+      const record = await persistence.getAuthorization(input.authorizationId)
+      if (!record?.credentialMutation) return null
+      if (record.credentialMutation.phase === "result_staged") return structuredClone(record)
+
+      const now = await persistence.now()
+      if (!mutationExpired(record, now)) return null
+      const ambiguous = record.credentialMutation.phase === "executing"
+      const failClosed = ambiguous && record.credentialMutation.kind !== "revocation"
+      const updated: ConnectorAuthorizationRecord = {
+        ...record,
+        status: failClosed ? "needs_reauthorization" : record.status,
+        selectionExpiresAt: failClosed ? undefined : record.selectionExpiresAt,
+        revision: failClosed ? record.revision + 1 : record.revision,
+        credentialMutation: undefined,
+        updatedAt: now,
+      }
+      await persistence.updateAuthorization(updated)
+      return structuredClone(updated)
+    })
+  }
+
+  markNeedsReauthorization(
+    input: MarkConnectorAuthorizationNeedsReauthorizationInput
+  ): Promise<ConnectorAuthorizationRecord | null> {
+    return this.write(input, async (persistence) => {
+      const record = await persistence.getAuthorization(input.authorizationId)
+      if (!matchesMutation(record, input)) return null
+      const staged = record.credentialMutation.stagedCredentials
+      const updated: ConnectorAuthorizationRecord = {
+        ...record,
+        ...(staged
+          ? {
+              credentials: structuredClone(staged.credentials),
+              credentialExpiresAt:
+                staged.credentialExpiresAt === undefined
+                  ? undefined
+                  : new Date(staged.credentialExpiresAt),
+              scopes: [...staged.scopes],
+            }
+          : {}),
+        status: "needs_reauthorization",
+        selectionExpiresAt: undefined,
+        revision: record.revision + 1,
+        credentialMutation: undefined,
+        updatedAt: await persistence.now(),
+      }
+      await persistence.updateAuthorization(updated)
+      return structuredClone(updated)
+    })
+  }
+
+  finalizeRefresh(
+    input: ConnectorCredentialMutationFence
+  ): Promise<ConnectorAuthorizationRecord | null> {
+    return this.write(input, async (persistence) => {
+      const record = await persistence.getAuthorization(input.authorizationId)
+      const staged = stagedCredentials(record, input, "refresh")
+      if (!record || !staged) return null
+      const updated = applyStagedCredentials(record, staged, await persistence.now(), {
+        accounts: record.accounts,
+      })
+      await persistence.updateAuthorization(updated)
+      return structuredClone(updated)
+    })
+  }
+
+  finalizeReauthorization(
+    input: FinalizeConnectorReauthorizationInput
+  ): Promise<ConnectorAuthorizationRecord | null> {
+    return this.write(input, async (persistence) => {
+      const record = await persistence.getAuthorization(input.authorizationId)
+      const staged = stagedCredentials(record, input, "reauthorization")
+      if (!record || !staged || !record.credentialMutation) return null
+      const attached = await persistence.listConnectionsByAuthorization(record.id, {
+        connectedOnly: true,
+      })
+      if (
+        !sameIds(
+          attached.map((connection) => connection.id),
+          record.credentialMutation.expectedConnectionIds ?? []
+        )
+      ) {
+        throw authorizationConflict(
+          "[Sixb] Connections attached to the connector authorization changed during reauthorization."
+        )
+      }
+      const accountsById = new Map(input.accounts.map((account) => [account.id, account]))
+      if (attached.some((connection) => !accountsById.has(connection.account.id))) {
+        throw authorizationConflict(
+          "[Sixb] Reauthorized connector grant no longer exposes every attached account."
+        )
+      }
+
+      const now = await persistence.now()
+      const updated = applyStagedCredentials(record, staged, now, { accounts: input.accounts })
+      await persistence.updateAuthorization(updated)
+      for (const connection of attached) {
+        await persistence.updateConnection({
+          ...connection,
+          account: structuredClone(accountsById.get(connection.account.id)!),
+          updatedAt: now,
+        })
+      }
+      return structuredClone(updated)
+    })
+  }
+
+  finalizeRevocation(
+    input: ConnectorCredentialMutationFence
+  ): Promise<ConnectorAuthorizationRecord | null> {
+    return this.write(input, async (persistence) => {
+      const record = await persistence.getAuthorization(input.authorizationId)
+      if (
+        !matchesMutation(record, input) ||
+        record.credentialMutation.kind !== "revocation" ||
+        record.credentialMutation.phase !== "result_staged"
+      ) {
+        return null
+      }
+      const updated: ConnectorAuthorizationRecord = {
+        ...record,
+        status: "revoked",
+        credentials: undefined,
+        credentialExpiresAt: undefined,
+        scopes: [],
+        accounts: [],
+        selectionExpiresAt: undefined,
+        revision: record.revision + 1,
+        credentialMutation: undefined,
+        updatedAt: await persistence.now(),
+      }
+      await persistence.updateAuthorization(updated)
+      return structuredClone(updated)
+    })
+  }
+}
+
+function authorizationConflict(message: string) {
+  return new ConnectorConnectionStorageError("authorization_conflict", message)
+}

--- a/packages/core/src/storage/connector-connections/provider/connections.ts
+++ b/packages/core/src/storage/connector-connections/provider/connections.ts
@@ -1,0 +1,291 @@
+import { ConnectorConnectionStorageError } from "../errors"
+import type {
+  ConnectorConnectionKey,
+  ConnectorConnectionRecord,
+  ConnectorConnectionRunSucceededRecord,
+  DisconnectConnectorConnectionResult,
+  GetConnectorConnectionInput,
+  ListConnectorConnectionsInput,
+  PutConnectorConnectionFromRunInput,
+  PutConnectorConnectionFromRunResult,
+  PutConnectorConnectionInput,
+  PutConnectorConnectionResult,
+} from "../types"
+import {
+  assertConnectionCanMove,
+  authorizationConflict,
+  ConnectorConnectionOperations,
+  type ConnectorConnectionPersistence,
+  connectionRunBase,
+  currentConnectionRun,
+  disconnectConnectionRecord,
+  invalidRun,
+  isSelectable,
+  markAuthorizationRevocationPending,
+} from "./shared"
+
+export class DurableConnectorConnections extends ConnectorConnectionOperations {
+  async putConnection(input: PutConnectorConnectionInput): Promise<PutConnectorConnectionResult> {
+    const outcome = await this.write(input, async (persistence) =>
+      this.putConnectionNow(persistence, input, await persistence.now())
+    )
+    if ("error" in outcome) throw outcome.error
+    return outcome
+  }
+
+  async putConnectionFromRun(
+    input: PutConnectorConnectionFromRunInput
+  ): Promise<PutConnectorConnectionFromRunResult> {
+    const outcome = await this.write(input, async (persistence) => {
+      const run = await currentConnectionRun(persistence, input.runId)
+      if (!run || run.status !== "waiting" || run.waitingFor !== "account_selection") {
+        return { error: invalidRun() }
+      }
+      const now = await persistence.now()
+      const result = await this.putConnectionNow(
+        persistence,
+        {
+          id: input.id,
+          projectId: input.projectId,
+          connectorId: input.connectorId,
+          owner: run.owner,
+          slot: run.slot,
+          authorizationId: run.authorizationId,
+          account: input.account,
+          replace: input.replace,
+        },
+        now
+      )
+      if ("error" in result) return result
+      const succeeded: ConnectorConnectionRunSucceededRecord = {
+        ...connectionRunBase(run, now),
+        status: "succeeded",
+        authorizationId: run.authorizationId,
+        ...(result.revocationPendingAuthorizationId === undefined
+          ? {}
+          : { cleanupAuthorizationId: result.revocationPendingAuthorizationId }),
+        connections: [structuredClone(result.connection)],
+        finishedAt: now,
+      }
+      await persistence.updateConnectionRun(succeeded)
+      return { ...result, run: structuredClone(succeeded) }
+    })
+    if ("error" in outcome) throw outcome.error
+    return outcome
+  }
+
+  getConnection(input: GetConnectorConnectionInput): Promise<ConnectorConnectionRecord | null> {
+    return this.read(input, async (persistence) => {
+      const connection = await persistence.getConnectionBySelector(input)
+      return connection?.status === "connected" ? structuredClone(connection) : null
+    })
+  }
+
+  getConnectionById(input: ConnectorConnectionKey): Promise<ConnectorConnectionRecord | null> {
+    return this.read(input, async (persistence) => {
+      const connection = await persistence.getConnectionById(input.connectionId)
+      return connection ? structuredClone(connection) : null
+    })
+  }
+
+  listConnections(
+    input: ListConnectorConnectionsInput
+  ): Promise<readonly ConnectorConnectionRecord[]> {
+    return this.read(input, async (persistence) =>
+      structuredClone(await persistence.listConnections())
+    )
+  }
+
+  listConnectionsByAuthorization(input: {
+    readonly projectId: string
+    readonly connectorId: string
+    readonly authorizationId: string
+  }): Promise<readonly ConnectorConnectionRecord[]> {
+    return this.read(input, async (persistence) => {
+      if (!(await persistence.getAuthorization(input.authorizationId))) return []
+      return structuredClone(
+        await persistence.listConnectionsByAuthorization(input.authorizationId, {
+          connectedOnly: true,
+        })
+      )
+    })
+  }
+
+  disconnectConnection(
+    input: ConnectorConnectionKey
+  ): Promise<DisconnectConnectorConnectionResult | null> {
+    return this.write(input, async (persistence) => {
+      const connection = await persistence.getConnectionById(input.connectionId)
+      if (!connection) return null
+      const authorization = await persistence.getAuthorization(connection.authorizationId)
+      if (!authorization) {
+        throw new ConnectorConnectionStorageError(
+          "authorization_conflict",
+          "[Sixb] Connector connection references an unavailable authorization."
+        )
+      }
+      if (connection.status === "disconnected") {
+        return {
+          connection: structuredClone(connection),
+          authorization: structuredClone(authorization),
+          ...(authorization.status === "revocation_pending"
+            ? { revocationPendingAuthorizationId: authorization.id }
+            : {}),
+        }
+      }
+
+      const now = await persistence.now()
+      const remaining = (
+        await persistence.listConnectionsByAuthorization(authorization.id, {
+          connectedOnly: true,
+        })
+      ).filter((candidate) => candidate.id !== connection.id)
+      assertConnectionCanMove(authorization, remaining.length === 0)
+      const disconnected = disconnectConnectionRecord(connection, now)
+      await persistence.updateConnection(disconnected)
+      const updatedAuthorization =
+        remaining.length === 0
+          ? markAuthorizationRevocationPending(authorization, now)
+          : authorization
+      if (updatedAuthorization !== authorization) {
+        await persistence.updateAuthorization(updatedAuthorization)
+      }
+      return {
+        connection: structuredClone(disconnected),
+        authorization: structuredClone(updatedAuthorization),
+        ...(updatedAuthorization.status === "revocation_pending" && remaining.length === 0
+          ? { revocationPendingAuthorizationId: updatedAuthorization.id }
+          : {}),
+      }
+    })
+  }
+
+  private async putConnectionNow(
+    persistence: ConnectorConnectionPersistence,
+    input: PutConnectorConnectionInput,
+    now: Date
+  ): Promise<PutConnectorConnectionResult | CommittedConnectorConnectionError> {
+    let authorization = await persistence.getAuthorization(input.authorizationId)
+    if (
+      !authorization ||
+      !isSelectable(authorization.status) ||
+      authorization.credentialMutation?.kind === "reauthorization"
+    ) {
+      throw authorizationConflict()
+    }
+    if (
+      authorization.status === "pending_selection" &&
+      authorization.selectionExpiresAt!.getTime() <= now.getTime()
+    ) {
+      authorization = {
+        ...authorization,
+        status: "revocation_pending",
+        selectionExpiresAt: undefined,
+        revision: authorization.revision + 1,
+        updatedAt: now,
+      }
+      await persistence.updateAuthorization(authorization)
+      return { error: authorizationConflict() }
+    }
+    const account = authorization.accounts.find((candidate) => candidate.id === input.account.id)
+    if (!account) {
+      throw new ConnectorConnectionStorageError(
+        "authorization_conflict",
+        "[Sixb] Connector connection account is not exposed by its authorization."
+      )
+    }
+    const existing = await persistence.getConnectionBySelector(input)
+    const sameAccount = existing?.account.id === account.id
+    if (existing && !sameAccount && !input.replace) {
+      throw new ConnectorConnectionStorageError(
+        "connection_conflict",
+        `[Sixb] Connector slot '${input.slot}' is already connected to another account; explicit replacement is required.`
+      )
+    }
+    if (!existing && (await persistence.getConnectionById(input.id))) {
+      throw new ConnectorConnectionStorageError(
+        "connection_conflict",
+        "[Sixb] Connector connection id already exists."
+      )
+    }
+
+    let revocationPendingAuthorizationId: string | undefined
+    if (existing?.status === "connected" && existing.authorizationId !== authorization.id) {
+      const previous = await persistence.getAuthorization(existing.authorizationId)
+      if (!previous) {
+        throw new ConnectorConnectionStorageError(
+          "authorization_conflict",
+          "[Sixb] Existing connector connection references an unavailable authorization."
+        )
+      }
+      const remaining = (
+        await persistence.listConnectionsByAuthorization(previous.id, { connectedOnly: true })
+      ).filter((connection) => connection.id !== existing.id)
+      assertConnectionCanMove(previous, remaining.length === 0)
+      if (remaining.length === 0) {
+        await persistence.updateAuthorization(markAuthorizationRevocationPending(previous, now))
+        revocationPendingAuthorizationId = previous.id
+      }
+    } else if (existing?.status === "connected") {
+      const previous = await persistence.getAuthorization(existing.authorizationId)
+      if (previous) assertConnectionCanMove(previous, false)
+    }
+
+    const updatedAuthorization =
+      authorization.status === "pending_selection"
+        ? {
+            ...authorization,
+            status: "active" as const,
+            selectionExpiresAt: undefined,
+            revision: authorization.revision + 1,
+            updatedAt: now,
+          }
+        : authorization
+    const connection: ConnectorConnectionRecord = existing
+      ? {
+          ...existing,
+          authorizationId: input.authorizationId,
+          account: structuredClone(account),
+          status: "connected",
+          disconnectedAt: undefined,
+          updatedAt: now,
+        }
+      : {
+          id: input.id,
+          projectId: input.projectId,
+          connectorId: input.connectorId,
+          owner: structuredClone(input.owner),
+          slot: input.slot,
+          authorizationId: input.authorizationId,
+          account: structuredClone(account),
+          status: "connected",
+          createdAt: now,
+          updatedAt: now,
+        }
+
+    if (updatedAuthorization !== authorization) {
+      await persistence.updateAuthorization(updatedAuthorization)
+    }
+    if (existing) {
+      await persistence.updateConnection(connection)
+    } else if (!(await persistence.insertConnection(connection))) {
+      throw new ConnectorConnectionStorageError(
+        "connection_conflict",
+        "[Sixb] Connector connection id already exists."
+      )
+    }
+    return {
+      connection: structuredClone(connection),
+      authorization: structuredClone(updatedAuthorization),
+      ...(revocationPendingAuthorizationId === undefined
+        ? {}
+        : { revocationPendingAuthorizationId }),
+      created: existing === null,
+      replaced: existing !== null && !sameAccount,
+    }
+  }
+}
+
+interface CommittedConnectorConnectionError {
+  readonly error: ConnectorConnectionStorageError
+}

--- a/packages/core/src/storage/connector-connections/provider/runs.ts
+++ b/packages/core/src/storage/connector-connections/provider/runs.ts
@@ -1,0 +1,369 @@
+import { parseSixbFailure } from "../../../errors/internal"
+import { ConnectorConnectionStorageError } from "../errors"
+import type {
+  AttachConnectorConnectionRunAuthorizationInput,
+  ClaimConnectorConnectionRunCallbackInput,
+  ClaimConnectorConnectionRunCallbackResult,
+  ConnectorAuthorizationAttemptRecord,
+  ConnectorConnectionRunAwaitingProviderRecord,
+  ConnectorConnectionRunAwaitingSelectionRecord,
+  ConnectorConnectionRunProcessingRecord,
+  ConnectorConnectionRunRecord,
+  ConnectorConnectionStorage,
+  CreateConnectorAuthorizationAttemptInput,
+  CreateConnectorConnectionRunInput,
+  CreateConnectorConnectionSelectionRunInput,
+  FinishConnectorConnectionRunInput,
+  GetConnectorConnectionRunInput,
+  WaitForConnectorConnectionRunSelectionInput,
+} from "../types"
+import { CONNECTOR_CONNECTION_RUN_FAILURE_CODES } from "../types"
+import {
+  assertPositiveDuration,
+  authorizationConflict,
+  ConnectorConnectionOperations,
+  connectionRunBase,
+  currentConnectionRun,
+  invalidAttempt,
+  markPendingAuthorizationForCleanup,
+  safeEqual,
+} from "./shared"
+
+export class DurableConnectorConnectionRuns extends ConnectorConnectionOperations {
+  createAuthorizationAttempt(
+    input: CreateConnectorAuthorizationAttemptInput
+  ): Promise<ConnectorAuthorizationAttemptRecord> {
+    assertPositiveDuration(input.ttlMs, "authorization attempt TTL")
+    return this.write(input, async (persistence) => {
+      if (input.connectionRunId !== undefined) {
+        const run = await persistence.getConnectionRun(input.connectionRunId)
+        const existingAttempt = await persistence.getAuthorizationAttemptByConnectionRunId(
+          input.connectionRunId
+        )
+        if (
+          !run ||
+          existingAttempt ||
+          run.status !== "waiting" ||
+          run.waitingFor !== "provider_authorization" ||
+          run.slot !== input.slot ||
+          run.initiatedByExecutionId !== input.initiatedByExecutionId
+        ) {
+          throw new ConnectorConnectionStorageError(
+            "attempt_conflict",
+            "[Sixb] Connector authorization attempt does not match its connection run."
+          )
+        }
+      }
+      const now = await persistence.now()
+      const record: ConnectorAuthorizationAttemptRecord = {
+        id: input.id,
+        projectId: input.projectId,
+        connectorId: input.connectorId,
+        owner: structuredClone(input.owner),
+        slot: input.slot,
+        initiatedByExecutionId: input.initiatedByExecutionId,
+        stateHash: input.stateHash,
+        codeVerifier: structuredClone(input.codeVerifier),
+        redirectUri: input.redirectUri,
+        ...(input.connectionRunId === undefined ? {} : { connectionRunId: input.connectionRunId }),
+        ...(input.returnTo === undefined ? {} : { returnTo: input.returnTo }),
+        ...(input.callbackBindingHash === undefined
+          ? {}
+          : { callbackBindingHash: input.callbackBindingHash }),
+        ...(input.reauthorizationId === undefined
+          ? {}
+          : { reauthorizationId: input.reauthorizationId }),
+        ...(input.reauthorizationRevision === undefined
+          ? {}
+          : { reauthorizationRevision: input.reauthorizationRevision }),
+        ...(input.reauthorizationConnectionIds === undefined
+          ? {}
+          : { reauthorizationConnectionIds: [...input.reauthorizationConnectionIds] }),
+        createdAt: now,
+        expiresAt: new Date(now.getTime() + input.ttlMs),
+      }
+      if (!(await persistence.insertAuthorizationAttempt(record))) {
+        throw new ConnectorConnectionStorageError(
+          "attempt_conflict",
+          "[Sixb] Connector authorization attempt already exists."
+        )
+      }
+      return structuredClone(record)
+    })
+  }
+
+  async consumeAuthorizationAttempt(
+    input: Parameters<ConnectorConnectionStorage["consumeAuthorizationAttempt"]>[0]
+  ): Promise<ConnectorAuthorizationAttemptRecord> {
+    const record = await this.write(input, async (persistence) => {
+      const record = await persistence.getAuthorizationAttempt(input.id)
+      const now = await persistence.now()
+      if (record && record.expiresAt.getTime() <= now.getTime()) {
+        await persistence.deleteAuthorizationAttempt(record.id)
+        return null
+      }
+      if (
+        !record ||
+        record.redirectUri !== input.redirectUri ||
+        !safeEqual(record.stateHash, input.stateHash)
+      ) {
+        return null
+      }
+
+      await persistence.deleteAuthorizationAttempt(input.id)
+      return structuredClone(record)
+    })
+    if (!record) throw invalidAttempt()
+    return record
+  }
+
+  createConnectionRun(
+    input: CreateConnectorConnectionRunInput
+  ): Promise<ConnectorConnectionRunRecord> {
+    assertPositiveDuration(input.ttlMs, "connection run TTL")
+    return this.write(input, async (persistence) => {
+      const now = await persistence.now()
+      const record: ConnectorConnectionRunAwaitingProviderRecord = {
+        id: input.id,
+        projectId: input.projectId,
+        connectorId: input.connectorId,
+        kind: input.kind,
+        owner: structuredClone(input.owner),
+        slot: input.slot,
+        initiatedByExecutionId: input.initiatedByExecutionId,
+        status: "waiting",
+        waitingFor: "provider_authorization",
+        createdAt: now,
+        updatedAt: now,
+        expiresAt: new Date(now.getTime() + input.ttlMs),
+      }
+      if (!(await persistence.insertConnectionRun(record))) {
+        throw new ConnectorConnectionStorageError(
+          "run_conflict",
+          "[Sixb] Connector connection run already exists."
+        )
+      }
+      return structuredClone(record)
+    })
+  }
+
+  createConnectionSelectionRun(
+    input: CreateConnectorConnectionSelectionRunInput
+  ): Promise<ConnectorConnectionRunAwaitingSelectionRecord> {
+    assertPositiveDuration(input.ttlMs, "connection run TTL")
+    return this.write(input, async (persistence) => {
+      const authorization = await persistence.getAuthorization(input.authorizationId)
+      if (!authorization || authorization.status !== "active" || authorization.credentialMutation) {
+        throw authorizationConflict()
+      }
+      const now = await persistence.now()
+      const record: ConnectorConnectionRunAwaitingSelectionRecord = {
+        id: input.id,
+        projectId: input.projectId,
+        connectorId: input.connectorId,
+        kind: "connect",
+        owner: structuredClone(input.owner),
+        slot: input.slot,
+        initiatedByExecutionId: input.initiatedByExecutionId,
+        status: "waiting",
+        waitingFor: "account_selection",
+        authorizationId: input.authorizationId,
+        createdAt: now,
+        updatedAt: now,
+        expiresAt: new Date(now.getTime() + input.ttlMs),
+      }
+      if (!(await persistence.insertConnectionRun(record))) {
+        throw new ConnectorConnectionStorageError(
+          "run_conflict",
+          "[Sixb] Connector connection run already exists."
+        )
+      }
+      return structuredClone(record)
+    })
+  }
+
+  async claimConnectionRunCallback(
+    input: ClaimConnectorConnectionRunCallbackInput
+  ): Promise<ClaimConnectorConnectionRunCallbackResult | null> {
+    assertPositiveDuration(input.processingTtlMs, "connection run processing TTL")
+    // Resolve the opaque attempt before entering the connector-scoped critical section. The
+    // transaction re-reads every proof, but now all writers acquire the connector lock before row
+    // locks instead of letting callback and expiry paths lock attempt/run rows in opposite orders.
+    const candidate = await this.read({ projectId: input.projectId }, (persistence) =>
+      persistence.getAuthorizationAttempt(input.attemptId)
+    )
+    if (!candidate) return null
+
+    return this.write(
+      { projectId: input.projectId, connectorId: candidate.connectorId },
+      async (persistence) => {
+        const attempt = await persistence.getAuthorizationAttempt(input.attemptId)
+        if (
+          !attempt ||
+          attempt.connectionRunId === undefined ||
+          attempt.returnTo === undefined ||
+          attempt.callbackBindingHash === undefined ||
+          attempt.redirectUri !== input.redirectUri ||
+          !safeEqual(attempt.stateHash, input.stateHash) ||
+          !safeEqual(attempt.callbackBindingHash, input.callbackBindingHash)
+        ) {
+          return null
+        }
+
+        const run = await persistence.getConnectionRun(attempt.connectionRunId)
+        if (
+          !run ||
+          run.status !== "waiting" ||
+          run.waitingFor !== "provider_authorization" ||
+          run.slot !== attempt.slot ||
+          run.initiatedByExecutionId !== attempt.initiatedByExecutionId
+        ) {
+          return null
+        }
+
+        const now = await persistence.now()
+        await persistence.deleteAuthorizationAttempt(attempt.id)
+        if (
+          attempt.expiresAt.getTime() <= now.getTime() ||
+          run.expiresAt.getTime() <= now.getTime()
+        ) {
+          const expired: Extract<ConnectorConnectionRunRecord, { status: "expired" }> = {
+            ...connectionRunBase(run, now),
+            status: "expired",
+            finishedAt: now,
+          }
+          await persistence.updateConnectionRun(expired)
+          return { type: "expired", run: structuredClone(expired), returnTo: attempt.returnTo }
+        }
+
+        const processing: ConnectorConnectionRunProcessingRecord = {
+          ...connectionRunBase(run, now),
+          status: "running",
+          processingId: input.processingId,
+          callbackStartedAt: now,
+          expiresAt: new Date(now.getTime() + input.processingTtlMs),
+          ...(attempt.reauthorizationId === undefined
+            ? {}
+            : { authorizationId: attempt.reauthorizationId }),
+        }
+        await persistence.updateConnectionRun(processing)
+        return {
+          type: "claimed",
+          run: structuredClone(processing),
+          attempt: structuredClone(attempt),
+          returnTo: attempt.returnTo,
+        }
+      }
+    )
+  }
+
+  attachConnectionRunAuthorization(
+    input: AttachConnectorConnectionRunAuthorizationInput
+  ): Promise<ConnectorConnectionRunProcessingRecord | null> {
+    return this.write(input, async (persistence) => {
+      const run = await currentConnectionRun(persistence, input.runId)
+      const authorization = await persistence.getAuthorization(input.authorizationId)
+      if (
+        !run ||
+        run.status !== "running" ||
+        run.processingId !== input.processingId ||
+        (run.authorizationId !== undefined && run.authorizationId !== input.authorizationId) ||
+        !authorization ||
+        authorization.status !== "pending_selection"
+      ) {
+        return null
+      }
+      const updated: ConnectorConnectionRunProcessingRecord = {
+        ...run,
+        authorizationId: input.authorizationId,
+        updatedAt: await persistence.now(),
+      }
+      await persistence.updateConnectionRun(updated)
+      return structuredClone(updated)
+    })
+  }
+
+  waitForConnectionRunSelection(
+    input: WaitForConnectorConnectionRunSelectionInput
+  ): Promise<ConnectorConnectionRunAwaitingSelectionRecord | null> {
+    return this.write(input, async (persistence) => {
+      const run = await currentConnectionRun(persistence, input.runId)
+      if (
+        !run ||
+        run.status !== "running" ||
+        run.kind !== "connect" ||
+        run.processingId !== input.processingId ||
+        run.authorizationId !== input.authorizationId
+      ) {
+        return null
+      }
+      const now = await persistence.now()
+      const waiting: ConnectorConnectionRunAwaitingSelectionRecord = {
+        ...connectionRunBase(run, now),
+        status: "waiting",
+        waitingFor: "account_selection",
+        authorizationId: input.authorizationId,
+        expiresAt: new Date(input.expiresAt),
+      }
+      await persistence.updateConnectionRun(waiting)
+      return structuredClone(waiting)
+    })
+  }
+
+  finishConnectionRun(
+    input: FinishConnectorConnectionRunInput
+  ): Promise<ConnectorConnectionRunRecord | null> {
+    return this.write(input, async (persistence) => {
+      const run = await currentConnectionRun(persistence, input.runId)
+      if (!run || run.status !== "running" || input.processingId !== run.processingId) return null
+      const now = await persistence.now()
+      const authorizationId =
+        input.status === "succeeded"
+          ? input.authorizationId
+          : input.status === "failed"
+            ? (input.authorizationId ?? run.authorizationId)
+            : run.authorizationId
+      if (input.status !== "succeeded" && run.kind === "connect" && authorizationId) {
+        await markPendingAuthorizationForCleanup(persistence, authorizationId, now)
+      }
+      const base = connectionRunBase(run, now)
+      const finished: ConnectorConnectionRunRecord =
+        input.status === "succeeded"
+          ? {
+              ...base,
+              status: "succeeded",
+              authorizationId: input.authorizationId,
+              ...(input.cleanupAuthorizationId === undefined
+                ? {}
+                : { cleanupAuthorizationId: input.cleanupAuthorizationId }),
+              connections: structuredClone(input.connections),
+              finishedAt: now,
+            }
+          : input.status === "failed"
+            ? {
+                ...base,
+                status: "failed",
+                ...(authorizationId === undefined ? {} : { authorizationId }),
+                error: parseSixbFailure(input.error, CONNECTOR_CONNECTION_RUN_FAILURE_CODES),
+                finishedAt: now,
+              }
+            : {
+                ...base,
+                status: "cancelled",
+                ...(authorizationId === undefined ? {} : { authorizationId }),
+                finishedAt: now,
+              }
+      await persistence.updateConnectionRun(finished)
+      return structuredClone(finished)
+    })
+  }
+
+  getConnectionRun(
+    input: GetConnectorConnectionRunInput
+  ): Promise<ConnectorConnectionRunRecord | null> {
+    return this.write(input, async (persistence) => {
+      const run = await currentConnectionRun(persistence, input.runId)
+      return run ? structuredClone(run) : null
+    })
+  }
+}

--- a/packages/core/src/storage/connector-connections/provider/shared.ts
+++ b/packages/core/src/storage/connector-connections/provider/shared.ts
@@ -1,0 +1,342 @@
+import { timingSafeEqual } from "node:crypto"
+import { createSixbError, toSixbFailure } from "../../../errors/internal"
+import { ConnectorConnectionStorageError } from "../errors"
+import type {
+  ClaimConnectorCredentialMutationInput,
+  ConnectorAuthorizationAttemptRecord,
+  ConnectorAuthorizationRecord,
+  ConnectorConnectionRecord,
+  ConnectorConnectionRunProcessingRecord,
+  ConnectorConnectionRunRecord,
+  ConnectorCredentialMutationFence,
+  GetConnectorConnectionInput,
+} from "../types"
+import { CONNECTOR_CONNECTION_RUN_FAILURE_CODES } from "../types"
+
+export interface ConnectorConnectionPersistenceScope {
+  readonly projectId: string
+  /** Omitted only while resolving a callback whose public proof intentionally carries no id. */
+  readonly connectorId?: string
+}
+
+/** Database-specific record access used by the shared connector lifecycle state machine. */
+export interface ConnectorConnectionPersistence {
+  now(): Promise<Date>
+
+  insertAuthorizationAttempt(record: ConnectorAuthorizationAttemptRecord): Promise<boolean>
+  getAuthorizationAttempt(id: string): Promise<ConnectorAuthorizationAttemptRecord | null>
+  getAuthorizationAttemptByConnectionRunId(
+    connectionRunId: string
+  ): Promise<ConnectorAuthorizationAttemptRecord | null>
+  deleteAuthorizationAttempt(id: string): Promise<boolean>
+
+  insertConnectionRun(record: ConnectorConnectionRunRecord): Promise<boolean>
+  getConnectionRun(id: string): Promise<ConnectorConnectionRunRecord | null>
+  updateConnectionRun(record: ConnectorConnectionRunRecord): Promise<void>
+
+  insertAuthorization(record: ConnectorAuthorizationRecord): Promise<boolean>
+  getAuthorization(id: string): Promise<ConnectorAuthorizationRecord | null>
+  updateAuthorization(record: ConnectorAuthorizationRecord): Promise<void>
+
+  insertConnection(record: ConnectorConnectionRecord): Promise<boolean>
+  getConnectionById(id: string): Promise<ConnectorConnectionRecord | null>
+  getConnectionBySelector(
+    input: Pick<GetConnectorConnectionInput, "owner" | "slot">
+  ): Promise<ConnectorConnectionRecord | null>
+  listConnections(): Promise<readonly ConnectorConnectionRecord[]>
+  listConnectionsByAuthorization(
+    authorizationId: string,
+    options?: { readonly connectedOnly?: boolean }
+  ): Promise<readonly ConnectorConnectionRecord[]>
+  updateConnection(record: ConnectorConnectionRecord): Promise<void>
+}
+
+/** Transaction and lock boundary supplied by a concrete durable storage provider. */
+export interface ConnectorConnectionPersistenceBackend {
+  read<T>(
+    scope: ConnectorConnectionPersistenceScope,
+    run: (persistence: ConnectorConnectionPersistence) => Promise<T>
+  ): Promise<T>
+  transaction<T>(
+    scope: ConnectorConnectionPersistenceScope,
+    run: (persistence: ConnectorConnectionPersistence) => Promise<T>
+  ): Promise<T>
+}
+
+export abstract class ConnectorConnectionOperations {
+  constructor(private readonly backend: ConnectorConnectionPersistenceBackend) {}
+
+  protected read<T>(
+    scope: ConnectorConnectionPersistenceScope,
+    run: (persistence: ConnectorConnectionPersistence) => Promise<T>
+  ): Promise<T> {
+    return this.backend.read(scope, run)
+  }
+
+  protected write<T>(
+    scope: ConnectorConnectionPersistenceScope,
+    run: (persistence: ConnectorConnectionPersistence) => Promise<T>
+  ): Promise<T> {
+    return this.backend.transaction(scope, run)
+  }
+}
+
+export async function currentConnectionRun(
+  persistence: ConnectorConnectionPersistence,
+  runId: string
+): Promise<ConnectorConnectionRunRecord | null> {
+  const run = await persistence.getConnectionRun(runId)
+  if (!run || (run.status !== "waiting" && run.status !== "running")) return run
+
+  const now = await persistence.now()
+  if (run.expiresAt.getTime() > now.getTime()) return run
+
+  if (run.status === "waiting" && run.waitingFor === "provider_authorization") {
+    const attempt = await persistence.getAuthorizationAttemptByConnectionRunId(run.id)
+    if (attempt) await persistence.deleteAuthorizationAttempt(attempt.id)
+  }
+  if (run.status === "waiting") {
+    if (run.kind === "connect" && run.waitingFor === "account_selection") {
+      await markPendingAuthorizationForCleanup(persistence, run.authorizationId, now)
+    }
+    const expired = expireConnectionRun(run, now)
+    await persistence.updateConnectionRun(expired)
+    return expired
+  }
+
+  if (run.kind === "connect" && run.authorizationId) {
+    await markPendingAuthorizationForCleanup(persistence, run.authorizationId, now)
+  }
+  const failed = failExpiredProcessingRun(run, now)
+  await persistence.updateConnectionRun(failed)
+  return failed
+}
+
+export async function markPendingAuthorizationForCleanup(
+  persistence: ConnectorConnectionPersistence,
+  authorizationId: string,
+  now: Date
+): Promise<void> {
+  const authorization = await persistence.getAuthorization(authorizationId)
+  if (!authorization || authorization.status !== "pending_selection") return
+  await persistence.updateAuthorization(markAuthorizationRevocationPending(authorization, now))
+}
+
+export function connectionRunBase(record: ConnectorConnectionRunRecord, updatedAt: Date) {
+  return {
+    id: record.id,
+    projectId: record.projectId,
+    connectorId: record.connectorId,
+    kind: record.kind,
+    owner: structuredClone(record.owner),
+    slot: record.slot,
+    initiatedByExecutionId: record.initiatedByExecutionId,
+    createdAt: new Date(record.createdAt),
+    updatedAt: new Date(updatedAt),
+  }
+}
+
+function expireConnectionRun(
+  record: Extract<ConnectorConnectionRunRecord, { readonly status: "waiting" }>,
+  now: Date
+) {
+  return {
+    ...connectionRunBase(record, now),
+    status: "expired" as const,
+    ...(record.waitingFor === "account_selection"
+      ? { authorizationId: record.authorizationId }
+      : {}),
+    finishedAt: new Date(now),
+  }
+}
+
+function failExpiredProcessingRun(record: ConnectorConnectionRunProcessingRecord, now: Date) {
+  return {
+    ...connectionRunBase(record, now),
+    status: "failed" as const,
+    ...(record.authorizationId === undefined ? {} : { authorizationId: record.authorizationId }),
+    error: toSixbFailure(
+      createSixbError(
+        "internal.unexpected",
+        "[Sixb] Connector callback processing did not complete before its deadline."
+      ),
+      { allowedCodes: CONNECTOR_CONNECTION_RUN_FAILURE_CODES, at: now }
+    ),
+    finishedAt: new Date(now),
+  }
+}
+
+export function disconnectConnectionRecord(
+  connection: ConnectorConnectionRecord,
+  now: Date
+): ConnectorConnectionRecord {
+  return {
+    ...connection,
+    status: "disconnected",
+    disconnectedAt: new Date(now),
+    updatedAt: new Date(now),
+  }
+}
+
+export function markAuthorizationRevocationPending(
+  authorization: ConnectorAuthorizationRecord,
+  now: Date
+): ConnectorAuthorizationRecord {
+  if (authorization.status === "revocation_pending" || authorization.status === "revoked") {
+    return authorization
+  }
+  if (authorization.credentialMutation) {
+    throw new ConnectorConnectionStorageError(
+      "authorization_conflict",
+      "[Sixb] Connector authorization cannot begin revocation while credentials are being mutated."
+    )
+  }
+  return {
+    ...authorization,
+    status: "revocation_pending",
+    selectionExpiresAt: undefined,
+    revision: authorization.revision + 1,
+    updatedAt: new Date(now),
+  }
+}
+
+export function assertConnectionCanMove(
+  authorization: ConnectorAuthorizationRecord,
+  removingLastConnection = true
+): void {
+  const mutation = authorization.credentialMutation
+  if (mutation?.kind === "reauthorization") {
+    throw new ConnectorConnectionStorageError(
+      "authorization_conflict",
+      "[Sixb] Connections cannot change while their connector authorization is being reauthorized."
+    )
+  }
+  if (removingLastConnection && mutation) {
+    throw new ConnectorConnectionStorageError(
+      "authorization_conflict",
+      "[Sixb] The last connector connection cannot be removed while credentials are being mutated."
+    )
+  }
+}
+
+export function safeEqual(left: string, right: string): boolean {
+  const leftBytes = Buffer.from(left)
+  const rightBytes = Buffer.from(right)
+  return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes)
+}
+
+export function invalidRun(): ConnectorConnectionStorageError {
+  return new ConnectorConnectionStorageError(
+    "run_invalid",
+    "[Sixb] Connector connection run is invalid, expired, or already used."
+  )
+}
+
+export function sameIds(left: readonly string[], right: readonly string[]): boolean {
+  const leftSorted = [...left].sort()
+  const rightSorted = [...right].sort()
+  return (
+    leftSorted.length === rightSorted.length &&
+    leftSorted.every((value, index) => value === rightSorted[index])
+  )
+}
+
+export function invalidAttempt(): ConnectorConnectionStorageError {
+  return new ConnectorConnectionStorageError(
+    "attempt_invalid",
+    "[Sixb] Connector authorization attempt is invalid, expired, or already used."
+  )
+}
+
+export function authorizationConflict(): ConnectorConnectionStorageError {
+  return new ConnectorConnectionStorageError(
+    "authorization_conflict",
+    "[Sixb] Connector connection requires a selectable authorization from the same project and connector."
+  )
+}
+
+export function assertPositiveDuration(value: number, name: string): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new ConnectorConnectionStorageError(
+      "invalid_input",
+      `[Sixb] Connector ${name} must be positive.`
+    )
+  }
+}
+
+export function canClaimMutation(
+  status: ConnectorAuthorizationRecord["status"],
+  kind: ClaimConnectorCredentialMutationInput["mutation"]["kind"]
+): boolean {
+  if (kind === "refresh") return status === "active"
+  if (kind === "reauthorization") {
+    return status === "active" || status === "needs_reauthorization"
+  }
+  return status !== "revoked"
+}
+
+export function isSelectable(status: ConnectorAuthorizationRecord["status"]): boolean {
+  return status === "pending_selection" || status === "active"
+}
+
+export function leaseExpiry(now: Date, durationMs: number, deadlineAt: Date): Date {
+  return new Date(Math.min(now.getTime() + durationMs, deadlineAt.getTime()))
+}
+
+export function mutationExpired(record: ConnectorAuthorizationRecord, now: Date): boolean {
+  return (
+    record.credentialMutation!.expiresAt.getTime() <= now.getTime() ||
+    record.credentialMutation!.deadlineAt.getTime() <= now.getTime()
+  )
+}
+
+export function matchesMutation(
+  record: ConnectorAuthorizationRecord | null,
+  input: ConnectorCredentialMutationFence,
+  holderId?: string
+): record is ConnectorAuthorizationRecord & {
+  readonly credentialMutation: NonNullable<ConnectorAuthorizationRecord["credentialMutation"]>
+} {
+  return (
+    record !== null &&
+    record.revision === input.expectedRevision &&
+    record.credentialMutation?.id === input.mutationId &&
+    (holderId === undefined || record.credentialMutation.holderId === holderId)
+  )
+}
+
+export function stagedCredentials(
+  record: ConnectorAuthorizationRecord | null,
+  input: ConnectorCredentialMutationFence,
+  kind: "refresh" | "reauthorization"
+) {
+  if (
+    !matchesMutation(record, input) ||
+    record.credentialMutation.kind !== kind ||
+    record.credentialMutation.phase !== "result_staged"
+  ) {
+    return null
+  }
+  return record.credentialMutation.stagedCredentials ?? null
+}
+
+export function applyStagedCredentials(
+  record: ConnectorAuthorizationRecord,
+  staged: NonNullable<ReturnType<typeof stagedCredentials>>,
+  now: Date,
+  input: { readonly accounts: readonly ConnectorAuthorizationRecord["accounts"][number][] }
+): ConnectorAuthorizationRecord {
+  return {
+    ...record,
+    credentials: structuredClone(staged.credentials),
+    credentialExpiresAt:
+      staged.credentialExpiresAt === undefined ? undefined : new Date(staged.credentialExpiresAt),
+    scopes: [...staged.scopes],
+    accounts: structuredClone(input.accounts),
+    status: "active",
+    selectionExpiresAt: undefined,
+    revision: record.revision + 1,
+    credentialMutation: undefined,
+    updatedAt: now,
+  }
+}

--- a/packages/core/src/storage/connector-connections/types.ts
+++ b/packages/core/src/storage/connector-connections/types.ts
@@ -41,7 +41,6 @@ interface ConnectorConnectionRunBase extends ConnectorConnectionSelector {
 export interface ConnectorConnectionRunAwaitingProviderRecord extends ConnectorConnectionRunBase {
   readonly status: "waiting"
   readonly waitingFor: "provider_authorization"
-  readonly authorizationAttemptId: string
   readonly expiresAt: Date
 }
 
@@ -106,7 +105,6 @@ export interface CreateConnectorConnectionRunInput extends ConnectorConnectionSe
   readonly connectorId: string
   readonly kind: ConnectorConnectionRunKind
   readonly initiatedByExecutionId: string
-  readonly authorizationAttemptId: string
   readonly ttlMs: number
 }
 

--- a/packages/core/src/testing/connector-connection-storage-contract.ts
+++ b/packages/core/src/testing/connector-connection-storage-contract.ts
@@ -84,6 +84,9 @@ export function runConnectorConnectionStorageContractSuite<
         await expect(
           storage.consumeAuthorizationAttempt(authorizationAttemptConsumption())
         ).rejects.toThrow("invalid, expired, or already used")
+        await expect(
+          storage.createAuthorizationAttempt(authorizationAttempt())
+        ).resolves.toMatchObject({ id: "attempt-a" })
       })
     })
 
@@ -98,6 +101,9 @@ export function runConnectorConnectionStorageContractSuite<
         await expect(
           storage.consumeAuthorizationAttempt(authorizationAttemptConsumption())
         ).rejects.toThrow("invalid, expired, or already used")
+        await expect(
+          storage.createAuthorizationAttempt(authorizationAttempt())
+        ).resolves.toMatchObject({ id: "attempt-a" })
       })
     })
 
@@ -126,7 +132,6 @@ export function runConnectorConnectionStorageContractSuite<
         const committedRun = connectionRun({
           id: "run-commit",
           initiatedByExecutionId: committedExecution.id,
-          authorizationAttemptId: committedAttempt.id,
         })
         await root.transaction(
           async (tx) => {
@@ -159,7 +164,6 @@ export function runConnectorConnectionStorageContractSuite<
         const rolledBackRun = connectionRun({
           id: "run-rollback",
           initiatedByExecutionId: rolledBackExecution.id,
-          authorizationAttemptId: rolledBackAttempt.id,
         })
         const rollback = new Error("rollback connector authorization attempt")
         await expect(
@@ -182,6 +186,30 @@ export function runConnectorConnectionStorageContractSuite<
         await expect(
           storage.consumeAuthorizationAttempt(authorizationAttemptConsumption(rolledBackAttempt.id))
         ).rejects.toThrow("invalid, expired, or already used")
+      })
+    })
+
+    test("links at most one headless attempt to an awaiting provider run", async () => {
+      await withStorage(async (storage) => {
+        const headlessAttempt = {
+          connectionRunId: "run-a",
+          returnTo: "https://app.example.com/connectors",
+          callbackBindingHash: "binding-hash",
+        } as const
+
+        await expect(
+          storage.createAuthorizationAttempt(authorizationAttempt(headlessAttempt))
+        ).rejects.toThrow("does not match its connection run")
+
+        await storage.createConnectionRun(connectionRun())
+        await expect(
+          storage.createAuthorizationAttempt(authorizationAttempt(headlessAttempt))
+        ).resolves.toMatchObject({ id: "attempt-a", connectionRunId: "run-a" })
+        await expect(
+          storage.createAuthorizationAttempt(
+            authorizationAttempt({ ...headlessAttempt, id: "attempt-b" })
+          )
+        ).rejects.toThrow("does not match its connection run")
       })
     })
 
@@ -438,6 +466,45 @@ export function runConnectorConnectionStorageContractSuite<
         expect(await storage.getAuthorization(authorizationKey(duplicateId.id))).toEqual(
           duplicateId
         )
+      })
+    })
+
+    test("commits expiry cleanup before rejecting account selection", async () => {
+      await withStorage(async (storage, root) => {
+        const authorization = await createAuthorization(storage, "authorization-a", "account-a")
+        await options.advanceTime(root, 60_000)
+
+        await expect(connect(storage, authorization, "connection-a", "account-a")).rejects.toThrow(
+          "selectable authorization"
+        )
+        await expect(
+          storage.getAuthorization(authorizationKey(authorization.id))
+        ).resolves.toMatchObject({ status: "revocation_pending" })
+      })
+    })
+
+    test("commits lazy run expiry before rejecting a late selection", async () => {
+      await withStorage(async (storage, root) => {
+        const authorization = await createAuthorization(storage, "authorization-a", "account-a")
+        await createSelectionRun(storage, authorization)
+        await options.advanceTime(root, 60_000)
+
+        await expect(
+          storage.putConnectionFromRun({
+            id: "connection-a",
+            projectId,
+            connectorId,
+            runId: "run-a",
+            account: { id: "account-a", label: "Account A" },
+            replace: false,
+          })
+        ).rejects.toThrow("invalid, expired, or already used")
+        await expect(
+          storage.getConnectionRun({ projectId, connectorId, runId: "run-a" })
+        ).resolves.toMatchObject({ status: "expired" })
+        await expect(
+          storage.getAuthorization(authorizationKey(authorization.id))
+        ).resolves.toMatchObject({ status: "revocation_pending" })
       })
     })
 
@@ -803,7 +870,6 @@ function connectionRun(
     owner: { type: "project" },
     slot: "default",
     initiatedByExecutionId: "execution-a",
-    authorizationAttemptId: "attempt-a",
     ttlMs: 60_000,
     ...overrides,
   }

--- a/storage/pg/README.md
+++ b/storage/pg/README.md
@@ -4,8 +4,8 @@ PostgreSQL storage provider for Sixb.
 
 One shared connection pool (porsager `postgres`) backs every Sixb store: objects, ontology commits,
 auth, agents, the immutable execution and AI usage ledgers, timeseries, and the run history for
-actions, syncs, pipelines, projections, workflows, and webhooks. This is the provider to use for
-anything you intend to operate.
+actions, syncs, pipelines, projections, workflows, webhooks, and managed connector connections.
+This is the provider to use for anything you intend to operate.
 
 ## Install
 

--- a/storage/pg/src/connector-connection-storage.ts
+++ b/storage/pg/src/connector-connection-storage.ts
@@ -1,0 +1,760 @@
+import {
+  type ConnectorConnectionPersistence,
+  type ConnectorConnectionPersistenceBackend,
+  type ConnectorConnectionPersistenceScope,
+  DurableConnectorConnectionStorage,
+} from "@sixb/core/internal/connector-connection-storage-provider"
+import type {
+  ConnectorAuthorizationAttemptRecord,
+  ConnectorAuthorizationRecord,
+  ConnectorConnectionRecord,
+  ConnectorConnectionRunRecord,
+  ConnectorCredentialMutation,
+  ConnectorStagedCredentials,
+} from "@sixb/core/storage"
+import type { SQLClient } from "./pg-client"
+import { isUniqueViolation } from "./storage-errors"
+import { lockAdvisoryKeys, type PgStoreClient, runPgTransaction } from "./transactions"
+
+export class PgConnectorConnectionStorage extends DurableConnectorConnectionStorage {
+  private readonly clock: ConnectorConnectionTestClock
+
+  constructor(sql: PgStoreClient) {
+    const clock = { offsetMs: 0 }
+    super(new PgConnectorConnectionPersistenceBackend(sql, clock))
+    this.clock = clock
+  }
+
+  /** Internal deterministic clock control used only by the provider contract suite. */
+  advanceTimeForTesting(durationMs: number): void {
+    this.clock.offsetMs += durationMs
+  }
+}
+
+class PgConnectorConnectionPersistenceBackend implements ConnectorConnectionPersistenceBackend {
+  constructor(
+    private readonly sql: PgStoreClient,
+    private readonly clock: ConnectorConnectionTestClock
+  ) {}
+
+  read<T>(
+    scope: ConnectorConnectionPersistenceScope,
+    run: (persistence: ConnectorConnectionPersistence) => Promise<T>
+  ): Promise<T> {
+    return run(new PgConnectorConnectionPersistence(this.sql, scope, false, this.clock))
+  }
+
+  transaction<T>(
+    scope: ConnectorConnectionPersistenceScope,
+    run: (persistence: ConnectorConnectionPersistence) => Promise<T>
+  ): Promise<T> {
+    return runPgTransaction(this.sql, async (tx) => {
+      if (scope.connectorId) {
+        await lockAdvisoryKeys(tx, [
+          ["connector-connections", scope.projectId, scope.connectorId].join(":"),
+        ])
+      }
+      return run(new PgConnectorConnectionPersistence(tx, scope, true, this.clock))
+    })
+  }
+}
+
+class PgConnectorConnectionPersistence implements ConnectorConnectionPersistence {
+  constructor(
+    private readonly sql: PgStoreClient,
+    private readonly scope: ConnectorConnectionPersistenceScope,
+    private readonly locking: boolean,
+    private readonly clock: ConnectorConnectionTestClock
+  ) {}
+
+  async now(): Promise<Date> {
+    const [row] = await this.sql<{ readonly now: Date | string }[]>`
+      SELECT clock_timestamp() AS now
+    `
+    if (!row) throw new Error("[SixbPg] Database clock returned no row.")
+    return new Date(new Date(row.now).getTime() + this.clock.offsetMs)
+  }
+
+  async insertAuthorizationAttempt(record: ConnectorAuthorizationAttemptRecord): Promise<boolean> {
+    try {
+      await this.sql`
+        INSERT INTO connector_authorization_attempts (
+          project_id, connector_id, id, slot, initiated_by_execution_id,
+          state_hash, code_verifier, redirect_uri, connection_run_id, return_to,
+          callback_binding_hash, reauthorization_id, reauthorization_revision,
+          reauthorization_connection_ids, created_at, expires_at
+        ) VALUES (
+          ${record.projectId}, ${record.connectorId}, ${record.id}, ${record.slot},
+          ${record.initiatedByExecutionId}, ${record.stateHash},
+          ${jsonParameter(this.sql, record.codeVerifier)}, ${record.redirectUri},
+          ${record.connectionRunId ?? null}, ${record.returnTo ?? null},
+          ${record.callbackBindingHash ?? null}, ${record.reauthorizationId ?? null},
+          ${record.reauthorizationRevision ?? null},
+          ${
+            record.reauthorizationConnectionIds
+              ? jsonParameter(this.sql, record.reauthorizationConnectionIds)
+              : null
+          },
+          ${record.createdAt}, ${record.expiresAt}
+        )
+      `
+      return true
+    } catch (error) {
+      if (isUniqueViolation(error)) return false
+      throw error
+    }
+  }
+
+  async getAuthorizationAttempt(id: string): Promise<ConnectorAuthorizationAttemptRecord | null> {
+    const rows = this.scope.connectorId
+      ? await this.sql<PgAuthorizationAttemptRow[]>`
+          SELECT * FROM connector_authorization_attempts
+          WHERE project_id = ${this.scope.projectId}
+            AND connector_id = ${this.scope.connectorId}
+            AND id = ${id}
+          ${this.lockClause()}
+        `
+      : await this.sql<PgAuthorizationAttemptRow[]>`
+          SELECT * FROM connector_authorization_attempts
+          WHERE project_id = ${this.scope.projectId} AND id = ${id}
+          ${this.lockClause()}
+        `
+    return rows[0] ? authorizationAttemptFromRow(rows[0]) : null
+  }
+
+  async getAuthorizationAttemptByConnectionRunId(
+    connectionRunId: string
+  ): Promise<ConnectorAuthorizationAttemptRecord | null> {
+    if (!this.scope.connectorId) return null
+    const rows = await this.sql<PgAuthorizationAttemptRow[]>`
+      SELECT * FROM connector_authorization_attempts
+      WHERE project_id = ${this.scope.projectId}
+        AND connector_id = ${this.scope.connectorId}
+        AND connection_run_id = ${connectionRunId}
+      ${this.lockClause()}
+    `
+    return rows[0] ? authorizationAttemptFromRow(rows[0]) : null
+  }
+
+  async deleteAuthorizationAttempt(id: string): Promise<boolean> {
+    const rows = this.scope.connectorId
+      ? await this.sql<{ readonly id: string }[]>`
+          DELETE FROM connector_authorization_attempts
+          WHERE project_id = ${this.scope.projectId}
+            AND connector_id = ${this.scope.connectorId}
+            AND id = ${id}
+          RETURNING id
+        `
+      : await this.sql<{ readonly id: string }[]>`
+          DELETE FROM connector_authorization_attempts
+          WHERE project_id = ${this.scope.projectId} AND id = ${id}
+          RETURNING id
+        `
+    return rows.length === 1
+  }
+
+  async insertConnectionRun(record: ConnectorConnectionRunRecord): Promise<boolean> {
+    try {
+      const values = runValues(record)
+      await this.sql`
+        INSERT INTO connector_connection_runs (
+          project_id, connector_id, id, kind, slot, initiated_by_execution_id,
+          status, waiting_for, processing_id, callback_started_at,
+          expires_at, authorization_id, cleanup_authorization_id, connections, error,
+          created_at, updated_at, finished_at
+        ) VALUES (
+          ${record.projectId}, ${record.connectorId}, ${record.id}, ${values.kind},
+          ${values.slot}, ${values.initiatedByExecutionId}, ${values.status},
+          ${values.waitingFor}, ${values.processingId},
+          ${values.callbackStartedAt}, ${values.expiresAt}, ${values.authorizationId},
+          ${values.cleanupAuthorizationId},
+          ${values.connections ? jsonParameter(this.sql, values.connections) : null},
+          ${values.error ? jsonParameter(this.sql, values.error) : null},
+          ${record.createdAt}, ${record.updatedAt}, ${values.finishedAt}
+        )
+      `
+      return true
+    } catch (error) {
+      if (isUniqueViolation(error)) return false
+      throw error
+    }
+  }
+
+  async getConnectionRun(id: string): Promise<ConnectorConnectionRunRecord | null> {
+    const rows = await this.runById(id)
+    return rows[0] ? connectionRunFromRow(rows[0]) : null
+  }
+
+  async updateConnectionRun(record: ConnectorConnectionRunRecord): Promise<void> {
+    const values = runValues(record)
+    const rows = await this.sql<{ readonly id: string }[]>`
+      UPDATE connector_connection_runs
+      SET kind = ${values.kind}, slot = ${values.slot},
+          initiated_by_execution_id = ${values.initiatedByExecutionId}, status = ${values.status},
+          waiting_for = ${values.waitingFor},
+          processing_id = ${values.processingId}, callback_started_at = ${values.callbackStartedAt},
+          expires_at = ${values.expiresAt}, authorization_id = ${values.authorizationId},
+          cleanup_authorization_id = ${values.cleanupAuthorizationId},
+          connections = ${values.connections ? jsonParameter(this.sql, values.connections) : null},
+          error = ${values.error ? jsonParameter(this.sql, values.error) : null},
+          updated_at = ${record.updatedAt}, finished_at = ${values.finishedAt}
+      WHERE project_id = ${record.projectId} AND connector_id = ${record.connectorId}
+        AND id = ${record.id}
+      RETURNING id
+    `
+    assertChanged(rows, "connector connection run", record.id)
+  }
+
+  async insertAuthorization(record: ConnectorAuthorizationRecord): Promise<boolean> {
+    try {
+      const values = authorizationValues(record)
+      await this.sql`
+        INSERT INTO connector_authorizations (
+          project_id, connector_id, id, authorized_by, credentials, credential_expires_at,
+          scopes, accounts, status, selection_expires_at, revision, mutation_id, mutation_kind,
+          mutation_phase, mutation_holder_id, mutation_expires_at, mutation_deadline_at,
+          mutation_expected_connection_ids, staged_credentials, staged_credential_expires_at,
+          staged_scopes, created_at, updated_at
+        ) VALUES (
+          ${record.projectId}, ${record.connectorId}, ${record.id},
+          ${jsonParameter(this.sql, record.authorizedBy)},
+          ${record.credentials ? jsonParameter(this.sql, record.credentials) : null},
+          ${record.credentialExpiresAt ?? null}, ${jsonParameter(this.sql, record.scopes)},
+          ${jsonParameter(this.sql, record.accounts)}, ${record.status},
+          ${record.selectionExpiresAt ?? null}, ${record.revision}, ${values.mutationId},
+          ${values.mutationKind}, ${values.mutationPhase}, ${values.mutationHolderId},
+          ${values.mutationExpiresAt}, ${values.mutationDeadlineAt},
+          ${
+            values.mutationExpectedConnectionIds
+              ? jsonParameter(this.sql, values.mutationExpectedConnectionIds)
+              : null
+          },
+          ${values.stagedCredentials ? jsonParameter(this.sql, values.stagedCredentials) : null},
+          ${values.stagedCredentialExpiresAt},
+          ${values.stagedScopes ? jsonParameter(this.sql, values.stagedScopes) : null},
+          ${record.createdAt}, ${record.updatedAt}
+        )
+      `
+      return true
+    } catch (error) {
+      if (isUniqueViolation(error)) return false
+      throw error
+    }
+  }
+
+  async getAuthorization(id: string): Promise<ConnectorAuthorizationRecord | null> {
+    const rows = await this.authorizationById(id)
+    return rows[0] ? authorizationFromRow(rows[0]) : null
+  }
+
+  async updateAuthorization(record: ConnectorAuthorizationRecord): Promise<void> {
+    const values = authorizationValues(record)
+    const rows = await this.sql<{ readonly id: string }[]>`
+      UPDATE connector_authorizations
+      SET authorized_by = ${jsonParameter(this.sql, record.authorizedBy)},
+          credentials = ${record.credentials ? jsonParameter(this.sql, record.credentials) : null},
+          credential_expires_at = ${record.credentialExpiresAt ?? null},
+          scopes = ${jsonParameter(this.sql, record.scopes)},
+          accounts = ${jsonParameter(this.sql, record.accounts)}, status = ${record.status},
+          selection_expires_at = ${record.selectionExpiresAt ?? null}, revision = ${record.revision},
+          mutation_id = ${values.mutationId}, mutation_kind = ${values.mutationKind},
+          mutation_phase = ${values.mutationPhase}, mutation_holder_id = ${values.mutationHolderId},
+          mutation_expires_at = ${values.mutationExpiresAt},
+          mutation_deadline_at = ${values.mutationDeadlineAt},
+          mutation_expected_connection_ids = ${
+            values.mutationExpectedConnectionIds
+              ? jsonParameter(this.sql, values.mutationExpectedConnectionIds)
+              : null
+          },
+          staged_credentials = ${
+            values.stagedCredentials ? jsonParameter(this.sql, values.stagedCredentials) : null
+          },
+          staged_credential_expires_at = ${values.stagedCredentialExpiresAt},
+          staged_scopes = ${
+            values.stagedScopes ? jsonParameter(this.sql, values.stagedScopes) : null
+          },
+          updated_at = ${record.updatedAt}
+      WHERE project_id = ${record.projectId} AND connector_id = ${record.connectorId}
+        AND id = ${record.id}
+      RETURNING id
+    `
+    assertChanged(rows, "connector authorization", record.id)
+  }
+
+  async insertConnection(record: ConnectorConnectionRecord): Promise<boolean> {
+    try {
+      await this.sql`
+        INSERT INTO connector_connections (
+          project_id, connector_id, id, authorization_id, slot, account,
+          account_id, status, disconnected_at, created_at, updated_at
+        ) VALUES (
+          ${record.projectId}, ${record.connectorId}, ${record.id}, ${record.authorizationId},
+          ${record.slot}, ${jsonParameter(this.sql, record.account)},
+          ${record.account.id}, ${record.status}, ${record.disconnectedAt ?? null},
+          ${record.createdAt}, ${record.updatedAt}
+        )
+      `
+      return true
+    } catch (error) {
+      if (isUniqueViolation(error)) return false
+      throw error
+    }
+  }
+
+  async getConnectionById(id: string): Promise<ConnectorConnectionRecord | null> {
+    const rows = await this.connectionById(id)
+    return rows[0] ? connectionFromRow(rows[0]) : null
+  }
+
+  async getConnectionBySelector(input: {
+    readonly owner: { readonly type: "project" }
+    readonly slot: string
+  }): Promise<ConnectorConnectionRecord | null> {
+    if (!this.scope.connectorId) return null
+    const rows = await this.sql<PgConnectionRow[]>`
+      SELECT * FROM connector_connections
+      WHERE project_id = ${this.scope.projectId} AND connector_id = ${this.scope.connectorId}
+        AND slot = ${input.slot}
+      ${this.lockClause()}
+    `
+    return rows[0] ? connectionFromRow(rows[0]) : null
+  }
+
+  async listConnections(): Promise<readonly ConnectorConnectionRecord[]> {
+    if (!this.scope.connectorId) return []
+    const rows = await this.sql<PgConnectionRow[]>`
+      SELECT * FROM connector_connections
+      WHERE project_id = ${this.scope.projectId} AND connector_id = ${this.scope.connectorId}
+      ORDER BY id
+      ${this.lockClause()}
+    `
+    return rows.map(connectionFromRow)
+  }
+
+  async listConnectionsByAuthorization(
+    authorizationId: string,
+    options: { readonly connectedOnly?: boolean } = {}
+  ): Promise<readonly ConnectorConnectionRecord[]> {
+    if (!this.scope.connectorId) return []
+    const rows = options.connectedOnly
+      ? await this.sql<PgConnectionRow[]>`
+          SELECT * FROM connector_connections
+          WHERE project_id = ${this.scope.projectId} AND connector_id = ${this.scope.connectorId}
+            AND authorization_id = ${authorizationId} AND status = 'connected'
+          ORDER BY id
+          ${this.lockClause()}
+        `
+      : await this.sql<PgConnectionRow[]>`
+          SELECT * FROM connector_connections
+          WHERE project_id = ${this.scope.projectId} AND connector_id = ${this.scope.connectorId}
+            AND authorization_id = ${authorizationId}
+          ORDER BY id
+          ${this.lockClause()}
+        `
+    return rows.map(connectionFromRow)
+  }
+
+  async updateConnection(record: ConnectorConnectionRecord): Promise<void> {
+    const rows = await this.sql<{ readonly id: string }[]>`
+      UPDATE connector_connections
+      SET authorization_id = ${record.authorizationId}, slot = ${record.slot},
+          account = ${jsonParameter(this.sql, record.account)},
+          account_id = ${record.account.id}, status = ${record.status},
+          disconnected_at = ${record.disconnectedAt ?? null}, updated_at = ${record.updatedAt}
+      WHERE project_id = ${record.projectId} AND connector_id = ${record.connectorId}
+        AND id = ${record.id}
+      RETURNING id
+    `
+    assertChanged(rows, "connector connection", record.id)
+  }
+
+  private runById(id: string): Promise<PgConnectionRunRow[]> {
+    return this.scope.connectorId
+      ? this.sql<PgConnectionRunRow[]>`
+          SELECT * FROM connector_connection_runs
+          WHERE project_id = ${this.scope.projectId}
+            AND connector_id = ${this.scope.connectorId} AND id = ${id}
+          ${this.lockClause()}
+        `
+      : this.sql<PgConnectionRunRow[]>`
+          SELECT * FROM connector_connection_runs
+          WHERE project_id = ${this.scope.projectId} AND id = ${id}
+          ${this.lockClause()}
+        `
+  }
+
+  private authorizationById(id: string): Promise<PgAuthorizationRow[]> {
+    return this.scope.connectorId
+      ? this.sql<PgAuthorizationRow[]>`
+          SELECT * FROM connector_authorizations
+          WHERE project_id = ${this.scope.projectId}
+            AND connector_id = ${this.scope.connectorId} AND id = ${id}
+          ${this.lockClause()}
+        `
+      : this.sql<PgAuthorizationRow[]>`
+          SELECT * FROM connector_authorizations
+          WHERE project_id = ${this.scope.projectId} AND id = ${id}
+          ${this.lockClause()}
+        `
+  }
+
+  private connectionById(id: string): Promise<PgConnectionRow[]> {
+    return this.scope.connectorId
+      ? this.sql<PgConnectionRow[]>`
+          SELECT * FROM connector_connections
+          WHERE project_id = ${this.scope.projectId}
+            AND connector_id = ${this.scope.connectorId} AND id = ${id}
+          ${this.lockClause()}
+        `
+      : this.sql<PgConnectionRow[]>`
+          SELECT * FROM connector_connections
+          WHERE project_id = ${this.scope.projectId} AND id = ${id}
+          ${this.lockClause()}
+        `
+  }
+
+  private lockClause() {
+    return this.locking ? this.sql`FOR UPDATE` : this.sql``
+  }
+}
+
+function authorizationAttemptFromRow(
+  row: PgAuthorizationAttemptRow
+): ConnectorAuthorizationAttemptRecord {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    connectorId: row.connector_id,
+    owner: { type: "project" },
+    slot: row.slot,
+    initiatedByExecutionId: row.initiated_by_execution_id,
+    stateHash: row.state_hash,
+    codeVerifier: row.code_verifier,
+    redirectUri: row.redirect_uri,
+    ...(row.connection_run_id === null ? {} : { connectionRunId: row.connection_run_id }),
+    ...(row.return_to === null ? {} : { returnTo: row.return_to }),
+    ...(row.callback_binding_hash === null
+      ? {}
+      : { callbackBindingHash: row.callback_binding_hash }),
+    ...(row.reauthorization_id === null ? {} : { reauthorizationId: row.reauthorization_id }),
+    ...(row.reauthorization_revision === null
+      ? {}
+      : { reauthorizationRevision: row.reauthorization_revision }),
+    ...(row.reauthorization_connection_ids === null
+      ? {}
+      : { reauthorizationConnectionIds: row.reauthorization_connection_ids }),
+    createdAt: date(row.created_at),
+    expiresAt: date(row.expires_at),
+  }
+}
+
+function runValues(record: ConnectorConnectionRunRecord) {
+  return {
+    kind: record.kind,
+    slot: record.slot,
+    initiatedByExecutionId: record.initiatedByExecutionId,
+    status: record.status,
+    waitingFor: record.status === "waiting" ? record.waitingFor : null,
+    processingId: record.status === "running" ? record.processingId : null,
+    callbackStartedAt: record.status === "running" ? record.callbackStartedAt : null,
+    expiresAt: record.status === "waiting" || record.status === "running" ? record.expiresAt : null,
+    authorizationId: "authorizationId" in record ? (record.authorizationId ?? null) : null,
+    cleanupAuthorizationId:
+      record.status === "succeeded" ? (record.cleanupAuthorizationId ?? null) : null,
+    connections: record.status === "succeeded" ? record.connections : null,
+    error: record.status === "failed" ? record.error : null,
+    finishedAt:
+      record.status === "succeeded" ||
+      record.status === "failed" ||
+      record.status === "cancelled" ||
+      record.status === "expired"
+        ? record.finishedAt
+        : null,
+  }
+}
+
+function connectionRunFromRow(row: PgConnectionRunRow): ConnectorConnectionRunRecord {
+  const base = {
+    id: row.id,
+    projectId: row.project_id,
+    connectorId: row.connector_id,
+    kind: row.kind,
+    owner: { type: "project" as const },
+    slot: row.slot,
+    initiatedByExecutionId: row.initiated_by_execution_id,
+    createdAt: date(row.created_at),
+    updatedAt: date(row.updated_at),
+  }
+  if (row.status === "waiting" && row.waiting_for === "provider_authorization") {
+    return {
+      ...base,
+      status: "waiting",
+      waitingFor: "provider_authorization",
+      expiresAt: date(required(row.expires_at, "run expiry")),
+    }
+  }
+  if (row.status === "waiting" && row.waiting_for === "account_selection") {
+    return {
+      ...base,
+      status: "waiting",
+      waitingFor: "account_selection",
+      authorizationId: required(row.authorization_id, "authorization id"),
+      expiresAt: date(required(row.expires_at, "run expiry")),
+    }
+  }
+  if (row.status === "running") {
+    return {
+      ...base,
+      status: "running",
+      processingId: required(row.processing_id, "processing id"),
+      callbackStartedAt: date(required(row.callback_started_at, "callback start")),
+      expiresAt: date(required(row.expires_at, "run expiry")),
+      ...(row.authorization_id === null ? {} : { authorizationId: row.authorization_id }),
+    }
+  }
+  const finishedAt = date(required(row.finished_at, "run finish"))
+  if (row.status === "succeeded") {
+    return {
+      ...base,
+      status: "succeeded",
+      authorizationId: required(row.authorization_id, "authorization id"),
+      ...(row.cleanup_authorization_id === null
+        ? {}
+        : { cleanupAuthorizationId: row.cleanup_authorization_id }),
+      connections: required(row.connections, "connections").map(connectionFromSerialized),
+      finishedAt,
+    }
+  }
+  if (row.status === "failed") {
+    return {
+      ...base,
+      status: "failed",
+      error: required(row.error, "run error"),
+      ...(row.authorization_id === null ? {} : { authorizationId: row.authorization_id }),
+      finishedAt,
+    }
+  }
+  if (row.status === "cancelled") {
+    return {
+      ...base,
+      status: "cancelled",
+      ...(row.authorization_id === null ? {} : { authorizationId: row.authorization_id }),
+      finishedAt,
+    }
+  }
+  if (row.status === "expired") {
+    return {
+      ...base,
+      status: "expired",
+      ...(row.authorization_id === null ? {} : { authorizationId: row.authorization_id }),
+      finishedAt,
+    }
+  }
+  throw new Error(`[SixbPg] Stored connector connection run status '${row.status}' is invalid.`)
+}
+
+function authorizationValues(record: ConnectorAuthorizationRecord) {
+  const mutation = record.credentialMutation
+  return {
+    mutationId: mutation?.id ?? null,
+    mutationKind: mutation?.kind ?? null,
+    mutationPhase: mutation?.phase ?? null,
+    mutationHolderId: mutation?.holderId ?? null,
+    mutationExpiresAt: mutation?.expiresAt ?? null,
+    mutationDeadlineAt: mutation?.deadlineAt ?? null,
+    mutationExpectedConnectionIds: mutation?.expectedConnectionIds ?? null,
+    stagedCredentials: mutation?.stagedCredentials?.credentials ?? null,
+    stagedCredentialExpiresAt: mutation?.stagedCredentials?.credentialExpiresAt ?? null,
+    stagedScopes: mutation?.stagedCredentials?.scopes ?? null,
+  }
+}
+
+function authorizationFromRow(row: PgAuthorizationRow): ConnectorAuthorizationRecord {
+  const mutation = mutationFromRow(row)
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    connectorId: row.connector_id,
+    authorizedBy: row.authorized_by,
+    ...(row.credentials === null ? {} : { credentials: row.credentials }),
+    ...(row.credential_expires_at === null
+      ? {}
+      : { credentialExpiresAt: date(row.credential_expires_at) }),
+    scopes: row.scopes,
+    accounts: row.accounts,
+    status: row.status,
+    ...(row.selection_expires_at === null
+      ? {}
+      : { selectionExpiresAt: date(row.selection_expires_at) }),
+    revision: row.revision,
+    ...(mutation === undefined ? {} : { credentialMutation: mutation }),
+    createdAt: date(row.created_at),
+    updatedAt: date(row.updated_at),
+  }
+}
+
+function mutationFromRow(row: PgAuthorizationRow): ConnectorCredentialMutation | undefined {
+  if (row.mutation_id === null) return undefined
+  const stagedCredentials: ConnectorStagedCredentials | undefined =
+    row.staged_credentials === null
+      ? undefined
+      : {
+          credentials: row.staged_credentials,
+          ...(row.staged_credential_expires_at === null
+            ? {}
+            : { credentialExpiresAt: date(row.staged_credential_expires_at) }),
+          scopes: required(row.staged_scopes, "staged credential scopes"),
+        }
+  return {
+    id: row.mutation_id,
+    kind: required(row.mutation_kind, "credential mutation kind"),
+    phase: required(row.mutation_phase, "credential mutation phase"),
+    holderId: required(row.mutation_holder_id, "credential mutation holder"),
+    expiresAt: date(required(row.mutation_expires_at, "credential mutation expiry")),
+    deadlineAt: date(required(row.mutation_deadline_at, "credential mutation deadline")),
+    ...(row.mutation_expected_connection_ids === null
+      ? {}
+      : { expectedConnectionIds: row.mutation_expected_connection_ids }),
+    ...(stagedCredentials === undefined ? {} : { stagedCredentials }),
+  }
+}
+
+function connectionFromRow(row: PgConnectionRow): ConnectorConnectionRecord {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    connectorId: row.connector_id,
+    authorizationId: row.authorization_id,
+    owner: { type: "project" },
+    slot: row.slot,
+    account: row.account,
+    status: row.status,
+    ...(row.disconnected_at === null ? {} : { disconnectedAt: date(row.disconnected_at) }),
+    createdAt: date(row.created_at),
+    updatedAt: date(row.updated_at),
+  }
+}
+
+type SerializedConnectorConnection = Omit<
+  ConnectorConnectionRecord,
+  "createdAt" | "updatedAt" | "disconnectedAt"
+> & {
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly disconnectedAt?: string
+}
+
+function connectionFromSerialized(
+  record: SerializedConnectorConnection
+): ConnectorConnectionRecord {
+  const { createdAt, updatedAt, disconnectedAt, ...connection } = record
+  return {
+    ...connection,
+    createdAt: new Date(createdAt),
+    updatedAt: new Date(updatedAt),
+    ...(disconnectedAt === undefined ? {} : { disconnectedAt: new Date(disconnectedAt) }),
+  }
+}
+
+type PgJsonValue = Parameters<SQLClient["json"]>[0]
+
+function jsonParameter(sql: PgStoreClient, value: unknown): ReturnType<PgStoreClient["json"]> {
+  return sql.json(value as PgJsonValue)
+}
+
+function date(value: Date | string): Date {
+  return new Date(value)
+}
+
+function required<T>(value: T | null, label: string): T {
+  if (value !== null) return value
+  throw new Error(`[SixbPg] Stored ${label} is missing.`)
+}
+
+function assertChanged(rows: readonly unknown[], label: string, id: string): void {
+  if (rows.length === 1) return
+  throw new Error(`[SixbPg] Stored ${label} '${id}' is unavailable.`)
+}
+
+interface ConnectorConnectionTestClock {
+  offsetMs: number
+}
+
+interface PgAuthorizationAttemptRow {
+  readonly project_id: string
+  readonly connector_id: string
+  readonly id: string
+  readonly slot: string
+  readonly initiated_by_execution_id: string
+  readonly state_hash: string
+  readonly code_verifier: ConnectorAuthorizationAttemptRecord["codeVerifier"]
+  readonly redirect_uri: string
+  readonly connection_run_id: string | null
+  readonly return_to: string | null
+  readonly callback_binding_hash: string | null
+  readonly reauthorization_id: string | null
+  readonly reauthorization_revision: number | null
+  readonly reauthorization_connection_ids: readonly string[] | null
+  readonly created_at: Date | string
+  readonly expires_at: Date | string
+}
+
+interface PgConnectionRunRow {
+  readonly project_id: string
+  readonly connector_id: string
+  readonly id: string
+  readonly kind: ConnectorConnectionRunRecord["kind"]
+  readonly slot: string
+  readonly initiated_by_execution_id: string
+  readonly status: ConnectorConnectionRunRecord["status"]
+  readonly waiting_for: "provider_authorization" | "account_selection" | null
+  readonly processing_id: string | null
+  readonly callback_started_at: Date | string | null
+  readonly expires_at: Date | string | null
+  readonly authorization_id: string | null
+  readonly cleanup_authorization_id: string | null
+  readonly connections: readonly SerializedConnectorConnection[] | null
+  readonly error: Extract<ConnectorConnectionRunRecord, { status: "failed" }>["error"] | null
+  readonly created_at: Date | string
+  readonly updated_at: Date | string
+  readonly finished_at: Date | string | null
+}
+
+interface PgAuthorizationRow {
+  readonly project_id: string
+  readonly connector_id: string
+  readonly id: string
+  readonly authorized_by: ConnectorAuthorizationRecord["authorizedBy"]
+  readonly credentials: ConnectorAuthorizationRecord["credentials"] | null
+  readonly credential_expires_at: Date | string | null
+  readonly scopes: readonly string[]
+  readonly accounts: ConnectorAuthorizationRecord["accounts"]
+  readonly status: ConnectorAuthorizationRecord["status"]
+  readonly selection_expires_at: Date | string | null
+  readonly revision: number
+  readonly mutation_id: string | null
+  readonly mutation_kind: ConnectorCredentialMutation["kind"] | null
+  readonly mutation_phase: ConnectorCredentialMutation["phase"] | null
+  readonly mutation_holder_id: string | null
+  readonly mutation_expires_at: Date | string | null
+  readonly mutation_deadline_at: Date | string | null
+  readonly mutation_expected_connection_ids: readonly string[] | null
+  readonly staged_credentials: ConnectorStagedCredentials["credentials"] | null
+  readonly staged_credential_expires_at: Date | string | null
+  readonly staged_scopes: readonly string[] | null
+  readonly created_at: Date | string
+  readonly updated_at: Date | string
+}
+
+interface PgConnectionRow {
+  readonly project_id: string
+  readonly connector_id: string
+  readonly id: string
+  readonly authorization_id: string
+  readonly slot: string
+  readonly account: ConnectorConnectionRecord["account"]
+  readonly status: ConnectorConnectionRecord["status"]
+  readonly disconnected_at: Date | string | null
+  readonly created_at: Date | string
+  readonly updated_at: Date | string
+}

--- a/storage/pg/src/index.ts
+++ b/storage/pg/src/index.ts
@@ -27,6 +27,7 @@ import {
 } from "@sixb/core/storage"
 import { PgAgentStorage } from "./agents"
 import { PgAuthStorage } from "./auth-storage"
+import { PgConnectorConnectionStorage } from "./connector-connection-storage"
 import { createPostgresStorageMigrators, dropSchema } from "./migrations"
 import { PgOntologyStorage, type PgOntologyTransactionContext } from "./ontology-storage"
 import { PgActionRunStorage } from "./pg-action-run-storage"
@@ -43,6 +44,7 @@ import { PgWebhookRunStorage } from "./pg-webhook-run-storage"
 import { PgWorkflowInterventionStorage } from "./pg-workflow-intervention-storage"
 import { PgWorkflowRunStorage } from "./pg-workflow-run-storage"
 import { isRetryableTransactionConflict } from "./storage-errors"
+import { registerPostgresStorageTestingAdapter } from "./testing"
 import { type PgStoreClient, runPgTransaction } from "./transactions"
 
 export interface PostgresStorageOptions {
@@ -142,6 +144,7 @@ export class PostgresStorage implements MigrationCapableStorage {
   readonly timeseries: Storage["timeseries"]
   readonly webhookRuns: PgWebhookRunStorage
   readonly rules: PgRulesStorage
+  readonly connectorConnections: PgConnectorConnectionStorage
   readonly migrators: readonly StorageMigrator[]
 
   private readonly sql: SQL
@@ -214,6 +217,10 @@ export class PostgresStorage implements MigrationCapableStorage {
     this.timeseries = createOperationScopedFacade(stores.timeseries, scope)
     this.webhookRuns = createOperationScopedFacade(stores.webhookRuns, scope)
     this.rules = createOperationScopedFacade(stores.rules, scope)
+    this.connectorConnections = createOperationScopedFacade(stores.connectorConnections, scope)
+    registerPostgresStorageTestingAdapter(this, (durationMs) =>
+      stores.connectorConnections.advanceTimeForTesting(durationMs)
+    )
   }
 
   async ping(): Promise<void> {
@@ -339,6 +346,7 @@ function createPostgresStores(
     timeseries: new PgTimeseriesStorage(sql),
     webhookRuns: new PgWebhookRunStorage(sql, executions),
     rules: new PgRulesStorage(sql),
+    connectorConnections: new PgConnectorConnectionStorage(sql),
   }
 }
 
@@ -358,6 +366,7 @@ interface PostgresStoreSet {
   readonly timeseries: PgTimeseriesStorage
   readonly webhookRuns: PgWebhookRunStorage
   readonly rules: PgRulesStorage
+  readonly connectorConnections: PgConnectorConnectionStorage
 }
 
 function resolveTimeoutMillis(value: number | undefined, label: string): number | undefined {

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -63,6 +63,9 @@ import webhookExecutionsSql from "./migrations/023-webhook-executions.sql" with 
 import ontologyCommitExecutionsSql from "./migrations/024-ontology-commit-executions.sql" with {
   type: "text",
 }
+import connectorConnectionsSql from "./migrations/025-connector-connections.sql" with {
+  type: "text",
+}
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -340,6 +343,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("022-projection-executions", projectionExecutionsSql),
     pgSql("023-webhook-executions", webhookExecutionsSql),
     pgSql("024-ontology-commit-executions", ontologyCommitExecutionsSql),
+    pgSql("025-connector-connections", connectorConnectionsSql),
   ],
 })
 

--- a/storage/pg/src/migrations/025-connector-connections.sql
+++ b/storage/pg/src/migrations/025-connector-connections.sql
@@ -1,0 +1,231 @@
+CREATE TABLE connector_connection_runs (
+  project_id TEXT NOT NULL,
+  connector_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('connect', 'reauthorize')),
+  slot TEXT NOT NULL,
+  initiated_by_execution_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('waiting', 'running', 'succeeded', 'failed', 'cancelled', 'expired')),
+  waiting_for TEXT CHECK (waiting_for IN ('provider_authorization', 'account_selection')),
+  processing_id TEXT,
+  callback_started_at TIMESTAMPTZ,
+  expires_at TIMESTAMPTZ,
+  authorization_id TEXT,
+  cleanup_authorization_id TEXT,
+  connections JSONB CHECK (connections IS NULL OR jsonb_typeof(connections) = 'array'),
+  error JSONB CHECK (error IS NULL OR jsonb_typeof(error) = 'object'),
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  finished_at TIMESTAMPTZ,
+  PRIMARY KEY (project_id, connector_id, id),
+  UNIQUE (project_id, id),
+  CHECK (
+    (
+      status = 'waiting'
+      AND waiting_for = 'provider_authorization'
+      AND processing_id IS NULL
+      AND callback_started_at IS NULL
+      AND expires_at IS NOT NULL
+      AND authorization_id IS NULL
+      AND cleanup_authorization_id IS NULL
+      AND connections IS NULL
+      AND error IS NULL
+      AND finished_at IS NULL
+    )
+    OR (
+      status = 'waiting'
+      AND waiting_for = 'account_selection'
+      AND processing_id IS NULL
+      AND callback_started_at IS NULL
+      AND expires_at IS NOT NULL
+      AND authorization_id IS NOT NULL
+      AND cleanup_authorization_id IS NULL
+      AND connections IS NULL
+      AND error IS NULL
+      AND finished_at IS NULL
+    )
+    OR (
+      status = 'running'
+      AND waiting_for IS NULL
+      AND processing_id IS NOT NULL
+      AND callback_started_at IS NOT NULL
+      AND expires_at IS NOT NULL
+      AND cleanup_authorization_id IS NULL
+      AND connections IS NULL
+      AND error IS NULL
+      AND finished_at IS NULL
+    )
+    OR (
+      status = 'succeeded'
+      AND waiting_for IS NULL
+      AND processing_id IS NULL
+      AND callback_started_at IS NULL
+      AND expires_at IS NULL
+      AND authorization_id IS NOT NULL
+      AND connections IS NOT NULL
+      AND error IS NULL
+      AND finished_at IS NOT NULL
+    )
+    OR (
+      status = 'failed'
+      AND waiting_for IS NULL
+      AND processing_id IS NULL
+      AND callback_started_at IS NULL
+      AND expires_at IS NULL
+      AND cleanup_authorization_id IS NULL
+      AND connections IS NULL
+      AND error IS NOT NULL
+      AND finished_at IS NOT NULL
+    )
+    OR (
+      status IN ('cancelled', 'expired')
+      AND waiting_for IS NULL
+      AND processing_id IS NULL
+      AND callback_started_at IS NULL
+      AND expires_at IS NULL
+      AND cleanup_authorization_id IS NULL
+      AND connections IS NULL
+      AND error IS NULL
+      AND finished_at IS NOT NULL
+    )
+  )
+);
+
+CREATE INDEX idx_connector_runs_status
+  ON connector_connection_runs (project_id, connector_id, status, updated_at);
+
+CREATE TABLE connector_authorization_attempts (
+  project_id TEXT NOT NULL,
+  connector_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  slot TEXT NOT NULL,
+  initiated_by_execution_id TEXT NOT NULL,
+  state_hash TEXT NOT NULL,
+  code_verifier JSONB NOT NULL CHECK (jsonb_typeof(code_verifier) = 'object'),
+  redirect_uri TEXT NOT NULL,
+  connection_run_id TEXT,
+  return_to TEXT,
+  callback_binding_hash TEXT,
+  reauthorization_id TEXT,
+  reauthorization_revision INTEGER CHECK (reauthorization_revision IS NULL OR reauthorization_revision >= 0),
+  reauthorization_connection_ids JSONB CHECK (
+    reauthorization_connection_ids IS NULL OR jsonb_typeof(reauthorization_connection_ids) = 'array'
+  ),
+  created_at TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (project_id, connector_id, id),
+  UNIQUE (project_id, id),
+  UNIQUE (project_id, connector_id, connection_run_id),
+  FOREIGN KEY (project_id, connector_id, connection_run_id)
+    REFERENCES connector_connection_runs (project_id, connector_id, id)
+    ON DELETE RESTRICT,
+  CHECK (
+    (connection_run_id IS NULL AND return_to IS NULL AND callback_binding_hash IS NULL)
+    OR (connection_run_id IS NOT NULL AND return_to IS NOT NULL AND callback_binding_hash IS NOT NULL)
+  ),
+  CHECK (
+    (reauthorization_id IS NULL AND reauthorization_revision IS NULL AND reauthorization_connection_ids IS NULL)
+    OR (reauthorization_id IS NOT NULL AND reauthorization_revision IS NOT NULL AND reauthorization_connection_ids IS NOT NULL)
+  )
+);
+
+CREATE INDEX idx_connector_attempts_expiry
+  ON connector_authorization_attempts (project_id, connector_id, expires_at);
+
+CREATE TABLE connector_authorizations (
+  project_id TEXT NOT NULL,
+  connector_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  authorized_by JSONB NOT NULL CHECK (jsonb_typeof(authorized_by) = 'object'),
+  credentials JSONB CHECK (credentials IS NULL OR jsonb_typeof(credentials) = 'object'),
+  credential_expires_at TIMESTAMPTZ,
+  scopes JSONB NOT NULL CHECK (jsonb_typeof(scopes) = 'array'),
+  accounts JSONB NOT NULL CHECK (jsonb_typeof(accounts) = 'array'),
+  status TEXT NOT NULL CHECK (status IN ('pending_selection', 'active', 'needs_reauthorization', 'revocation_pending', 'revoked')),
+  selection_expires_at TIMESTAMPTZ,
+  revision INTEGER NOT NULL CHECK (revision >= 0),
+  mutation_id TEXT,
+  mutation_kind TEXT CHECK (mutation_kind IN ('refresh', 'reauthorization', 'revocation')),
+  mutation_phase TEXT CHECK (mutation_phase IN ('prepared', 'executing', 'result_staged')),
+  mutation_holder_id TEXT,
+  mutation_expires_at TIMESTAMPTZ,
+  mutation_deadline_at TIMESTAMPTZ,
+  mutation_expected_connection_ids JSONB CHECK (
+    mutation_expected_connection_ids IS NULL OR jsonb_typeof(mutation_expected_connection_ids) = 'array'
+  ),
+  staged_credentials JSONB CHECK (
+    staged_credentials IS NULL OR jsonb_typeof(staged_credentials) = 'object'
+  ),
+  staged_credential_expires_at TIMESTAMPTZ,
+  staged_scopes JSONB CHECK (staged_scopes IS NULL OR jsonb_typeof(staged_scopes) = 'array'),
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (project_id, connector_id, id),
+  UNIQUE (project_id, id),
+  CHECK (
+    (mutation_id IS NULL AND mutation_kind IS NULL AND mutation_phase IS NULL AND mutation_holder_id IS NULL AND mutation_expires_at IS NULL AND mutation_deadline_at IS NULL AND mutation_expected_connection_ids IS NULL AND staged_credentials IS NULL AND staged_credential_expires_at IS NULL AND staged_scopes IS NULL)
+    OR (mutation_id IS NOT NULL AND mutation_kind IS NOT NULL AND mutation_phase IS NOT NULL AND mutation_holder_id IS NOT NULL AND mutation_expires_at IS NOT NULL AND mutation_deadline_at IS NOT NULL)
+  ),
+  CHECK (
+    (
+      mutation_phase IS NULL
+      AND staged_credentials IS NULL
+      AND staged_credential_expires_at IS NULL
+      AND staged_scopes IS NULL
+    )
+    OR (
+      mutation_phase IN ('prepared', 'executing')
+      AND staged_credentials IS NULL
+      AND staged_credential_expires_at IS NULL
+      AND staged_scopes IS NULL
+    )
+    OR (
+      mutation_phase = 'result_staged'
+      AND mutation_kind = 'revocation'
+      AND staged_credentials IS NULL
+      AND staged_credential_expires_at IS NULL
+      AND staged_scopes IS NULL
+    )
+    OR (
+      mutation_phase = 'result_staged'
+      AND mutation_kind IN ('refresh', 'reauthorization')
+      AND staged_credentials IS NOT NULL
+      AND staged_scopes IS NOT NULL
+    )
+  ),
+  CHECK ((status = 'pending_selection') = (selection_expires_at IS NOT NULL)),
+  CHECK ((status = 'revoked') = (credentials IS NULL))
+);
+
+CREATE INDEX idx_connector_authorizations_status
+  ON connector_authorizations (project_id, connector_id, status, updated_at);
+CREATE INDEX idx_connector_authorizations_mutation_expiry
+  ON connector_authorizations (project_id, connector_id, mutation_expires_at)
+  WHERE mutation_id IS NOT NULL;
+
+CREATE TABLE connector_connections (
+  project_id TEXT NOT NULL,
+  connector_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  authorization_id TEXT NOT NULL,
+  slot TEXT NOT NULL,
+  account JSONB NOT NULL CHECK (jsonb_typeof(account) = 'object'),
+  account_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('connected', 'disconnected')),
+  disconnected_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (project_id, connector_id, id),
+  UNIQUE (project_id, id),
+  UNIQUE (project_id, connector_id, slot),
+  FOREIGN KEY (project_id, connector_id, authorization_id)
+    REFERENCES connector_authorizations (project_id, connector_id, id)
+    ON DELETE RESTRICT,
+  CHECK ((status = 'connected') = (disconnected_at IS NULL)),
+  CHECK (account ? 'id' AND account ->> 'id' = account_id)
+);
+
+CREATE INDEX idx_connector_connections_authorization
+  ON connector_connections (project_id, connector_id, authorization_id, status, id);
+CREATE INDEX idx_connector_connections_status
+  ON connector_connections (project_id, connector_id, status, id);

--- a/storage/pg/src/testing.ts
+++ b/storage/pg/src/testing.ts
@@ -1,0 +1,18 @@
+export interface PostgresStorageTestingAdapter {
+  advanceConnectorConnectionTime(durationMs: number): void
+}
+
+const adapters = new WeakMap<object, PostgresStorageTestingAdapter>()
+
+export function registerPostgresStorageTestingAdapter(
+  storage: object,
+  advanceConnectorConnectionTime: (durationMs: number) => void
+): void {
+  adapters.set(storage, { advanceConnectorConnectionTime })
+}
+
+export function getPostgresStorageTestingAdapter(storage: object): PostgresStorageTestingAdapter {
+  const adapter = adapters.get(storage)
+  if (!adapter) throw new Error("[SixbPg] Storage testing adapter is unavailable.")
+  return adapter
+}

--- a/storage/pg/tests/pg-connector-connection-storage.e2e.ts
+++ b/storage/pg/tests/pg-connector-connection-storage.e2e.ts
@@ -1,0 +1,164 @@
+import { expect, test } from "bun:test"
+import { runConnectorConnectionStorageContractSuite } from "@sixb/core/testing"
+import { PostgresStorage } from "../src"
+import { getPostgresStorageTestingAdapter } from "../src/testing"
+import { createTestStorage } from "./helpers"
+
+runConnectorConnectionStorageContractSuite("PgConnectorConnectionStorage", {
+  createStorage: async () => (await createTestStorage()).storage,
+  advanceTime: (storage, durationMs) =>
+    getPostgresStorageTestingAdapter(storage).advanceConnectorConnectionTime(durationMs),
+  teardown: async (storage) => {
+    await storage.dropSchema()
+    await storage.close()
+  },
+})
+
+test("serializes callback, slot and credential claims across storage replicas", async () => {
+  const { storage: first, schemaName } = await createTestStorage()
+  const connectionString = process.env.DATABASE_URL
+  if (!connectionString) throw new Error("[SixbPg] DATABASE_URL is required.")
+  const second = new PostgresStorage({ connectionString, schemaName, max: 2 })
+  const projectId = "project-a"
+  const connectorId = "social"
+  const credentials = {
+    version: 1,
+    algorithm: "A256GCM",
+    nonce: "nonce",
+    ciphertext: "ciphertext",
+    tag: "tag",
+  } as const
+
+  try {
+    await first.connectorConnections.createConnectionRun({
+      id: "run-a",
+      projectId,
+      connectorId,
+      kind: "connect",
+      owner: { type: "project" },
+      slot: "callback",
+      initiatedByExecutionId: "execution-a",
+      ttlMs: 60_000,
+    })
+    await first.connectorConnections.createAuthorizationAttempt({
+      id: "attempt-a",
+      projectId,
+      connectorId,
+      owner: { type: "project" },
+      slot: "callback",
+      initiatedByExecutionId: "execution-a",
+      stateHash: "state-hash",
+      codeVerifier: credentials,
+      redirectUri: "https://example.com/oauth/callback",
+      connectionRunId: "run-a",
+      returnTo: "https://app.example.com/connectors",
+      callbackBindingHash: "binding-hash",
+      ttlMs: 60_000,
+    })
+    const callbackInput = {
+      projectId,
+      attemptId: "attempt-a",
+      stateHash: "state-hash",
+      callbackBindingHash: "binding-hash",
+      redirectUri: "https://example.com/oauth/callback",
+      processingId: "processing-a",
+      processingTtlMs: 60_000,
+    }
+    const callbacks = await Promise.all([
+      first.connectorConnections.claimConnectionRunCallback(callbackInput),
+      second.connectorConnections.claimConnectionRunCallback({
+        ...callbackInput,
+        processingId: "processing-b",
+      }),
+    ])
+    expect(callbacks.filter((result) => result?.type === "claimed")).toHaveLength(1)
+    expect(callbacks.filter((result) => result === null)).toHaveLength(1)
+
+    const [firstAuthorization, secondAuthorization] = await Promise.all([
+      first.connectorConnections.createAuthorization({
+        id: "authorization-a",
+        projectId,
+        connectorId,
+        authorizedBy: { type: "user", id: "user-a" },
+        credentials,
+        scopes: [],
+        accounts: [{ id: "account-a", label: "Account A" }],
+        selectionTtlMs: 60_000,
+      }),
+      second.connectorConnections.createAuthorization({
+        id: "authorization-b",
+        projectId,
+        connectorId,
+        authorizedBy: { type: "user", id: "user-b" },
+        credentials,
+        scopes: [],
+        accounts: [{ id: "account-b", label: "Account B" }],
+        selectionTtlMs: 60_000,
+      }),
+    ])
+
+    const selections = await Promise.allSettled([
+      first.connectorConnections.putConnection({
+        id: "connection-a",
+        projectId,
+        connectorId,
+        authorizationId: firstAuthorization.id,
+        owner: { type: "project" },
+        slot: "default",
+        account: { id: "account-a", label: "ignored" },
+        replace: false,
+      }),
+      second.connectorConnections.putConnection({
+        id: "connection-b",
+        projectId,
+        connectorId,
+        authorizationId: secondAuthorization.id,
+        owner: { type: "project" },
+        slot: "default",
+        account: { id: "account-b", label: "ignored" },
+        replace: false,
+      }),
+    ])
+
+    expect(selections.filter((result) => result.status === "fulfilled")).toHaveLength(1)
+    expect(selections.filter((result) => result.status === "rejected")).toHaveLength(1)
+    const connection = await first.connectorConnections.getConnection({
+      projectId,
+      connectorId,
+      owner: { type: "project" },
+      slot: "default",
+    })
+    expect(connection).not.toBeNull()
+    const authorization = await first.connectorConnections.getAuthorization({
+      projectId,
+      connectorId,
+      authorizationId: connection!.authorizationId,
+    })
+    if (!authorization) throw new Error("Expected the winning authorization.")
+
+    const claims = await Promise.all([
+      first.connectorConnections.claimCredentialMutation({
+        projectId,
+        connectorId,
+        authorizationId: authorization.id,
+        expectedRevision: authorization.revision,
+        mutation: { id: "mutation-a", kind: "refresh", holderId: "worker-a" },
+        leaseDurationMs: 30_000,
+        operationTimeoutMs: 60_000,
+      }),
+      second.connectorConnections.claimCredentialMutation({
+        projectId,
+        connectorId,
+        authorizationId: authorization.id,
+        expectedRevision: authorization.revision,
+        mutation: { id: "mutation-b", kind: "refresh", holderId: "worker-b" },
+        leaseDurationMs: 30_000,
+        operationTimeoutMs: 60_000,
+      }),
+    ])
+    expect(claims.filter((claim) => claim !== null)).toHaveLength(1)
+  } finally {
+    await first.dropSchema()
+    await Promise.all([first.close(), second.close()])
+  }
+})

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -76,6 +76,7 @@ describe("Postgres storage migrations", () => {
             "022-projection-executions",
             "023-webhook-executions",
             "024-ontology-commit-executions",
+            "025-connector-connections",
           ],
         },
       ])
@@ -247,6 +248,13 @@ describe("Postgres storage migrations", () => {
           id: "024-ontology-commit-executions",
           status: "applied",
           version: 24,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "025-connector-connections",
+          status: "applied",
+          version: 25,
         },
       ])
     })
@@ -1261,6 +1269,38 @@ describe("Postgres storage migrations", () => {
     })
   })
 
+  test("stores a headless connector attempt as the run's single protocol child", async () => {
+    await withStorage(false, async (storage, schemaName) => {
+      await migrateStorage(storage)
+
+      expect(await readTableColumns(schemaName, "connector_connection_runs")).not.toContain(
+        "authorization_attempt_id"
+      )
+      expect(await readTableColumns(schemaName, "connector_authorization_attempts")).not.toContain(
+        "owner_type"
+      )
+      expect(await readTableColumns(schemaName, "connector_connections")).not.toContain(
+        "owner_type"
+      )
+      expect(
+        await readUniqueConstraints(schemaName, "connector_authorization_attempts")
+      ).toContainEqual(["project_id", "connector_id", "connection_run_id"])
+      expect(
+        await readTableForeignKeys(schemaName, "connector_authorization_attempts")
+      ).toContainEqual({
+        column_name: "connection_run_id",
+        delete_action: "r",
+        foreign_column_name: "id",
+        foreign_table_name: "connector_connection_runs",
+      })
+      expect(await readUniqueConstraints(schemaName, "connector_connections")).toContainEqual([
+        "project_id",
+        "connector_id",
+        "slot",
+      ])
+    })
+  })
+
   test("drops only obsolete run usage projections from an existing schema", async () => {
     // Regression guard: remove migration 020 (or any one DROP COLUMN) and this leaves the old
     // projection column behind; deleting the run rows instead breaks the preservation assertions.
@@ -1606,6 +1646,13 @@ describe("Postgres storage migrations", () => {
           id: "024-ontology-commit-executions",
           status: "applied",
           version: 24,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "025-connector-connections",
+          status: "applied",
+          version: 25,
         },
       ])
     } finally {

--- a/storage/sqlite/README.md
+++ b/storage/sqlite/README.md
@@ -4,8 +4,9 @@ SQLite storage provider for Sixb, built on `bun:sqlite`.
 
 Backs every Sixb store — objects, ontology commits, auth, agents, the immutable execution and AI
 usage ledgers, timeseries, and the run history for actions, syncs, pipelines, projections,
-workflows, and webhooks — from a single local database file. This is the storage `bun create sixb`
-scaffolds, and part of what makes a fresh project run with no service to install.
+workflows, webhooks, and managed connector connections — from a single local database file. This
+is the storage `bun create sixb` scaffolds, and part of what makes a fresh project run with no
+service to install.
 
 ## Install
 

--- a/storage/sqlite/src/connector-connection-storage.ts
+++ b/storage/sqlite/src/connector-connection-storage.ts
@@ -1,0 +1,784 @@
+import type { Database, SQLQueryBindings } from "bun:sqlite"
+import {
+  type ConnectorConnectionPersistence,
+  type ConnectorConnectionPersistenceBackend,
+  type ConnectorConnectionPersistenceScope,
+  DurableConnectorConnectionStorage,
+} from "@sixb/core/internal/connector-connection-storage-provider"
+import type {
+  ConnectorAuthorizationAttemptRecord,
+  ConnectorAuthorizationRecord,
+  ConnectorConnectionRecord,
+  ConnectorConnectionRunRecord,
+  ConnectorCredentialMutation,
+} from "@sixb/core/storage"
+import { isUniqueConstraintError } from "./storage-errors"
+import { runImmediateTransactionAsync, type SqliteStoreConnection } from "./transactions"
+
+export class SqliteConnectorConnectionStorage extends DurableConnectorConnectionStorage {
+  private readonly clock: ConnectorConnectionTestClock
+
+  constructor(connection: SqliteStoreConnection) {
+    const clock = { offsetMs: 0 }
+    super(new SqliteConnectorConnectionPersistenceBackend(connection.db, clock))
+    this.clock = clock
+  }
+
+  /** Internal deterministic clock control used only by the provider contract suite. */
+  advanceTimeForTesting(durationMs: number): void {
+    this.clock.offsetMs += durationMs
+  }
+}
+
+class SqliteConnectorConnectionPersistenceBackend implements ConnectorConnectionPersistenceBackend {
+  constructor(
+    private readonly db: Database,
+    private readonly clock: ConnectorConnectionTestClock
+  ) {}
+
+  read<T>(
+    scope: ConnectorConnectionPersistenceScope,
+    run: (persistence: ConnectorConnectionPersistence) => Promise<T>
+  ): Promise<T> {
+    return run(new SqliteConnectorConnectionPersistence(this.db, scope, this.clock))
+  }
+
+  transaction<T>(
+    scope: ConnectorConnectionPersistenceScope,
+    run: (persistence: ConnectorConnectionPersistence) => Promise<T>
+  ): Promise<T> {
+    return runImmediateTransactionAsync(this.db, () =>
+      run(new SqliteConnectorConnectionPersistence(this.db, scope, this.clock))
+    )
+  }
+}
+
+class SqliteConnectorConnectionPersistence implements ConnectorConnectionPersistence {
+  constructor(
+    private readonly db: Database,
+    private readonly scope: ConnectorConnectionPersistenceScope,
+    private readonly clock: ConnectorConnectionTestClock
+  ) {}
+
+  async now(): Promise<Date> {
+    const row = this.db.query("SELECT strftime('%Y-%m-%dT%H:%M:%fZ', 'now') AS now").get() as {
+      readonly now: string
+    }
+    return new Date(new Date(row.now).getTime() + this.clock.offsetMs)
+  }
+
+  async insertAuthorizationAttempt(record: ConnectorAuthorizationAttemptRecord): Promise<boolean> {
+    try {
+      this.db
+        .query(
+          `
+          INSERT INTO connector_authorization_attempts (
+            project_id, connector_id, id, slot, initiated_by_execution_id,
+            state_hash, code_verifier, redirect_uri, connection_run_id, return_to,
+            callback_binding_hash, reauthorization_id, reauthorization_revision,
+            reauthorization_connection_ids, created_at, expires_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+        )
+        .run(
+          record.projectId,
+          record.connectorId,
+          record.id,
+          record.slot,
+          record.initiatedByExecutionId,
+          record.stateHash,
+          json(record.codeVerifier),
+          record.redirectUri,
+          record.connectionRunId ?? null,
+          record.returnTo ?? null,
+          record.callbackBindingHash ?? null,
+          record.reauthorizationId ?? null,
+          record.reauthorizationRevision ?? null,
+          record.reauthorizationConnectionIds ? json(record.reauthorizationConnectionIds) : null,
+          iso(record.createdAt),
+          iso(record.expiresAt)
+        )
+      return true
+    } catch (error) {
+      if (isUniqueConstraintError(error)) return false
+      throw error
+    }
+  }
+
+  async getAuthorizationAttempt(id: string): Promise<ConnectorAuthorizationAttemptRecord | null> {
+    const row = this.getById<SqliteAuthorizationAttemptRow>("connector_authorization_attempts", id)
+    return row ? authorizationAttemptFromRow(row) : null
+  }
+
+  async getAuthorizationAttemptByConnectionRunId(
+    connectionRunId: string
+  ): Promise<ConnectorAuthorizationAttemptRecord | null> {
+    if (!this.scope.connectorId) return null
+    const row = this.db
+      .query(
+        `
+        SELECT * FROM connector_authorization_attempts
+        WHERE project_id = ? AND connector_id = ? AND connection_run_id = ?
+      `
+      )
+      .get(
+        this.scope.projectId,
+        this.scope.connectorId,
+        connectionRunId
+      ) as SqliteAuthorizationAttemptRow | null
+    return row ? authorizationAttemptFromRow(row) : null
+  }
+
+  async deleteAuthorizationAttempt(id: string): Promise<boolean> {
+    return this.deleteById("connector_authorization_attempts", id)
+  }
+
+  async insertConnectionRun(record: ConnectorConnectionRunRecord): Promise<boolean> {
+    try {
+      this.insertRun(record)
+      return true
+    } catch (error) {
+      if (isUniqueConstraintError(error)) return false
+      throw error
+    }
+  }
+
+  async getConnectionRun(id: string): Promise<ConnectorConnectionRunRecord | null> {
+    const row = this.getById<SqliteConnectionRunRow>("connector_connection_runs", id)
+    return row ? connectionRunFromRow(row) : null
+  }
+
+  async updateConnectionRun(record: ConnectorConnectionRunRecord): Promise<void> {
+    const values = runValues(record)
+    const result = this.db
+      .query(
+        `
+        UPDATE connector_connection_runs
+        SET kind = ?, slot = ?, initiated_by_execution_id = ?, status = ?,
+            waiting_for = ?, processing_id = ?,
+            callback_started_at = ?, expires_at = ?, authorization_id = ?,
+            cleanup_authorization_id = ?, connections = ?, error = ?, updated_at = ?, finished_at = ?
+        WHERE project_id = ? AND connector_id = ? AND id = ?
+      `
+      )
+      .run(...values, record.projectId, record.connectorId, record.id)
+    assertChanged(result.changes, "connector connection run", record.id)
+  }
+
+  async insertAuthorization(record: ConnectorAuthorizationRecord): Promise<boolean> {
+    try {
+      this.insertAuthorizationRow(record)
+      return true
+    } catch (error) {
+      if (isUniqueConstraintError(error)) return false
+      throw error
+    }
+  }
+
+  async getAuthorization(id: string): Promise<ConnectorAuthorizationRecord | null> {
+    const row = this.getById<SqliteAuthorizationRow>("connector_authorizations", id)
+    return row ? authorizationFromRow(row) : null
+  }
+
+  async updateAuthorization(record: ConnectorAuthorizationRecord): Promise<void> {
+    const result = this.db
+      .query(
+        `
+        UPDATE connector_authorizations
+        SET authorized_by = ?, credentials = ?, credential_expires_at = ?, scopes = ?, accounts = ?,
+            status = ?, selection_expires_at = ?, revision = ?, mutation_id = ?, mutation_kind = ?,
+            mutation_phase = ?, mutation_holder_id = ?, mutation_expires_at = ?,
+            mutation_deadline_at = ?, mutation_expected_connection_ids = ?, staged_credentials = ?,
+            staged_credential_expires_at = ?, staged_scopes = ?, updated_at = ?
+        WHERE project_id = ? AND connector_id = ? AND id = ?
+      `
+      )
+      .run(...authorizationValues(record), record.projectId, record.connectorId, record.id)
+    assertChanged(result.changes, "connector authorization", record.id)
+  }
+
+  async insertConnection(record: ConnectorConnectionRecord): Promise<boolean> {
+    try {
+      this.db
+        .query(
+          `
+          INSERT INTO connector_connections (
+            project_id, connector_id, id, authorization_id, slot, account,
+            account_id, status, disconnected_at, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+        )
+        .run(
+          record.projectId,
+          record.connectorId,
+          record.id,
+          record.authorizationId,
+          record.slot,
+          json(record.account),
+          record.account.id,
+          record.status,
+          optionalIso(record.disconnectedAt),
+          iso(record.createdAt),
+          iso(record.updatedAt)
+        )
+      return true
+    } catch (error) {
+      if (isUniqueConstraintError(error)) return false
+      throw error
+    }
+  }
+
+  async getConnectionById(id: string): Promise<ConnectorConnectionRecord | null> {
+    const row = this.getById<SqliteConnectionRow>("connector_connections", id)
+    return row ? connectionFromRow(row) : null
+  }
+
+  async getConnectionBySelector(input: {
+    readonly owner: { readonly type: "project" }
+    readonly slot: string
+  }): Promise<ConnectorConnectionRecord | null> {
+    if (!this.scope.connectorId) return null
+    const row = this.db
+      .query(
+        `
+        SELECT * FROM connector_connections
+        WHERE project_id = ? AND connector_id = ? AND slot = ?
+      `
+      )
+      .get(this.scope.projectId, this.scope.connectorId, input.slot) as SqliteConnectionRow | null
+    return row ? connectionFromRow(row) : null
+  }
+
+  async listConnections(): Promise<readonly ConnectorConnectionRecord[]> {
+    if (!this.scope.connectorId) return []
+    const rows = this.db
+      .query(
+        `
+        SELECT * FROM connector_connections
+        WHERE project_id = ? AND connector_id = ?
+        ORDER BY id
+      `
+      )
+      .all(this.scope.projectId, this.scope.connectorId) as SqliteConnectionRow[]
+    return rows.map(connectionFromRow)
+  }
+
+  async listConnectionsByAuthorization(
+    authorizationId: string,
+    options: { readonly connectedOnly?: boolean } = {}
+  ): Promise<readonly ConnectorConnectionRecord[]> {
+    if (!this.scope.connectorId) return []
+    const rows = options.connectedOnly
+      ? (this.db
+          .query(
+            `
+            SELECT * FROM connector_connections
+            WHERE project_id = ? AND connector_id = ? AND authorization_id = ?
+              AND status = 'connected'
+            ORDER BY id
+          `
+          )
+          .all(
+            this.scope.projectId,
+            this.scope.connectorId,
+            authorizationId
+          ) as SqliteConnectionRow[])
+      : (this.db
+          .query(
+            `
+            SELECT * FROM connector_connections
+            WHERE project_id = ? AND connector_id = ? AND authorization_id = ?
+            ORDER BY id
+          `
+          )
+          .all(
+            this.scope.projectId,
+            this.scope.connectorId,
+            authorizationId
+          ) as SqliteConnectionRow[])
+    return rows.map(connectionFromRow)
+  }
+
+  async updateConnection(record: ConnectorConnectionRecord): Promise<void> {
+    const result = this.db
+      .query(
+        `
+        UPDATE connector_connections
+        SET authorization_id = ?, slot = ?, account = ?, account_id = ?,
+            status = ?, disconnected_at = ?, updated_at = ?
+        WHERE project_id = ? AND connector_id = ? AND id = ?
+      `
+      )
+      .run(
+        record.authorizationId,
+        record.slot,
+        json(record.account),
+        record.account.id,
+        record.status,
+        optionalIso(record.disconnectedAt),
+        iso(record.updatedAt),
+        record.projectId,
+        record.connectorId,
+        record.id
+      )
+    assertChanged(result.changes, "connector connection", record.id)
+  }
+
+  private insertRun(record: ConnectorConnectionRunRecord): void {
+    const values = runValues(record)
+    this.db
+      .query(
+        `
+        INSERT INTO connector_connection_runs (
+          project_id, connector_id, id, kind, slot, initiated_by_execution_id,
+          status, waiting_for, processing_id, callback_started_at,
+          expires_at, authorization_id, cleanup_authorization_id, connections, error,
+          created_at, updated_at, finished_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+      )
+      .run(
+        record.projectId,
+        record.connectorId,
+        record.id,
+        ...values.slice(0, -2),
+        iso(record.createdAt),
+        ...values.slice(-2)
+      )
+  }
+
+  private insertAuthorizationRow(record: ConnectorAuthorizationRecord): void {
+    const values = authorizationValues(record)
+    this.db
+      .query(
+        `
+        INSERT INTO connector_authorizations (
+          project_id, connector_id, id, authorized_by, credentials, credential_expires_at,
+          scopes, accounts, status, selection_expires_at, revision, mutation_id, mutation_kind,
+          mutation_phase, mutation_holder_id, mutation_expires_at, mutation_deadline_at,
+          mutation_expected_connection_ids, staged_credentials, staged_credential_expires_at,
+          staged_scopes, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+      )
+      .run(
+        record.projectId,
+        record.connectorId,
+        record.id,
+        ...values.slice(0, -1),
+        iso(record.createdAt),
+        ...values.slice(-1)
+      )
+  }
+
+  private getById<TRow>(table: ConnectorTable, id: string): TRow | null {
+    if (this.scope.connectorId) {
+      return this.db
+        .query(`SELECT * FROM ${table} WHERE project_id = ? AND connector_id = ? AND id = ?`)
+        .get(this.scope.projectId, this.scope.connectorId, id) as TRow | null
+    }
+    return this.db
+      .query(`SELECT * FROM ${table} WHERE project_id = ? AND id = ?`)
+      .get(this.scope.projectId, id) as TRow | null
+  }
+
+  private deleteById(table: ConnectorTable, id: string): boolean {
+    const result = this.scope.connectorId
+      ? this.db
+          .query(`DELETE FROM ${table} WHERE project_id = ? AND connector_id = ? AND id = ?`)
+          .run(this.scope.projectId, this.scope.connectorId, id)
+      : this.db
+          .query(`DELETE FROM ${table} WHERE project_id = ? AND id = ?`)
+          .run(this.scope.projectId, id)
+    return result.changes === 1
+  }
+}
+
+type ConnectorTable =
+  | "connector_authorization_attempts"
+  | "connector_connection_runs"
+  | "connector_authorizations"
+  | "connector_connections"
+
+function authorizationAttemptFromRow(
+  row: SqliteAuthorizationAttemptRow
+): ConnectorAuthorizationAttemptRecord {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    connectorId: row.connector_id,
+    owner: { type: "project" },
+    slot: row.slot,
+    initiatedByExecutionId: row.initiated_by_execution_id,
+    stateHash: row.state_hash,
+    codeVerifier: parseJson(row.code_verifier),
+    redirectUri: row.redirect_uri,
+    ...(row.connection_run_id === null ? {} : { connectionRunId: row.connection_run_id }),
+    ...(row.return_to === null ? {} : { returnTo: row.return_to }),
+    ...(row.callback_binding_hash === null
+      ? {}
+      : { callbackBindingHash: row.callback_binding_hash }),
+    ...(row.reauthorization_id === null ? {} : { reauthorizationId: row.reauthorization_id }),
+    ...(row.reauthorization_revision === null
+      ? {}
+      : { reauthorizationRevision: row.reauthorization_revision }),
+    ...(row.reauthorization_connection_ids === null
+      ? {}
+      : { reauthorizationConnectionIds: parseJson(row.reauthorization_connection_ids) }),
+    createdAt: new Date(row.created_at),
+    expiresAt: new Date(row.expires_at),
+  }
+}
+
+function runValues(record: ConnectorConnectionRunRecord): readonly SQLQueryBindings[] {
+  const waitingFor = record.status === "waiting" ? record.waitingFor : null
+  const processingId = record.status === "running" ? record.processingId : null
+  const callbackStartedAt = record.status === "running" ? iso(record.callbackStartedAt) : null
+  const expiresAt =
+    record.status === "waiting" || record.status === "running" ? iso(record.expiresAt) : null
+  const authorizationId = "authorizationId" in record ? (record.authorizationId ?? null) : null
+  const cleanupAuthorizationId =
+    record.status === "succeeded" ? (record.cleanupAuthorizationId ?? null) : null
+  const connections = record.status === "succeeded" ? json(record.connections) : null
+  const error = record.status === "failed" ? json(record.error) : null
+  const finishedAt =
+    record.status === "succeeded" ||
+    record.status === "failed" ||
+    record.status === "cancelled" ||
+    record.status === "expired"
+      ? iso(record.finishedAt)
+      : null
+  return [
+    record.kind,
+    record.slot,
+    record.initiatedByExecutionId,
+    record.status,
+    waitingFor,
+    processingId,
+    callbackStartedAt,
+    expiresAt,
+    authorizationId,
+    cleanupAuthorizationId,
+    connections,
+    error,
+    iso(record.updatedAt),
+    finishedAt,
+  ]
+}
+
+function connectionRunFromRow(row: SqliteConnectionRunRow): ConnectorConnectionRunRecord {
+  const base = {
+    id: row.id,
+    projectId: row.project_id,
+    connectorId: row.connector_id,
+    kind: row.kind,
+    owner: { type: "project" as const },
+    slot: row.slot,
+    initiatedByExecutionId: row.initiated_by_execution_id,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  }
+  if (row.status === "waiting" && row.waiting_for === "provider_authorization") {
+    return {
+      ...base,
+      status: "waiting",
+      waitingFor: "provider_authorization",
+      expiresAt: new Date(required(row.expires_at, "run expiry")),
+    }
+  }
+  if (row.status === "waiting" && row.waiting_for === "account_selection") {
+    return {
+      ...base,
+      status: "waiting",
+      waitingFor: "account_selection",
+      authorizationId: required(row.authorization_id, "authorization id"),
+      expiresAt: new Date(required(row.expires_at, "run expiry")),
+    }
+  }
+  if (row.status === "running") {
+    return {
+      ...base,
+      status: "running",
+      processingId: required(row.processing_id, "processing id"),
+      callbackStartedAt: new Date(required(row.callback_started_at, "callback start")),
+      expiresAt: new Date(required(row.expires_at, "run expiry")),
+      ...(row.authorization_id === null ? {} : { authorizationId: row.authorization_id }),
+    }
+  }
+  const finishedAt = new Date(required(row.finished_at, "run finish"))
+  if (row.status === "succeeded") {
+    return {
+      ...base,
+      status: "succeeded",
+      authorizationId: required(row.authorization_id, "authorization id"),
+      ...(row.cleanup_authorization_id === null
+        ? {}
+        : { cleanupAuthorizationId: row.cleanup_authorization_id }),
+      connections: parseJson<readonly SerializedConnectorConnection[]>(
+        required(row.connections, "connections")
+      ).map(connectionFromSerialized),
+      finishedAt,
+    }
+  }
+  if (row.status === "failed") {
+    return {
+      ...base,
+      status: "failed",
+      error: parseJson(required(row.error, "run error")),
+      ...(row.authorization_id === null ? {} : { authorizationId: row.authorization_id }),
+      finishedAt,
+    }
+  }
+  if (row.status === "cancelled") {
+    return {
+      ...base,
+      status: "cancelled",
+      ...(row.authorization_id === null ? {} : { authorizationId: row.authorization_id }),
+      finishedAt,
+    }
+  }
+  if (row.status === "expired") {
+    return {
+      ...base,
+      status: "expired",
+      ...(row.authorization_id === null ? {} : { authorizationId: row.authorization_id }),
+      finishedAt,
+    }
+  }
+  throw invalidStoredValue("connector connection run status", row.status)
+}
+
+function authorizationValues(record: ConnectorAuthorizationRecord): readonly SQLQueryBindings[] {
+  const mutation = record.credentialMutation
+  const staged = mutation?.stagedCredentials
+  return [
+    json(record.authorizedBy),
+    record.credentials ? json(record.credentials) : null,
+    optionalIso(record.credentialExpiresAt),
+    json(record.scopes),
+    json(record.accounts),
+    record.status,
+    optionalIso(record.selectionExpiresAt),
+    record.revision,
+    mutation?.id ?? null,
+    mutation?.kind ?? null,
+    mutation?.phase ?? null,
+    mutation?.holderId ?? null,
+    optionalIso(mutation?.expiresAt),
+    optionalIso(mutation?.deadlineAt),
+    mutation?.expectedConnectionIds ? json(mutation.expectedConnectionIds) : null,
+    staged ? json(staged.credentials) : null,
+    optionalIso(staged?.credentialExpiresAt),
+    staged ? json(staged.scopes) : null,
+    iso(record.updatedAt),
+  ]
+}
+
+function authorizationFromRow(row: SqliteAuthorizationRow): ConnectorAuthorizationRecord {
+  const mutation = mutationFromRow(row)
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    connectorId: row.connector_id,
+    authorizedBy: parseJson(row.authorized_by),
+    ...(row.credentials === null ? {} : { credentials: parseJson(row.credentials) }),
+    ...(row.credential_expires_at === null
+      ? {}
+      : { credentialExpiresAt: new Date(row.credential_expires_at) }),
+    scopes: parseJson(row.scopes),
+    accounts: parseJson(row.accounts),
+    status: row.status,
+    ...(row.selection_expires_at === null
+      ? {}
+      : { selectionExpiresAt: new Date(row.selection_expires_at) }),
+    revision: row.revision,
+    ...(mutation === undefined ? {} : { credentialMutation: mutation }),
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  }
+}
+
+function mutationFromRow(row: SqliteAuthorizationRow): ConnectorCredentialMutation | undefined {
+  if (row.mutation_id === null) return undefined
+  const kind = required(row.mutation_kind, "credential mutation kind")
+  const phase = required(row.mutation_phase, "credential mutation phase")
+  const stagedCredentials: ConnectorCredentialMutation["stagedCredentials"] =
+    row.staged_credentials === null
+      ? undefined
+      : {
+          credentials: parseJson<
+            NonNullable<ConnectorCredentialMutation["stagedCredentials"]>["credentials"]
+          >(row.staged_credentials),
+          ...(row.staged_credential_expires_at === null
+            ? {}
+            : { credentialExpiresAt: new Date(row.staged_credential_expires_at) }),
+          scopes: parseJson<readonly string[]>(
+            required(row.staged_scopes, "staged credential scopes")
+          ),
+        }
+  return {
+    id: row.mutation_id,
+    kind,
+    phase,
+    holderId: required(row.mutation_holder_id, "credential mutation holder"),
+    expiresAt: new Date(required(row.mutation_expires_at, "credential mutation expiry")),
+    deadlineAt: new Date(required(row.mutation_deadline_at, "credential mutation deadline")),
+    ...(row.mutation_expected_connection_ids === null
+      ? {}
+      : {
+          expectedConnectionIds: parseJson<readonly string[]>(row.mutation_expected_connection_ids),
+        }),
+    ...(stagedCredentials === undefined ? {} : { stagedCredentials }),
+  }
+}
+
+function connectionFromRow(row: SqliteConnectionRow): ConnectorConnectionRecord {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    connectorId: row.connector_id,
+    authorizationId: row.authorization_id,
+    owner: { type: "project" },
+    slot: row.slot,
+    account: parseJson(row.account),
+    status: row.status,
+    ...(row.disconnected_at === null ? {} : { disconnectedAt: new Date(row.disconnected_at) }),
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  }
+}
+
+type SerializedConnectorConnection = Omit<
+  ConnectorConnectionRecord,
+  "createdAt" | "updatedAt" | "disconnectedAt"
+> & {
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly disconnectedAt?: string
+}
+
+function connectionFromSerialized(
+  record: SerializedConnectorConnection
+): ConnectorConnectionRecord {
+  const { createdAt, updatedAt, disconnectedAt, ...connection } = record
+  return {
+    ...connection,
+    createdAt: new Date(createdAt),
+    updatedAt: new Date(updatedAt),
+    ...(disconnectedAt === undefined ? {} : { disconnectedAt: new Date(disconnectedAt) }),
+  }
+}
+
+function json(value: unknown): string {
+  return JSON.stringify(value)
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value) as T
+}
+
+function iso(value: Date): string {
+  return value.toISOString()
+}
+
+function optionalIso(value: Date | undefined): string | null {
+  return value?.toISOString() ?? null
+}
+
+function required<T>(value: T | null, label: string): T {
+  if (value !== null) return value
+  throw new Error(`[SixbSqlite] Stored ${label} is missing.`)
+}
+
+function invalidStoredValue(label: string, value: unknown): Error {
+  return new Error(`[SixbSqlite] Stored ${label} '${String(value)}' is invalid.`)
+}
+
+function assertChanged(changes: number, label: string, id: string): void {
+  if (changes === 1) return
+  throw new Error(`[SixbSqlite] Stored ${label} '${id}' is unavailable.`)
+}
+
+interface SqliteAuthorizationAttemptRow {
+  readonly project_id: string
+  readonly connector_id: string
+  readonly id: string
+  readonly slot: string
+  readonly initiated_by_execution_id: string
+  readonly state_hash: string
+  readonly code_verifier: string
+  readonly redirect_uri: string
+  readonly connection_run_id: string | null
+  readonly return_to: string | null
+  readonly callback_binding_hash: string | null
+  readonly reauthorization_id: string | null
+  readonly reauthorization_revision: number | null
+  readonly reauthorization_connection_ids: string | null
+  readonly created_at: string
+  readonly expires_at: string
+}
+
+interface SqliteConnectionRunRow {
+  readonly project_id: string
+  readonly connector_id: string
+  readonly id: string
+  readonly kind: ConnectorConnectionRunRecord["kind"]
+  readonly slot: string
+  readonly initiated_by_execution_id: string
+  readonly status: ConnectorConnectionRunRecord["status"]
+  readonly waiting_for: "provider_authorization" | "account_selection" | null
+  readonly processing_id: string | null
+  readonly callback_started_at: string | null
+  readonly expires_at: string | null
+  readonly authorization_id: string | null
+  readonly cleanup_authorization_id: string | null
+  readonly connections: string | null
+  readonly error: string | null
+  readonly created_at: string
+  readonly updated_at: string
+  readonly finished_at: string | null
+}
+
+interface SqliteAuthorizationRow {
+  readonly project_id: string
+  readonly connector_id: string
+  readonly id: string
+  readonly authorized_by: string
+  readonly credentials: string | null
+  readonly credential_expires_at: string | null
+  readonly scopes: string
+  readonly accounts: string
+  readonly status: ConnectorAuthorizationRecord["status"]
+  readonly selection_expires_at: string | null
+  readonly revision: number
+  readonly mutation_id: string | null
+  readonly mutation_kind: ConnectorCredentialMutation["kind"] | null
+  readonly mutation_phase: ConnectorCredentialMutation["phase"] | null
+  readonly mutation_holder_id: string | null
+  readonly mutation_expires_at: string | null
+  readonly mutation_deadline_at: string | null
+  readonly mutation_expected_connection_ids: string | null
+  readonly staged_credentials: string | null
+  readonly staged_credential_expires_at: string | null
+  readonly staged_scopes: string | null
+  readonly created_at: string
+  readonly updated_at: string
+}
+
+interface SqliteConnectionRow {
+  readonly project_id: string
+  readonly connector_id: string
+  readonly id: string
+  readonly authorization_id: string
+  readonly slot: string
+  readonly account: string
+  readonly account_id: string
+  readonly status: ConnectorConnectionRecord["status"]
+  readonly disconnected_at: string | null
+  readonly created_at: string
+  readonly updated_at: string
+}
+
+interface ConnectorConnectionTestClock {
+  offsetMs: number
+}

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -28,6 +28,7 @@ import { SqliteActionRunStorage } from "./action-run-storage"
 import { SqliteAgentStorage } from "./agents"
 import { SqliteAiUsageStorage } from "./ai-usage-storage"
 import { SqliteAuthStorage } from "./auth-storage"
+import { SqliteConnectorConnectionStorage } from "./connector-connection-storage"
 import { SqliteExecutionStorage } from "./execution-storage"
 import {
   createSqliteStorageMigrators,
@@ -40,6 +41,7 @@ import { SqlitePipelineRunStorage } from "./pipeline-run-storage"
 import { SqliteProjectionRunStorage } from "./projection-run-storage"
 import { SqliteRulesStorage } from "./rules-storage"
 import { SqliteSyncRunStorage } from "./sync-run-storage"
+import { registerSqliteStorageTestingAdapter } from "./testing"
 import { SqliteTimeseriesStorage } from "./timeseries-storage"
 import {
   closeSqliteStoreConnection,
@@ -60,7 +62,7 @@ export interface SqliteStorageOptions {
  * SQLite storage provider for Sixb.
  *
  * Bundles object, timeseries, auth, execution, AI usage, sync run, pipeline run, projection run,
- * workflow run, and webhook run storage backed by SQLite.
+ * workflow run, webhook run, and connector connection storage backed by SQLite.
  *
  * Usage:
  * ```ts
@@ -88,6 +90,7 @@ export class SqliteStorage implements MigrationCapableStorage {
   readonly timeseries: Storage["timeseries"]
   readonly webhookRuns: SqliteWebhookRunStorage
   readonly rules: SqliteRulesStorage
+  readonly connectorConnections: SqliteConnectorConnectionStorage
   readonly migrators: readonly StorageMigrator[]
 
   private readonly connection: SqliteStoreConnection
@@ -149,7 +152,11 @@ export class SqliteStorage implements MigrationCapableStorage {
     this.workflowInterventions = createOperationScopedFacade(stores.workflowInterventions, scope)
     this.webhookRuns = createOperationScopedFacade(stores.webhookRuns, scope)
     this.rules = createOperationScopedFacade(stores.rules, scope)
+    this.connectorConnections = createOperationScopedFacade(stores.connectorConnections, scope)
     this.migrators = options.path ? createSqliteStorageMigrators(options.path) : []
+    registerSqliteStorageTestingAdapter(this, (durationMs) =>
+      stores.connectorConnections.advanceTimeForTesting(durationMs)
+    )
   }
 
   async ping(): Promise<void> {
@@ -300,6 +307,7 @@ function createSqliteStores(
     workflowInterventions: new SqliteWorkflowInterventionStorage({ connection }),
     webhookRuns: new SqliteWebhookRunStorage({ connection, executions }),
     rules: new SqliteRulesStorage({ connection }),
+    connectorConnections: new SqliteConnectorConnectionStorage(connection),
   }
 }
 
@@ -319,6 +327,7 @@ interface SqliteStoreSet {
   readonly timeseries: SqliteTimeseriesStorage
   readonly webhookRuns: SqliteWebhookRunStorage
   readonly rules: SqliteRulesStorage
+  readonly connectorConnections: SqliteConnectorConnectionStorage
 }
 
 export { migrateSqliteStorage } from "./migrations"

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -66,6 +66,9 @@ import webhookExecutionsSql from "./migrations/023-webhook-executions.sql" with 
 import ontologyCommitExecutionsSql from "./migrations/024-ontology-commit-executions.sql" with {
   type: "text",
 }
+import connectorConnectionsSql from "./migrations/025-connector-connections.sql" with {
+  type: "text",
+}
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -145,6 +148,7 @@ export const sqliteStorageMigrations = defineMigrations({
       },
       { checksum: checksum(ontologyCommitExecutionsSql) }
     ),
+    sqliteSql("025-connector-connections", connectorConnectionsSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/025-connector-connections.sql
+++ b/storage/sqlite/src/migrations/025-connector-connections.sql
@@ -1,0 +1,257 @@
+CREATE TABLE connector_connection_runs (
+  project_id TEXT NOT NULL,
+  connector_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('connect', 'reauthorize')),
+  slot TEXT NOT NULL,
+  initiated_by_execution_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('waiting', 'running', 'succeeded', 'failed', 'cancelled', 'expired')),
+  waiting_for TEXT CHECK (waiting_for IN ('provider_authorization', 'account_selection')),
+  processing_id TEXT,
+  callback_started_at TEXT,
+  expires_at TEXT,
+  authorization_id TEXT,
+  cleanup_authorization_id TEXT,
+  connections TEXT CHECK (
+    connections IS NULL OR (json_valid(connections) AND json_type(connections) = 'array')
+  ),
+  error TEXT CHECK (error IS NULL OR (json_valid(error) AND json_type(error) = 'object')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  finished_at TEXT,
+  PRIMARY KEY (project_id, connector_id, id),
+  UNIQUE (project_id, id),
+  CHECK (
+    (
+      status = 'waiting'
+      AND waiting_for = 'provider_authorization'
+      AND processing_id IS NULL
+      AND callback_started_at IS NULL
+      AND expires_at IS NOT NULL
+      AND authorization_id IS NULL
+      AND cleanup_authorization_id IS NULL
+      AND connections IS NULL
+      AND error IS NULL
+      AND finished_at IS NULL
+    )
+    OR
+    (
+      status = 'waiting'
+      AND waiting_for = 'account_selection'
+      AND processing_id IS NULL
+      AND callback_started_at IS NULL
+      AND expires_at IS NOT NULL
+      AND authorization_id IS NOT NULL
+      AND cleanup_authorization_id IS NULL
+      AND connections IS NULL
+      AND error IS NULL
+      AND finished_at IS NULL
+    )
+    OR
+    (
+      status = 'running'
+      AND waiting_for IS NULL
+      AND processing_id IS NOT NULL
+      AND callback_started_at IS NOT NULL
+      AND expires_at IS NOT NULL
+      AND cleanup_authorization_id IS NULL
+      AND connections IS NULL
+      AND error IS NULL
+      AND finished_at IS NULL
+    )
+    OR
+    (
+      status = 'succeeded'
+      AND waiting_for IS NULL
+      AND processing_id IS NULL
+      AND callback_started_at IS NULL
+      AND expires_at IS NULL
+      AND authorization_id IS NOT NULL
+      AND connections IS NOT NULL
+      AND error IS NULL
+      AND finished_at IS NOT NULL
+    )
+    OR
+    (
+      status = 'failed'
+      AND waiting_for IS NULL
+      AND processing_id IS NULL
+      AND callback_started_at IS NULL
+      AND expires_at IS NULL
+      AND cleanup_authorization_id IS NULL
+      AND connections IS NULL
+      AND error IS NOT NULL
+      AND finished_at IS NOT NULL
+    )
+    OR
+    (
+      status IN ('cancelled', 'expired')
+      AND waiting_for IS NULL
+      AND processing_id IS NULL
+      AND callback_started_at IS NULL
+      AND expires_at IS NULL
+      AND cleanup_authorization_id IS NULL
+      AND connections IS NULL
+      AND error IS NULL
+      AND finished_at IS NOT NULL
+    )
+  )
+);
+
+CREATE INDEX idx_connector_runs_status
+  ON connector_connection_runs (project_id, connector_id, status, updated_at);
+
+CREATE TABLE connector_authorization_attempts (
+  project_id TEXT NOT NULL,
+  connector_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  slot TEXT NOT NULL,
+  initiated_by_execution_id TEXT NOT NULL,
+  state_hash TEXT NOT NULL,
+  code_verifier TEXT NOT NULL CHECK (
+    json_valid(code_verifier) AND json_type(code_verifier) = 'object'
+  ),
+  redirect_uri TEXT NOT NULL,
+  connection_run_id TEXT,
+  return_to TEXT,
+  callback_binding_hash TEXT,
+  reauthorization_id TEXT,
+  reauthorization_revision INTEGER CHECK (
+    reauthorization_revision IS NULL OR reauthorization_revision >= 0
+  ),
+  reauthorization_connection_ids TEXT CHECK (
+    reauthorization_connection_ids IS NULL
+    OR (json_valid(reauthorization_connection_ids) AND json_type(reauthorization_connection_ids) = 'array')
+  ),
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  PRIMARY KEY (project_id, connector_id, id),
+  UNIQUE (project_id, id),
+  UNIQUE (project_id, connector_id, connection_run_id),
+  FOREIGN KEY (project_id, connector_id, connection_run_id)
+    REFERENCES connector_connection_runs (project_id, connector_id, id)
+    ON DELETE RESTRICT,
+  CHECK (
+    (connection_run_id IS NULL AND return_to IS NULL AND callback_binding_hash IS NULL)
+    OR
+    (connection_run_id IS NOT NULL AND return_to IS NOT NULL AND callback_binding_hash IS NOT NULL)
+  ),
+  CHECK (
+    (reauthorization_id IS NULL AND reauthorization_revision IS NULL AND reauthorization_connection_ids IS NULL)
+    OR
+    (reauthorization_id IS NOT NULL AND reauthorization_revision IS NOT NULL AND reauthorization_connection_ids IS NOT NULL)
+  )
+);
+
+CREATE INDEX idx_connector_attempts_expiry
+  ON connector_authorization_attempts (project_id, connector_id, expires_at);
+
+CREATE TABLE connector_authorizations (
+  project_id TEXT NOT NULL,
+  connector_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  authorized_by TEXT NOT NULL CHECK (
+    json_valid(authorized_by) AND json_type(authorized_by) = 'object'
+  ),
+  credentials TEXT CHECK (
+    credentials IS NULL OR (json_valid(credentials) AND json_type(credentials) = 'object')
+  ),
+  credential_expires_at TEXT,
+  scopes TEXT NOT NULL CHECK (json_valid(scopes) AND json_type(scopes) = 'array'),
+  accounts TEXT NOT NULL CHECK (json_valid(accounts) AND json_type(accounts) = 'array'),
+  status TEXT NOT NULL CHECK (status IN ('pending_selection', 'active', 'needs_reauthorization', 'revocation_pending', 'revoked')),
+  selection_expires_at TEXT,
+  revision INTEGER NOT NULL CHECK (revision >= 0),
+  mutation_id TEXT,
+  mutation_kind TEXT CHECK (mutation_kind IN ('refresh', 'reauthorization', 'revocation')),
+  mutation_phase TEXT CHECK (mutation_phase IN ('prepared', 'executing', 'result_staged')),
+  mutation_holder_id TEXT,
+  mutation_expires_at TEXT,
+  mutation_deadline_at TEXT,
+  mutation_expected_connection_ids TEXT CHECK (
+    mutation_expected_connection_ids IS NULL
+    OR (json_valid(mutation_expected_connection_ids) AND json_type(mutation_expected_connection_ids) = 'array')
+  ),
+  staged_credentials TEXT CHECK (
+    staged_credentials IS NULL
+    OR (json_valid(staged_credentials) AND json_type(staged_credentials) = 'object')
+  ),
+  staged_credential_expires_at TEXT,
+  staged_scopes TEXT CHECK (
+    staged_scopes IS NULL OR (json_valid(staged_scopes) AND json_type(staged_scopes) = 'array')
+  ),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (project_id, connector_id, id),
+  UNIQUE (project_id, id),
+  CHECK (
+    (mutation_id IS NULL AND mutation_kind IS NULL AND mutation_phase IS NULL AND mutation_holder_id IS NULL AND mutation_expires_at IS NULL AND mutation_deadline_at IS NULL AND mutation_expected_connection_ids IS NULL AND staged_credentials IS NULL AND staged_credential_expires_at IS NULL AND staged_scopes IS NULL)
+    OR
+    (mutation_id IS NOT NULL AND mutation_kind IS NOT NULL AND mutation_phase IS NOT NULL AND mutation_holder_id IS NOT NULL AND mutation_expires_at IS NOT NULL AND mutation_deadline_at IS NOT NULL)
+  ),
+  CHECK (
+    (
+      mutation_phase IS NULL
+      AND staged_credentials IS NULL
+      AND staged_credential_expires_at IS NULL
+      AND staged_scopes IS NULL
+    )
+    OR
+    (
+      mutation_phase IN ('prepared', 'executing')
+      AND staged_credentials IS NULL
+      AND staged_credential_expires_at IS NULL
+      AND staged_scopes IS NULL
+    )
+    OR
+    (
+      mutation_phase = 'result_staged'
+      AND mutation_kind = 'revocation'
+      AND staged_credentials IS NULL
+      AND staged_credential_expires_at IS NULL
+      AND staged_scopes IS NULL
+    )
+    OR
+    (
+      mutation_phase = 'result_staged'
+      AND mutation_kind IN ('refresh', 'reauthorization')
+      AND staged_credentials IS NOT NULL
+      AND staged_scopes IS NOT NULL
+    )
+  ),
+  CHECK ((status = 'pending_selection') = (selection_expires_at IS NOT NULL)),
+  CHECK ((status = 'revoked') = (credentials IS NULL))
+);
+
+CREATE INDEX idx_connector_authorizations_status
+  ON connector_authorizations (project_id, connector_id, status, updated_at);
+CREATE INDEX idx_connector_authorizations_mutation_expiry
+  ON connector_authorizations (project_id, connector_id, mutation_expires_at)
+  WHERE mutation_id IS NOT NULL;
+
+CREATE TABLE connector_connections (
+  project_id TEXT NOT NULL,
+  connector_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  authorization_id TEXT NOT NULL,
+  slot TEXT NOT NULL,
+  account TEXT NOT NULL CHECK (json_valid(account) AND json_type(account) = 'object'),
+  account_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('connected', 'disconnected')),
+  disconnected_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (project_id, connector_id, id),
+  UNIQUE (project_id, id),
+  UNIQUE (project_id, connector_id, slot),
+  FOREIGN KEY (project_id, connector_id, authorization_id)
+    REFERENCES connector_authorizations (project_id, connector_id, id)
+    ON DELETE RESTRICT,
+  CHECK ((status = 'connected') = (disconnected_at IS NULL)),
+  CHECK (json_extract(account, '$.id') IS NOT NULL AND json_extract(account, '$.id') = account_id)
+);
+
+CREATE INDEX idx_connector_connections_authorization
+  ON connector_connections (project_id, connector_id, authorization_id, status, id);
+CREATE INDEX idx_connector_connections_status
+  ON connector_connections (project_id, connector_id, status, id);

--- a/storage/sqlite/src/testing.ts
+++ b/storage/sqlite/src/testing.ts
@@ -1,0 +1,20 @@
+export interface SqliteStorageTestingAdapter {
+  advanceConnectorConnectionTime(durationMs: number): void
+}
+
+const adapters = new WeakMap<object, SqliteStorageTestingAdapter>()
+
+export function registerSqliteStorageTestingAdapter(
+  storage: object,
+  advanceConnectorConnectionTime: (durationMs: number) => void
+): void {
+  adapters.set(storage, {
+    advanceConnectorConnectionTime,
+  })
+}
+
+export function getSqliteStorageTestingAdapter(storage: object): SqliteStorageTestingAdapter {
+  const adapter = adapters.get(storage)
+  if (!adapter) throw new Error("[SixbSqlite] Storage testing adapter is unavailable.")
+  return adapter
+}

--- a/storage/sqlite/tests/sqlite-connector-connection-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-connector-connection-storage.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { migrateStorage } from "@sixb/core"
+import { runConnectorConnectionStorageContractSuite } from "@sixb/core/testing"
+import { SqliteStorage } from "../src"
+import { getSqliteStorageTestingAdapter } from "../src/testing"
+
+runConnectorConnectionStorageContractSuite("SqliteConnectorConnectionStorage", {
+  createStorage: () => new SqliteStorage(),
+  advanceTime: (storage, durationMs) =>
+    getSqliteStorageTestingAdapter(storage).advanceConnectorConnectionTime(durationMs),
+  teardown: (storage) => storage.close(),
+})
+
+test("persists connector attempts, runs, authorizations and connections across restarts", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "sixb-sqlite-connectors-"))
+  let storage: SqliteStorage | undefined
+  try {
+    storage = new SqliteStorage({ path: directory })
+    await migrateStorage(storage)
+    const connections = storage.connectorConnections
+    await connections.createConnectionRun({
+      id: "run-a",
+      projectId: "project-a",
+      connectorId: "social",
+      kind: "connect",
+      owner: { type: "project" },
+      slot: "default",
+      initiatedByExecutionId: "execution-a",
+      ttlMs: 60_000,
+    })
+    await connections.createAuthorizationAttempt({
+      id: "attempt-a",
+      projectId: "project-a",
+      connectorId: "social",
+      owner: { type: "project" },
+      slot: "default",
+      initiatedByExecutionId: "execution-a",
+      stateHash: "state-hash",
+      codeVerifier: sealedCredential(),
+      redirectUri: "https://example.com/oauth/callback",
+      connectionRunId: "run-a",
+      returnTo: "https://app.example.com/connectors",
+      callbackBindingHash: "binding-hash",
+      ttlMs: 60_000,
+    })
+    const authorization = await connections.createAuthorization({
+      id: "authorization-a",
+      projectId: "project-a",
+      connectorId: "social",
+      authorizedBy: { type: "user", id: "user-a" },
+      credentials: sealedCredential(),
+      scopes: ["read"],
+      accounts: [{ id: "account-a", label: "Account A" }],
+      selectionTtlMs: 60_000,
+    })
+    await connections.putConnection({
+      id: "connection-a",
+      projectId: "project-a",
+      connectorId: "social",
+      authorizationId: authorization.id,
+      owner: { type: "project" },
+      slot: "default",
+      account: { id: "account-a", label: "Account A" },
+      replace: false,
+    })
+    storage.close()
+
+    storage = new SqliteStorage({ path: directory })
+    await expect(
+      storage.connectorConnections.getConnectionRun({
+        projectId: "project-a",
+        connectorId: "social",
+        runId: "run-a",
+      })
+    ).resolves.toMatchObject({ id: "run-a", status: "waiting" })
+    await expect(
+      storage.connectorConnections.consumeAuthorizationAttempt({
+        id: "attempt-a",
+        projectId: "project-a",
+        connectorId: "social",
+        stateHash: "state-hash",
+        redirectUri: "https://example.com/oauth/callback",
+      })
+    ).resolves.toMatchObject({ id: "attempt-a" })
+    await expect(
+      storage.connectorConnections.getAuthorization({
+        projectId: "project-a",
+        connectorId: "social",
+        authorizationId: "authorization-a",
+      })
+    ).resolves.toMatchObject({ id: "authorization-a", status: "active" })
+    await expect(
+      storage.connectorConnections.getConnectionById({
+        projectId: "project-a",
+        connectorId: "social",
+        connectionId: "connection-a",
+      })
+    ).resolves.toMatchObject({ id: "connection-a", account: { id: "account-a" } })
+  } finally {
+    storage?.close()
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+function sealedCredential() {
+  return {
+    version: 1 as const,
+    algorithm: "A256GCM" as const,
+    nonce: "nonce",
+    ciphertext: "ciphertext",
+    tag: "tag",
+  }
+}

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -196,6 +196,13 @@ const expectedStorageMigrationRows = [
     status: "applied",
     version: 24,
   },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "025-connector-connections",
+    status: "applied",
+    version: 25,
+  },
 ]
 
 afterEach(async () => {
@@ -1567,6 +1574,36 @@ describe("SQLite storage migrations", () => {
       expect(readMemoryIndexColumns(db, "idx_ontology_commits_execution")).toEqual([
         "project_id",
         "execution_id",
+      ])
+    } finally {
+      db.close()
+    }
+  })
+
+  test("stores a headless connector attempt as the run's single protocol child", () => {
+    const db = new Database(":memory:")
+    try {
+      for (const migration of sqliteStorageMigrations.steps) migration.up(db)
+
+      expect(readMemoryTableColumns(db, "connector_connection_runs")).not.toContain(
+        "authorization_attempt_id"
+      )
+      expect(readMemoryTableColumns(db, "connector_authorization_attempts")).not.toContain(
+        "owner_type"
+      )
+      expect(readMemoryTableColumns(db, "connector_connections")).not.toContain("owner_type")
+      expect(readMemoryUniqueIndexes(db, "connector_authorization_attempts")).toContainEqual([
+        "project_id",
+        "connector_id",
+        "connection_run_id",
+      ])
+      expect(readMemoryForeignKeyTables(db, "connector_authorization_attempts")).toContain(
+        "connector_connection_runs"
+      )
+      expect(readMemoryUniqueIndexes(db, "connector_connections")).toContainEqual([
+        "project_id",
+        "connector_id",
+        "slot",
       ])
     } finally {
       db.close()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,6 +65,9 @@
       "@sixb/core/internal/connector-connections": [
         "./packages/core/src/connectors/connections/internal.ts"
       ],
+      "@sixb/core/internal/connector-connection-storage-provider": [
+        "./packages/core/src/storage/connector-connections/provider.ts"
+      ],
       "@sixb/core/internal/edits": ["./packages/core/src/edits/index.ts"],
       "@sixb/core/internal/error-reporting": ["./packages/core/src/error-reporting/internal.ts"],
       "@sixb/core/internal/errors": ["./packages/core/src/errors/internal.ts"],


### PR DESCRIPTION
## Why

- OAuth connections must survive restarts and work across server replicas.
- The in-memory provider remains appropriate for development, not production.

## What

- Add durable `ConnectorConnectionStorage` implementations for PostgreSQL and SQLite.
- Share the lifecycle state machine in Core; providers own only persistence, transactions and database time.
- Wire connector storage into both storage packages automatically.
- Document durable connector support and migration requirements.

```text
Connector lifecycle
        │
        ▼
Shared durable state machine
        │
        ├── PostgreSQL persistence
        └── SQLite persistence
```

## Guarantees

- Atomic connection runs, account selection, replacement and credential mutations.
- Database-authoritative expirations and fenced refresh/reauthorization/revocation.
- One stable connection per `(project, connector, slot)`.
- One transient OAuth attempt per connection run, enforced by FK and uniqueness.
- Project ownership remains explicit in the API and implicit in the V1 schema.
- OAuth credentials and PKCE verifiers remain encrypted envelopes at rest.

## Verification

- Shared conformance suite: in-memory, PostgreSQL and SQLite.
- PostgreSQL replica-concurrency coverage.
- Migration, restart, rollback and expiry coverage.
- Typecheck, build and Biome checks pass.

Part of #384.
