### PR TITLE
linkedin: add Advertising and Community Management connector

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -179,6 +179,21 @@
         "@sixb/core": "workspace:^",
       },
     },
+    "connectors/linkedin": {
+      "name": "@sixb/connector-linkedin",
+      "version": "0.1.1",
+      "dependencies": {
+        "@sixb/connector-rest": "workspace:^",
+      },
+      "devDependencies": {
+        "@sixb/core": "workspace:*",
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+      "peerDependencies": {
+        "@sixb/core": "workspace:^",
+      },
+    },
     "connectors/mercury": {
       "name": "@sixb/connector-mercury",
       "version": "0.1.1",
@@ -1402,6 +1417,8 @@
     "@sixb/connector-google": ["@sixb/connector-google@workspace:connectors/google"],
 
     "@sixb/connector-imap": ["@sixb/connector-imap@workspace:connectors/imap"],
+
+    "@sixb/connector-linkedin": ["@sixb/connector-linkedin@workspace:connectors/linkedin"],
 
     "@sixb/connector-mercury": ["@sixb/connector-mercury@workspace:connectors/mercury"],
 

--- a/connectors/linkedin/LICENSE
+++ b/connectors/linkedin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sixb contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/connectors/linkedin/README.md
+++ b/connectors/linkedin/README.md
@@ -1,0 +1,276 @@
+# @sixb/connector-linkedin
+
+Typed LinkedIn Advertising and Community Management API connector for Sixb. It is a direct Rest.li
+client for advertising entities and reporting, administered Pages, organic posts and engagement,
+organization analytics, and authenticated-member analytics. The connector preserves LinkedIn wire
+payloads instead of introducing a second domain model, so every request remains easy to compare
+with the upstream documentation.
+
+## Register
+
+Until Sixb's managed OAuth flow lands, provide an access token directly or through an async
+resolver:
+
+```ts
+import { defineConnector } from "@sixb/core"
+import { linkedin } from "@sixb/connector-linkedin"
+
+export const linkedinConnector = defineConnector(
+  "linkedin",
+  linkedin({
+    accessToken: () => process.env.LINKEDIN_ACCESS_TOKEN!,
+  })
+)
+```
+
+`createSixb()` discovers definitions in the project's `connectors/` directory. Resolve the client
+with:
+
+```ts
+const li = await sixb.connector(linkedinConnector)
+```
+
+The token resolver runs for every attempt, including retries. The future managed OAuth adapter can
+therefore supply a current access token without changing any resource.
+
+## Access and versioning
+
+The client targets LinkedIn's versioned `/rest` API and sends both required headers on every call:
+
+- `Linkedin-Version: 202608` by default
+- `X-Restli-Protocol-Version: 2.0.0`
+
+Pass `version` explicitly when pinning a different supported monthly version. LinkedIn sunsets
+Marketing API versions, so upgrading the version should be an intentional application change.
+
+The application and member must have the relevant LinkedIn API product and OAuth scopes. A
+Community Management Development Tier request must start on a new LinkedIn developer application
+with no other provisioned product. LinkedIn's current Standard Tier process can subsequently add
+Community Management to an existing Advertising API application after the separate application has
+been approved and used for verification. Until that upgrade, configure the Advertising and
+Community connector instances with their respective application tokens.
+
+| Operation | OAuth scope |
+| --- | --- |
+| Read advertising entities | `r_ads` |
+| Create or update advertising entities | `rw_ads` |
+| Read ad analytics and revenue attribution | `r_ads_reporting` |
+| Discover Page roles, read organization details, and read Page/follower/share analytics | `rw_organization_admin` |
+| Read organization posts and organization video analytics | `r_organization_social` |
+| Create, update, or delete organization posts | `w_organization_social` |
+| Read organization comments, reactions, and social metadata | `r_organization_social_feed` |
+| Create, update, or delete organization comments and reactions | `w_organization_social_feed` |
+| Create, update, or delete member posts | `w_member_social` |
+| Create, update, or delete member comments and reactions | `w_member_social_feed` |
+| Read member posts, comments, and reactions | `r_member_social_feed` (restricted) |
+| Read the authenticated member's follower analytics | `r_member_profileAnalytics` |
+| Read the authenticated member's post and video analytics | `r_member_postAnalytics` |
+
+The connector does not perform the OAuth authorization-code exchange or token refresh. Those remain
+the responsibility of the supplied token resolver until the framework's managed OAuth connection is
+available.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `accessToken` | Required bearer token or async token resolver. |
+| `version` | LinkedIn Marketing API version without a dash. Defaults to `202608`. |
+| `baseUrl` | Defaults to `https://api.linkedin.com/rest/`; mainly useful for testing. |
+| `timeoutMs` | Optional timeout for each request attempt. |
+| `minDelayMs` | Optional minimum delay between request starts. |
+| `retry` | Method-aware transient-failure policy. Defaults to two retries for reads only. |
+| `queryTunnelingThreshold` | Query byte length at which GET query tunneling is used. Defaults to 3500. |
+
+Retries cover network errors, `429`, and `5xx` responses and honor `Retry-After`. Writes are not
+retried by default because an interrupted create or update may already have been applied upstream.
+
+## Advertising API
+
+| Client method | LinkedIn endpoint |
+| --- | --- |
+| `li.adAccounts.get(id)` | `GET /adAccounts/{id}` |
+| `li.adAccounts.search(options?)` / `.searchAll(options?)` | `GET /adAccounts?q=search` |
+| `li.adAccounts.create(input)` | `POST /adAccounts` |
+| `li.adAccounts.update(id, input)` | `POST /adAccounts/{id}` partial update |
+| `li.adAccountUsers.get(account, user)` | `GET /adAccountUsers/(account:...,user:...)` |
+| `li.adAccountUsers.listByAccount(account, options?)` | `GET /adAccountUsers?q=accounts` |
+| `li.adAccountUsers.listByAuthenticatedUser(options?)` | `GET /adAccountUsers?q=authenticatedUser` |
+| `li.adAccountUsers.grant(input)` / `.update(input)` / `.revoke(account, user)` | Account user writes |
+| `li.adAccount(id).campaignGroups.*` | `/adAccounts/{id}/adCampaignGroups` |
+| `li.adAccount(id).campaigns.*` | `/adAccounts/{id}/adCampaigns` |
+| `li.adAccount(id).creatives.*` | `/adAccounts/{id}/creatives` |
+| `li.adAnalytics.analytics(query)` | `GET /adAnalytics?q=analytics` |
+| `li.adAnalytics.statistics(query)` | `GET /adAnalytics?q=statistics` |
+| `li.adAnalytics.attributedRevenue(query)` | `GET /adAnalytics?q=attributedRevenueMetrics` |
+
+Every search method returns one normalized page with `items` and the upstream next-page token.
+`searchAll()` is an async iterator that follows tokens and fails if LinkedIn repeats one, avoiding
+an accidental infinite sync.
+
+```ts
+for await (const campaign of li.adAccount(123).campaigns.searchAll({
+  statuses: ["ACTIVE"],
+  pageSize: 100,
+})) {
+  // Persist the upstream campaign as-is or map it into an ontology object.
+}
+```
+
+URN helpers provide the exact template-literal types used by LinkedIn:
+
+```ts
+import { sponsoredAccountUrn, sponsoredCampaignUrn } from "@sixb/connector-linkedin"
+
+const account = sponsoredAccountUrn(123)
+const campaign = sponsoredCampaignUrn(456)
+```
+
+## Reporting
+
+Reporting validates dates, field count, and pivot count before making a request. Metric names remain
+open strings because LinkedIn changes the reporting schema monthly; supply a row generic when the
+selected fields are known locally:
+
+```ts
+type CampaignMetrics = {
+  readonly pivotValues: readonly string[]
+  readonly impressions: number
+  readonly costInLocalCurrency: string
+}
+
+const rows = await li.adAnalytics.analytics<CampaignMetrics>({
+  pivot: "CAMPAIGN",
+  dateRange: { start: { year: 2026, month: 8, day: 1 } },
+  timeGranularity: "DAILY",
+  fields: ["pivotValues", "impressions", "costInLocalCurrency"],
+  accounts: [sponsoredAccountUrn(123)],
+})
+```
+
+Long reporting queries automatically use LinkedIn's query-tunneling convention: a form-encoded
+`POST` with `X-HTTP-Method-Override: GET`. This changes only the transport; retry policy still treats
+the operation as a read.
+
+## Community Management API
+
+The Community surfaces cover the core Page-management and organic-data flow:
+
+| Client method | LinkedIn endpoint |
+| --- | --- |
+| `li.organizationAcls.listForAuthenticatedMember(options?)` | `GET /organizationAcls?q=roleAssignee` |
+| `li.organizationAcls.listByOrganization(organization, options?)` | `GET /organizationAcls?q=organization` |
+| `li.organizations.get(id)` | `GET /organizations/{id}` |
+| `li.organizations.findByVanityName(name)` | `GET /organizations?q=vanityName` |
+| `li.organizations.listByParent(parent, options?)` | `GET /organizations?q=parentOrganization` |
+| `li.organizations.followerCount(organization)` | `GET /networkSizes/{organization}` |
+| `li.posts.get(post, viewContext?)` | `GET /posts/{post}` |
+| `li.posts.listByAuthor(author, options?)` / `.listAllByAuthor(...)` | `GET /posts?q=author` |
+| `li.posts.create(input)` / `.update(post, input)` / `.delete(post)` | Post writes |
+| `li.socialMetadata.get(entity)` / `.setCommentsState(entity, actor, state)` | `/socialMetadata/{entity}` |
+| `li.comments.list(entity, options?)` / `.get(entity, id)` | `/socialActions/{entity}/comments` |
+| `li.comments.create(...)` / `.update(...)` / `.delete(...)` | Comment writes |
+| `li.reactions.get(actor, entity)` / `.listByEntity(entity, options?)` | `/reactions` reads |
+| `li.reactions.create(input)` / `.delete(actor, entity)` | Reaction writes |
+| `li.images.get(urn)` / `li.videos.get(urn)` / `li.documents.get(urn)` | Media metadata and signed download URLs |
+| `li.organizationAnalytics.followers(organization, intervals?)` | `/organizationalEntityFollowerStatistics` |
+| `li.organizationAnalytics.pages(organization, intervals?)` | `/organizationPageStatistics` |
+| `li.organizationAnalytics.shares(organization, query?)` | `/organizationalEntityShareStatistics` |
+| `li.organizationAnalytics.video(query)` | `/videoAnalytics` |
+| `li.memberAnalytics.followers()` / `.followerHistory(range?)` | `/memberFollowersCount` |
+| `li.memberAnalytics.post(query)` / `.posts(query)` | `/memberCreatorPostAnalytics` |
+| `li.memberAnalytics.video(query)` | `/memberCreatorVideoAnalytics` |
+
+Start by discovering the organizations administered by the signed-in member, then load organic
+content and analytics with the returned organization URN:
+
+```ts
+const roles = await li.organizationAcls.listForAuthenticatedMember({
+  role: "ADMINISTRATOR",
+  state: "APPROVED",
+})
+
+for (const role of roles.items) {
+  const organization = role.organizationTarget ?? role.organization
+  if (!organization) continue
+
+  const posts = li.posts.listAllByAuthor(organization, { sortBy: "LAST_MODIFIED" })
+  const followerCount = await li.organizations.followerCount(organization)
+  const lifetimeShareStats = await li.organizationAnalytics.shares(organization)
+  // Persist `posts`, `followerCount`, and `lifetimeShareStats` in the desired datasets.
+}
+```
+
+Posts are modeled as the versioned `/posts` wire format. `content` types article, media,
+multi-image, poll, reference, carousel, and celebration payloads while remaining open to new
+LinkedIn formats. Resolve image, video, and document URNs through `li.images`, `li.videos`, and
+`li.documents`; their signed download URLs can expire, so resolve them close to use. Upload
+initialization and multipart transfer remain explicit upstream workflows and are not hidden behind
+post creation.
+
+Organization share analytics are organic-only and limited upstream to a rolling 12-month window.
+Use `li.adAnalytics` for sponsored performance. Lifetime follower demographics also have an
+important LinkedIn wire-format detail: the `organicFollowerCount` field contains the rolled-up paid
+and organic total for demographic facets. Use `li.organizations.followerCount(...)` for the current
+total Page follower count.
+
+Member analytics always concern the member represented by the access token. They do not provide
+analytics for arbitrary member profiles. Reading member-authored posts still depends on
+`r_member_social`, which LinkedIn currently treats as a closed permission; Page-authored posts use
+the organization scopes above.
+
+### Development Tier behavior
+
+LinkedIn's Community Management Development Tier currently limits traffic to 500 calls per
+application per day and 100 calls per member per day. It also excludes `BATCH_GET` and social-action
+webhooks. The client therefore exposes offset iterators instead of batch convenience methods and
+does not advertise a webhook surface that would fail in Development Tier.
+
+Offset iterators honor `paging.links[rel=next]`. This matters for `/posts`, which may return fewer
+items than requested even though a next page exists. Iteration also rejects a non-advancing offset
+instead of looping forever.
+
+## Resource behavior
+
+- Most creation methods return `{ id }` from LinkedIn's `x-restli-id` response header. Comment
+  creation also returns the parsed comment as `data`, including the composite `commentUrn` needed
+  for nested replies. Reaction creation returns LinkedIn's reaction response directly.
+- Updates use Rest.li partial updates and reject empty patches locally.
+- `deleteDraft` is named narrowly because LinkedIn only permits hard deletion for eligible entities
+  such as drafts. For other entities, use `update` with `PENDING_DELETION` as documented by LinkedIn.
+- Creative content unions and analytics metrics are intentionally extensible. Stable common fields
+  are typed, while new upstream formats and metrics pass through without data loss.
+- `LinkedinApiError` exposes status, service code, request ID, response headers, and the parsed
+  upstream error body for observability.
+
+LinkedIn imposes application- and member-level rate limits and returns their current values through
+developer tooling rather than fixed API headers. Use `minDelayMs`, the default transient read retry,
+and workflow-level scheduling according to the limits assigned to the application.
+
+Before creating campaigns, applications remain responsible for LinkedIn's current advertising
+policies, audience targeting restrictions, and any political advertising declarations required for
+the served region.
+
+## References
+
+- [LinkedIn Advertising API quick start](https://learn.microsoft.com/en-us/linkedin/marketing/quick-start?view=li-lms-2026-08)
+- [Community Management overview](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/community-management-overview?view=li-lms-2026-08)
+- [Community Management permissions](https://learn.microsoft.com/en-us/linkedin/marketing/increasing-access?view=li-lms-2026-08)
+- [Organization access control](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/organizations/organization-access-control-by-role?view=li-lms-2026-08)
+- [Organization lookup](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/organizations/organization-lookup-api?view=li-lms-2026-08)
+- [Posts](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api?view=li-lms-2026-08)
+- [Comments](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/comments-api?view=li-lms-2026-08)
+- [Reactions](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/reactions-api?view=li-lms-2026-08)
+- [Social metadata](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/social-metadata-api?view=li-lms-2026-08)
+- [Images](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/images-api?view=li-lms-2026-08)
+- [Videos](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/videos-api?view=li-lms-2026-08)
+- [Documents](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/documents-api?view=li-lms-2026-08)
+- [Organization follower, Page, share, and video analytics](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/community-management-overview?view=li-lms-2026-08#page-analytics)
+- [Member analytics](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/community-management-overview?view=li-lms-2026-08#member-analytics)
+- [Ad account structure](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-accounts?view=li-lms-2026-08)
+- [Ad reporting](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2026-08)
+- [Marketing API versioning](https://learn.microsoft.com/en-us/linkedin/marketing/versioning?view=li-lms-2026-08)
+- [Rest.li query tunneling](https://learn.microsoft.com/en-us/linkedin/shared/api-guide/concepts/query-tunneling)
+- [Sixb connectors](https://docs.sixb.ai/data/connectors)
+- [Sixb managed OAuth idea](https://github.com/sixb-ai/sixb/issues/384) and
+  [foundation PR](https://github.com/sixb-ai/sixb/pull/411)

--- a/connectors/linkedin/README.md
+++ b/connectors/linkedin/README.md
@@ -8,30 +8,65 @@ with the upstream documentation.
 
 ## Register
 
-Until Sixb's managed OAuth flow lands, provide an access token directly or through an async
-resolver:
+LinkedIn requires Community Management to be requested from an application that has no other
+provisioned product. Register one connector definition per LinkedIn developer application while
+the Advertising and Community products remain separate:
 
 ```ts
 import { defineConnector } from "@sixb/core"
 import { linkedin } from "@sixb/connector-linkedin"
 
-export const linkedinConnector = defineConnector(
-  "linkedin",
+export const linkedinAdvertising = defineConnector(
+  "linkedin-advertising",
   linkedin({
-    accessToken: () => process.env.LINKEDIN_ACCESS_TOKEN!,
+    clientId: process.env.LINKEDIN_ADS_CLIENT_ID!,
+    clientSecret: process.env.LINKEDIN_ADS_CLIENT_SECRET!,
+    accountType: "ad-account",
+    scopes: ["r_ads", "r_ads_reporting"],
+  })
+)
+
+export const linkedinCommunity = defineConnector(
+  "linkedin-community",
+  linkedin({
+    clientId: process.env.LINKEDIN_COMMUNITY_CLIENT_ID!,
+    clientSecret: process.env.LINKEDIN_COMMUNITY_CLIENT_SECRET!,
+    accountType: "organization",
+    scopes: [
+      "rw_organization_admin",
+      "r_organization_social",
+      "r_organization_social_feed",
+    ],
   })
 )
 ```
 
-`createSixb()` discovers definitions in the project's `connectors/` directory. Resolve the client
-with:
+`createSixb()` discovers definitions in the project's `connectors/` directory. Sixb owns the OAuth
+state, encrypted credentials, account selection, refresh coordination, and connection lifecycle.
+Register the server-owned callback URL in each LinkedIn application:
 
-```ts
-const li = await sixb.connector(linkedinConnector)
+```text
+https://<sixb-api-origin>/auth/connectors/callback
 ```
 
-The token resolver runs for every attempt, including retries. The future managed OAuth adapter can
-therefore supply a current access token without changing any resource.
+The `accountType` controls the accounts offered by Sixb after authorization:
+
+- `ad-account` calls `adAccountUsers?q=authenticatedUser`, then presents the accessible Campaign
+  Manager accounts.
+- `organization` calls `organizationAcls?q=roleAssignee`, then presents the approved administered
+  Pages.
+
+Advertising and Community grants therefore remain isolated while application code resolves each
+connection by its stable slot:
+
+```ts
+const li = await sixb.connector(linkedinCommunity, {
+  owner: { type: "project" },
+  slot: "organic-marketing",
+})
+
+console.log(li.account) // Selected organization URN and label
+```
 
 ## Access and versioning
 
@@ -48,7 +83,7 @@ Community Management Development Tier request must start on a new LinkedIn devel
 with no other provisioned product. LinkedIn's current Standard Tier process can subsequently add
 Community Management to an existing Advertising API application after the separate application has
 been approved and used for verification. Until that upgrade, configure the Advertising and
-Community connector instances with their respective application tokens.
+Community connector instances with their respective application credentials and OAuth scopes.
 
 | Operation | OAuth scope |
 | --- | --- |
@@ -66,15 +101,33 @@ Community connector instances with their respective application tokens.
 | Read the authenticated member's follower analytics | `r_member_profileAnalytics` |
 | Read the authenticated member's post and video analytics | `r_member_postAnalytics` |
 
-The connector does not perform the OAuth authorization-code exchange or token refresh. Those remain
-the responsibility of the supplied token resolver until the framework's managed OAuth connection is
-available.
+The connector implements LinkedIn's confidential authorization-code flow. LinkedIn only issues
+programmatic refresh tokens to eligible approved partners. If no refresh token is present, Sixb
+keeps the access token until its documented expiry and then moves the connection to
+`needs_reauthorization`; it never invents a refresh path. LinkedIn also returns a separate refresh
+token lifetime, which the current core credential contract cannot store. When that lifetime ends,
+the provider's definitive `invalid_grant` response moves the connection to the same reauthorization
+state.
+
+### LinkedIn PKCE compatibility
+
+Sixb currently requires every managed OAuth adapter to preserve its `state`, `code_challenge`, and
+`code_challenge_method=S256` parameters. LinkedIn documents PKCE only for a separate native flow
+that requires loopback callback URLs, while Sixb uses a server-owned HTTPS callback and LinkedIn's
+confidential web flow. The connector preserves the core-provided PKCE parameters on the standard
+authorization URL so the adapter passes core validation, but it does not send the undocumented
+`code_verifier` to LinkedIn's confidential token endpoint. Consequently, the LinkedIn flow relies
+on Sixb's one-use state and HttpOnly browser binding, the exact HTTPS redirect URI, and the
+application secret until the core can make PKCE capability provider-specific.
 
 ## Options
 
 | Option | Description |
 | --- | --- |
-| `accessToken` | Required bearer token or async token resolver. |
+| `clientId` | Required LinkedIn developer application client ID. |
+| `clientSecret` | Required LinkedIn developer application client secret. |
+| `scopes` | Required least-privilege list of LinkedIn OAuth scopes. |
+| `accountType` | `ad-account` or `organization`; determines managed account discovery. |
 | `version` | LinkedIn Marketing API version without a dash. Defaults to `202608`. |
 | `baseUrl` | Defaults to `https://api.linkedin.com/rest/`; mainly useful for testing. |
 | `timeoutMs` | Optional timeout for each request attempt. |
@@ -84,6 +137,9 @@ available.
 
 Retries cover network errors, `429`, and `5xx` responses and honor `Retry-After`. Writes are not
 retried by default because an interrupted create or update may already have been applied upstream.
+For reads, a `401` invalidates the exact token revision and safely replays the request once with the
+token supplied by Sixb. A write that returns `401` is never replayed or invalidated through the REST
+layer because its upstream effect may be ambiguous.
 
 ## Advertising API
 
@@ -271,6 +327,8 @@ the served region.
 - [Ad reporting](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2026-08)
 - [Marketing API versioning](https://learn.microsoft.com/en-us/linkedin/marketing/versioning?view=li-lms-2026-08)
 - [Rest.li query tunneling](https://learn.microsoft.com/en-us/linkedin/shared/api-guide/concepts/query-tunneling)
+- [LinkedIn authorization code flow](https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow)
+- [LinkedIn programmatic refresh tokens](https://learn.microsoft.com/en-us/linkedin/shared/authentication/programmatic-refresh-tokens)
+- [LinkedIn native PKCE flow](https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow-native)
 - [Sixb connectors](https://docs.sixb.ai/data/connectors)
-- [Sixb managed OAuth idea](https://github.com/sixb-ai/sixb/issues/384) and
-  [foundation PR](https://github.com/sixb-ai/sixb/pull/411)
+- [Sixb managed OAuth implementation](https://github.com/sixb-ai/sixb/issues/384)

--- a/connectors/linkedin/package.json
+++ b/connectors/linkedin/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@sixb/connector-linkedin",
+  "version": "0.1.1",
+  "description": "LinkedIn Advertising and Community Management API connector for Sixb",
+  "keywords": [
+    "sixb",
+    "bun",
+    "connector",
+    "integration",
+    "linkedin",
+    "advertising",
+    "community-management"
+  ],
+  "homepage": "https://sixb.ai",
+  "bugs": {
+    "url": "https://github.com/sixb-ai/sixb/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sixb-ai/sixb.git",
+    "directory": "connectors/linkedin"
+  },
+  "author": "Sixb contributors",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "bun": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "bun ../../scripts/build-package.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "prepack": "bun run build"
+  },
+  "dependencies": {
+    "@sixb/connector-rest": "workspace:^"
+  },
+  "peerDependencies": {
+    "@sixb/core": "workspace:^"
+  },
+  "devDependencies": {
+    "@sixb/core": "workspace:*",
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "engines": {
+    "bun": ">=1.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE"
+  ]
+}

--- a/connectors/linkedin/src/accounts.ts
+++ b/connectors/linkedin/src/accounts.ts
@@ -1,0 +1,120 @@
+import type { ConnectorAccountCandidate } from "@sixb/core"
+import type { LinkedinHttp } from "./http"
+import { createAdAccountUsersResource } from "./resources/ad-account-users"
+import { createAdAccountsResource } from "./resources/ad-accounts"
+import { createOrganizationAclsResource } from "./resources/organization-acls"
+import { createOrganizationsResource } from "./resources/organizations"
+import type { LinkedinConnectedAccount } from "./types/client"
+import type { LinkedinOrganizationUrn, LinkedinSponsoredAccountUrn } from "./types/common"
+import type { LinkedinAccountType } from "./types/options"
+
+export async function discoverLinkedinAccounts(
+  accountType: LinkedinAccountType,
+  http: LinkedinHttp
+): Promise<readonly ConnectorAccountCandidate[]> {
+  return accountType === "organization" ? discoverOrganizations(http) : discoverAdAccounts(http)
+}
+
+export function connectedLinkedinAccount(
+  accountType: LinkedinAccountType,
+  account: ConnectorAccountCandidate
+): LinkedinConnectedAccount {
+  if (accountType === "organization") {
+    assertUrn(account.id, "urn:li:organization:", "organization")
+    return accountMetadata(accountType, account.id as LinkedinOrganizationUrn, account)
+  }
+  assertUrn(account.id, "urn:li:sponsoredAccount:", "ad account")
+  return accountMetadata(accountType, account.id as LinkedinSponsoredAccountUrn, account)
+}
+
+export function assertDiscoveryScopes(
+  accountType: LinkedinAccountType,
+  scopes: readonly string[]
+): void {
+  if (accountType !== "organization" && accountType !== "ad-account") {
+    throw new Error("[SixbLinkedin] accountType must be 'organization' or 'ad-account'.")
+  }
+  const accepted = accountType === "organization" ? ["rw_organization_admin"] : ["r_ads", "rw_ads"]
+  if (!accepted.some((scope) => scopes.includes(scope))) {
+    throw new Error(
+      accountType === "organization"
+        ? "[SixbLinkedin] organization account discovery requires rw_organization_admin."
+        : "[SixbLinkedin] ad-account discovery requires r_ads or rw_ads."
+    )
+  }
+}
+
+async function discoverOrganizations(http: LinkedinHttp): Promise<ConnectorAccountCandidate[]> {
+  const acls = createOrganizationAclsResource(http)
+  const organizations = createOrganizationsResource(http)
+  const urns = new Set<LinkedinOrganizationUrn>()
+  for await (const acl of acls.listAllForAuthenticatedMember({ state: "APPROVED" })) {
+    const urn = acl.organizationTarget ?? acl.organization
+    if (urn) urns.add(urn)
+  }
+
+  const accounts: ConnectorAccountCandidate[] = []
+  for (const urn of urns) {
+    const organization = await organizations.get(numericUrnId(urn, "urn:li:organization:"))
+    accounts.push({
+      id: urn,
+      label: organization.localizedName ?? localizedValue(organization.name) ?? urn,
+      description: organization.vanityName
+        ? `LinkedIn Page · linkedin.com/company/${organization.vanityName}`
+        : "LinkedIn Page",
+    })
+  }
+  return accounts
+}
+
+async function discoverAdAccounts(http: LinkedinHttp): Promise<ConnectorAccountCandidate[]> {
+  const users = createAdAccountUsersResource(http)
+  const adAccounts = createAdAccountsResource(http)
+  const urns = new Set<LinkedinSponsoredAccountUrn>()
+  for await (const user of users.listAllByAuthenticatedUser()) urns.add(user.account)
+
+  const accounts: ConnectorAccountCandidate[] = []
+  for (const urn of urns) {
+    const account = await adAccounts.get(numericUrnId(urn, "urn:li:sponsoredAccount:"))
+    accounts.push({
+      id: urn,
+      label: account.name,
+      description: ["LinkedIn ad account", account.status, account.currency]
+        .filter(Boolean)
+        .join(" · "),
+    })
+  }
+  return accounts
+}
+
+function localizedValue(
+  value: { readonly localized: Readonly<Record<string, string>> } | undefined
+) {
+  return value ? Object.values(value.localized)[0] : undefined
+}
+
+function numericUrnId(urn: string, prefix: string): string {
+  assertUrn(urn, prefix, "account")
+  return urn.slice(prefix.length)
+}
+
+function assertUrn(value: string, prefix: string, field: string): void {
+  const id = value.startsWith(prefix) ? value.slice(prefix.length) : ""
+  if (!/^\d+$/.test(id) || id === "0") {
+    throw new Error(`[SixbLinkedin] selected ${field} has an invalid LinkedIn URN.`)
+  }
+}
+
+function accountMetadata<TType extends LinkedinAccountType, TId extends string>(
+  type: TType,
+  id: TId,
+  account: ConnectorAccountCandidate
+) {
+  return {
+    type,
+    id,
+    label: account.label,
+    ...(account.description === undefined ? {} : { description: account.description }),
+    ...(account.avatarUrl === undefined ? {} : { avatarUrl: account.avatarUrl }),
+  }
+}

--- a/connectors/linkedin/src/client.ts
+++ b/connectors/linkedin/src/client.ts
@@ -1,0 +1,49 @@
+import type { LinkedinHttp } from "./http"
+import { createAdAccountUsersResource } from "./resources/ad-account-users"
+import { createAdAccountsResource } from "./resources/ad-accounts"
+import { createAdAnalyticsResource } from "./resources/ad-analytics"
+import { createCampaignGroupsResource } from "./resources/campaign-groups"
+import { createCampaignsResource } from "./resources/campaigns"
+import { createCommentsResource } from "./resources/comments"
+import { createCreativesResource } from "./resources/creatives"
+import {
+  createDocumentsResource,
+  createImagesResource,
+  createVideosResource,
+} from "./resources/media"
+import { createMemberAnalyticsResource } from "./resources/member-analytics"
+import { createOrganizationAclsResource } from "./resources/organization-acls"
+import { createOrganizationAnalyticsResource } from "./resources/organization-analytics"
+import { createOrganizationsResource } from "./resources/organizations"
+import { createPostsResource } from "./resources/posts"
+import { createReactionsResource } from "./resources/reactions"
+import { createSocialMetadataResource } from "./resources/social-metadata"
+import { pathId } from "./restli"
+import type { LinkedinClient } from "./types/client"
+
+export function createLinkedinClient(http: LinkedinHttp): LinkedinClient {
+  return {
+    adAccounts: createAdAccountsResource(http),
+    adAccountUsers: createAdAccountUsersResource(http),
+    adAnalytics: createAdAnalyticsResource(http),
+    organizationAcls: createOrganizationAclsResource(http),
+    organizations: createOrganizationsResource(http),
+    posts: createPostsResource(http),
+    socialMetadata: createSocialMetadataResource(http),
+    comments: createCommentsResource(http),
+    reactions: createReactionsResource(http),
+    organizationAnalytics: createOrganizationAnalyticsResource(http),
+    memberAnalytics: createMemberAnalyticsResource(http),
+    images: createImagesResource(http),
+    videos: createVideosResource(http),
+    documents: createDocumentsResource(http),
+    adAccount(id) {
+      const accountId = pathId(id, "ad account id")
+      return {
+        campaignGroups: createCampaignGroupsResource(http, accountId),
+        campaigns: createCampaignsResource(http, accountId),
+        creatives: createCreativesResource(http, accountId),
+      }
+    },
+  }
+}

--- a/connectors/linkedin/src/client.ts
+++ b/connectors/linkedin/src/client.ts
@@ -19,10 +19,14 @@ import { createPostsResource } from "./resources/posts"
 import { createReactionsResource } from "./resources/reactions"
 import { createSocialMetadataResource } from "./resources/social-metadata"
 import { pathId } from "./restli"
-import type { LinkedinClient } from "./types/client"
+import type { LinkedinClient, LinkedinConnectedAccount } from "./types/client"
 
-export function createLinkedinClient(http: LinkedinHttp): LinkedinClient {
+export function createLinkedinClient(
+  http: LinkedinHttp,
+  account: LinkedinConnectedAccount
+): LinkedinClient {
   return {
+    account,
     adAccounts: createAdAccountsResource(http),
     adAccountUsers: createAdAccountUsersResource(http),
     adAnalytics: createAdAnalyticsResource(http),

--- a/connectors/linkedin/src/errors.ts
+++ b/connectors/linkedin/src/errors.ts
@@ -1,0 +1,70 @@
+export class LinkedinApiError extends Error {
+  readonly name = "LinkedinApiError"
+  readonly headers: Headers
+  readonly requestId: string | null
+  readonly retryAfterMs: number | null
+  readonly serviceErrorCode: string | number | null
+
+  constructor(
+    readonly status: number,
+    readonly responseBody: unknown,
+    headers: HeadersInit = {}
+  ) {
+    super(formatError(status, responseBody))
+    this.headers = new Headers(headers)
+    this.requestId = this.headers.get("x-li-uuid") ?? this.headers.get("x-restli-id") ?? null
+    this.retryAfterMs = parseRetryAfter(this.headers.get("retry-after"))
+    this.serviceErrorCode = extractServiceErrorCode(responseBody)
+  }
+}
+
+function extractServiceErrorCode(value: unknown): string | number | null {
+  if (!isRecord(value)) return null
+  return typeof value.serviceErrorCode === "string" || typeof value.serviceErrorCode === "number"
+    ? value.serviceErrorCode
+    : null
+}
+
+/** Internal marker for local validation failures that must never be retried as network errors. */
+export class LinkedinConfigurationError extends Error {
+  readonly name = "LinkedinConfigurationError"
+}
+
+function formatError(status: number, body: unknown): string {
+  const message = extractMessage(body)
+  return message
+    ? `[SixbLinkedin] LinkedIn API request failed with ${status}: ${message}`
+    : `[SixbLinkedin] LinkedIn API request failed with ${status}.`
+}
+
+function extractMessage(value: unknown): string | null {
+  if (typeof value === "string" && value.trim()) {
+    return value
+  }
+  if (!isRecord(value)) {
+    return null
+  }
+
+  for (const candidate of [value.message, value.error, value.errorMessage]) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate
+    }
+  }
+  return null
+}
+
+function parseRetryAfter(value: string | null): number | null {
+  if (!value) return null
+
+  const seconds = Number(value)
+  if (Number.isFinite(seconds)) {
+    return Math.max(seconds, 0) * 1000
+  }
+
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? null : Math.max(timestamp - Date.now(), 0)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/connectors/linkedin/src/http.ts
+++ b/connectors/linkedin/src/http.ts
@@ -49,7 +49,11 @@ export function createLinkedinHttp(rest: RestClient, options: LinkedinHttpOption
       let error: unknown = null
       try {
         await schedule()
-        response = await rest.request(prepared.path, prepared.init)
+        response = await rest.request(prepared.path, prepared.init, {
+          // Query tunneling changes a logical GET into a transport POST. Preserve the logical
+          // idempotency so the REST layer may safely refresh and replay it after a 401.
+          idempotent: method === "GET",
+        })
       } catch (caughtError) {
         error = caughtError
       }

--- a/connectors/linkedin/src/http.ts
+++ b/connectors/linkedin/src/http.ts
@@ -1,0 +1,231 @@
+import type { RestClient } from "@sixb/connector-rest"
+import { LinkedinApiError, LinkedinConfigurationError } from "./errors"
+import type { LinkedinCreatedEntity, LinkedinCreatedResource } from "./types/common"
+import type {
+  LinkedinRequestMethod,
+  LinkedinRetryContext,
+  LinkedinRetryPolicy,
+} from "./types/options"
+
+export interface LinkedinHttp {
+  get<T>(path: string, init?: RequestInit): Promise<T>
+  post<T>(path: string, body?: unknown, init?: RequestInit): Promise<T>
+  put<T>(path: string, body?: unknown, init?: RequestInit): Promise<T>
+  delete<T>(path: string, init?: RequestInit): Promise<T>
+  create(path: string, body: unknown, init?: RequestInit): Promise<LinkedinCreatedEntity>
+  createWithResponse<T>(
+    path: string,
+    body: unknown,
+    init?: RequestInit
+  ): Promise<LinkedinCreatedResource<T>>
+}
+
+export interface LinkedinHttpOptions {
+  readonly minDelayMs?: number
+  readonly retry?: LinkedinRetryPolicy
+  readonly signal?: AbortSignal
+  readonly queryTunnelingThreshold: number
+}
+
+const DEFAULT_MAX_RETRIES = 2
+
+export function createLinkedinHttp(rest: RestClient, options: LinkedinHttpOptions): LinkedinHttp {
+  const retryPolicy = options.retry ?? {}
+  const maxRetries = retryPolicy.maxRetries ?? DEFAULT_MAX_RETRIES
+  assertNonNegativeInteger(maxRetries, "retry.maxRetries")
+  assertNonNegativeInteger(options.queryTunnelingThreshold, "queryTunnelingThreshold")
+  const schedule = createRequestScheduler(options.minDelayMs ?? 0)
+
+  async function request<T>(
+    method: LinkedinRequestMethod,
+    path: string,
+    body?: unknown,
+    init?: RequestInit
+  ): Promise<{ readonly data: T; readonly headers: Headers }> {
+    const prepared = prepareRequest(method, path, body, init, options)
+
+    for (let attempt = 0; ; attempt++) {
+      let response: Response | null = null
+      let error: unknown = null
+      try {
+        await schedule()
+        response = await rest.request(prepared.path, prepared.init)
+      } catch (caughtError) {
+        error = caughtError
+      }
+
+      const context: LinkedinRetryContext = { attempt, method, response, error }
+      const shouldRetry =
+        attempt < maxRetries &&
+        !(error instanceof LinkedinConfigurationError) &&
+        (retryPolicy.shouldRetry?.(context) ?? shouldRetryByDefault(context))
+
+      if (shouldRetry) {
+        if (response?.body) await response.body.cancel().catch(() => undefined)
+        await sleep(retryPolicy.delayMs?.(context) ?? defaultRetryDelayMs(context))
+        continue
+      }
+      if (error) throw error
+
+      const resolved = response as Response
+      return { data: await readResponse<T>(resolved), headers: resolved.headers }
+    }
+  }
+
+  return {
+    get: <T>(path: string, init?: RequestInit) =>
+      request<T>("GET", path, undefined, init).then((result) => result.data),
+    post: <T>(path: string, body?: unknown, init?: RequestInit) =>
+      request<T>("POST", path, body, init).then((result) => result.data),
+    put: <T>(path: string, body?: unknown, init?: RequestInit) =>
+      request<T>("PUT", path, body, init).then((result) => result.data),
+    delete: <T>(path: string, init?: RequestInit) =>
+      request<T>("DELETE", path, undefined, init).then((result) => result.data),
+    async create(path, body, init) {
+      const result = await request<unknown>("POST", path, body, init)
+      return { id: createdId(result.headers) }
+    },
+    async createWithResponse<T>(path: string, body: unknown, init?: RequestInit) {
+      const result = await request<T>("POST", path, body, init)
+      return { id: createdId(result.headers), data: result.data }
+    },
+  }
+}
+
+function createdId(headers: Headers): string {
+  const id = headers.get("x-restli-id")
+  if (!id) {
+    throw new Error("[SixbLinkedin] Create response is missing the x-restli-id header.")
+  }
+  return id
+}
+
+function prepareRequest(
+  method: LinkedinRequestMethod,
+  path: string,
+  body: unknown,
+  init: RequestInit | undefined,
+  options: LinkedinHttpOptions
+): { readonly path: string; readonly init: RequestInit } {
+  const headers = new Headers(init?.headers)
+  const signal = mergeSignals(init?.signal, options.signal)
+
+  if (method === "GET" && shouldTunnel(path, options.queryTunnelingThreshold)) {
+    const separator = path.indexOf("?")
+    const query = path.slice(separator + 1)
+    headers.set("content-type", "application/x-www-form-urlencoded")
+    headers.set("x-http-method-override", "GET")
+    return {
+      path: path.slice(0, separator),
+      init: { ...init, method: "POST", headers, body: query, signal },
+    }
+  }
+
+  const serializedBody = serializeBody(body, headers)
+  return {
+    path,
+    init: { ...init, method, headers, body: serializedBody, signal },
+  }
+}
+
+function shouldTunnel(path: string, threshold: number): boolean {
+  const separator = path.indexOf("?")
+  if (separator < 0) return false
+  return new TextEncoder().encode(path.slice(separator + 1)).byteLength >= threshold
+}
+
+function serializeBody(body: unknown, headers: Headers): BodyInit | undefined {
+  if (body === undefined) return undefined
+  if (
+    typeof body === "string" ||
+    body instanceof Blob ||
+    body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body) ||
+    body instanceof FormData ||
+    body instanceof URLSearchParams ||
+    body instanceof ReadableStream
+  ) {
+    return body as BodyInit
+  }
+
+  if (!headers.has("content-type")) headers.set("content-type", "application/json")
+  return JSON.stringify(body)
+}
+
+async function readResponse<T>(response: Response): Promise<T> {
+  const body = await readBody(response)
+  if (!response.ok) {
+    throw new LinkedinApiError(response.status, body, response.headers)
+  }
+  return body as T
+}
+
+async function readBody(response: Response): Promise<unknown> {
+  if (response.status === 204) return undefined
+  const text = await response.text()
+  if (!text) return undefined
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+function shouldRetryByDefault(context: LinkedinRetryContext): boolean {
+  if (context.method !== "GET" || isAbortError(context.error)) return false
+  if (context.error) return true
+  const status = context.response?.status
+  return status === 429 || (status !== undefined && status >= 500)
+}
+
+function defaultRetryDelayMs(context: LinkedinRetryContext): number {
+  const retryAfter = parseRetryAfter(context.response?.headers.get("retry-after") ?? null)
+  return retryAfter ?? Math.min(1000 * 2 ** context.attempt, 30_000)
+}
+
+function parseRetryAfter(value: string | null): number | null {
+  if (!value) return null
+  const seconds = Number(value)
+  if (Number.isFinite(seconds)) return Math.max(seconds, 0) * 1000
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? null : Math.max(timestamp - Date.now(), 0)
+}
+
+function mergeSignals(
+  requestSignal: AbortSignal | null | undefined,
+  contextSignal: AbortSignal | undefined
+): AbortSignal | undefined {
+  if (requestSignal && contextSignal) return AbortSignal.any([requestSignal, contextSignal])
+  return requestSignal ?? contextSignal
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError"
+}
+
+function createRequestScheduler(minDelayMs: number): () => Promise<void> {
+  if (!Number.isFinite(minDelayMs) || minDelayMs < 0) {
+    throw new Error("[SixbLinkedin] minDelayMs must be a non-negative finite number.")
+  }
+
+  let nextAvailableAt = 0
+  let queue = Promise.resolve()
+  return () => {
+    const scheduled = queue.then(async () => {
+      await sleep(Math.max(nextAvailableAt - Date.now(), 0))
+      nextAvailableAt = Date.now() + minDelayMs
+    })
+    queue = scheduled.catch(() => undefined)
+    return scheduled
+  }
+}
+
+function assertNonNegativeInteger(value: number, field: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`[SixbLinkedin] ${field} must be a non-negative integer.`)
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve()
+}

--- a/connectors/linkedin/src/index.ts
+++ b/connectors/linkedin/src/index.ts
@@ -1,0 +1,33 @@
+export { LinkedinApiError } from "./errors"
+export type { LinkedinConnector } from "./linkedin"
+export {
+  DEFAULT_LINKEDIN_BASE_URL,
+  DEFAULT_LINKEDIN_VERSION,
+  LINKEDIN_RESTLI_PROTOCOL_VERSION,
+  linkedin,
+} from "./linkedin"
+export type { AdAccountUsersResource } from "./resources/ad-account-users"
+export type { AdAccountsResource } from "./resources/ad-accounts"
+export type { AdAnalyticsResource } from "./resources/ad-analytics"
+export type { CampaignGroupsResource } from "./resources/campaign-groups"
+export type { CampaignsResource } from "./resources/campaigns"
+export type { CommentsResource } from "./resources/comments"
+export type { CreativesResource } from "./resources/creatives"
+export type { DocumentsResource, ImagesResource, VideosResource } from "./resources/media"
+export type { MemberAnalyticsResource } from "./resources/member-analytics"
+export type { OrganizationAclsResource } from "./resources/organization-acls"
+export type { OrganizationAnalyticsResource } from "./resources/organization-analytics"
+export type { OrganizationsResource } from "./resources/organizations"
+export type { PostsResource } from "./resources/posts"
+export type { ReactionsResource } from "./resources/reactions"
+export type { SocialMetadataResource } from "./resources/social-metadata"
+export type * from "./types/index"
+export {
+  organizationUrn,
+  shareUrn,
+  sponsoredAccountUrn,
+  sponsoredCampaignGroupUrn,
+  sponsoredCampaignUrn,
+  sponsoredCreativeUrn,
+  ugcPostUrn,
+} from "./urns"

--- a/connectors/linkedin/src/index.ts
+++ b/connectors/linkedin/src/index.ts
@@ -6,6 +6,7 @@ export {
   LINKEDIN_RESTLI_PROTOCOL_VERSION,
   linkedin,
 } from "./linkedin"
+export { LINKEDIN_ACCESS_TOKEN_URL, LINKEDIN_AUTHORIZATION_URL } from "./oauth"
 export type { AdAccountUsersResource } from "./resources/ad-account-users"
 export type { AdAccountsResource } from "./resources/ad-accounts"
 export type { AdAnalyticsResource } from "./resources/ad-analytics"

--- a/connectors/linkedin/src/linkedin.ts
+++ b/connectors/linkedin/src/linkedin.ts
@@ -1,0 +1,82 @@
+import { rest } from "@sixb/connector-rest"
+import type { ConnectorAdapter } from "@sixb/core"
+import { createLinkedinClient } from "./client"
+import { LinkedinConfigurationError } from "./errors"
+import { createLinkedinHttp } from "./http"
+import { assertNonEmpty } from "./restli"
+import type { LinkedinClient } from "./types/client"
+import type { LinkedinAccessTokenResolver, LinkedinConnectorOptions } from "./types/options"
+
+export const DEFAULT_LINKEDIN_BASE_URL = "https://api.linkedin.com/rest/"
+export const DEFAULT_LINKEDIN_VERSION = "202608"
+export const LINKEDIN_RESTLI_PROTOCOL_VERSION = "2.0.0"
+const DEFAULT_QUERY_TUNNELING_THRESHOLD = 3_500
+
+export type LinkedinConnector = ConnectorAdapter<"linkedin", LinkedinClient>
+
+/**
+ * LinkedIn Advertising and Community Management API connector built on `@sixb/connector-rest`.
+ *
+ * Authentication is intentionally supplied as a token resolver. This keeps the API client
+ * independent from token persistence and lets the upcoming managed OAuth connector provide the
+ * same live token source without changing any resource implementation.
+ */
+export function linkedin(options: LinkedinConnectorOptions): LinkedinConnector {
+  assertTokenResolver(options.accessToken)
+  const version = options.version ?? DEFAULT_LINKEDIN_VERSION
+  if (!/^\d{6}$/.test(version)) {
+    throw new Error("[SixbLinkedin] version must use LinkedIn's YYYYMM format.")
+  }
+
+  const baseUrl = normalizeBaseUrl(options.baseUrl ?? DEFAULT_LINKEDIN_BASE_URL)
+  const restAdapter = rest({
+    baseUrl,
+    headers: async () => ({
+      Accept: "application/json",
+      Authorization: `Bearer ${await resolveToken(options.accessToken)}`,
+      "Linkedin-Version": version,
+      "X-Restli-Protocol-Version": LINKEDIN_RESTLI_PROTOCOL_VERSION,
+    }),
+    timeoutMs: options.timeoutMs,
+    // Logical-method-aware retries and query tunneling live in the LinkedIn HTTP layer.
+    retry: { maxRetries: 0 },
+  })
+
+  return {
+    type: "linkedin",
+    async connect(context) {
+      const client = await restAdapter.connect(context)
+      return createLinkedinClient(
+        createLinkedinHttp(client, {
+          minDelayMs: options.minDelayMs,
+          retry: options.retry,
+          signal: context.signal,
+          queryTunnelingThreshold:
+            options.queryTunnelingThreshold ?? DEFAULT_QUERY_TUNNELING_THRESHOLD,
+        })
+      )
+    },
+  }
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  assertNonEmpty(baseUrl, "baseUrl")
+  return baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`
+}
+
+function assertTokenResolver(token: LinkedinAccessTokenResolver): void {
+  if (typeof token === "string" && !token.trim()) {
+    throw new Error("[SixbLinkedin] accessToken must not be empty.")
+  }
+  if (typeof token !== "string" && typeof token !== "function") {
+    throw new Error("[SixbLinkedin] accessToken must be a string or a function.")
+  }
+}
+
+async function resolveToken(token: LinkedinAccessTokenResolver): Promise<string> {
+  const value = typeof token === "function" ? await token() : token
+  if (!value.trim()) {
+    throw new LinkedinConfigurationError("[SixbLinkedin] accessToken must not be empty.")
+  }
+  return value
+}

--- a/connectors/linkedin/src/linkedin.ts
+++ b/connectors/linkedin/src/linkedin.ts
@@ -1,60 +1,126 @@
-import { rest } from "@sixb/connector-rest"
-import type { ConnectorAdapter } from "@sixb/core"
+import { type RestRequestContext, rest } from "@sixb/connector-rest"
+import type {
+  ConnectorAccessToken,
+  ConnectorContext,
+  ConnectorOAuthCredentials,
+  ConnectorTokenSource,
+  OAuthConnectorAdapter,
+} from "@sixb/core"
+import {
+  assertDiscoveryScopes,
+  connectedLinkedinAccount,
+  discoverLinkedinAccounts,
+} from "./accounts"
 import { createLinkedinClient } from "./client"
 import { LinkedinConfigurationError } from "./errors"
-import { createLinkedinHttp } from "./http"
+import { createLinkedinHttp, type LinkedinHttp } from "./http"
+import { createLinkedinOAuth } from "./oauth"
 import { assertNonEmpty } from "./restli"
 import type { LinkedinClient } from "./types/client"
-import type { LinkedinAccessTokenResolver, LinkedinConnectorOptions } from "./types/options"
+import type { LinkedinConnectorOptions } from "./types/options"
 
 export const DEFAULT_LINKEDIN_BASE_URL = "https://api.linkedin.com/rest/"
 export const DEFAULT_LINKEDIN_VERSION = "202608"
 export const LINKEDIN_RESTLI_PROTOCOL_VERSION = "2.0.0"
 const DEFAULT_QUERY_TUNNELING_THRESHOLD = 3_500
 
-export type LinkedinConnector = ConnectorAdapter<"linkedin", LinkedinClient>
+export type LinkedinConnector = OAuthConnectorAdapter<"linkedin", LinkedinClient>
 
-/**
- * LinkedIn Advertising and Community Management API connector built on `@sixb/connector-rest`.
- *
- * Authentication is intentionally supplied as a token resolver. This keeps the API client
- * independent from token persistence and lets the upcoming managed OAuth connector provide the
- * same live token source without changing any resource implementation.
- */
+/** LinkedIn Advertising and Community Management adapter backed by Sixb-managed OAuth. */
 export function linkedin(options: LinkedinConnectorOptions): LinkedinConnector {
-  assertTokenResolver(options.accessToken)
+  const authentication = createLinkedinOAuth(options)
   const version = options.version ?? DEFAULT_LINKEDIN_VERSION
   if (!/^\d{6}$/.test(version)) {
     throw new Error("[SixbLinkedin] version must use LinkedIn's YYYYMM format.")
   }
+  assertDiscoveryScopes(options.accountType, options.scopes)
 
-  const baseUrl = normalizeBaseUrl(options.baseUrl ?? DEFAULT_LINKEDIN_BASE_URL)
-  const restAdapter = rest({
-    baseUrl,
-    headers: async () => ({
-      Accept: "application/json",
-      Authorization: `Bearer ${await resolveToken(options.accessToken)}`,
-      "Linkedin-Version": version,
-      "X-Restli-Protocol-Version": LINKEDIN_RESTLI_PROTOCOL_VERSION,
-    }),
+  const resolvedOptions: ResolvedLinkedinOptions = {
+    baseUrl: normalizeBaseUrl(options.baseUrl ?? DEFAULT_LINKEDIN_BASE_URL),
+    version,
     timeoutMs: options.timeoutMs,
-    // Logical-method-aware retries and query tunneling live in the LinkedIn HTTP layer.
-    retry: { maxRetries: 0 },
-  })
+    minDelayMs: options.minDelayMs,
+    retry: options.retry,
+    queryTunnelingThreshold: options.queryTunnelingThreshold ?? DEFAULT_QUERY_TUNNELING_THRESHOLD,
+  }
 
   return {
     type: "linkedin",
+    authentication: {
+      type: "oauth2",
+      ...authentication,
+    },
+    async discoverAccounts(context, credentials) {
+      const http = await createHttp(context, fixedTokenSource(credentials), resolvedOptions, false)
+      return discoverLinkedinAccounts(options.accountType, http)
+    },
     async connect(context) {
-      const client = await restAdapter.connect(context)
+      const http = await createHttp(context, context.tokenSource, resolvedOptions, true)
       return createLinkedinClient(
-        createLinkedinHttp(client, {
-          minDelayMs: options.minDelayMs,
-          retry: options.retry,
-          signal: context.signal,
-          queryTunnelingThreshold:
-            options.queryTunnelingThreshold ?? DEFAULT_QUERY_TUNNELING_THRESHOLD,
-        })
+        http,
+        connectedLinkedinAccount(options.accountType, context.account)
       )
+    },
+  }
+}
+
+interface ResolvedLinkedinOptions {
+  readonly baseUrl: string
+  readonly version: string
+  readonly timeoutMs: LinkedinConnectorOptions["timeoutMs"]
+  readonly minDelayMs: LinkedinConnectorOptions["minDelayMs"]
+  readonly retry: LinkedinConnectorOptions["retry"]
+  readonly queryTunnelingThreshold: number
+}
+
+async function createHttp(
+  context: ConnectorContext,
+  tokenSource: ConnectorTokenSource,
+  options: ResolvedLinkedinOptions,
+  invalidateUnauthorized: boolean
+): Promise<LinkedinHttp> {
+  const requestTokens = new WeakMap<RestRequestContext, ConnectorAccessToken>()
+  const restAdapter = rest({
+    baseUrl: options.baseUrl,
+    headers: async (requestContext) => {
+      const token = await tokenSource.get()
+      if (!token.accessToken.trim()) {
+        throw new LinkedinConfigurationError(
+          "[SixbLinkedin] managed OAuth returned an empty access token."
+        )
+      }
+      requestTokens.set(requestContext, token)
+      return {
+        Accept: "application/json",
+        Authorization: `${token.tokenType ?? "Bearer"} ${token.accessToken}`,
+        "Linkedin-Version": options.version,
+        "X-Restli-Protocol-Version": LINKEDIN_RESTLI_PROTOCOL_VERSION,
+      }
+    },
+    timeoutMs: options.timeoutMs,
+    onUnauthorized: invalidateUnauthorized
+      ? (requestContext) => requestTokens.get(requestContext)?.invalidate()
+      : undefined,
+    // Logical-method-aware retries and query tunneling live in the LinkedIn HTTP layer.
+    retry: { maxRetries: 0 },
+  })
+  const client = await restAdapter.connect(context)
+  return createLinkedinHttp(client, {
+    minDelayMs: options.minDelayMs,
+    retry: options.retry,
+    signal: context.signal,
+    queryTunnelingThreshold: options.queryTunnelingThreshold,
+  })
+}
+
+function fixedTokenSource(credentials: ConnectorOAuthCredentials): ConnectorTokenSource {
+  return {
+    async get() {
+      return {
+        accessToken: credentials.accessToken,
+        tokenType: credentials.tokenType,
+        invalidate() {},
+      }
     },
   }
 }
@@ -62,21 +128,4 @@ export function linkedin(options: LinkedinConnectorOptions): LinkedinConnector {
 function normalizeBaseUrl(baseUrl: string): string {
   assertNonEmpty(baseUrl, "baseUrl")
   return baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`
-}
-
-function assertTokenResolver(token: LinkedinAccessTokenResolver): void {
-  if (typeof token === "string" && !token.trim()) {
-    throw new Error("[SixbLinkedin] accessToken must not be empty.")
-  }
-  if (typeof token !== "string" && typeof token !== "function") {
-    throw new Error("[SixbLinkedin] accessToken must be a string or a function.")
-  }
-}
-
-async function resolveToken(token: LinkedinAccessTokenResolver): Promise<string> {
-  const value = typeof token === "function" ? await token() : token
-  if (!value.trim()) {
-    throw new LinkedinConfigurationError("[SixbLinkedin] accessToken must not be empty.")
-  }
-  return value
 }

--- a/connectors/linkedin/src/oauth.ts
+++ b/connectors/linkedin/src/oauth.ts
@@ -1,0 +1,252 @@
+import {
+  type ConnectorContext,
+  type ConnectorOAuthCredentials,
+  ConnectorOAuthError,
+  type OAuthConnectorAuthorizationContext,
+  type OAuthConnectorAuthorizationUrlInput,
+  type OAuthConnectorCodeExchangeInput,
+} from "@sixb/core"
+import { assertNonEmpty } from "./restli"
+import type { LinkedinOAuthScope } from "./types/options"
+
+export const LINKEDIN_AUTHORIZATION_URL = "https://www.linkedin.com/oauth/v2/authorization"
+export const LINKEDIN_ACCESS_TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
+
+export interface LinkedinOAuthOptions {
+  readonly clientId: string
+  readonly clientSecret: string
+  readonly scopes: readonly LinkedinOAuthScope[]
+}
+
+export function createLinkedinOAuth(options: LinkedinOAuthOptions) {
+  const clientId = nonEmpty(options.clientId, "clientId")
+  const clientSecret = nonEmpty(options.clientSecret, "clientSecret")
+  const scopes = normalizeScopes(options.scopes)
+
+  return {
+    authorizationUrl(
+      context: OAuthConnectorAuthorizationContext,
+      input: OAuthConnectorAuthorizationUrlInput
+    ): URL {
+      const url = new URL(LINKEDIN_AUTHORIZATION_URL)
+      url.searchParams.set("response_type", "code")
+      url.searchParams.set("client_id", clientId)
+      url.searchParams.set("redirect_uri", context.redirectUri)
+      url.searchParams.set("state", input.state)
+      url.searchParams.set("scope", scopes.join(" "))
+
+      // Sixb currently requires these parameters for every managed OAuth adapter. LinkedIn's
+      // confidential web flow does not document PKCE and its native PKCE flow only accepts
+      // loopback redirects, so the verifier is deliberately not sent during the token exchange.
+      url.searchParams.set("code_challenge", input.codeChallenge)
+      url.searchParams.set("code_challenge_method", input.codeChallengeMethod)
+      return url
+    },
+
+    exchangeCode(
+      context: OAuthConnectorAuthorizationContext,
+      input: OAuthConnectorCodeExchangeInput
+    ): Promise<ConnectorOAuthCredentials> {
+      return exchangeToken(
+        {
+          grant_type: "authorization_code",
+          code: input.code,
+          client_id: clientId,
+          client_secret: clientSecret,
+          redirect_uri: context.redirectUri,
+        },
+        context,
+        "authorization code"
+      )
+    },
+
+    async refresh(
+      context: ConnectorContext,
+      credentials: ConnectorOAuthCredentials
+    ): Promise<ConnectorOAuthCredentials> {
+      if (!credentials.refreshToken) {
+        throw new ConnectorOAuthError(
+          "terminal",
+          "[SixbLinkedin] LinkedIn did not issue a programmatic refresh token; reauthorization is required."
+        )
+      }
+      return exchangeToken(
+        {
+          grant_type: "refresh_token",
+          refresh_token: credentials.refreshToken,
+          client_id: clientId,
+          client_secret: clientSecret,
+        },
+        context,
+        "refresh token"
+      )
+    },
+  } as const
+}
+
+async function exchangeToken(
+  parameters: Readonly<Record<string, string>>,
+  context: ConnectorContext,
+  operation: "authorization code" | "refresh token"
+): Promise<ConnectorOAuthCredentials> {
+  let response: Response
+  try {
+    response = await fetch(LINKEDIN_ACCESS_TOKEN_URL, {
+      method: "POST",
+      headers: { Accept: "application/json", "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(parameters),
+      signal: context.signal,
+    })
+  } catch (error) {
+    throw new ConnectorOAuthError(
+      "ambiguous",
+      `[SixbLinkedin] LinkedIn ${operation} exchange outcome is unknown.`,
+      { cause: error }
+    )
+  }
+
+  let body: unknown
+  try {
+    body = await readBody(response)
+  } catch (error) {
+    throw new ConnectorOAuthError(
+      "ambiguous",
+      `[SixbLinkedin] LinkedIn ${operation} response could not be read.`,
+      { cause: error }
+    )
+  }
+  if (!response.ok) {
+    const kind =
+      response.status === 429 ? "retryable" : response.status < 500 ? "terminal" : "ambiguous"
+    throw new ConnectorOAuthError(
+      kind,
+      `[SixbLinkedin] LinkedIn rejected the ${operation} exchange (${response.status})${providerMessage(body)}.`
+    )
+  }
+
+  if (!isRecord(body) || typeof body.access_token !== "string" || !body.access_token.trim()) {
+    throw new ConnectorOAuthError(
+      "ambiguous",
+      `[SixbLinkedin] LinkedIn returned an invalid ${operation} response.`
+    )
+  }
+
+  const expiresIn = positiveSeconds(body.expires_in, "expires_in", operation)
+  const refreshToken = optionalNonEmptyString(body.refresh_token, "refresh_token", operation)
+  const tokenType = optionalNonEmptyString(body.token_type, "token_type", operation)
+  const responseScopes = parseScopes(body.scope, operation)
+  return {
+    accessToken: body.access_token,
+    ...(refreshToken === undefined ? {} : { refreshToken }),
+    ...(tokenType === undefined ? {} : { tokenType }),
+    ...(responseScopes === undefined ? {} : { scopes: responseScopes }),
+    ...(expiresIn === undefined ? {} : { expiresAt: new Date(Date.now() + expiresIn * 1000) }),
+  }
+}
+
+async function readBody(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (!text) return undefined
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+function positiveSeconds(
+  value: unknown,
+  field: string,
+  operation: "authorization code" | "refresh token"
+): number | undefined {
+  if (value === undefined) return undefined
+  const seconds = typeof value === "string" ? Number(value) : value
+  if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds <= 0) {
+    throw new ConnectorOAuthError(
+      "ambiguous",
+      `[SixbLinkedin] LinkedIn returned an invalid ${field} in the ${operation} response.`
+    )
+  }
+  return seconds
+}
+
+function optionalNonEmptyString(
+  value: unknown,
+  field: string,
+  operation: "authorization code" | "refresh token"
+): string | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== "string" || !value.trim()) {
+    throw new ConnectorOAuthError(
+      "ambiguous",
+      `[SixbLinkedin] LinkedIn returned an invalid ${field} in the ${operation} response.`
+    )
+  }
+  return value
+}
+
+function parseScopes(
+  value: unknown,
+  operation: "authorization code" | "refresh token"
+): readonly string[] | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== "string") {
+    throw new ConnectorOAuthError(
+      "ambiguous",
+      `[SixbLinkedin] LinkedIn returned invalid scopes in the ${operation} response.`
+    )
+  }
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(value.replace(/\+/g, " "))
+  } catch (error) {
+    throw new ConnectorOAuthError(
+      "ambiguous",
+      `[SixbLinkedin] LinkedIn returned invalid URL-encoded scopes in the ${operation} response.`,
+      { cause: error }
+    )
+  }
+  const scopes = decoded.split(/\s+/).filter(Boolean)
+  if (scopes.length === 0) {
+    throw new ConnectorOAuthError(
+      "ambiguous",
+      `[SixbLinkedin] LinkedIn returned invalid scopes in the ${operation} response.`
+    )
+  }
+  return scopes
+}
+
+function providerMessage(body: unknown): string {
+  if (!isRecord(body)) return ""
+  const code = typeof body.error === "string" ? body.error : undefined
+  const description =
+    typeof body.error_description === "string" ? body.error_description : undefined
+  const message = [code, description].filter(Boolean).join(": ")
+  return message ? `: ${message}` : ""
+}
+
+function normalizeScopes(scopes: readonly LinkedinOAuthScope[]): readonly LinkedinOAuthScope[] {
+  if (!Array.isArray(scopes) || scopes.length === 0) {
+    throw new Error("[SixbLinkedin] scopes must contain at least one OAuth scope.")
+  }
+  const normalized = scopes.map((scope) => {
+    assertNonEmpty(scope, "OAuth scope")
+    if (/\s/.test(scope)) {
+      throw new Error("[SixbLinkedin] each OAuth scope must be a single value without whitespace.")
+    }
+    return scope
+  })
+  if (new Set(normalized).size !== normalized.length) {
+    throw new Error("[SixbLinkedin] scopes must not contain duplicate values.")
+  }
+  return normalized
+}
+
+function nonEmpty(value: string, field: string): string {
+  assertNonEmpty(value, field)
+  return value
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/connectors/linkedin/src/pagination.ts
+++ b/connectors/linkedin/src/pagination.ts
@@ -1,0 +1,75 @@
+import type {
+  LinkedinCursorOptions,
+  LinkedinCursorPage,
+  LinkedinOffsetOptions,
+  LinkedinOffsetPage,
+} from "./types/common"
+
+type CursorListMethod<TOptions extends LinkedinCursorOptions, TItem> = (
+  options: TOptions
+) => Promise<LinkedinCursorPage<TItem>>
+
+export async function* listAllCursor<TOptions extends LinkedinCursorOptions, TItem>(
+  list: CursorListMethod<TOptions, TItem>,
+  options?: TOptions
+): AsyncIterable<TItem> {
+  let pageToken = options?.pageToken
+  const seenTokens = new Set<string>()
+  if (pageToken) seenTokens.add(pageToken)
+
+  for (;;) {
+    const page = await list({ ...options, pageToken } as TOptions)
+    for (const item of page.items) yield item
+
+    if (!page.nextPageToken) return
+    if (seenTokens.has(page.nextPageToken)) {
+      throw new Error("[SixbLinkedin] Pagination returned a repeated nextPageToken.")
+    }
+    seenTokens.add(page.nextPageToken)
+    pageToken = page.nextPageToken
+  }
+}
+
+type OffsetListMethod<TOptions extends LinkedinOffsetOptions, TItem> = (
+  options: TOptions
+) => Promise<LinkedinOffsetPage<TItem>>
+
+export async function* listAllOffset<TOptions extends LinkedinOffsetOptions, TItem>(
+  list: OffsetListMethod<TOptions, TItem>,
+  options?: TOptions
+): AsyncIterable<TItem> {
+  let start = options?.start ?? 0
+  const requestedCount = options?.count ?? 100
+
+  for (;;) {
+    const page = await list({ ...options, start, count: requestedCount } as TOptions)
+    for (const item of page.items) yield item
+
+    const nextLink = page.paging.links?.find((link) => link.rel?.toLowerCase() === "next")
+    if (page.items.length === 0 && !nextLink) return
+
+    const nextStart =
+      startFromLink(nextLink?.href) ??
+      page.paging.start + Math.max(page.paging.count, page.items.length)
+    if (page.paging.total !== undefined && nextStart >= page.paging.total && !nextLink) return
+    if (page.paging.total === undefined && page.items.length < requestedCount && !nextLink) {
+      return
+    }
+    if (nextStart <= start) {
+      throw new Error("[SixbLinkedin] Pagination did not advance the start offset.")
+    }
+    start = nextStart
+  }
+}
+
+function startFromLink(href: string | undefined): number | undefined {
+  if (!href) return undefined
+  try {
+    const value = new URL(href, "https://api.linkedin.com").searchParams.get("start")
+    if (value === null) return undefined
+    const start = Number(value)
+    return Number.isInteger(start) && start >= 0 ? start : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/connectors/linkedin/src/resources/ad-account-users.ts
+++ b/connectors/linkedin/src/resources/ad-account-users.ts
@@ -1,0 +1,105 @@
+import type { LinkedinHttp } from "../http"
+import { listAllOffset } from "../pagination"
+import { assertOffset, urnPath, withQuery } from "../restli"
+import type { LinkedinAdAccountUser, LinkedinAdAccountUserInput } from "../types/advertising"
+import type {
+  LinkedinOffsetOptions,
+  LinkedinOffsetPage,
+  LinkedinPaging,
+  LinkedinPersonUrn,
+  LinkedinSponsoredAccountUrn,
+} from "../types/common"
+
+export interface AdAccountUsersResource {
+  /** `GET /adAccountUsers/(account=...,user=...)` */
+  get(account: LinkedinSponsoredAccountUrn, user: LinkedinPersonUrn): Promise<LinkedinAdAccountUser>
+  /** `GET /adAccountUsers?q=authenticatedUser` */
+  listByAuthenticatedUser(
+    options?: LinkedinOffsetOptions
+  ): Promise<LinkedinOffsetPage<LinkedinAdAccountUser>>
+  listAllByAuthenticatedUser(options?: LinkedinOffsetOptions): AsyncIterable<LinkedinAdAccountUser>
+  /** `GET /adAccountUsers?q=accounts&accounts=...` */
+  listByAccount(
+    account: LinkedinSponsoredAccountUrn,
+    options?: LinkedinOffsetOptions
+  ): Promise<LinkedinOffsetPage<LinkedinAdAccountUser>>
+  listAllByAccount(
+    account: LinkedinSponsoredAccountUrn,
+    options?: LinkedinOffsetOptions
+  ): AsyncIterable<LinkedinAdAccountUser>
+  /** `PUT /adAccountUsers/(account=...,user=...)` */
+  grant(input: LinkedinAdAccountUserInput): Promise<void>
+  /** `POST /adAccountUsers/(account=...,user=...)` */
+  update(input: LinkedinAdAccountUserInput): Promise<void>
+  /** `DELETE /adAccountUsers/(account=...,user=...)` */
+  revoke(account: LinkedinSponsoredAccountUrn, user: LinkedinPersonUrn): Promise<void>
+}
+
+interface ListResponse {
+  readonly elements?: readonly LinkedinAdAccountUser[]
+  readonly paging?: LinkedinPaging
+}
+
+export function createAdAccountUsersResource(http: LinkedinHttp): AdAccountUsersResource {
+  const resource: AdAccountUsersResource = {
+    get(account, user) {
+      return http.get(compoundPath(account, user))
+    },
+    listByAuthenticatedUser(options) {
+      return list(http, "authenticatedUser", undefined, options)
+    },
+    listAllByAuthenticatedUser(options) {
+      return listAllOffset(resource.listByAuthenticatedUser, options)
+    },
+    listByAccount(account, options) {
+      urnPath(account, "ad account URN")
+      return list(http, "accounts", account, options)
+    },
+    listAllByAccount(account, options) {
+      return listAllOffset((page) => resource.listByAccount(account, page), options)
+    },
+    grant(input) {
+      return http.put(compoundPath(input.account, input.user), input)
+    },
+    update(input) {
+      return http.post(compoundPath(input.account, input.user), {
+        patch: { $set: input },
+      })
+    },
+    revoke(account, user) {
+      return http.delete(compoundPath(account, user))
+    },
+  }
+  return resource
+}
+
+async function list(
+  http: LinkedinHttp,
+  finder: "authenticatedUser" | "accounts",
+  account: LinkedinSponsoredAccountUrn | undefined,
+  options: LinkedinOffsetOptions | undefined
+): Promise<LinkedinOffsetPage<LinkedinAdAccountUser>> {
+  assertOffset(options?.start, "start", 0)
+  assertOffset(options?.count, "count", 1)
+  const response = await http.get<ListResponse>(
+    withQuery("adAccountUsers", {
+      q: finder,
+      accounts: account,
+      start: options?.start,
+      count: options?.count,
+    })
+  )
+  return {
+    items: response.elements ?? [],
+    paging: response.paging ?? {
+      start: options?.start ?? 0,
+      count: response.elements?.length ?? 0,
+    },
+  }
+}
+
+function compoundPath(account: LinkedinSponsoredAccountUrn, user: LinkedinPersonUrn): string {
+  urnPath(account, "ad account URN")
+  urnPath(user, "person URN")
+  return `adAccountUsers/(account=${encodeURIComponent(account)},user=${encodeURIComponent(user)})`
+}

--- a/connectors/linkedin/src/resources/ad-accounts.ts
+++ b/connectors/linkedin/src/resources/ad-accounts.ts
@@ -1,0 +1,85 @@
+import type { LinkedinHttp } from "../http"
+import { listAllCursor } from "../pagination"
+import { assertNonEmpty, assertPageSize, pathId, restliSearch, withQuery } from "../restli"
+import type {
+  LinkedinAdAccount,
+  LinkedinAdAccountSearchOptions,
+  LinkedinCreateAdAccountInput,
+  LinkedinUpdateAdAccountInput,
+} from "../types/advertising"
+import type { LinkedinCreatedEntity, LinkedinCursorPage, LinkedinId } from "../types/common"
+
+export interface AdAccountsResource {
+  /** `GET /adAccounts/{id}` */
+  get(id: LinkedinId): Promise<LinkedinAdAccount>
+  /** `GET /adAccounts?q=search` */
+  search(options?: LinkedinAdAccountSearchOptions): Promise<LinkedinCursorPage<LinkedinAdAccount>>
+  searchAll(options?: LinkedinAdAccountSearchOptions): AsyncIterable<LinkedinAdAccount>
+  /** `POST /adAccounts` */
+  create(input: LinkedinCreateAdAccountInput): Promise<LinkedinCreatedEntity>
+  /** `POST /adAccounts/{id}` with `PARTIAL_UPDATE`. */
+  update(id: LinkedinId, input: LinkedinUpdateAdAccountInput): Promise<void>
+  /** Permanently delete a DRAFT account. Non-draft accounts must be marked PENDING_DELETION. */
+  deleteDraft(id: LinkedinId): Promise<void>
+}
+
+interface SearchResponse {
+  readonly elements?: readonly LinkedinAdAccount[]
+  readonly metadata?: { readonly nextPageToken?: string }
+}
+
+export function createAdAccountsResource(http: LinkedinHttp): AdAccountsResource {
+  const resource: AdAccountsResource = {
+    get(id) {
+      return http.get(`adAccounts/${pathId(id, "ad account id")}`)
+    },
+    async search(options) {
+      assertPageSize(options?.pageSize, 1_000)
+      const response = await http.get<SearchResponse>(
+        withQuery("adAccounts", {
+          q: "search",
+          search: restliSearch({
+            id: options?.ids,
+            name: options?.names,
+            reference: options?.references,
+            status: options?.statuses,
+            type: options?.types,
+            test: options?.test,
+          }),
+          sortOrder: options?.sortOrder,
+          pageSize: options?.pageSize,
+          pageToken: options?.pageToken,
+        })
+      )
+      return {
+        items: response.elements ?? [],
+        nextPageToken: response.metadata?.nextPageToken,
+      }
+    },
+    searchAll(options) {
+      return listAllCursor(resource.search, options)
+    },
+    create(input) {
+      assertNonEmpty(input.name, "ad account name")
+      return http.create("adAccounts", input)
+    },
+    update(id, input) {
+      return http.post(`adAccounts/${pathId(id, "ad account id")}`, patch(input), {
+        headers: { "X-RestLi-Method": "PARTIAL_UPDATE" },
+      })
+    },
+    deleteDraft(id) {
+      return http.delete(`adAccounts/${pathId(id, "ad account id")}`)
+    },
+  }
+  return resource
+}
+
+function patch(input: LinkedinUpdateAdAccountInput): {
+  readonly patch: { readonly $set: unknown }
+} {
+  if (Object.keys(input).length === 0) {
+    throw new Error("[SixbLinkedin] ad account update must set at least one field.")
+  }
+  return { patch: { $set: input } }
+}

--- a/connectors/linkedin/src/resources/ad-analytics.ts
+++ b/connectors/linkedin/src/resources/ad-analytics.ts
@@ -1,0 +1,155 @@
+import type { LinkedinHttp } from "../http"
+import { restliDateRange, restliList, withQuery } from "../restli"
+import type {
+  LinkedinAdAnalyticsQuery,
+  LinkedinAdAnalyticsRow,
+  LinkedinAdStatisticsQuery,
+  LinkedinAttributedRevenueQuery,
+} from "../types/analytics"
+
+export interface AdAnalyticsResource {
+  /** `GET /adAnalytics?q=analytics` — one pivot. */
+  analytics<TRow extends LinkedinAdAnalyticsRow = LinkedinAdAnalyticsRow>(
+    query: LinkedinAdAnalyticsQuery
+  ): Promise<readonly TRow[]>
+  /** `GET /adAnalytics?q=statistics` — one to three pivots. */
+  statistics<TRow extends LinkedinAdAnalyticsRow = LinkedinAdAnalyticsRow>(
+    query: LinkedinAdStatisticsQuery
+  ): Promise<readonly TRow[]>
+  /** `GET /adAnalytics?q=attributedRevenueMetrics`. */
+  attributedRevenue<TRow extends LinkedinAdAnalyticsRow = LinkedinAdAnalyticsRow>(
+    query: LinkedinAttributedRevenueQuery
+  ): Promise<readonly TRow[]>
+}
+
+interface AnalyticsResponse<TRow> {
+  readonly elements?: readonly TRow[]
+}
+
+export function createAdAnalyticsResource(http: LinkedinHttp): AdAnalyticsResource {
+  return {
+    analytics(query) {
+      assertCommonQuery(query)
+      return fetchRows(
+        http,
+        withQuery("adAnalytics", {
+          q: "analytics",
+          pivot: query.pivot,
+          dateRange: restliDateRange(query.dateRange),
+          timeGranularity: query.timeGranularity,
+          fields: query.fields.join(","),
+          campaignType: query.campaignType,
+          shares: list(query.shares),
+          campaigns: list(query.campaigns),
+          campaignGroups: list(query.campaignGroups),
+          accounts: list(query.accounts),
+          companies: list(query.companies),
+          "sortBy.field": query.sortBy?.field,
+          "sortBy.order": query.sortBy?.order,
+        })
+      )
+    },
+    statistics(query) {
+      assertCommonQuery(query)
+      if (query.pivots.length < 1 || query.pivots.length > 3) {
+        return Promise.reject(new Error("[SixbLinkedin] statistics requires one to three pivots."))
+      }
+      return fetchRows(
+        http,
+        withQuery("adAnalytics", {
+          q: "statistics",
+          pivots: restliList(query.pivots),
+          dateRange: restliDateRange(query.dateRange),
+          timeGranularity: query.timeGranularity,
+          fields: query.fields.join(","),
+          objectiveType: query.objectiveType,
+          campaignType: query.campaignType,
+          shares: list(query.shares),
+          campaigns: list(query.campaigns),
+          campaignGroups: list(query.campaignGroups),
+          accounts: list(query.accounts),
+          companies: list(query.companies),
+          "sortBy.field": query.sortBy?.field,
+          "sortBy.order": query.sortBy?.order,
+        })
+      )
+    },
+    attributedRevenue(query) {
+      assertFields(query.fields)
+      assertDateRange(query.dateRange)
+      if (query.pivots.length < 1 || query.pivots.length > 3) {
+        return Promise.reject(
+          new Error("[SixbLinkedin] attributed revenue requires one to three pivots.")
+        )
+      }
+      return fetchRows(
+        http,
+        withQuery("adAnalytics", {
+          q: "attributedRevenueMetrics",
+          pivots: restliList(query.pivots),
+          account: restliList([query.account]),
+          dateRange: restliDateRange(query.dateRange),
+          fields: query.fields.join(","),
+          campaigns: list(query.campaigns),
+          campaignGroups: list(query.campaignGroups),
+        })
+      )
+    },
+  }
+}
+
+async function fetchRows<TRow extends LinkedinAdAnalyticsRow>(
+  http: LinkedinHttp,
+  path: string
+): Promise<readonly TRow[]> {
+  const response = await http.get<AnalyticsResponse<TRow>>(path)
+  return response.elements ?? []
+}
+
+function assertCommonQuery(query: LinkedinAdAnalyticsQuery | LinkedinAdStatisticsQuery): void {
+  assertFields(query.fields)
+  assertDateRange(query.dateRange)
+  if (
+    !query.shares?.length &&
+    !query.campaigns?.length &&
+    !query.campaignGroups?.length &&
+    !query.accounts?.length &&
+    !query.companies?.length
+  ) {
+    throw new Error("[SixbLinkedin] ad analytics requires at least one entity facet.")
+  }
+}
+
+function assertFields(fields: readonly string[]): void {
+  if (fields.length < 1 || fields.length > 20 || fields.some((field) => !field.trim())) {
+    throw new Error("[SixbLinkedin] ad analytics fields must contain between 1 and 20 names.")
+  }
+}
+
+function assertDateRange(range: LinkedinAdAnalyticsQuery["dateRange"]): void {
+  const start = utcDate(range.start)
+  const end = range.end ? utcDate(range.end) : undefined
+  if (end !== undefined && start > end) {
+    throw new Error("[SixbLinkedin] dateRange.start must not be after dateRange.end.")
+  }
+}
+
+function utcDate(date: LinkedinAdAnalyticsQuery["dateRange"]["start"]): number {
+  const timestamp = Date.UTC(date.year, date.month - 1, date.day)
+  const resolved = new Date(timestamp)
+  if (
+    !Number.isInteger(date.year) ||
+    !Number.isInteger(date.month) ||
+    !Number.isInteger(date.day) ||
+    resolved.getUTCFullYear() !== date.year ||
+    resolved.getUTCMonth() + 1 !== date.month ||
+    resolved.getUTCDate() !== date.day
+  ) {
+    throw new Error("[SixbLinkedin] ad analytics dateRange contains an invalid UTC date.")
+  }
+  return timestamp
+}
+
+function list(values: readonly string[] | undefined) {
+  return values?.length ? restliList(values) : undefined
+}

--- a/connectors/linkedin/src/resources/campaign-groups.ts
+++ b/connectors/linkedin/src/resources/campaign-groups.ts
@@ -1,0 +1,98 @@
+import type { LinkedinHttp } from "../http"
+import { listAllCursor } from "../pagination"
+import { assertNonEmpty, assertPageSize, pathId, restliSearch, withQuery } from "../restli"
+import type {
+  LinkedinCampaignGroup,
+  LinkedinCampaignGroupSearchOptions,
+  LinkedinCreateCampaignGroupInput,
+  LinkedinUpdateCampaignGroupInput,
+} from "../types/advertising"
+import type { LinkedinCreatedEntity, LinkedinCursorPage, LinkedinId } from "../types/common"
+
+export interface CampaignGroupsResource {
+  get(id: LinkedinId): Promise<LinkedinCampaignGroup>
+  search(
+    options: LinkedinCampaignGroupSearchOptions
+  ): Promise<LinkedinCursorPage<LinkedinCampaignGroup>>
+  searchAll(options: LinkedinCampaignGroupSearchOptions): AsyncIterable<LinkedinCampaignGroup>
+  create(input: LinkedinCreateCampaignGroupInput): Promise<LinkedinCreatedEntity>
+  update(
+    id: LinkedinId,
+    input: LinkedinUpdateCampaignGroupInput,
+    deleteFields?: readonly (keyof LinkedinUpdateCampaignGroupInput)[]
+  ): Promise<void>
+  deleteDraft(id: LinkedinId): Promise<void>
+}
+
+interface SearchResponse {
+  readonly elements?: readonly LinkedinCampaignGroup[]
+  readonly metadata?: { readonly nextPageToken?: string }
+}
+
+export function createCampaignGroupsResource(
+  http: LinkedinHttp,
+  accountId: string
+): CampaignGroupsResource {
+  const path = `adAccounts/${accountId}/adCampaignGroups`
+  const resource: CampaignGroupsResource = {
+    get(id) {
+      return http.get(`${path}/${pathId(id, "campaign group id")}`)
+    },
+    async search(options) {
+      assertSearch(options)
+      assertPageSize(options.pageSize, 1_000)
+      const response = await http.get<SearchResponse>(
+        withQuery(path, {
+          q: "search",
+          search: restliSearch({
+            id: options.ids,
+            name: options.names,
+            status: options.statuses,
+            test: options.test,
+          }),
+          sortOrder: options.sortOrder,
+          pageSize: options.pageSize,
+          pageToken: options.pageToken,
+        })
+      )
+      return {
+        items: response.elements ?? [],
+        nextPageToken: response.metadata?.nextPageToken,
+      }
+    },
+    searchAll(options) {
+      return listAllCursor(resource.search, options)
+    },
+    create(input) {
+      assertNonEmpty(input.name, "campaign group name")
+      return http.create(path, input)
+    },
+    update(id, input, deleteFields) {
+      if (Object.keys(input).length === 0 && !deleteFields?.length) {
+        return Promise.reject(
+          new Error("[SixbLinkedin] campaign group update must change at least one field.")
+        )
+      }
+      return http.post(
+        `${path}/${pathId(id, "campaign group id")}`,
+        { patch: { $set: input, $delete: deleteFields } },
+        { headers: { "X-RestLi-Method": "PARTIAL_UPDATE" } }
+      )
+    },
+    deleteDraft(id) {
+      return http.delete(`${path}/${pathId(id, "campaign group id")}`)
+    },
+  }
+  return resource
+}
+
+function assertSearch(options: LinkedinCampaignGroupSearchOptions): void {
+  if (
+    !options.ids?.length &&
+    !options.names?.length &&
+    !options.statuses?.length &&
+    options.test === undefined
+  ) {
+    throw new Error("[SixbLinkedin] campaign group search requires at least one criterion.")
+  }
+}

--- a/connectors/linkedin/src/resources/campaigns.ts
+++ b/connectors/linkedin/src/resources/campaigns.ts
@@ -1,0 +1,99 @@
+import type { LinkedinHttp } from "../http"
+import { listAllCursor } from "../pagination"
+import { assertNonEmpty, assertPageSize, pathId, restliSearch, withQuery } from "../restli"
+import type {
+  LinkedinCampaign,
+  LinkedinCampaignSearchOptions,
+  LinkedinCreateCampaignInput,
+  LinkedinUpdateCampaignInput,
+} from "../types/advertising"
+import type { LinkedinCreatedEntity, LinkedinCursorPage, LinkedinId } from "../types/common"
+
+export interface CampaignsResource {
+  get(id: LinkedinId): Promise<LinkedinCampaign>
+  search(options: LinkedinCampaignSearchOptions): Promise<LinkedinCursorPage<LinkedinCampaign>>
+  searchAll(options: LinkedinCampaignSearchOptions): AsyncIterable<LinkedinCampaign>
+  create(input: LinkedinCreateCampaignInput): Promise<LinkedinCreatedEntity>
+  update(
+    id: LinkedinId,
+    input: LinkedinUpdateCampaignInput,
+    deleteFields?: readonly (keyof LinkedinUpdateCampaignInput)[]
+  ): Promise<void>
+  deleteDraft(id: LinkedinId): Promise<void>
+}
+
+interface SearchResponse {
+  readonly elements?: readonly LinkedinCampaign[]
+  readonly metadata?: { readonly nextPageToken?: string }
+}
+
+export function createCampaignsResource(http: LinkedinHttp, accountId: string): CampaignsResource {
+  const path = `adAccounts/${accountId}/adCampaigns`
+  const resource: CampaignsResource = {
+    get(id) {
+      return http.get(`${path}/${pathId(id, "campaign id")}`)
+    },
+    async search(options) {
+      assertSearch(options)
+      assertPageSize(options.pageSize, 1_000)
+      const response = await http.get<SearchResponse>(
+        withQuery(path, {
+          q: "search",
+          search: restliSearch({
+            id: options.ids,
+            campaignGroup: options.campaignGroups,
+            associatedEntity: options.associatedEntities,
+            name: options.names,
+            status: options.statuses,
+            type: options.types,
+            test: options.test,
+          }),
+          sortOrder: options.sortOrder,
+          pageSize: options.pageSize,
+          pageToken: options.pageToken,
+        })
+      )
+      return {
+        items: response.elements ?? [],
+        nextPageToken: response.metadata?.nextPageToken,
+      }
+    },
+    searchAll(options) {
+      return listAllCursor(resource.search, options)
+    },
+    create(input) {
+      assertNonEmpty(input.name, "campaign name")
+      return http.create(path, input)
+    },
+    update(id, input, deleteFields) {
+      if (Object.keys(input).length === 0 && !deleteFields?.length) {
+        return Promise.reject(
+          new Error("[SixbLinkedin] campaign update must change at least one field.")
+        )
+      }
+      return http.post(
+        `${path}/${pathId(id, "campaign id")}`,
+        { patch: { $set: input, $delete: deleteFields } },
+        { headers: { "X-RestLi-Method": "PARTIAL_UPDATE" } }
+      )
+    },
+    deleteDraft(id) {
+      return http.delete(`${path}/${pathId(id, "campaign id")}`)
+    },
+  }
+  return resource
+}
+
+function assertSearch(options: LinkedinCampaignSearchOptions): void {
+  if (
+    !options.ids?.length &&
+    !options.campaignGroups?.length &&
+    !options.associatedEntities?.length &&
+    !options.names?.length &&
+    !options.statuses?.length &&
+    !options.types?.length &&
+    options.test === undefined
+  ) {
+    throw new Error("[SixbLinkedin] campaign search requires at least one criterion.")
+  }
+}

--- a/connectors/linkedin/src/resources/comments.ts
+++ b/connectors/linkedin/src/resources/comments.ts
@@ -1,0 +1,108 @@
+import type { LinkedinHttp } from "../http"
+import { listAllOffset } from "../pagination"
+import { assertOffset, pathId, urnPath, withQuery } from "../restli"
+import type {
+  LinkedinCreatedResource,
+  LinkedinOffsetOptions,
+  LinkedinOffsetPage,
+  LinkedinOrganizationUrn,
+  LinkedinPersonUrn,
+} from "../types/common"
+import type {
+  LinkedinComment,
+  LinkedinCreateCommentInput,
+  LinkedinSocialEntityUrn,
+  LinkedinUpdateCommentInput,
+} from "../types/community"
+import { type ElementsResponse, offsetPage } from "./community-utils"
+
+export interface CommentsResource {
+  list(
+    entity: LinkedinSocialEntityUrn,
+    options?: LinkedinOffsetOptions
+  ): Promise<LinkedinOffsetPage<LinkedinComment>>
+  listAll(
+    entity: LinkedinSocialEntityUrn,
+    options?: LinkedinOffsetOptions
+  ): AsyncIterable<LinkedinComment>
+  get(entity: LinkedinSocialEntityUrn, commentId: string | number): Promise<LinkedinComment>
+  create(
+    entity: LinkedinSocialEntityUrn,
+    input: LinkedinCreateCommentInput
+  ): Promise<LinkedinCreatedResource<LinkedinComment>>
+  update(
+    entity: LinkedinSocialEntityUrn,
+    commentId: string | number,
+    input: LinkedinUpdateCommentInput
+  ): Promise<LinkedinComment>
+  delete(
+    entity: LinkedinSocialEntityUrn,
+    commentId: string | number,
+    actor?: LinkedinOrganizationUrn | LinkedinPersonUrn
+  ): Promise<void>
+}
+
+export function createCommentsResource(http: LinkedinHttp): CommentsResource {
+  const resource: CommentsResource = {
+    async list(entity, options) {
+      assertOffset(options?.start, "start", 0)
+      assertOffset(options?.count, "count", 1)
+      const response = await http.get<ElementsResponse<LinkedinComment>>(
+        withQuery(collectionPath(entity), {
+          start: options?.start,
+          count: options?.count,
+        })
+      )
+      return offsetPage(response, options)
+    },
+    listAll(entity, options) {
+      return listAllOffset((page) => resource.list(entity, page), options)
+    },
+    get(entity, commentId) {
+      return http.get(`${collectionPath(entity)}/${pathId(commentId, "comment id")}`)
+    },
+    create(entity, input) {
+      urnPath(input.actor, "comment actor URN")
+      if (entity.startsWith("urn:li:comment:") && (!input.object || !input.parentComment)) {
+        return Promise.reject(
+          new Error(
+            "[SixbLinkedin] nested comments require both object and parentComment in the input."
+          )
+        )
+      }
+      if (input.object) urnPath(input.object, "comment object URN")
+      if (input.parentComment) urnPath(input.parentComment, "parent comment URN")
+      if (!input.message.text.trim()) {
+        return Promise.reject(new Error("[SixbLinkedin] comment text must not be empty."))
+      }
+      return http.createWithResponse<LinkedinComment>(collectionPath(entity), {
+        ...input,
+        object: input.object ?? entity,
+      })
+    },
+    update(entity, commentId, input) {
+      if (!input.message.text.trim()) {
+        return Promise.reject(new Error("[SixbLinkedin] comment text must not be empty."))
+      }
+      if (input.actor) urnPath(input.actor, "comment actor URN")
+      return http.post(
+        withQuery(`${collectionPath(entity)}/${pathId(commentId, "comment id")}`, {
+          actor: input.actor,
+        }),
+        { patch: { message: { $set: input.message } } },
+        { headers: { "X-RestLi-Method": "PARTIAL_UPDATE" } }
+      )
+    },
+    delete(entity, commentId, actor) {
+      if (actor) urnPath(actor, "comment actor URN")
+      return http.delete(
+        withQuery(`${collectionPath(entity)}/${pathId(commentId, "comment id")}`, { actor })
+      )
+    },
+  }
+  return resource
+}
+
+function collectionPath(entity: LinkedinSocialEntityUrn): string {
+  return `socialActions/${urnPath(entity, "social entity URN")}/comments`
+}

--- a/connectors/linkedin/src/resources/community-utils.ts
+++ b/connectors/linkedin/src/resources/community-utils.ts
@@ -1,0 +1,72 @@
+import type {
+  LinkedinDate,
+  LinkedinOffsetOptions,
+  LinkedinOffsetPage,
+  LinkedinOptionalDateRange,
+  LinkedinPaging,
+  LinkedinTimeIntervals,
+  LinkedinTimeRange,
+} from "../types/common"
+
+export interface ElementsResponse<TItem> {
+  readonly elements?: readonly TItem[]
+  readonly paging?: LinkedinPaging
+}
+
+export function offsetPage<TItem>(
+  response: ElementsResponse<TItem>,
+  options?: LinkedinOffsetOptions
+): LinkedinOffsetPage<TItem> {
+  return {
+    items: response.elements ?? [],
+    paging: response.paging ?? {
+      start: options?.start ?? 0,
+      count: response.elements?.length ?? 0,
+    },
+  }
+}
+
+export function assertOptionalDateRange(
+  range: LinkedinOptionalDateRange | undefined,
+  field = "dateRange"
+): void {
+  if (!range) return
+  const start = range.start ? utcDate(range.start, `${field}.start`) : undefined
+  const end = range.end ? utcDate(range.end, `${field}.end`) : undefined
+  if (start !== undefined && end !== undefined && start >= end) {
+    throw new Error(`[SixbLinkedin] ${field}.start must be before ${field}.end.`)
+  }
+}
+
+export function assertTimeIntervals(value: LinkedinTimeIntervals | undefined): void {
+  if (!value) return
+  assertTimeRange(value.timeRange, "timeIntervals.timeRange")
+}
+
+export function assertTimeRange(value: LinkedinTimeRange | undefined, field = "timeRange"): void {
+  if (!value) return
+  for (const [name, timestamp] of Object.entries(value)) {
+    if (!Number.isSafeInteger(timestamp) || timestamp < 0) {
+      throw new Error(`[SixbLinkedin] ${field}.${name} must be a non-negative epoch timestamp.`)
+    }
+  }
+  if (value.start !== undefined && value.end !== undefined && value.start >= value.end) {
+    throw new Error(`[SixbLinkedin] ${field}.start must be before ${field}.end.`)
+  }
+}
+
+function utcDate(value: LinkedinDate, field: string): number {
+  const timestamp = Date.UTC(value.year, value.month - 1, value.day)
+  const resolved = new Date(timestamp)
+  if (
+    !Number.isInteger(value.year) ||
+    !Number.isInteger(value.month) ||
+    !Number.isInteger(value.day) ||
+    resolved.getUTCFullYear() !== value.year ||
+    resolved.getUTCMonth() + 1 !== value.month ||
+    resolved.getUTCDate() !== value.day
+  ) {
+    throw new Error(`[SixbLinkedin] ${field} must be a valid UTC calendar date.`)
+  }
+  return timestamp
+}

--- a/connectors/linkedin/src/resources/creatives.ts
+++ b/connectors/linkedin/src/resources/creatives.ts
@@ -1,0 +1,105 @@
+import type { LinkedinHttp } from "../http"
+import { listAllCursor } from "../pagination"
+import { assertPageSize, restliList, urnPath, withQuery } from "../restli"
+import type {
+  LinkedinCreateCreativeInput,
+  LinkedinCreateInlineCreativeInput,
+  LinkedinCreative,
+  LinkedinCreativeContent,
+  LinkedinCreativeSearchOptions,
+  LinkedinUpdateCreativeInput,
+} from "../types/advertising"
+import type {
+  LinkedinCreatedEntity,
+  LinkedinCursorPage,
+  LinkedinSponsoredCreativeUrn,
+} from "../types/common"
+
+export interface CreativesResource {
+  get<TContent extends LinkedinCreativeContent = LinkedinCreativeContent>(
+    id: LinkedinSponsoredCreativeUrn
+  ): Promise<LinkedinCreative<TContent>>
+  search(options?: LinkedinCreativeSearchOptions): Promise<LinkedinCursorPage<LinkedinCreative>>
+  searchAll(options?: LinkedinCreativeSearchOptions): AsyncIterable<LinkedinCreative>
+  create<TContent extends LinkedinCreativeContent = LinkedinCreativeContent>(
+    input: LinkedinCreateCreativeInput<TContent>
+  ): Promise<LinkedinCreatedEntity>
+  /** Create a creative and its post in one `action=createInline` request. */
+  createInline(input: LinkedinCreateInlineCreativeInput): Promise<LinkedinCreatedEntity>
+  update(id: LinkedinSponsoredCreativeUrn, input: LinkedinUpdateCreativeInput): Promise<void>
+  deleteDraft(id: LinkedinSponsoredCreativeUrn): Promise<void>
+}
+
+interface SearchResponse {
+  readonly elements?: readonly LinkedinCreative[]
+  readonly metadata?: {
+    readonly nextPageToken?: string
+    readonly totalResultCount?: number
+  }
+}
+
+export function createCreativesResource(http: LinkedinHttp, accountId: string): CreativesResource {
+  const path = `adAccounts/${accountId}/creatives`
+  const resource: CreativesResource = {
+    get(id) {
+      return http.get(`${path}/${urnPath(id, "creative URN")}`)
+    },
+    async search(options) {
+      assertPageSize(options?.pageSize, 100)
+      const response = await http.get<SearchResponse>(
+        withQuery(path, {
+          q: "criteria",
+          campaigns: list(options?.campaigns),
+          contentReferences: list(options?.contentReferences),
+          creatives: list(options?.creatives),
+          intendedStatuses: list(options?.intendedStatuses),
+          isTestAccount: options?.isTestAccount,
+          isTotalIncluded: options?.isTotalIncluded,
+          leadgenCreativeCallToActionDestinations: list(
+            options?.leadgenCreativeCallToActionDestinations
+          ),
+          sortOrder: options?.sortOrder,
+          pageSize: options?.pageSize,
+          pageToken: options?.pageToken,
+        }),
+        { headers: { "X-RestLi-Method": "FINDER" } }
+      )
+      return {
+        items: response.elements ?? [],
+        nextPageToken: response.metadata?.nextPageToken,
+        totalCount: response.metadata?.totalResultCount,
+      }
+    },
+    searchAll(options) {
+      return listAllCursor(resource.search, options)
+    },
+    create(input) {
+      return http.create(path, input)
+    },
+    createInline(input) {
+      return http.create(withQuery(path, { action: "createInline" }), input)
+    },
+    update(id, input) {
+      if (Object.keys(input).length === 0) {
+        return Promise.reject(
+          new Error("[SixbLinkedin] creative update must set at least one field.")
+        )
+      }
+      return http.post(
+        `${path}/${urnPath(id, "creative URN")}`,
+        { patch: { $set: input } },
+        { headers: { "X-RestLi-Method": "PARTIAL_UPDATE" } }
+      )
+    },
+    deleteDraft(id) {
+      return http.delete(`${path}/${urnPath(id, "creative URN")}`, {
+        headers: { "X-RestLi-Method": "DELETE" },
+      })
+    },
+  }
+  return resource
+}
+
+function list(values: readonly (string | number)[] | undefined) {
+  return values?.length ? restliList(values) : undefined
+}

--- a/connectors/linkedin/src/resources/media.ts
+++ b/connectors/linkedin/src/resources/media.ts
@@ -1,0 +1,43 @@
+import type { LinkedinHttp } from "../http"
+import { urnPath } from "../restli"
+import type { LinkedinDocumentUrn, LinkedinImageUrn, LinkedinVideoUrn } from "../types/common"
+import type { LinkedinDocument, LinkedinImage, LinkedinVideo } from "../types/media"
+
+export interface ImagesResource {
+  /** Resolve current image metadata and its signed download URL. */
+  get(image: LinkedinImageUrn): Promise<LinkedinImage>
+}
+
+export interface VideosResource {
+  /** Resolve current video metadata and its signed download URL. */
+  get(video: LinkedinVideoUrn): Promise<LinkedinVideo>
+}
+
+export interface DocumentsResource {
+  /** Resolve current document metadata and its signed download URL. */
+  get(document: LinkedinDocumentUrn): Promise<LinkedinDocument>
+}
+
+export function createImagesResource(http: LinkedinHttp): ImagesResource {
+  return {
+    get(image) {
+      return http.get(`images/${urnPath(image, "image URN")}`)
+    },
+  }
+}
+
+export function createVideosResource(http: LinkedinHttp): VideosResource {
+  return {
+    get(video) {
+      return http.get(`videos/${urnPath(video, "video URN")}`)
+    },
+  }
+}
+
+export function createDocumentsResource(http: LinkedinHttp): DocumentsResource {
+  return {
+    get(document) {
+      return http.get(`documents/${urnPath(document, "document URN")}`)
+    },
+  }
+}

--- a/connectors/linkedin/src/resources/member-analytics.ts
+++ b/connectors/linkedin/src/resources/member-analytics.ts
@@ -1,0 +1,114 @@
+import type { LinkedinHttp } from "../http"
+import { restliOptionalDateRange, restliPostEntity, withQuery } from "../restli"
+import type { LinkedinOptionalDateRange } from "../types/common"
+import type {
+  LinkedinMemberFollowerStatistic,
+  LinkedinMemberPostAnalyticsQuery,
+  LinkedinMemberPostEntityAnalyticsQuery,
+  LinkedinMemberPostMetric,
+  LinkedinMemberPostStatistic,
+  LinkedinMemberVideoAnalyticsQuery,
+  LinkedinMemberVideoStatistic,
+} from "../types/community-analytics"
+import { assertOptionalDateRange, type ElementsResponse } from "./community-utils"
+
+export interface MemberAnalyticsResource {
+  /** Lifetime follower count for the authenticated member. */
+  followers(): Promise<readonly LinkedinMemberFollowerStatistic[]>
+  /** Daily follower count for the authenticated member. */
+  followerHistory(
+    dateRange?: LinkedinOptionalDateRange
+  ): Promise<readonly LinkedinMemberFollowerStatistic[]>
+  post(
+    query: LinkedinMemberPostEntityAnalyticsQuery
+  ): Promise<readonly LinkedinMemberPostStatistic[]>
+  /** Aggregated analytics across the authenticated member's posts. */
+  posts(query: LinkedinMemberPostAnalyticsQuery): Promise<readonly LinkedinMemberPostStatistic[]>
+  video(query: LinkedinMemberVideoAnalyticsQuery): Promise<readonly LinkedinMemberVideoStatistic[]>
+}
+
+export function createMemberAnalyticsResource(http: LinkedinHttp): MemberAnalyticsResource {
+  return {
+    followers() {
+      return rows(http, withQuery("memberFollowersCount", { q: "me" }))
+    },
+    followerHistory(dateRange) {
+      assertOptionalDateRange(dateRange)
+      return rows(
+        http,
+        withQuery("memberFollowersCount", {
+          q: "dateRange",
+          dateRange: dateRange ? restliOptionalDateRange(dateRange) : undefined,
+        })
+      )
+    },
+    post(query) {
+      assertMemberPostQuery(query, true)
+      return rows(
+        http,
+        withQuery("memberCreatorPostAnalytics", {
+          q: "entity",
+          entity: restliPostEntity(query.entity),
+          queryType: query.queryType,
+          aggregation: query.aggregation,
+          dateRange: query.dateRange ? restliOptionalDateRange(query.dateRange) : undefined,
+        })
+      )
+    },
+    posts(query) {
+      assertMemberPostQuery(query, false)
+      return rows(
+        http,
+        withQuery("memberCreatorPostAnalytics", {
+          q: "me",
+          queryType: query.queryType,
+          aggregation: query.aggregation,
+          dateRange: query.dateRange ? restliOptionalDateRange(query.dateRange) : undefined,
+        })
+      )
+    },
+    video(query) {
+      assertOptionalDateRange(query.dateRange)
+      return rows(
+        http,
+        withQuery("memberCreatorVideoAnalytics", {
+          q: "entity",
+          entity: restliPostEntity(query.entity),
+          queryType: query.queryType,
+          aggregation: query.aggregation,
+          dateRange: query.dateRange ? restliOptionalDateRange(query.dateRange) : undefined,
+        })
+      )
+    },
+  }
+}
+
+async function rows<TItem>(http: LinkedinHttp, path: string): Promise<readonly TItem[]> {
+  const response = await http.get<ElementsResponse<TItem>>(path)
+  return response.elements ?? []
+}
+
+const ENTITY_DAILY_UNSUPPORTED = new Set<LinkedinMemberPostMetric>([
+  "IMPRESSION",
+  "MEMBERS_REACHED",
+  "LINK_CLICKS",
+  "FOLLOWER_GAINED_FROM_CONTENT",
+  "PROFILE_VIEW_FROM_CONTENT",
+])
+
+const AGGREGATE_DAILY_UNSUPPORTED = new Set<LinkedinMemberPostMetric>([
+  "MEMBERS_REACHED",
+  "LINK_CLICKS",
+  "FOLLOWER_GAINED_FROM_CONTENT",
+  "PROFILE_VIEW_FROM_CONTENT",
+])
+
+function assertMemberPostQuery(query: LinkedinMemberPostAnalyticsQuery, entity: boolean): void {
+  assertOptionalDateRange(query.dateRange)
+  const unsupported = entity ? ENTITY_DAILY_UNSUPPORTED : AGGREGATE_DAILY_UNSUPPORTED
+  if (query.aggregation === "DAILY" && unsupported.has(query.queryType)) {
+    throw new Error(
+      `[SixbLinkedin] ${query.queryType} does not support DAILY member post aggregation.`
+    )
+  }
+}

--- a/connectors/linkedin/src/resources/organization-acls.ts
+++ b/connectors/linkedin/src/resources/organization-acls.ts
@@ -1,0 +1,65 @@
+import type { LinkedinHttp } from "../http"
+import { listAllOffset } from "../pagination"
+import { assertOffset, urnPath, withQuery } from "../restli"
+import type { LinkedinOffsetPage, LinkedinOrganizationUrn } from "../types/common"
+import type { LinkedinOrganizationAcl, LinkedinOrganizationAclOptions } from "../types/community"
+import { type ElementsResponse, offsetPage } from "./community-utils"
+
+export interface OrganizationAclsResource {
+  /** Find approved or pending roles held by the authenticated member. */
+  listForAuthenticatedMember(
+    options?: LinkedinOrganizationAclOptions
+  ): Promise<LinkedinOffsetPage<LinkedinOrganizationAcl>>
+  listAllForAuthenticatedMember(
+    options?: LinkedinOrganizationAclOptions
+  ): AsyncIterable<LinkedinOrganizationAcl>
+  /** Find members with a role on an organization. */
+  listByOrganization(
+    organization: LinkedinOrganizationUrn,
+    options?: LinkedinOrganizationAclOptions
+  ): Promise<LinkedinOffsetPage<LinkedinOrganizationAcl>>
+  listAllByOrganization(
+    organization: LinkedinOrganizationUrn,
+    options?: LinkedinOrganizationAclOptions
+  ): AsyncIterable<LinkedinOrganizationAcl>
+}
+
+export function createOrganizationAclsResource(http: LinkedinHttp): OrganizationAclsResource {
+  const resource: OrganizationAclsResource = {
+    listForAuthenticatedMember(options) {
+      return list(http, "roleAssignee", undefined, options)
+    },
+    listAllForAuthenticatedMember(options) {
+      return listAllOffset(resource.listForAuthenticatedMember, options)
+    },
+    listByOrganization(organization, options) {
+      urnPath(organization, "organization URN")
+      return list(http, "organization", organization, options)
+    },
+    listAllByOrganization(organization, options) {
+      return listAllOffset((page) => resource.listByOrganization(organization, page), options)
+    },
+  }
+  return resource
+}
+
+async function list(
+  http: LinkedinHttp,
+  finder: "roleAssignee" | "organization",
+  organization: LinkedinOrganizationUrn | undefined,
+  options: LinkedinOrganizationAclOptions | undefined
+): Promise<LinkedinOffsetPage<LinkedinOrganizationAcl>> {
+  assertOffset(options?.start, "start", 0)
+  assertOffset(options?.count, "count", 1)
+  const response = await http.get<ElementsResponse<LinkedinOrganizationAcl>>(
+    withQuery("organizationAcls", {
+      q: finder,
+      organization,
+      role: options?.role,
+      state: options?.state,
+      start: options?.start,
+      count: options?.count,
+    })
+  )
+  return offsetPage(response, options)
+}

--- a/connectors/linkedin/src/resources/organization-analytics.ts
+++ b/connectors/linkedin/src/resources/organization-analytics.ts
@@ -1,0 +1,145 @@
+import type { LinkedinHttp } from "../http"
+import {
+  type QueryParams,
+  restliList,
+  restliTimeIntervals,
+  restliTimeRange,
+  urnPath,
+  withQuery,
+} from "../restli"
+import type { LinkedinOrganizationUrn, LinkedinTimeIntervals } from "../types/common"
+import type {
+  LinkedinOrganizationFollowerStatistic,
+  LinkedinOrganizationPageStatistic,
+  LinkedinOrganizationShareStatistic,
+  LinkedinOrganizationShareStatisticsQuery,
+  LinkedinOrganizationVideoAnalyticsQuery,
+  LinkedinOrganizationVideoStatistic,
+} from "../types/community-analytics"
+import { assertTimeIntervals, assertTimeRange, type ElementsResponse } from "./community-utils"
+
+export interface OrganizationAnalyticsResource {
+  /** Lifetime demographic breakdown, or time-bound follower gains. */
+  followers(
+    organization: LinkedinOrganizationUrn,
+    timeIntervals?: LinkedinTimeIntervals
+  ): Promise<readonly LinkedinOrganizationFollowerStatistic[]>
+  /** Lifetime or time-bound views and clicks for an organization Page. */
+  pages(
+    organization: LinkedinOrganizationUrn,
+    timeIntervals?: LinkedinTimeIntervals
+  ): Promise<readonly LinkedinOrganizationPageStatistic[]>
+  /** Organic-only share statistics from LinkedIn's rolling 12-month window. */
+  shares(
+    organization: LinkedinOrganizationUrn,
+    query?: LinkedinOrganizationShareStatisticsQuery
+  ): Promise<readonly LinkedinOrganizationShareStatistic[]>
+  video(
+    query: LinkedinOrganizationVideoAnalyticsQuery
+  ): Promise<readonly LinkedinOrganizationVideoStatistic[]>
+}
+
+export function createOrganizationAnalyticsResource(
+  http: LinkedinHttp
+): OrganizationAnalyticsResource {
+  return {
+    followers(organization, timeIntervals) {
+      return organizationRows(
+        http,
+        "organizationalEntityFollowerStatistics",
+        "organizationalEntity",
+        organization,
+        timeIntervals
+      )
+    },
+    pages(organization, timeIntervals) {
+      assertSupportedGranularity(timeIntervals, ["DAY", "MONTH"], "Page statistics")
+      return organizationRows(
+        http,
+        "organizationPageStatistics",
+        "organization",
+        organization,
+        timeIntervals
+      )
+    },
+    shares(organization, query) {
+      urnPath(organization, "organization URN")
+      assertTimeIntervals(query?.timeIntervals)
+      assertSupportedGranularity(query?.timeIntervals, ["DAY", "MONTH"], "Share statistics")
+      if (query?.timeIntervals && query.posts?.length) {
+        return Promise.reject(
+          new Error("[SixbLinkedin] specific posts cannot be combined with timeIntervals.")
+        )
+      }
+
+      const shares = query?.posts?.filter((post) => post.startsWith("urn:li:share:"))
+      const ugcPosts = query?.posts?.filter((post) => post.startsWith("urn:li:ugcPost:"))
+      query?.posts?.forEach((post) => {
+        urnPath(post, "post URN")
+      })
+      const params: Record<string, QueryParams[string]> = {
+        q: "organizationalEntity",
+        organizationalEntity: organization,
+        timeIntervals: query?.timeIntervals ? restliTimeIntervals(query.timeIntervals) : undefined,
+        shares: shares?.length ? restliList(shares) : undefined,
+      }
+      ugcPosts?.forEach((post, index) => {
+        params[`ugcPosts[${index}]`] = post
+      })
+      return rows<LinkedinOrganizationShareStatistic>(
+        http,
+        withQuery("organizationalEntityShareStatistics", params)
+      )
+    },
+    video(query) {
+      urnPath(query.entity, "video post URN")
+      assertTimeRange(query.timeRange)
+      return rows<LinkedinOrganizationVideoStatistic>(
+        http,
+        withQuery("videoAnalytics", {
+          q: "entity",
+          entity: query.entity,
+          type: query.type,
+          aggregation: query.aggregation,
+          timeRange: query.timeRange ? restliTimeRange(query.timeRange) : undefined,
+        })
+      )
+    },
+  }
+}
+
+async function organizationRows<TItem>(
+  http: LinkedinHttp,
+  path: string,
+  organizationField: "organizationalEntity" | "organization",
+  organization: LinkedinOrganizationUrn,
+  timeIntervals: LinkedinTimeIntervals | undefined
+): Promise<readonly TItem[]> {
+  urnPath(organization, "organization URN")
+  assertTimeIntervals(timeIntervals)
+  return rows<TItem>(
+    http,
+    withQuery(path, {
+      q: organizationField,
+      [organizationField]: organization,
+      timeIntervals: timeIntervals ? restliTimeIntervals(timeIntervals) : undefined,
+    })
+  )
+}
+
+async function rows<TItem>(http: LinkedinHttp, path: string): Promise<readonly TItem[]> {
+  const response = await http.get<ElementsResponse<TItem>>(path)
+  return response.elements ?? []
+}
+
+function assertSupportedGranularity(
+  value: LinkedinTimeIntervals | undefined,
+  supported: readonly LinkedinTimeIntervals["timeGranularityType"][],
+  resource: string
+): void {
+  if (value && !supported.includes(value.timeGranularityType)) {
+    throw new Error(
+      `[SixbLinkedin] ${resource} supports ${supported.join(" or ")} granularity only.`
+    )
+  }
+}

--- a/connectors/linkedin/src/resources/organizations.ts
+++ b/connectors/linkedin/src/resources/organizations.ts
@@ -1,0 +1,77 @@
+import type { LinkedinHttp } from "../http"
+import { listAllOffset } from "../pagination"
+import { assertNonEmpty, assertOffset, pathId, urnPath, withQuery } from "../restli"
+import type {
+  LinkedinId,
+  LinkedinOffsetOptions,
+  LinkedinOffsetPage,
+  LinkedinOrganizationUrn,
+} from "../types/common"
+import type { LinkedinOrganization } from "../types/community"
+import { type ElementsResponse, offsetPage } from "./community-utils"
+
+export interface OrganizationsResource {
+  /** Get an organization administered by the authenticated member. */
+  get(id: LinkedinId): Promise<LinkedinOrganization>
+  findByVanityName(vanityName: string): Promise<LinkedinOrganization | undefined>
+  listByParent(
+    parent: LinkedinOrganizationUrn,
+    options?: LinkedinOffsetOptions
+  ): Promise<LinkedinOffsetPage<LinkedinOrganization>>
+  listAllByParent(
+    parent: LinkedinOrganizationUrn,
+    options?: LinkedinOffsetOptions
+  ): AsyncIterable<LinkedinOrganization>
+  /** Current organization follower count from `/networkSizes`. */
+  followerCount(organization: LinkedinOrganizationUrn): Promise<number>
+}
+
+export function createOrganizationsResource(http: LinkedinHttp): OrganizationsResource {
+  const resource: OrganizationsResource = {
+    get(id) {
+      return http.get(`organizations/${pathId(id, "organization id")}`)
+    },
+    async findByVanityName(vanityName) {
+      assertNonEmpty(vanityName, "organization vanity name")
+      const response = await http.get<ElementsResponse<LinkedinOrganization>>(
+        withQuery("organizations", { q: "vanityName", vanityName })
+      )
+      return response.elements?.[0]
+    },
+    listByParent(parent, options) {
+      urnPath(parent, "parent organization URN")
+      return listByParent(http, parent, options)
+    },
+    listAllByParent(parent, options) {
+      return listAllOffset((page) => resource.listByParent(parent, page), options)
+    },
+    async followerCount(organization) {
+      urnPath(organization, "organization URN")
+      const response = await http.get<{ readonly firstDegreeSize: number }>(
+        withQuery(`networkSizes/${encodeURIComponent(organization)}`, {
+          edgeType: "COMPANY_FOLLOWED_BY_MEMBER",
+        })
+      )
+      return response.firstDegreeSize
+    },
+  }
+  return resource
+}
+
+async function listByParent(
+  http: LinkedinHttp,
+  parent: LinkedinOrganizationUrn,
+  options: LinkedinOffsetOptions | undefined
+): Promise<LinkedinOffsetPage<LinkedinOrganization>> {
+  assertOffset(options?.start, "start", 0)
+  assertOffset(options?.count, "count", 1)
+  const response = await http.get<ElementsResponse<LinkedinOrganization>>(
+    withQuery("organizations", {
+      q: "parentOrganization",
+      parent,
+      start: options?.start,
+      count: options?.count,
+    })
+  )
+  return offsetPage(response, options)
+}

--- a/connectors/linkedin/src/resources/posts.ts
+++ b/connectors/linkedin/src/resources/posts.ts
@@ -1,0 +1,121 @@
+import type { LinkedinHttp } from "../http"
+import { listAllOffset } from "../pagination"
+import { assertOffset, urnPath, withQuery } from "../restli"
+import type {
+  LinkedinCreatedEntity,
+  LinkedinOffsetPage,
+  LinkedinOrganizationUrn,
+  LinkedinPersonUrn,
+  LinkedinPostUrn,
+} from "../types/common"
+import type {
+  LinkedinCreatePostInput,
+  LinkedinPost,
+  LinkedinPostListOptions,
+  LinkedinPostViewContext,
+  LinkedinUpdatePostInput,
+} from "../types/community"
+import { type ElementsResponse, offsetPage } from "./community-utils"
+
+export interface PostsResource {
+  get(post: LinkedinPostUrn, viewContext?: LinkedinPostViewContext): Promise<LinkedinPost>
+  listByAuthor(
+    author: LinkedinOrganizationUrn | LinkedinPersonUrn,
+    options?: LinkedinPostListOptions
+  ): Promise<LinkedinOffsetPage<LinkedinPost>>
+  listAllByAuthor(
+    author: LinkedinOrganizationUrn | LinkedinPersonUrn,
+    options?: LinkedinPostListOptions
+  ): AsyncIterable<LinkedinPost>
+  create(input: LinkedinCreatePostInput): Promise<LinkedinCreatedEntity>
+  update(post: LinkedinPostUrn, input: LinkedinUpdatePostInput): Promise<void>
+  delete(post: LinkedinPostUrn): Promise<void>
+}
+
+export function createPostsResource(http: LinkedinHttp): PostsResource {
+  const resource: PostsResource = {
+    get(post, viewContext) {
+      return http.get(withQuery(`posts/${urnPath(post, "post URN")}`, { viewContext }))
+    },
+    async listByAuthor(author, options) {
+      urnPath(author, "post author URN")
+      assertOffset(options?.start, "start", 0)
+      assertOffset(options?.count, "count", 1)
+      if (options?.count !== undefined && options.count > 100) {
+        throw new Error("[SixbLinkedin] post count must be between 1 and 100.")
+      }
+      const response = await http.get<ElementsResponse<LinkedinPost>>(
+        withQuery("posts", {
+          q: "author",
+          author,
+          sortBy: options?.sortBy,
+          start: options?.start,
+          count: options?.count,
+        }),
+        { headers: { "X-RestLi-Method": "FINDER" } }
+      )
+      return offsetPage(response, options)
+    },
+    listAllByAuthor(author, options) {
+      return listAllOffset(
+        (page) => resource.listByAuthor(author, page),
+        options?.count === undefined ? { ...options, count: 100 } : options
+      )
+    },
+    async create(input) {
+      assertCreatePostInput(input)
+      urnPath(input.author, "post author URN")
+      return http.create("posts", input)
+    },
+    update(post, input) {
+      if (Object.keys(input).length === 0) {
+        return Promise.reject(new Error("[SixbLinkedin] post update must set at least one field."))
+      }
+      return http.post(
+        `posts/${urnPath(post, "post URN")}`,
+        { patch: { $set: input } },
+        { headers: { "X-RestLi-Method": "PARTIAL_UPDATE" } }
+      )
+    },
+    delete(post) {
+      return http.delete(`posts/${urnPath(post, "post URN")}`)
+    },
+  }
+  return resource
+}
+
+function assertCreatePostInput(input: LinkedinCreatePostInput): void {
+  if (typeof input.commentary !== "string") {
+    throw new Error("[SixbLinkedin] post commentary is required.")
+  }
+  if (input.lifecycleState !== "PUBLISHED") {
+    throw new Error("[SixbLinkedin] post lifecycleState must be PUBLISHED during creation.")
+  }
+
+  const poll = input.content?.poll
+  if (!poll) return
+
+  if (characterCount(poll.question) < 1 || characterCount(poll.question) > 140) {
+    throw new Error("[SixbLinkedin] poll question must contain between 1 and 140 characters.")
+  }
+  if (poll.options.length < 2 || poll.options.length > 4) {
+    throw new Error("[SixbLinkedin] poll must contain between 2 and 4 options.")
+  }
+  for (const option of poll.options) {
+    if (characterCount(option.text) < 1 || characterCount(option.text) > 30) {
+      throw new Error("[SixbLinkedin] poll option text must contain between 1 and 30 characters.")
+    }
+  }
+  if (poll.settings.voteSelectionType === "MULTIPLE_VOTE") {
+    throw new Error("[SixbLinkedin] LinkedIn does not currently support multiple-vote polls.")
+  }
+  if (poll.settings.isVoterVisibleToAuthor === false) {
+    throw new Error(
+      "[SixbLinkedin] LinkedIn requires isVoterVisibleToAuthor to be true when it is provided."
+    )
+  }
+}
+
+function characterCount(value: string): number {
+  return [...value].length
+}

--- a/connectors/linkedin/src/resources/reactions.ts
+++ b/connectors/linkedin/src/resources/reactions.ts
@@ -1,0 +1,83 @@
+import type { LinkedinHttp } from "../http"
+import { listAllOffset } from "../pagination"
+import { assertOffset, restliRecord, urnPath, withQuery } from "../restli"
+import type {
+  LinkedinOffsetPage,
+  LinkedinOrganizationUrn,
+  LinkedinPersonUrn,
+  LinkedinUrn,
+} from "../types/common"
+import type {
+  LinkedinCreateReactionInput,
+  LinkedinReaction,
+  LinkedinReactionListOptions,
+} from "../types/community"
+import { type ElementsResponse, offsetPage } from "./community-utils"
+
+export interface ReactionsResource {
+  get(
+    actor: LinkedinOrganizationUrn | LinkedinPersonUrn,
+    entity: LinkedinUrn
+  ): Promise<LinkedinReaction>
+  listByEntity(
+    entity: LinkedinUrn,
+    options?: LinkedinReactionListOptions
+  ): Promise<LinkedinOffsetPage<LinkedinReaction>>
+  listAllByEntity(
+    entity: LinkedinUrn,
+    options?: LinkedinReactionListOptions
+  ): AsyncIterable<LinkedinReaction>
+  create(input: LinkedinCreateReactionInput): Promise<LinkedinReaction>
+  delete(actor: LinkedinOrganizationUrn | LinkedinPersonUrn, entity: LinkedinUrn): Promise<void>
+}
+
+export function createReactionsResource(http: LinkedinHttp): ReactionsResource {
+  const resource: ReactionsResource = {
+    get(actor, entity) {
+      return http.get(compoundPath(actor, entity))
+    },
+    async listByEntity(entity, options) {
+      urnPath(entity, "reaction entity URN")
+      assertOffset(options?.start, "start", 0)
+      assertOffset(options?.count, "count", 1)
+      const response = await http.get<ElementsResponse<LinkedinReaction>>(
+        withQuery(`reactions/(entity:${encodeURIComponent(entity)})`, {
+          q: "entity",
+          sort: restliRecord({ value: options?.sort ?? "REVERSE_CHRONOLOGICAL" }),
+          start: options?.start,
+          count: options?.count,
+        })
+      )
+      return offsetPage(response, options)
+    },
+    listAllByEntity(entity, options) {
+      return listAllOffset((page) => resource.listByEntity(entity, page), options)
+    },
+    create(input) {
+      urnPath(input.actor, "reaction actor URN")
+      urnPath(input.entity, "reaction entity URN")
+      if (input.reactionType === "MAYBE") {
+        return Promise.reject(
+          new Error("[SixbLinkedin] MAYBE is deprecated and cannot be used to create a reaction.")
+        )
+      }
+      return http.post(withQuery("reactions", { actor: input.actor }), {
+        root: input.entity,
+        reactionType: input.reactionType,
+      })
+    },
+    delete(actor, entity) {
+      return http.delete(compoundPath(actor, entity))
+    },
+  }
+  return resource
+}
+
+function compoundPath(
+  actor: LinkedinOrganizationUrn | LinkedinPersonUrn,
+  entity: LinkedinUrn
+): string {
+  urnPath(actor, "reaction actor URN")
+  urnPath(entity, "reaction entity URN")
+  return `reactions/(actor:${encodeURIComponent(actor)},entity:${encodeURIComponent(entity)})`
+}

--- a/connectors/linkedin/src/resources/social-metadata.ts
+++ b/connectors/linkedin/src/resources/social-metadata.ts
@@ -1,0 +1,31 @@
+import type { LinkedinHttp } from "../http"
+import { urnPath, withQuery } from "../restli"
+import type { LinkedinOrganizationUrn, LinkedinPersonUrn, LinkedinPostUrn } from "../types/common"
+import type { LinkedinSocialEntityUrn, LinkedinSocialMetadata } from "../types/community"
+
+export interface SocialMetadataResource {
+  /** Aggregate comment and reaction counts for an organic or sponsored entity. */
+  get(entity: LinkedinSocialEntityUrn): Promise<LinkedinSocialMetadata>
+  /**
+   * Enable or disable thread comments. Setting CLOSED permanently deletes existing comments.
+   */
+  setCommentsState(
+    entity: LinkedinPostUrn,
+    actor: LinkedinOrganizationUrn | LinkedinPersonUrn,
+    state: "OPEN" | "CLOSED"
+  ): Promise<void>
+}
+
+export function createSocialMetadataResource(http: LinkedinHttp): SocialMetadataResource {
+  return {
+    get(entity) {
+      return http.get(`socialMetadata/${urnPath(entity, "social entity URN")}`)
+    },
+    setCommentsState(entity, actor, state) {
+      urnPath(actor, "social metadata actor URN")
+      return http.post(withQuery(`socialMetadata/${urnPath(entity, "post URN")}`, { actor }), {
+        patch: { $set: { commentsState: state } },
+      })
+    },
+  }
+}

--- a/connectors/linkedin/src/restli.ts
+++ b/connectors/linkedin/src/restli.ts
@@ -1,0 +1,144 @@
+import type {
+  LinkedinDate,
+  LinkedinDateRange,
+  LinkedinId,
+  LinkedinOptionalDateRange,
+  LinkedinPostUrn,
+  LinkedinTimeIntervals,
+  LinkedinTimeRange,
+} from "./types/common"
+
+export type QueryScalar = string | number | boolean
+export type QueryValue = QueryScalar | RestliQueryValue | undefined
+export type QueryParams = Readonly<Record<string, QueryValue>>
+
+interface RestliQueryValue {
+  readonly kind: "restli"
+  readonly encoded: string
+}
+
+/** Build a URL query while preserving Rest.li structural delimiters. */
+export function withQuery(path: string, query?: QueryParams): string {
+  const normalizedPath = path.startsWith("/") ? path.slice(1) : path
+  if (!query) return normalizedPath
+
+  const entries: string[] = []
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === "") continue
+    const encoded = isRestliValue(value) ? value.encoded : encodeURIComponent(String(value))
+    entries.push(`${encodeURIComponent(key)}=${encoded}`)
+  }
+
+  return entries.length > 0 ? `${normalizedPath}?${entries.join("&")}` : normalizedPath
+}
+
+/** Rest.li protocol 2.0 list, with each value encoded independently from the list syntax. */
+export function restliList(values: readonly QueryScalar[]): RestliQueryValue {
+  return restli(`List(${values.map((value) => encodeURIComponent(String(value))).join(",")})`)
+}
+
+/** Search document used by ad account, campaign group, and campaign finders. */
+export function restliSearch(
+  fields: Readonly<Record<string, readonly QueryScalar[] | boolean | undefined>>
+): RestliQueryValue | undefined {
+  const entries: string[] = []
+  for (const [field, value] of Object.entries(fields)) {
+    if (value === undefined || (Array.isArray(value) && value.length === 0)) continue
+    entries.push(
+      Array.isArray(value)
+        ? `${field}:(values:${restliList(value).encoded})`
+        : `${field}:${String(value)}`
+    )
+  }
+  return entries.length > 0 ? restli(`(${entries.join(",")})`) : undefined
+}
+
+export function restliDateRange(value: LinkedinDateRange): RestliQueryValue {
+  const start = restliDate(value.start)
+  const end = value.end ? `,end:${restliDate(value.end)}` : ""
+  return restli(`(start:${start}${end})`)
+}
+
+export function restliOptionalDateRange(value: LinkedinOptionalDateRange): RestliQueryValue {
+  const start = value.start ? `start:${restliDate(value.start)}` : undefined
+  const end = value.end ? `end:${restliDate(value.end)}` : undefined
+  return restli(`(${[start, end].filter(Boolean).join(",")})`)
+}
+
+export function restliTimeRange(value: LinkedinTimeRange): RestliQueryValue {
+  const start = value.start === undefined ? undefined : `start:${value.start}`
+  const end = value.end === undefined ? undefined : `end:${value.end}`
+  return restli(`(${[start, end].filter(Boolean).join(",")})`)
+}
+
+export function restliTimeIntervals(value: LinkedinTimeIntervals): RestliQueryValue {
+  return restli(
+    `(timeRange:${restliTimeRange(value.timeRange).encoded},timeGranularityType:${value.timeGranularityType})`
+  )
+}
+
+/** Rest.li record whose scalar values are encoded independently from the record syntax. */
+export function restliRecord(
+  fields: Readonly<Record<string, QueryScalar | undefined>>
+): RestliQueryValue {
+  const entries = Object.entries(fields)
+    .filter((entry): entry is [string, QueryScalar] => entry[1] !== undefined)
+    .map(([key, value]) => `${key}:${encodeURIComponent(String(value))}`)
+  return restli(`(${entries.join(",")})`)
+}
+
+/** Union record expected by member analytics for a share or UGC post entity. */
+export function restliPostEntity(post: LinkedinPostUrn): RestliQueryValue {
+  urnPath(post, "post URN")
+  return restliRecord({ [post.startsWith("urn:li:share:") ? "share" : "ugc"]: post })
+}
+
+export function pathId(id: LinkedinId, field: string): string {
+  const value = String(id)
+  if (!/^\d+$/.test(value) || value === "0") {
+    throw new Error(`[SixbLinkedin] ${field} must be a positive numeric ID.`)
+  }
+  return value
+}
+
+export function urnPath(value: string, field: string): string {
+  assertNonEmpty(value, field)
+  if (!value.startsWith("urn:li:")) {
+    throw new Error(`[SixbLinkedin] ${field} must be a LinkedIn URN.`)
+  }
+  return encodeURIComponent(value)
+}
+
+export function assertNonEmpty(value: string, field: string): void {
+  if (!value?.trim()) {
+    throw new Error(`[SixbLinkedin] ${field} must not be empty.`)
+  }
+}
+
+export function assertPageSize(value: number | undefined, max: number): void {
+  if (value === undefined) return
+  if (!Number.isInteger(value) || value < 1 || value > max) {
+    throw new Error(`[SixbLinkedin] pageSize must be an integer between 1 and ${max}.`)
+  }
+}
+
+export function assertOffset(value: number | undefined, field: string, minimum: number): void {
+  if (value === undefined) return
+  if (!Number.isInteger(value) || value < minimum) {
+    throw new Error(
+      `[SixbLinkedin] ${field} must be an integer greater than or equal to ${minimum}.`
+    )
+  }
+}
+
+function restli(encoded: string): RestliQueryValue {
+  return { kind: "restli", encoded }
+}
+
+function isRestliValue(value: QueryValue): value is RestliQueryValue {
+  return typeof value === "object" && value !== null && value.kind === "restli"
+}
+
+function restliDate(value: LinkedinDate): string {
+  return `(year:${value.year},month:${value.month},day:${value.day})`
+}

--- a/connectors/linkedin/src/types/advertising.ts
+++ b/connectors/linkedin/src/types/advertising.ts
@@ -1,0 +1,447 @@
+import type {
+  LinkedinChangeAuditStamps,
+  LinkedinExtensibleString,
+  LinkedinId,
+  LinkedinMoney,
+  LinkedinOrganizationUrn,
+  LinkedinPersonUrn,
+  LinkedinRunSchedule,
+  LinkedinSortOrder,
+  LinkedinSponsoredAccountUrn,
+  LinkedinSponsoredCampaignGroupUrn,
+  LinkedinSponsoredCampaignUrn,
+  LinkedinSponsoredCreativeUrn,
+  LinkedinUrn,
+  LinkedinVersionTag,
+} from "./common"
+
+export type LinkedinAdAccountStatus =
+  | "ACTIVE"
+  | "CANCELED"
+  | "DRAFT"
+  | "PENDING_DELETION"
+  | "REMOVED"
+
+export type LinkedinAdAccountType = "BUSINESS" | "ENTERPRISE"
+
+export interface LinkedinAdAccount {
+  readonly id: number
+  readonly name: string
+  readonly currency?: string
+  readonly type: LinkedinAdAccountType
+  readonly status?: LinkedinAdAccountStatus
+  readonly test?: boolean
+  readonly reference?: LinkedinPersonUrn | LinkedinOrganizationUrn
+  readonly notifiedOnCampaignOptimization?: boolean
+  readonly notifiedOnCreativeApproval?: boolean
+  readonly notifiedOnCreativeRejection?: boolean
+  readonly notifiedOnEndOfCampaign?: boolean
+  readonly notifiedOnNewFeaturesEnabled?: boolean
+  readonly servingStatuses?: readonly string[]
+  readonly changeAuditStamps?: LinkedinChangeAuditStamps
+  readonly version?: LinkedinVersionTag
+  readonly referenceInfo?: unknown
+}
+
+export interface LinkedinCreateAdAccountInput {
+  readonly name: string
+  readonly type: "BUSINESS"
+  readonly currency?: string
+  readonly reference?: LinkedinPersonUrn | LinkedinOrganizationUrn
+  readonly test?: boolean
+  readonly notifiedOnCampaignOptimization?: boolean
+  readonly notifiedOnCreativeApproval?: boolean
+  readonly notifiedOnCreativeRejection?: boolean
+  readonly notifiedOnEndOfCampaign?: boolean
+  readonly notifiedOnNewFeaturesEnabled?: boolean
+}
+
+export type LinkedinUpdateAdAccountInput = Partial<
+  Pick<
+    LinkedinAdAccount,
+    | "name"
+    | "currency"
+    | "reference"
+    | "status"
+    | "notifiedOnCampaignOptimization"
+    | "notifiedOnCreativeApproval"
+    | "notifiedOnCreativeRejection"
+    | "notifiedOnEndOfCampaign"
+    | "notifiedOnNewFeaturesEnabled"
+  >
+>
+
+export interface LinkedinAdAccountSearchOptions {
+  readonly ids?: readonly LinkedinId[]
+  readonly names?: readonly string[]
+  readonly references?: readonly (LinkedinPersonUrn | LinkedinOrganizationUrn)[]
+  readonly statuses?: readonly LinkedinAdAccountStatus[]
+  readonly types?: readonly LinkedinAdAccountType[]
+  readonly test?: boolean
+  readonly sortOrder?: LinkedinSortOrder
+  readonly pageSize?: number
+  readonly pageToken?: string
+}
+
+export type LinkedinAdAccountUserRole =
+  | "VIEWER"
+  | "CREATIVE_MANAGER"
+  | "CAMPAIGN_MANAGER"
+  | "ACCOUNT_MANAGER"
+  | "ACCOUNT_BILLING_ADMIN"
+
+export interface LinkedinAdAccountUser {
+  readonly account: LinkedinSponsoredAccountUrn
+  readonly user: LinkedinPersonUrn
+  readonly role: LinkedinAdAccountUserRole
+  readonly createdAt?: number
+  readonly lastModifiedAt?: number
+  readonly changeAuditStamps?: LinkedinChangeAuditStamps
+  readonly version?: LinkedinVersionTag
+}
+
+export interface LinkedinAdAccountUserInput {
+  readonly account: LinkedinSponsoredAccountUrn
+  readonly user: LinkedinPersonUrn
+  readonly role: LinkedinAdAccountUserRole
+}
+
+export type LinkedinCampaignType = "TEXT_AD" | "SPONSORED_UPDATES" | "SPONSORED_INMAILS" | "DYNAMIC"
+
+export type LinkedinCampaignObjectiveType = LinkedinExtensibleString<
+  | "BRAND_AWARENESS"
+  | "ENGAGEMENT"
+  | "JOB_APPLICANTS"
+  | "LEAD_GENERATION"
+  | "WEBSITE_CONVERSIONS"
+  | "WEBSITE_VISITS"
+  | "VIDEO_VIEWS"
+>
+
+export type LinkedinCampaignGroupStatus =
+  | "ACTIVE"
+  | "ARCHIVED"
+  | "CANCELED"
+  | "DRAFT"
+  | "PAUSED"
+  | "PENDING_DELETION"
+  | "REMOVED"
+
+export interface LinkedinBudgetOptimization {
+  readonly bidStrategy?: "MAXIMUM_DELIVERY" | "MANUAL" | "COST_CAP"
+  readonly budgetOptimizationStrategy: "DYNAMIC"
+}
+
+export interface LinkedinCampaignGroup {
+  readonly id: number
+  readonly account: LinkedinSponsoredAccountUrn
+  readonly name: string
+  readonly runSchedule: LinkedinRunSchedule
+  readonly status: LinkedinCampaignGroupStatus
+  readonly totalBudget?: LinkedinMoney
+  readonly dailyBudget?: LinkedinMoney
+  readonly objectiveType?: LinkedinCampaignObjectiveType
+  readonly budgetOptimization?: LinkedinBudgetOptimization
+  readonly backfilled?: boolean
+  readonly test?: boolean
+  readonly allowedCampaignTypes?: readonly LinkedinCampaignType[]
+  readonly servingStatuses?: readonly string[]
+  readonly changeAuditStamps?: LinkedinChangeAuditStamps
+  readonly accountInfo?: LinkedinAdAccount
+}
+
+export interface LinkedinCreateCampaignGroupInput {
+  readonly account: LinkedinSponsoredAccountUrn
+  readonly name: string
+  readonly runSchedule: LinkedinRunSchedule
+  readonly status: "ACTIVE" | "DRAFT"
+  readonly totalBudget?: LinkedinMoney
+  readonly dailyBudget?: LinkedinMoney
+  readonly objectiveType?: LinkedinCampaignObjectiveType
+  readonly budgetOptimization?: LinkedinBudgetOptimization
+}
+
+export type LinkedinUpdateCampaignGroupInput = Partial<
+  Pick<
+    LinkedinCampaignGroup,
+    "name" | "runSchedule" | "status" | "totalBudget" | "dailyBudget" | "budgetOptimization"
+  >
+>
+
+export interface LinkedinCampaignGroupSearchOptions {
+  readonly ids?: readonly (LinkedinId | LinkedinSponsoredCampaignGroupUrn)[]
+  readonly names?: readonly string[]
+  readonly statuses?: readonly LinkedinCampaignGroupStatus[]
+  readonly test?: boolean
+  readonly sortOrder?: LinkedinSortOrder
+  readonly pageSize?: number
+  readonly pageToken?: string
+}
+
+export type LinkedinCampaignStatus =
+  | "ACTIVE"
+  | "PAUSED"
+  | "ARCHIVED"
+  | "COMPLETED"
+  | "CANCELED"
+  | "DRAFT"
+  | "PENDING_DELETION"
+  | "REMOVED"
+
+export type LinkedinCampaignCostType = "CPM" | "CPC" | "CPV"
+export type LinkedinCampaignCreativeSelection = "ROUND_ROBIN" | "OPTIMIZED"
+export type LinkedinCampaignPacingStrategy = "LIFETIME" | "ACCELERATED"
+export type LinkedinPoliticalIntent = "POLITICAL" | "NOT_POLITICAL" | "NOT_DECLARED"
+export type LinkedinOptimizationTargetType = LinkedinExtensibleString<
+  | "NONE"
+  | "ENHANCED_CONVERSION"
+  | "MAX_IMPRESSION"
+  | "MAX_CLICK"
+  | "MAX_CONVERSION"
+  | "MAX_VIDEO_VIEW"
+  | "MAX_LEAD"
+  | "MAX_QUALIFIED_LEAD"
+  | "MAX_REACH"
+>
+
+export interface LinkedinLocale {
+  readonly country: string
+  readonly language: string
+}
+
+export type LinkedinTargetingFacet = `urn:li:adTargetingFacet:${string}`
+export type LinkedinTargetingFacetMap = Readonly<
+  Partial<Record<LinkedinTargetingFacet, readonly LinkedinUrn[]>>
+>
+
+export interface LinkedinTargetingOrExpression {
+  readonly or: LinkedinTargetingFacetMap
+}
+
+export interface LinkedinTargetingAndExpression {
+  readonly and: readonly LinkedinTargetingOrExpression[]
+}
+
+export interface LinkedinTargetingCriteria {
+  readonly include: LinkedinTargetingAndExpression | LinkedinTargetingOrExpression
+  readonly exclude?: LinkedinTargetingAndExpression | LinkedinTargetingOrExpression
+}
+
+export interface LinkedinOffsitePreferences {
+  readonly iabCategories?: {
+    readonly include?: readonly LinkedinUrn[]
+    readonly exclude?: readonly LinkedinUrn[]
+  }
+  readonly publisherRestrictionFiles?: {
+    readonly include?: readonly LinkedinUrn[]
+    readonly exclude?: readonly LinkedinUrn[]
+  }
+}
+
+export interface LinkedinFrequencyOptimizationPreference {
+  readonly frequencyOptimizationPreference: {
+    readonly optimizationType: "MAX_FREQUENCY"
+    readonly frequency: number
+    readonly timeSpan: { readonly duration: 7; readonly unit: "DAY" }
+  }
+}
+
+export interface LinkedinCampaign {
+  readonly id: number
+  readonly account: LinkedinSponsoredAccountUrn
+  readonly campaignGroup: LinkedinSponsoredCampaignGroupUrn
+  readonly name: string
+  readonly costType: LinkedinCampaignCostType
+  readonly locale: LinkedinLocale
+  readonly offsiteDeliveryEnabled: boolean
+  readonly targetingCriteria: LinkedinTargetingCriteria
+  readonly type: LinkedinCampaignType
+  readonly unitCost: LinkedinMoney
+  readonly status: LinkedinCampaignStatus
+  readonly associatedEntity?: LinkedinUrn
+  readonly audienceExpansionEnabled?: boolean
+  readonly connectedTelevisionOnly?: boolean
+  readonly creativeSelection?: LinkedinCampaignCreativeSelection
+  readonly dailyBudget?: LinkedinMoney
+  readonly totalBudget?: LinkedinMoney
+  readonly objectiveType?: LinkedinCampaignObjectiveType
+  readonly offsitePreferences?: LinkedinOffsitePreferences
+  readonly optimizationPreference?: LinkedinFrequencyOptimizationPreference
+  readonly optimizationTargetType?: LinkedinOptimizationTargetType
+  readonly format?: string
+  readonly pacingStrategy?: LinkedinCampaignPacingStrategy
+  readonly politicalIntent?: LinkedinPoliticalIntent
+  readonly runSchedule?: LinkedinRunSchedule
+  readonly test?: boolean
+  readonly servingStatuses?: readonly string[]
+  readonly changeAuditStamps?: LinkedinChangeAuditStamps
+  readonly version?: LinkedinVersionTag
+  readonly accountInfo?: LinkedinAdAccount
+  readonly campaignGroupInfo?: LinkedinCampaignGroup
+  readonly associatedEntityInfo?: unknown
+}
+
+type LinkedinCampaignBudget =
+  | { readonly dailyBudget: LinkedinMoney; readonly totalBudget?: LinkedinMoney }
+  | { readonly dailyBudget?: LinkedinMoney; readonly totalBudget: LinkedinMoney }
+
+export type LinkedinCreateCampaignInput = Omit<
+  LinkedinCampaign,
+  | "id"
+  | "test"
+  | "servingStatuses"
+  | "changeAuditStamps"
+  | "version"
+  | "accountInfo"
+  | "campaignGroupInfo"
+  | "associatedEntityInfo"
+  | "dailyBudget"
+  | "totalBudget"
+  | "status"
+  | "politicalIntent"
+> &
+  LinkedinCampaignBudget & {
+    readonly status: "ACTIVE" | "DRAFT"
+    /** Required by current LinkedIn Marketing API versions. */
+    readonly politicalIntent: LinkedinPoliticalIntent
+  }
+
+export type LinkedinUpdateCampaignInput = Partial<
+  Pick<
+    LinkedinCampaign,
+    | "associatedEntity"
+    | "audienceExpansionEnabled"
+    | "creativeSelection"
+    | "dailyBudget"
+    | "totalBudget"
+    | "name"
+    | "offsiteDeliveryEnabled"
+    | "offsitePreferences"
+    | "optimizationPreference"
+    | "optimizationTargetType"
+    | "politicalIntent"
+    | "runSchedule"
+    | "status"
+    | "targetingCriteria"
+    | "unitCost"
+  >
+>
+
+export interface LinkedinCampaignSearchOptions {
+  readonly ids?: readonly (LinkedinId | LinkedinSponsoredCampaignUrn)[]
+  readonly campaignGroups?: readonly LinkedinSponsoredCampaignGroupUrn[]
+  readonly associatedEntities?: readonly LinkedinUrn[]
+  readonly names?: readonly string[]
+  readonly statuses?: readonly LinkedinCampaignStatus[]
+  readonly types?: readonly LinkedinCampaignType[]
+  readonly test?: boolean
+  readonly sortOrder?: LinkedinSortOrder
+  readonly pageSize?: number
+  readonly pageToken?: string
+}
+
+export type LinkedinCreativeStatus =
+  | "ACTIVE"
+  | "PAUSED"
+  | "DRAFT"
+  | "ARCHIVED"
+  | "CANCELED"
+  | "PENDING_DELETION"
+  | "REMOVED"
+
+export interface LinkedinEventAdContent {
+  readonly post: LinkedinUrn
+  readonly event: LinkedinUrn
+  readonly directSponsoredContent?: boolean
+  readonly preEventRegistrationImage?: LinkedinUrn
+  readonly hidePreviewVideo?: boolean
+  readonly contentAuthor?: LinkedinPersonUrn | LinkedinOrganizationUrn
+}
+
+/**
+ * Creative bodies vary by ad format and evolve monthly. Known common shapes are typed, while the
+ * open keys preserve new LinkedIn content unions without discarding data.
+ */
+export interface LinkedinCreativeContent {
+  readonly reference?: LinkedinUrn
+  readonly eventAd?: LinkedinEventAdContent
+  readonly [contentType: string]: unknown
+}
+
+export interface LinkedinLeadgenCallToAction {
+  readonly destination: LinkedinUrn
+  readonly label: LinkedinExtensibleString<
+    | "APPLY"
+    | "DOWNLOAD"
+    | "VIEW_QUOTE"
+    | "LEARN_MORE"
+    | "SIGN_UP"
+    | "SUBSCRIBE"
+    | "REGISTER"
+    | "REQUEST_DEMO"
+    | "JOIN"
+    | "ATTEND"
+    | "UNLOCK_FULL_DOCUMENT"
+  >
+}
+
+export interface LinkedinCreativeReview {
+  readonly status: "PENDING" | "APPROVED" | "REJECTED" | "NEEDS_REVIEW"
+  readonly rejectionReasons?: readonly string[]
+}
+
+export interface LinkedinCreative<
+  TContent extends LinkedinCreativeContent = LinkedinCreativeContent,
+> {
+  readonly id: LinkedinSponsoredCreativeUrn
+  readonly account: LinkedinSponsoredAccountUrn
+  readonly campaign: LinkedinSponsoredCampaignUrn
+  readonly intendedStatus: LinkedinCreativeStatus
+  readonly content?: TContent
+  readonly inlineContent?: unknown
+  readonly name?: string
+  readonly leadgenCallToAction?: LinkedinLeadgenCallToAction
+  readonly createdAt?: number
+  readonly createdBy?: LinkedinPersonUrn
+  readonly lastModifiedAt?: number
+  readonly lastModifiedBy?: LinkedinPersonUrn
+  readonly isServing?: boolean
+  readonly isTest?: boolean
+  readonly review?: LinkedinCreativeReview
+  readonly servingHoldReasons?: readonly string[]
+}
+
+export interface LinkedinCreateCreativeInput<
+  TContent extends LinkedinCreativeContent = LinkedinCreativeContent,
+> {
+  readonly campaign: LinkedinSponsoredCampaignUrn
+  readonly intendedStatus?: LinkedinCreativeStatus
+  readonly content?: TContent
+  readonly name?: string
+  readonly leadgenCallToAction?: LinkedinLeadgenCallToAction
+}
+
+export interface LinkedinCreateInlineCreativeInput {
+  /**
+   * The full `creative` union accepted by LinkedIn's `createInline` action. The payload deliberately
+   * stays open because the supported post formats evolve independently of the Creative schema.
+   */
+  readonly creative: Readonly<Record<string, unknown>>
+}
+
+export type LinkedinUpdateCreativeInput = Partial<
+  Pick<LinkedinCreative, "intendedStatus" | "name" | "leadgenCallToAction" | "content">
+>
+
+export interface LinkedinCreativeSearchOptions {
+  readonly campaigns?: readonly LinkedinSponsoredCampaignUrn[]
+  readonly contentReferences?: readonly LinkedinUrn[]
+  readonly creatives?: readonly LinkedinSponsoredCreativeUrn[]
+  readonly intendedStatuses?: readonly LinkedinCreativeStatus[]
+  readonly isTestAccount?: boolean
+  readonly isTotalIncluded?: boolean
+  readonly leadgenCreativeCallToActionDestinations?: readonly LinkedinUrn[]
+  readonly sortOrder?: LinkedinSortOrder
+  readonly pageSize?: number
+  readonly pageToken?: string
+}

--- a/connectors/linkedin/src/types/analytics.ts
+++ b/connectors/linkedin/src/types/analytics.ts
@@ -1,0 +1,113 @@
+import type { LinkedinCampaignObjectiveType, LinkedinCampaignType } from "./advertising"
+import type {
+  LinkedinDateRange,
+  LinkedinOrganizationUrn,
+  LinkedinSortOrder,
+  LinkedinSponsoredAccountUrn,
+  LinkedinSponsoredCampaignGroupUrn,
+  LinkedinSponsoredCampaignUrn,
+  LinkedinUrn,
+} from "./common"
+
+export type LinkedinAdAnalyticsPivot =
+  | "COMPANY"
+  | "ACCOUNT"
+  | "SHARE"
+  | "CAMPAIGN"
+  | "CREATIVE"
+  | "CAMPAIGN_GROUP"
+  | "CONVERSION"
+  | "CONVERSATION_NODE"
+  | "CONVERSATION_NODE_OPTION_INDEX"
+  | "SERVING_LOCATION"
+  | "CARD_INDEX"
+  | "MEMBER_COMPANY_SIZE"
+  | "MEMBER_INDUSTRY"
+  | "MEMBER_SENIORITY"
+  | "MEMBER_JOB_TITLE"
+  | "MEMBER_JOB_FUNCTION"
+  | "MEMBER_COUNTRY_V2"
+  | "MEMBER_REGION_V2"
+  | "MEMBER_COMPANY"
+  | "PLACEMENT_NAME"
+  | "IMPRESSION_DEVICE_TYPE"
+  | "EVENT_STAGE"
+  | "OBJECTIVE_TYPE"
+
+export type LinkedinAdAnalyticsTimeGranularity = "ALL" | "DAILY" | "MONTHLY" | "YEARLY"
+
+export type LinkedinAdAnalyticsSortField =
+  | "COST_IN_LOCAL_CURRENCY"
+  | "IMPRESSIONS"
+  | "CLICKS"
+  | "ONE_CLICK_LEADS"
+  | "OPENS"
+  | "SENDS"
+  | "EXTERNAL_WEBSITE_CONVERSIONS"
+
+export interface LinkedinAdAnalyticsFacets {
+  readonly shares?: readonly LinkedinUrn[]
+  readonly campaigns?: readonly LinkedinSponsoredCampaignUrn[]
+  readonly campaignGroups?: readonly LinkedinSponsoredCampaignGroupUrn[]
+  readonly accounts?: readonly LinkedinSponsoredAccountUrn[]
+  readonly companies?: readonly LinkedinOrganizationUrn[]
+}
+
+export interface LinkedinAdAnalyticsQuery extends LinkedinAdAnalyticsFacets {
+  readonly pivot: LinkedinAdAnalyticsPivot
+  readonly dateRange: LinkedinDateRange
+  readonly timeGranularity: LinkedinAdAnalyticsTimeGranularity
+  /** Up to 20 metric fields. Values remain open because LinkedIn adds metrics monthly. */
+  readonly fields: readonly string[]
+  readonly campaignType?: LinkedinCampaignType
+  readonly sortBy?: {
+    readonly field: LinkedinAdAnalyticsSortField
+    readonly order: LinkedinSortOrder
+  }
+}
+
+export interface LinkedinAdStatisticsQuery extends LinkedinAdAnalyticsFacets {
+  /** One to three pivots. */
+  readonly pivots: readonly LinkedinAdAnalyticsPivot[]
+  readonly dateRange: LinkedinDateRange
+  readonly timeGranularity: LinkedinAdAnalyticsTimeGranularity
+  /** Up to 20 metric fields. Values remain open because LinkedIn adds metrics monthly. */
+  readonly fields: readonly string[]
+  readonly objectiveType?: LinkedinCampaignObjectiveType
+  readonly campaignType?: LinkedinCampaignType
+  readonly sortBy?: {
+    readonly field: LinkedinAdAnalyticsSortField
+    readonly order: LinkedinSortOrder
+  }
+}
+
+export interface LinkedinAttributedRevenueQuery {
+  readonly pivots: readonly ("ACCOUNT" | "CAMPAIGN_GROUP" | "CAMPAIGN")[]
+  readonly account: LinkedinSponsoredAccountUrn
+  readonly dateRange: LinkedinDateRange
+  readonly campaigns?: readonly LinkedinSponsoredCampaignUrn[]
+  readonly campaignGroups?: readonly LinkedinSponsoredCampaignGroupUrn[]
+  readonly fields: readonly string[]
+}
+
+/**
+ * One row returned by `adAnalytics`. Decimal metrics stay strings and all requested metric keys are
+ * passed through. Supply a generic row type to a finder when the selected fields are known locally.
+ */
+export interface LinkedinAdAnalyticsRow {
+  readonly dateRange?: LinkedinDateRange
+  readonly pivotValues?: readonly string[]
+  readonly revenueAttributionMetrics?: LinkedinRevenueAttributionMetrics
+  readonly [metric: string]: unknown
+}
+
+export interface LinkedinRevenueAttributionMetrics {
+  readonly revenueWonInUsd?: string
+  readonly returnOnAdSpend?: number
+  readonly closedWonOpportunities?: number
+  readonly opportunityAmountInUsd?: string
+  readonly openOpportunities?: number
+  readonly opportunityWinRate?: number
+  readonly averageDealSizeInUsd?: string
+  readonly averageDaysToClose?: number
+}

--- a/connectors/linkedin/src/types/client.ts
+++ b/connectors/linkedin/src/types/client.ts
@@ -13,7 +13,23 @@ import type { OrganizationsResource } from "../resources/organizations"
 import type { PostsResource } from "../resources/posts"
 import type { ReactionsResource } from "../resources/reactions"
 import type { SocialMetadataResource } from "../resources/social-metadata"
-import type { LinkedinId } from "./common"
+import type { LinkedinId, LinkedinOrganizationUrn, LinkedinSponsoredAccountUrn } from "./common"
+
+export type LinkedinConnectedAccount =
+  | {
+      readonly type: "organization"
+      readonly id: LinkedinOrganizationUrn
+      readonly label: string
+      readonly description?: string
+      readonly avatarUrl?: string
+    }
+  | {
+      readonly type: "ad-account"
+      readonly id: LinkedinSponsoredAccountUrn
+      readonly label: string
+      readonly description?: string
+      readonly avatarUrl?: string
+    }
 
 export interface LinkedinAdAccountClient {
   readonly campaignGroups: CampaignGroupsResource
@@ -22,6 +38,8 @@ export interface LinkedinAdAccountClient {
 }
 
 export interface LinkedinClient {
+  /** Account selected for this managed Sixb connection. */
+  readonly account: LinkedinConnectedAccount
   readonly adAccounts: AdAccountsResource
   readonly adAccountUsers: AdAccountUsersResource
   readonly adAnalytics: AdAnalyticsResource

--- a/connectors/linkedin/src/types/client.ts
+++ b/connectors/linkedin/src/types/client.ts
@@ -1,0 +1,40 @@
+import type { AdAccountUsersResource } from "../resources/ad-account-users"
+import type { AdAccountsResource } from "../resources/ad-accounts"
+import type { AdAnalyticsResource } from "../resources/ad-analytics"
+import type { CampaignGroupsResource } from "../resources/campaign-groups"
+import type { CampaignsResource } from "../resources/campaigns"
+import type { CommentsResource } from "../resources/comments"
+import type { CreativesResource } from "../resources/creatives"
+import type { DocumentsResource, ImagesResource, VideosResource } from "../resources/media"
+import type { MemberAnalyticsResource } from "../resources/member-analytics"
+import type { OrganizationAclsResource } from "../resources/organization-acls"
+import type { OrganizationAnalyticsResource } from "../resources/organization-analytics"
+import type { OrganizationsResource } from "../resources/organizations"
+import type { PostsResource } from "../resources/posts"
+import type { ReactionsResource } from "../resources/reactions"
+import type { SocialMetadataResource } from "../resources/social-metadata"
+import type { LinkedinId } from "./common"
+
+export interface LinkedinAdAccountClient {
+  readonly campaignGroups: CampaignGroupsResource
+  readonly campaigns: CampaignsResource
+  readonly creatives: CreativesResource
+}
+
+export interface LinkedinClient {
+  readonly adAccounts: AdAccountsResource
+  readonly adAccountUsers: AdAccountUsersResource
+  readonly adAnalytics: AdAnalyticsResource
+  readonly organizationAcls: OrganizationAclsResource
+  readonly organizations: OrganizationsResource
+  readonly posts: PostsResource
+  readonly socialMetadata: SocialMetadataResource
+  readonly comments: CommentsResource
+  readonly reactions: ReactionsResource
+  readonly organizationAnalytics: OrganizationAnalyticsResource
+  readonly memberAnalytics: MemberAnalyticsResource
+  readonly images: ImagesResource
+  readonly videos: VideosResource
+  readonly documents: DocumentsResource
+  adAccount(id: LinkedinId): LinkedinAdAccountClient
+}

--- a/connectors/linkedin/src/types/common.ts
+++ b/connectors/linkedin/src/types/common.ts
@@ -1,0 +1,133 @@
+export type LinkedinId = string | number
+
+export type LinkedinUrn = `urn:li:${string}`
+export type LinkedinSponsoredAccountUrn = `urn:li:sponsoredAccount:${string}`
+export type LinkedinSponsoredCampaignGroupUrn = `urn:li:sponsoredCampaignGroup:${string}`
+export type LinkedinSponsoredCampaignUrn = `urn:li:sponsoredCampaign:${string}`
+export type LinkedinSponsoredCreativeUrn = `urn:li:sponsoredCreative:${string}`
+export type LinkedinPersonUrn = `urn:li:person:${string}`
+export type LinkedinOrganizationUrn = `urn:li:organization:${string}`
+export type LinkedinShareUrn = `urn:li:share:${string}`
+export type LinkedinUgcPostUrn = `urn:li:ugcPost:${string}`
+export type LinkedinPostUrn = LinkedinShareUrn | LinkedinUgcPostUrn
+export type LinkedinCommentUrn = `urn:li:comment:${string}`
+export type LinkedinReactionUrn = `urn:li:reaction:${string}`
+export type LinkedinActivityUrn = `urn:li:activity:${string}`
+export type LinkedinImageUrn = `urn:li:image:${string}`
+export type LinkedinVideoUrn = `urn:li:video:${string}`
+export type LinkedinDocumentUrn = `urn:li:document:${string}`
+export type LinkedinDigitalMediaAssetUrn = `urn:li:digitalmediaAsset:${string}`
+
+export type LinkedinSortOrder = "ASCENDING" | "DESCENDING"
+
+export interface LinkedinMoney {
+  /** Decimal amount. LinkedIn represents money as a string to preserve precision. */
+  readonly amount: string
+  /** ISO 4217 currency code. */
+  readonly currencyCode: string
+}
+
+export interface LinkedinRunSchedule {
+  /** Inclusive start time, in milliseconds since the Unix epoch. */
+  readonly start: number
+  /** Exclusive end time, in milliseconds since the Unix epoch. */
+  readonly end?: number
+}
+
+export interface LinkedinAuditStamp {
+  readonly actor?: LinkedinUrn
+  readonly impersonator?: LinkedinUrn
+  readonly time: number
+}
+
+export interface LinkedinChangeAuditStamps {
+  readonly created?: LinkedinAuditStamp
+  readonly lastModified?: LinkedinAuditStamp
+}
+
+export interface LinkedinVersionTag {
+  readonly versionTag: string
+}
+
+export interface LinkedinCursorOptions {
+  /** Defaults to 100. LinkedIn caps most searches at 1,000 and creative searches at 100. */
+  readonly pageSize?: number
+  readonly pageToken?: string
+}
+
+export interface LinkedinCursorPage<TItem> {
+  readonly items: readonly TItem[]
+  readonly nextPageToken?: string
+  /** Present when the finder supports and receives `isTotalIncluded: true`. */
+  readonly totalCount?: number
+}
+
+export interface LinkedinPagingLink {
+  readonly href?: string
+  readonly rel?: string
+  readonly type?: string
+}
+
+export interface LinkedinPaging {
+  readonly start: number
+  readonly count: number
+  readonly total?: number
+  readonly links?: readonly LinkedinPagingLink[]
+}
+
+export interface LinkedinOffsetPage<TItem> {
+  readonly items: readonly TItem[]
+  readonly paging: LinkedinPaging
+}
+
+export interface LinkedinOffsetOptions {
+  readonly start?: number
+  readonly count?: number
+}
+
+export interface LinkedinCreatedEntity {
+  /** Value returned by LinkedIn in the `x-restli-id` response header. */
+  readonly id: string
+}
+
+export interface LinkedinCreatedResource<TResource> extends LinkedinCreatedEntity {
+  /** Parsed response body returned alongside the Rest.li identifier. */
+  readonly data: TResource
+}
+
+export interface LinkedinPatch<TFields extends object> {
+  readonly $set?: Partial<TFields>
+  readonly $delete?: readonly (keyof TFields & string)[]
+}
+
+export interface LinkedinDate {
+  readonly year: number
+  readonly month: number
+  readonly day: number
+}
+
+export interface LinkedinDateRange {
+  readonly start: LinkedinDate
+  readonly end?: LinkedinDate
+}
+
+export interface LinkedinOptionalDateRange {
+  readonly start?: LinkedinDate
+  readonly end?: LinkedinDate
+}
+
+export interface LinkedinTimeRange {
+  /** Inclusive start time, in milliseconds since the Unix epoch. */
+  readonly start?: number
+  /** Exclusive end time, in milliseconds since the Unix epoch. */
+  readonly end?: number
+}
+
+export type LinkedinTimeGranularity = "DAY" | "WEEK" | "MONTH"
+
+export interface LinkedinTimeIntervals {
+  readonly timeRange: LinkedinTimeRange
+  readonly timeGranularityType: LinkedinTimeGranularity
+}
+
+export type LinkedinExtensibleString<T extends string> = T | (string & {})

--- a/connectors/linkedin/src/types/community-analytics.ts
+++ b/connectors/linkedin/src/types/community-analytics.ts
@@ -1,0 +1,191 @@
+import type {
+  LinkedinDateRange,
+  LinkedinExtensibleString,
+  LinkedinOptionalDateRange,
+  LinkedinOrganizationUrn,
+  LinkedinPostUrn,
+  LinkedinTimeIntervals,
+  LinkedinTimeRange,
+  LinkedinUgcPostUrn,
+  LinkedinUrn,
+} from "./common"
+
+export interface LinkedinFollowerCounts {
+  /** For demographic facets, LinkedIn rolls organic and paid followers into this field. */
+  readonly organicFollowerCount: number
+  readonly paidFollowerCount: number
+}
+
+export interface LinkedinFollowerFacetCount {
+  readonly followerCounts: LinkedinFollowerCounts
+  readonly associationType?: string
+  readonly function?: LinkedinUrn
+  readonly geo?: LinkedinUrn
+  readonly industry?: LinkedinUrn
+  readonly seniority?: LinkedinUrn
+  readonly staffCountRange?: string
+  [field: string]: unknown
+}
+
+export interface LinkedinOrganizationFollowerStatistic {
+  readonly organizationalEntity: LinkedinOrganizationUrn
+  readonly followerCountsByAssociationType?: readonly LinkedinFollowerFacetCount[]
+  readonly followerCountsByFunction?: readonly LinkedinFollowerFacetCount[]
+  readonly followerCountsByGeo?: readonly LinkedinFollowerFacetCount[]
+  readonly followerCountsByGeoCountry?: readonly LinkedinFollowerFacetCount[]
+  readonly followerCountsByIndustry?: readonly LinkedinFollowerFacetCount[]
+  readonly followerCountsBySeniority?: readonly LinkedinFollowerFacetCount[]
+  readonly followerCountsByStaffCountRange?: readonly LinkedinFollowerFacetCount[]
+  readonly followerGains?: LinkedinFollowerCounts
+  readonly timeRange?: LinkedinTimeRange
+  [field: string]: unknown
+}
+
+export interface LinkedinPageViews {
+  readonly allPageViews?: number
+  readonly overviewPageViews?: number
+  readonly careersPageViews?: number
+  readonly jobsPageViews?: number
+  readonly peoplePageViews?: number
+  readonly productsPageViews?: number
+  readonly uniquePageViews?: number
+  [metric: string]: number | undefined
+}
+
+export interface LinkedinPageClicks {
+  readonly careersPageClicks?: number
+  readonly careersPagePromoLinksClicks?: number
+  readonly customButtonClicks?: number
+  readonly desktopCustomButtonClicks?: number
+  readonly mobileCustomButtonClicks?: number
+  [metric: string]: number | undefined
+}
+
+export interface LinkedinPageStatistics {
+  readonly views?: LinkedinPageViews
+  readonly clicks?: LinkedinPageClicks
+  [group: string]: unknown
+}
+
+export interface LinkedinOrganizationPageStatistic {
+  readonly organization: LinkedinOrganizationUrn
+  readonly totalPageStatistics?: LinkedinPageStatistics
+  readonly pageStatisticsBySeniority?: readonly Readonly<Record<string, unknown>>[]
+  readonly pageStatisticsByIndustry?: readonly Readonly<Record<string, unknown>>[]
+  readonly pageStatisticsByStaffCountRange?: readonly Readonly<Record<string, unknown>>[]
+  readonly pageStatisticsByFunction?: readonly Readonly<Record<string, unknown>>[]
+  readonly pageStatisticsByGeoCountry?: readonly Readonly<Record<string, unknown>>[]
+  readonly pageStatisticsByGeo?: readonly Readonly<Record<string, unknown>>[]
+  readonly timeRange?: LinkedinTimeRange
+  [field: string]: unknown
+}
+
+export interface LinkedinShareStatistics {
+  readonly clickCount: number
+  readonly commentCount: number
+  readonly engagement: number
+  readonly impressionCount: number
+  readonly likeCount: number
+  readonly shareCount: number
+  readonly uniqueImpressionsCount?: number
+  readonly uniqueImpressionsCounts?: number
+  [metric: string]: number | undefined
+}
+
+export interface LinkedinOrganizationShareStatistic {
+  readonly organizationalEntity: LinkedinOrganizationUrn
+  readonly totalShareStatistics: LinkedinShareStatistics
+  readonly share?: LinkedinPostUrn
+  readonly ugcPost?: LinkedinUgcPostUrn
+  readonly timeRange?: LinkedinTimeRange
+  [field: string]: unknown
+}
+
+export type LinkedinOrganizationVideoMetric =
+  | "VIDEO_VIEW"
+  | "VIEWER"
+  | "TIME_WATCHED"
+  | "TIME_WATCHED_FOR_VIDEO_VIEWS"
+
+export type LinkedinOrganizationVideoAggregation = "DAY" | "WEEK" | "ALL"
+
+export interface LinkedinOrganizationVideoAnalyticsQuery {
+  readonly entity: LinkedinUgcPostUrn
+  readonly type: LinkedinOrganizationVideoMetric
+  readonly aggregation?: LinkedinOrganizationVideoAggregation
+  readonly timeRange?: LinkedinTimeRange
+}
+
+export interface LinkedinOrganizationVideoStatistic {
+  readonly entity: LinkedinUgcPostUrn
+  readonly value: number
+  readonly type?: LinkedinOrganizationVideoMetric
+  readonly statisticsType?: LinkedinOrganizationVideoMetric
+  readonly timeRange?: LinkedinTimeRange
+  [field: string]: unknown
+}
+
+export interface LinkedinOrganizationShareStatisticsQuery {
+  readonly timeIntervals?: LinkedinTimeIntervals
+  /** Specific posts cannot be combined with `timeIntervals`. */
+  readonly posts?: readonly LinkedinPostUrn[]
+}
+
+export type LinkedinMemberPostMetric = LinkedinExtensibleString<
+  | "IMPRESSION"
+  | "MEMBERS_REACHED"
+  | "RESHARE"
+  | "REACTION"
+  | "COMMENT"
+  | "POST_SAVE"
+  | "POST_SEND"
+  | "LINK_CLICKS"
+  | "PREMIUM_CTA_CLICKS"
+  | "FOLLOWER_GAINED_FROM_CONTENT"
+  | "PROFILE_VIEW_FROM_CONTENT"
+>
+
+export type LinkedinMemberAnalyticsAggregation = "DAILY" | "TOTAL"
+
+export interface LinkedinMemberPostAnalyticsQuery {
+  readonly queryType: LinkedinMemberPostMetric
+  readonly aggregation?: LinkedinMemberAnalyticsAggregation
+  readonly dateRange?: LinkedinOptionalDateRange
+}
+
+export interface LinkedinMemberPostEntityAnalyticsQuery extends LinkedinMemberPostAnalyticsQuery {
+  readonly entity: LinkedinPostUrn
+}
+
+export interface LinkedinMemberPostStatistic {
+  readonly count: number
+  readonly metricType: LinkedinMemberPostMetric | Readonly<Record<string, LinkedinMemberPostMetric>>
+  readonly targetEntity?: { readonly share: LinkedinPostUrn } | { readonly ugc: LinkedinPostUrn }
+  readonly dateRange?: LinkedinDateRange
+  [field: string]: unknown
+}
+
+export interface LinkedinMemberFollowerStatistic {
+  readonly memberFollowersCount: number
+  readonly dateRange?: LinkedinDateRange
+  [field: string]: unknown
+}
+
+export type LinkedinMemberVideoMetric = "VIDEO_PLAY" | "VIDEO_VIEWER" | "VIDEO_WATCH_TIME"
+
+export interface LinkedinMemberVideoAnalyticsQuery {
+  readonly entity: LinkedinPostUrn
+  readonly queryType: LinkedinMemberVideoMetric
+  readonly aggregation?: LinkedinMemberAnalyticsAggregation
+  readonly dateRange?: LinkedinOptionalDateRange
+}
+
+export interface LinkedinMemberVideoStatistic {
+  readonly count: number
+  readonly metricType:
+    | LinkedinMemberVideoMetric
+    | Readonly<Record<string, LinkedinMemberVideoMetric>>
+  readonly targetEntity: { readonly share: LinkedinPostUrn } | { readonly ugc: LinkedinPostUrn }
+  readonly dateRange?: LinkedinDateRange
+  [field: string]: unknown
+}

--- a/connectors/linkedin/src/types/community.ts
+++ b/connectors/linkedin/src/types/community.ts
@@ -1,0 +1,355 @@
+import type {
+  LinkedinActivityUrn,
+  LinkedinAuditStamp,
+  LinkedinCommentUrn,
+  LinkedinDigitalMediaAssetUrn,
+  LinkedinDocumentUrn,
+  LinkedinExtensibleString,
+  LinkedinImageUrn,
+  LinkedinOffsetOptions,
+  LinkedinOrganizationUrn,
+  LinkedinPersonUrn,
+  LinkedinPostUrn,
+  LinkedinReactionUrn,
+  LinkedinUrn,
+  LinkedinVideoUrn,
+} from "./common"
+
+export type LinkedinOrganizationType = LinkedinExtensibleString<
+  | "ASSOCIATION"
+  | "COMPANY"
+  | "EDUCATIONAL_INSTITUTION"
+  | "GOVERNMENT_AGENCY"
+  | "NON_PROFIT"
+  | "PARTNERSHIP"
+  | "PRIVATELY_HELD"
+  | "PUBLIC_COMPANY"
+  | "SELF_EMPLOYED"
+  | "SELF_OWNED"
+  | "SOLE_PROPRIETORSHIP"
+>
+
+export type LinkedinPrimaryOrganizationType = LinkedinExtensibleString<"NONE" | "SCHOOL" | "BRAND">
+
+export interface LinkedinLocalizedString {
+  readonly localized: Readonly<Record<string, string>>
+  readonly preferredLocale?: {
+    readonly country: string
+    readonly language: string
+  }
+}
+
+export interface LinkedinOrganizationLocation {
+  readonly locationType?: string
+  readonly address?: {
+    readonly line1?: string
+    readonly line2?: string
+    readonly city?: string
+    readonly geographicArea?: string
+    readonly country?: string
+    readonly postalCode?: string
+    [field: string]: unknown
+  }
+  readonly description?: LinkedinLocalizedString
+  readonly geoLocation?: LinkedinUrn
+  readonly staffCountRange?: string
+  [field: string]: unknown
+}
+
+/** Wire representation returned by `/organizations`. Unknown fields are preserved across versions. */
+export interface LinkedinOrganization {
+  readonly id: number
+  readonly localizedName?: string
+  readonly localizedWebsite?: string
+  readonly vanityName?: string
+  readonly name?: LinkedinLocalizedString
+  readonly description?: LinkedinLocalizedString
+  readonly website?: LinkedinLocalizedString
+  readonly logoV2?: {
+    readonly original?: LinkedinDigitalMediaAssetUrn | LinkedinImageUrn
+    readonly cropped?: LinkedinDigitalMediaAssetUrn | LinkedinImageUrn
+    readonly cropInfo?: Readonly<Record<string, unknown>>
+    [field: string]: unknown
+  }
+  readonly locations?: readonly LinkedinOrganizationLocation[]
+  readonly primaryOrganizationType?: LinkedinPrimaryOrganizationType
+  readonly organizationType?: LinkedinOrganizationType
+  readonly industries?: readonly LinkedinUrn[]
+  readonly staffCountRange?: string
+  readonly specialties?: readonly LinkedinLocalizedString[]
+  readonly foundedOn?: { readonly year: number }
+  readonly parentRelationship?: {
+    readonly parent: LinkedinOrganizationUrn
+    readonly relationshipStatus?: string
+    [field: string]: unknown
+  }
+  readonly versionTag?: string
+  [field: string]: unknown
+}
+
+export type LinkedinOrganizationRole = LinkedinExtensibleString<
+  | "ADMINISTRATOR"
+  | "ANALYST"
+  | "CONTENT_ADMIN"
+  | "CONTENT_ADMINISTRATOR"
+  | "CURATOR"
+  | "DIRECT_SPONSORED_CONTENT_POSTER"
+  | "LEAD_CAPTURE_ADMINISTRATOR"
+  | "LEAD_GEN_FORMS_MANAGER"
+  | "RECRUITING_POSTER"
+>
+
+export type LinkedinOrganizationAclState = "APPROVED" | "REJECTED" | "REQUESTED" | "REVOKED"
+
+export interface LinkedinOrganizationAcl {
+  readonly role: LinkedinOrganizationRole
+  readonly state: LinkedinOrganizationAclState
+  readonly roleAssignee: LinkedinPersonUrn
+  /** Current response field. */
+  readonly organizationTarget?: LinkedinOrganizationUrn
+  /** Older versioned responses may still use this field. */
+  readonly organization?: LinkedinOrganizationUrn
+  readonly createdAt?: number
+  readonly lastModifiedAt?: number
+  [field: string]: unknown
+}
+
+export interface LinkedinOrganizationAclOptions extends LinkedinOffsetOptions {
+  readonly role?: LinkedinOrganizationRole
+  readonly state?: LinkedinOrganizationAclState
+}
+
+export type LinkedinPostLifecycleState = LinkedinExtensibleString<
+  "DRAFT" | "PUBLISHED" | "PUBLISH_REQUESTED" | "PUBLISH_FAILED"
+>
+export type LinkedinPostVisibility = LinkedinExtensibleString<
+  "PUBLIC" | "CONNECTIONS" | "LOGGED_IN" | "CONTAINER"
+>
+export type LinkedinPostSortBy = "CREATED" | "LAST_MODIFIED"
+export type LinkedinPostViewContext = "AUTHOR" | "READER"
+
+export interface LinkedinPostDistribution {
+  readonly feedDistribution?: "MAIN_FEED" | "NONE"
+  readonly targetEntities?: readonly Readonly<Record<string, unknown>>[]
+  readonly thirdPartyDistributionChannels?: readonly string[]
+  [field: string]: unknown
+}
+
+export interface LinkedinPostArticleContent {
+  readonly source: string
+  readonly title?: string
+  readonly description?: string
+  readonly thumbnail?: LinkedinImageUrn
+  readonly thumbnailAltText?: string
+  [field: string]: unknown
+}
+
+export interface LinkedinPostMediaContent {
+  readonly id: LinkedinImageUrn | LinkedinVideoUrn | LinkedinDocumentUrn | LinkedinUrn
+  readonly title?: string
+  readonly altText?: string
+  [field: string]: unknown
+}
+
+export interface LinkedinPostMultiImageContent {
+  readonly images: readonly {
+    readonly id: LinkedinImageUrn
+    readonly altText?: string
+    [field: string]: unknown
+  }[]
+}
+
+export interface LinkedinPostPollContent {
+  readonly question: string
+  readonly options: readonly {
+    readonly text: string
+    readonly isVotedByViewer?: boolean
+    readonly voteCount?: number
+    [field: string]: unknown
+  }[]
+  readonly settings: {
+    readonly duration: "ONE_DAY" | "THREE_DAYS" | "SEVEN_DAYS" | "FOURTEEN_DAYS"
+    readonly voteSelectionType?: "SINGLE_VOTE" | "MULTIPLE_VOTE"
+    readonly isVoterVisibleToAuthor?: boolean
+    [field: string]: unknown
+  }
+  readonly uniqueVotersCount?: number
+  [field: string]: unknown
+}
+
+export interface LinkedinPostReferenceContent {
+  readonly id: LinkedinUrn
+  [field: string]: unknown
+}
+
+export interface LinkedinPostContent {
+  readonly article?: LinkedinPostArticleContent
+  readonly media?: LinkedinPostMediaContent
+  readonly multiImage?: LinkedinPostMultiImageContent
+  readonly poll?: LinkedinPostPollContent
+  readonly reference?: LinkedinPostReferenceContent
+  readonly carousel?: Readonly<Record<string, unknown>>
+  readonly celebration?: Readonly<Record<string, unknown>>
+  [format: string]: unknown
+}
+
+export type LinkedinPostCallToActionLabel = LinkedinExtensibleString<
+  | "APPLY"
+  | "DOWNLOAD"
+  | "VIEW_QUOTE"
+  | "LEARN_MORE"
+  | "SIGN_UP"
+  | "SUBSCRIBE"
+  | "REGISTER"
+  | "JOIN"
+  | "ATTEND"
+  | "REQUEST_DEMO"
+  | "SEE_MORE"
+  | "BUY_NOW"
+  | "SHOP_NOW"
+>
+
+export interface LinkedinPostLifecycleStateInfo {
+  readonly contentStatus?: string
+  readonly reviewStatus?: string
+  readonly isEditedByAuthor?: boolean
+  [field: string]: unknown
+}
+
+export interface LinkedinPostReshareContext {
+  readonly parent: LinkedinPostUrn
+  readonly root?: LinkedinPostUrn
+  [field: string]: unknown
+}
+
+export interface LinkedinPost {
+  readonly id: LinkedinPostUrn
+  readonly author: LinkedinOrganizationUrn | LinkedinPersonUrn
+  readonly commentary: string
+  readonly container?: LinkedinUrn
+  readonly content?: LinkedinPostContent
+  readonly contentLandingPage?: string
+  readonly contentCallToActionLabel?: LinkedinPostCallToActionLabel
+  readonly distribution?: LinkedinPostDistribution
+  readonly visibility: LinkedinPostVisibility
+  readonly lifecycleState: LinkedinPostLifecycleState
+  readonly createdAt?: number
+  readonly lastModifiedAt?: number
+  readonly publishedAt?: number
+  readonly isReshareDisabledByAuthor?: boolean
+  readonly lifecycleStateInfo?: LinkedinPostLifecycleStateInfo
+  readonly reshareContext?: LinkedinPostReshareContext
+  readonly adContext?: Readonly<Record<string, unknown>>
+  [field: string]: unknown
+}
+
+export interface LinkedinPostListOptions extends LinkedinOffsetOptions {
+  readonly sortBy?: LinkedinPostSortBy
+}
+
+export interface LinkedinCreatePostInput {
+  readonly author: LinkedinOrganizationUrn | LinkedinPersonUrn
+  readonly commentary: string
+  readonly container?: LinkedinUrn
+  readonly content?: LinkedinPostContent
+  readonly contentLandingPage?: string
+  readonly contentCallToActionLabel?: LinkedinPostCallToActionLabel
+  readonly distribution: LinkedinPostDistribution
+  readonly visibility: LinkedinPostVisibility
+  /** LinkedIn only accepts PUBLISHED during post creation. */
+  readonly lifecycleState: "PUBLISHED"
+  readonly isReshareDisabledByAuthor?: boolean
+  readonly reshareContext?: Pick<LinkedinPostReshareContext, "parent">
+  readonly adContext?: Readonly<Record<string, unknown>>
+}
+
+export interface LinkedinUpdatePostInput {
+  readonly commentary?: string
+  readonly contentCallToActionLabel?: LinkedinPostCallToActionLabel
+  readonly contentLandingPage?: string
+  readonly lifecycleState?: LinkedinPostLifecycleState
+  readonly adContext?: Readonly<Record<string, unknown>>
+}
+
+export type LinkedinCommentsState = "OPEN" | "CLOSED" | "PROCESSING" | "DELETED"
+export type LinkedinReactionType = LinkedinExtensibleString<
+  "LIKE" | "PRAISE" | "MAYBE" | "EMPATHY" | "INTEREST" | "APPRECIATION" | "ENTERTAINMENT"
+>
+
+export interface LinkedinSocialMetadata {
+  readonly entity: LinkedinUrn
+  readonly commentsState?: LinkedinCommentsState
+  readonly commentSummary?: {
+    readonly count: number
+    readonly topLevelCount?: number
+    [field: string]: unknown
+  }
+  readonly reactionSummaries?: Readonly<
+    Record<string, { readonly count: number; readonly reactionType?: LinkedinReactionType }>
+  >
+  [field: string]: unknown
+}
+
+export type LinkedinSocialEntityUrn = LinkedinPostUrn | LinkedinCommentUrn
+
+export interface LinkedinCommentMessageAttribute {
+  readonly start: number
+  readonly length: number
+  readonly value?: Readonly<Record<string, unknown>>
+  [field: string]: unknown
+}
+
+export interface LinkedinCommentMessage {
+  readonly text: string
+  readonly attributes?: readonly LinkedinCommentMessageAttribute[]
+}
+
+export interface LinkedinComment {
+  readonly id: string
+  readonly commentUrn?: LinkedinCommentUrn
+  readonly actor: LinkedinOrganizationUrn | LinkedinPersonUrn
+  readonly object?: LinkedinUrn
+  readonly parentComment?: LinkedinCommentUrn
+  readonly message: LinkedinCommentMessage
+  readonly content?: readonly Readonly<Record<string, unknown>>[]
+  readonly created?: LinkedinAuditStamp
+  readonly lastModified?: LinkedinAuditStamp
+  readonly agent?: LinkedinUrn
+  readonly likesSummary?: Readonly<Record<string, unknown>>
+  [field: string]: unknown
+}
+
+export interface LinkedinCreateCommentInput {
+  readonly actor: LinkedinOrganizationUrn | LinkedinPersonUrn
+  /** Required for a nested comment because the request target is then a comment URN. */
+  readonly object?: LinkedinPostUrn | LinkedinActivityUrn
+  readonly parentComment?: LinkedinCommentUrn
+  readonly message: LinkedinCommentMessage
+  readonly content?: readonly Readonly<Record<string, unknown>>[]
+}
+
+export interface LinkedinUpdateCommentInput {
+  readonly actor?: LinkedinOrganizationUrn | LinkedinPersonUrn
+  readonly message: LinkedinCommentMessage
+}
+
+export interface LinkedinReaction {
+  readonly id?: LinkedinReactionUrn
+  readonly reactionType: LinkedinReactionType
+  readonly root: LinkedinUrn
+  readonly created?: LinkedinAuditStamp
+  readonly lastModified?: LinkedinAuditStamp
+  [field: string]: unknown
+}
+
+export type LinkedinReactionSortOrder = "CHRONOLOGICAL" | "REVERSE_CHRONOLOGICAL" | "RELEVANCE"
+
+export interface LinkedinReactionListOptions extends LinkedinOffsetOptions {
+  readonly sort?: LinkedinReactionSortOrder
+}
+
+export interface LinkedinCreateReactionInput {
+  readonly actor: LinkedinOrganizationUrn | LinkedinPersonUrn
+  readonly entity: LinkedinUrn
+  readonly reactionType: LinkedinReactionType
+}

--- a/connectors/linkedin/src/types/index.ts
+++ b/connectors/linkedin/src/types/index.ts
@@ -1,0 +1,8 @@
+export type * from "./advertising"
+export type * from "./analytics"
+export type * from "./client"
+export type * from "./common"
+export type * from "./community"
+export type * from "./community-analytics"
+export type * from "./media"
+export type * from "./options"

--- a/connectors/linkedin/src/types/media.ts
+++ b/connectors/linkedin/src/types/media.ts
@@ -1,0 +1,54 @@
+import type {
+  LinkedinDocumentUrn,
+  LinkedinImageUrn,
+  LinkedinOrganizationUrn,
+  LinkedinPersonUrn,
+  LinkedinSponsoredAccountUrn,
+  LinkedinVideoUrn,
+} from "./common"
+
+export type LinkedinMediaStatus =
+  | "WAITING_UPLOAD"
+  | "PROCESSING"
+  | "PROCESSING_FAILED"
+  | "AVAILABLE"
+
+export interface LinkedinMediaLibraryMetadata {
+  readonly associatedAccount: LinkedinSponsoredAccountUrn
+  readonly assetName: string
+  readonly mediaLibraryStatus?: "ACTIVE" | "ARCHIVED"
+  [field: string]: unknown
+}
+
+interface LinkedinMediaAsset {
+  readonly owner: LinkedinOrganizationUrn | LinkedinPersonUrn | LinkedinSponsoredAccountUrn
+  readonly status?: LinkedinMediaStatus
+  readonly downloadUrl?: string
+  readonly downloadUrlExpiresAt?: number
+  readonly mediaLibraryMetadata?: LinkedinMediaLibraryMetadata
+  [field: string]: unknown
+}
+
+export interface LinkedinImage extends LinkedinMediaAsset {
+  readonly id: LinkedinImageUrn
+  readonly aspectRatioHeight?: number
+  readonly aspectRatioWidth?: number
+  readonly altText?: string
+}
+
+export interface LinkedinVideo extends LinkedinMediaAsset {
+  readonly id: LinkedinVideoUrn
+  /** Duration in milliseconds. */
+  readonly duration?: number
+  readonly aspectRatioHeight?: number
+  readonly aspectRatioWidth?: number
+  readonly thumbnail?: string
+  readonly captions?: string
+  readonly transcript?: string
+}
+
+export interface LinkedinDocument extends LinkedinMediaAsset {
+  readonly id: LinkedinDocumentUrn
+  readonly thumbnail?: string
+  readonly pageCount?: number
+}

--- a/connectors/linkedin/src/types/options.ts
+++ b/connectors/linkedin/src/types/options.ts
@@ -1,4 +1,26 @@
-export type LinkedinAccessTokenResolver = string | (() => string | Promise<string>)
+import type { LinkedinExtensibleString } from "./common"
+
+export type LinkedinAccountType = "ad-account" | "organization"
+
+/**
+ * OAuth scopes currently used by LinkedIn's Advertising and Community Management products.
+ * The open-string fallback keeps monthly LinkedIn additions usable without a connector release.
+ */
+export type LinkedinOAuthScope = LinkedinExtensibleString<
+  | "r_ads"
+  | "rw_ads"
+  | "r_ads_reporting"
+  | "rw_organization_admin"
+  | "r_organization_social"
+  | "w_organization_social"
+  | "r_organization_social_feed"
+  | "w_organization_social_feed"
+  | "r_member_social_feed"
+  | "w_member_social"
+  | "w_member_social_feed"
+  | "r_member_profileAnalytics"
+  | "r_member_postAnalytics"
+>
 
 export type LinkedinRequestMethod = "GET" | "POST" | "PUT" | "DELETE"
 
@@ -18,8 +40,14 @@ export interface LinkedinRetryPolicy {
 }
 
 export interface LinkedinConnectorOptions {
-  /** OAuth access token or a live resolver. The resolver is evaluated for every attempt. */
-  readonly accessToken: LinkedinAccessTokenResolver
+  /** Client ID of the LinkedIn developer application for this connector definition. */
+  readonly clientId: string
+  /** Client secret of the LinkedIn developer application. Never exposed to connected clients. */
+  readonly clientSecret: string
+  /** OAuth scopes requested from LinkedIn. Keep this list to the minimum required by the syncs. */
+  readonly scopes: readonly LinkedinOAuthScope[]
+  /** Account surface exposed to Sixb's account-selection flow. */
+  readonly accountType: LinkedinAccountType
   /** LinkedIn Marketing API version in YYYYMM form. Defaults to 202608. */
   readonly version?: string
   /** Defaults to https://api.linkedin.com/rest/. */

--- a/connectors/linkedin/src/types/options.ts
+++ b/connectors/linkedin/src/types/options.ts
@@ -1,0 +1,37 @@
+export type LinkedinAccessTokenResolver = string | (() => string | Promise<string>)
+
+export type LinkedinRequestMethod = "GET" | "POST" | "PUT" | "DELETE"
+
+export interface LinkedinRetryContext {
+  readonly attempt: number
+  /** Logical method. A tunneled GET remains `GET`. */
+  readonly method: LinkedinRequestMethod
+  readonly response: Response | null
+  readonly error: unknown
+}
+
+export interface LinkedinRetryPolicy {
+  /** Number of retries after the initial request. Defaults to 2. */
+  readonly maxRetries?: number
+  shouldRetry?(context: LinkedinRetryContext): boolean
+  delayMs?(context: LinkedinRetryContext): number
+}
+
+export interface LinkedinConnectorOptions {
+  /** OAuth access token or a live resolver. The resolver is evaluated for every attempt. */
+  readonly accessToken: LinkedinAccessTokenResolver
+  /** LinkedIn Marketing API version in YYYYMM form. Defaults to 202608. */
+  readonly version?: string
+  /** Defaults to https://api.linkedin.com/rest/. */
+  readonly baseUrl?: string
+  readonly timeoutMs?: number
+  /** Optional delay between requests. */
+  readonly minDelayMs?: number
+  /** By default, only transient logical GET failures are retried. */
+  readonly retry?: LinkedinRetryPolicy
+  /**
+   * GET query-string length at which query tunneling is used. Defaults to 3,500 bytes, below
+   * LinkedIn's 4 KB query-string limit. Set to 0 to tunnel every GET with a query string.
+   */
+  readonly queryTunnelingThreshold?: number
+}

--- a/connectors/linkedin/src/urns.ts
+++ b/connectors/linkedin/src/urns.ts
@@ -1,0 +1,39 @@
+import { pathId } from "./restli"
+import type {
+  LinkedinId,
+  LinkedinOrganizationUrn,
+  LinkedinShareUrn,
+  LinkedinSponsoredAccountUrn,
+  LinkedinSponsoredCampaignGroupUrn,
+  LinkedinSponsoredCampaignUrn,
+  LinkedinSponsoredCreativeUrn,
+  LinkedinUgcPostUrn,
+} from "./types/common"
+
+export function organizationUrn(id: LinkedinId): LinkedinOrganizationUrn {
+  return `urn:li:organization:${pathId(id, "organization id")}`
+}
+
+export function shareUrn(id: LinkedinId): LinkedinShareUrn {
+  return `urn:li:share:${pathId(id, "share id")}`
+}
+
+export function ugcPostUrn(id: LinkedinId): LinkedinUgcPostUrn {
+  return `urn:li:ugcPost:${pathId(id, "UGC post id")}`
+}
+
+export function sponsoredAccountUrn(id: LinkedinId): LinkedinSponsoredAccountUrn {
+  return `urn:li:sponsoredAccount:${pathId(id, "ad account id")}`
+}
+
+export function sponsoredCampaignGroupUrn(id: LinkedinId): LinkedinSponsoredCampaignGroupUrn {
+  return `urn:li:sponsoredCampaignGroup:${pathId(id, "campaign group id")}`
+}
+
+export function sponsoredCampaignUrn(id: LinkedinId): LinkedinSponsoredCampaignUrn {
+  return `urn:li:sponsoredCampaign:${pathId(id, "campaign id")}`
+}
+
+export function sponsoredCreativeUrn(id: LinkedinId): LinkedinSponsoredCreativeUrn {
+  return `urn:li:sponsoredCreative:${pathId(id, "creative id")}`
+}

--- a/connectors/linkedin/tests/account-discovery.test.ts
+++ b/connectors/linkedin/tests/account-discovery.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { linkedin } from "../src"
+import { CONTEXT, DEFAULT_OPTIONS, json, recorder } from "./helpers"
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+const CREDENTIALS = { accessToken: "discovery-token", tokenType: "Bearer" }
+
+describe("linkedin managed account discovery", () => {
+  test("discovers and deduplicates approved administered Pages", async () => {
+    const calls = recorder([
+      json({
+        elements: [
+          {
+            role: "ADMINISTRATOR",
+            state: "APPROVED",
+            roleAssignee: "urn:li:person:9",
+            organizationTarget: "urn:li:organization:42",
+          },
+          {
+            role: "ANALYST",
+            state: "APPROVED",
+            roleAssignee: "urn:li:person:9",
+            organizationTarget: "urn:li:organization:42",
+          },
+        ],
+        paging: { start: 0, count: 2, total: 2 },
+      }),
+      json({ id: 42, localizedName: "Sixb", vanityName: "sixb-ai" }),
+    ])
+    const connector = linkedin({
+      ...DEFAULT_OPTIONS,
+      scopes: ["rw_organization_admin"],
+      accountType: "organization",
+    })
+
+    const accounts = await connector.discoverAccounts(CONTEXT, CREDENTIALS)
+
+    expect(accounts).toEqual([
+      {
+        id: "urn:li:organization:42",
+        label: "Sixb",
+        description: "LinkedIn Page · linkedin.com/company/sixb-ai",
+      },
+    ])
+    expect(calls.map((call) => call.url)).toEqual([
+      "https://api.linkedin.com/rest/organizationAcls?q=roleAssignee&state=APPROVED&start=0&count=100",
+      "https://api.linkedin.com/rest/organizations/42",
+    ])
+    expect(
+      calls.every((call) => call.headers.get("authorization") === "Bearer discovery-token")
+    ).toBe(true)
+  })
+
+  test("discovers accessible advertising accounts", async () => {
+    recorder([
+      json({
+        elements: [
+          {
+            account: "urn:li:sponsoredAccount:123",
+            user: "urn:li:person:9",
+            role: "ACCOUNT_MANAGER",
+          },
+        ],
+        paging: { start: 0, count: 1, total: 1 },
+      }),
+      json({
+        id: 123,
+        name: "Sixb Ads",
+        type: "BUSINESS",
+        status: "ACTIVE",
+        currency: "EUR",
+      }),
+    ])
+
+    const accounts = await linkedin(DEFAULT_OPTIONS).discoverAccounts(CONTEXT, CREDENTIALS)
+
+    expect(accounts).toEqual([
+      {
+        id: "urn:li:sponsoredAccount:123",
+        label: "Sixb Ads",
+        description: "LinkedIn ad account · ACTIVE · EUR",
+      },
+    ])
+  })
+})

--- a/connectors/linkedin/tests/accounts.test.ts
+++ b/connectors/linkedin/tests/accounts.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { sponsoredAccountUrn } from "../src"
+import { collect, createTestClient, empty, json, recorder } from "./helpers"
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("linkedin advertising accounts", () => {
+  test("search serializes Rest.li criteria and exposes the next cursor", async () => {
+    const calls = recorder([
+      json({
+        elements: [{ id: 1, name: "Acme", type: "BUSINESS", status: "ACTIVE" }],
+        metadata: { nextPageToken: "next-token" },
+      }),
+    ])
+    const client = await createTestClient()
+
+    const page = await client.adAccounts.search({
+      statuses: ["ACTIVE", "CANCELED"],
+      types: ["BUSINESS"],
+      test: false,
+      sortOrder: "DESCENDING",
+      pageSize: 250,
+    })
+
+    const url = new URL(calls[0]?.url ?? "")
+    expect(url.pathname).toBe("/rest/adAccounts")
+    expect(url.searchParams.get("q")).toBe("search")
+    expect(url.searchParams.get("search")).toBe(
+      "(status:(values:List(ACTIVE,CANCELED)),type:(values:List(BUSINESS)),test:false)"
+    )
+    expect(url.searchParams.get("pageSize")).toBe("250")
+    expect(page.nextPageToken).toBe("next-token")
+    expect(page.items[0]?.name).toBe("Acme")
+  })
+
+  test("searchAll follows cursor metadata without changing the search", async () => {
+    const calls = recorder((call) => {
+      const token = new URL(call.url).searchParams.get("pageToken")
+      return token
+        ? json({ elements: [{ id: 2, name: "B", type: "BUSINESS" }], metadata: {} })
+        : json({
+            elements: [{ id: 1, name: "A", type: "BUSINESS" }],
+            metadata: { nextPageToken: "page-2" },
+          })
+    })
+    const client = await createTestClient()
+
+    const accounts = await collect(client.adAccounts.searchAll({ statuses: ["ACTIVE"] }))
+
+    expect(accounts.map((account) => account.id)).toEqual([1, 2])
+    expect(new URL(calls[1]?.url ?? "").searchParams.get("pageToken")).toBe("page-2")
+    expect(new URL(calls[1]?.url ?? "").searchParams.get("search")).toContain("ACTIVE")
+  })
+
+  test("create reads x-restli-id and update uses a partial update", async () => {
+    const calls = recorder([empty(201, { "x-restli-id": "123" }), empty()])
+    const client = await createTestClient()
+
+    const created = await client.adAccounts.create({ name: "Acme", type: "BUSINESS" })
+    await client.adAccounts.update(123, { name: "Renamed" })
+
+    expect(created.id).toBe("123")
+    expect(calls[0]?.method).toBe("POST")
+    expect(JSON.parse(calls[0]?.body ?? "{}")).toEqual({ name: "Acme", type: "BUSINESS" })
+    expect(calls[1]?.headers.get("x-restli-method")).toBe("PARTIAL_UPDATE")
+    expect(JSON.parse(calls[1]?.body ?? "{}")).toEqual({
+      patch: { $set: { name: "Renamed" } },
+    })
+  })
+
+  test("account users use the compound key and authenticated-user finder", async () => {
+    const account = sponsoredAccountUrn(123)
+    const user = "urn:li:person:abc" as const
+    const calls = recorder([
+      json({ account, user, role: "ACCOUNT_MANAGER" }),
+      json({
+        elements: [{ account, user, role: "ACCOUNT_MANAGER" }],
+        paging: { start: 0, count: 1, total: 1, links: [] },
+      }),
+      empty(),
+    ])
+    const client = await createTestClient()
+
+    await client.adAccountUsers.get(account, user)
+    const page = await client.adAccountUsers.listByAuthenticatedUser({ count: 10 })
+    await client.adAccountUsers.revoke(account, user)
+
+    expect(decodeURIComponent(new URL(calls[0]?.url ?? "").pathname)).toContain(
+      "(account=urn:li:sponsoredAccount:123,user=urn:li:person:abc)"
+    )
+    expect(new URL(calls[1]?.url ?? "").searchParams.get("q")).toBe("authenticatedUser")
+    expect(page.paging.total).toBe(1)
+    expect(calls[2]?.method).toBe("DELETE")
+  })
+})

--- a/connectors/linkedin/tests/analytics.test.ts
+++ b/connectors/linkedin/tests/analytics.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { sponsoredAccountUrn, sponsoredCampaignUrn } from "../src"
+import { createTestClient, json, recorder } from "./helpers"
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("linkedin ad analytics", () => {
+  test("serializes analytics dates, facets, fields, and sorting", async () => {
+    const calls = recorder([
+      json({
+        elements: [
+          {
+            pivotValues: ["urn:li:sponsoredCampaign:456"],
+            impressions: 100,
+            costInLocalCurrency: "12.50",
+          },
+        ],
+      }),
+    ])
+    const client = await createTestClient()
+
+    const rows = await client.adAnalytics.analytics({
+      pivot: "CAMPAIGN",
+      dateRange: {
+        start: { year: 2026, month: 8, day: 1 },
+        end: { year: 2026, month: 8, day: 20 },
+      },
+      timeGranularity: "DAILY",
+      fields: ["impressions", "costInLocalCurrency", "pivotValues"],
+      accounts: [sponsoredAccountUrn(123)],
+      sortBy: { field: "IMPRESSIONS", order: "DESCENDING" },
+    })
+
+    const params = new URL(calls[0]?.url ?? "").searchParams
+    expect(params.get("q")).toBe("analytics")
+    expect(params.get("dateRange")).toBe(
+      "(start:(year:2026,month:8,day:1),end:(year:2026,month:8,day:20))"
+    )
+    expect(params.get("accounts")).toBe("List(urn:li:sponsoredAccount:123)")
+    expect(params.get("fields")).toBe("impressions,costInLocalCurrency,pivotValues")
+    expect(params.get("sortBy.field")).toBe("IMPRESSIONS")
+    expect(rows[0]?.costInLocalCurrency).toBe("12.50")
+  })
+
+  test("supports statistics with up to three pivots", async () => {
+    const calls = recorder([json({ elements: [] })])
+    const client = await createTestClient()
+
+    await client.adAnalytics.statistics({
+      pivots: ["CAMPAIGN", "CREATIVE"],
+      dateRange: { start: { year: 2026, month: 1, day: 1 } },
+      timeGranularity: "ALL",
+      fields: ["impressions", "pivotValues"],
+      campaigns: [sponsoredCampaignUrn(456)],
+    })
+
+    expect(new URL(calls[0]?.url ?? "").searchParams.get("pivots")).toBe("List(CAMPAIGN,CREATIVE)")
+  })
+
+  test("serializes the attributed-revenue account as a Rest.li list", async () => {
+    const calls = recorder([json({ elements: [] })])
+    const client = await createTestClient()
+
+    await client.adAnalytics.attributedRevenue({
+      pivots: ["ACCOUNT"],
+      account: sponsoredAccountUrn(123),
+      dateRange: { start: { year: 2026, month: 1, day: 1 } },
+      fields: ["revenueAttributionMetrics", "dateRange", "pivotValues"],
+    })
+
+    const params = new URL(calls[0]?.url ?? "").searchParams
+    expect(params.get("q")).toBe("attributedRevenueMetrics")
+    expect(params.get("account")).toBe("List(urn:li:sponsoredAccount:123)")
+  })
+
+  test("tunnels long GET queries through a form-encoded POST", async () => {
+    const calls = recorder([json({ elements: [] })])
+    const client = await createTestClient({ queryTunnelingThreshold: 0 })
+
+    await client.adAnalytics.analytics({
+      pivot: "CAMPAIGN",
+      dateRange: { start: { year: 2026, month: 8, day: 1 } },
+      timeGranularity: "ALL",
+      fields: ["impressions", "clicks"],
+      accounts: [sponsoredAccountUrn(123)],
+    })
+
+    expect(calls[0]?.method).toBe("POST")
+    expect(calls[0]?.url).toBe("https://api.linkedin.com/rest/adAnalytics")
+    expect(calls[0]?.headers.get("x-http-method-override")).toBe("GET")
+    expect(calls[0]?.headers.get("content-type")).toBe("application/x-www-form-urlencoded")
+    expect(calls[0]?.body).toContain("q=analytics")
+    expect(calls[0]?.body).toContain("accounts=List(urn%3Ali%3AsponsoredAccount%3A123)")
+  })
+
+  test("rejects invalid report shapes before making a request", async () => {
+    const client = await createTestClient()
+    expect(() =>
+      client.adAnalytics.analytics({
+        pivot: "CAMPAIGN",
+        dateRange: { start: { year: 2026, month: 2, day: 30 } },
+        timeGranularity: "ALL",
+        fields: ["impressions"],
+        accounts: [sponsoredAccountUrn(123)],
+      })
+    ).toThrow("invalid UTC date")
+
+    expect(() =>
+      client.adAnalytics.statistics({
+        pivots: [],
+        dateRange: { start: { year: 2026, month: 1, day: 1 } },
+        timeGranularity: "ALL",
+        fields: ["impressions"],
+        accounts: [sponsoredAccountUrn(123)],
+      })
+    ).toThrow("one to three pivots")
+  })
+})

--- a/connectors/linkedin/tests/campaigns.test.ts
+++ b/connectors/linkedin/tests/campaigns.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { sponsoredAccountUrn, sponsoredCampaignGroupUrn, sponsoredCampaignUrn } from "../src"
+import { createTestClient, empty, json, recorder } from "./helpers"
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("linkedin campaigns", () => {
+  test("scopes campaign-group searches to an ad account", async () => {
+    const calls = recorder([json({ elements: [], metadata: {} })])
+    const client = await createTestClient()
+
+    await client.adAccount(123).campaignGroups.search({ statuses: ["ACTIVE", "DRAFT"] })
+
+    const url = new URL(calls[0]?.url ?? "")
+    expect(url.pathname).toBe("/rest/adAccounts/123/adCampaignGroups")
+    expect(url.searchParams.get("search")).toBe("(status:(values:List(ACTIVE,DRAFT)))")
+  })
+
+  test("creates a campaign faithfully and returns the response id", async () => {
+    const calls = recorder([empty(201, { "x-restli-id": "987" })])
+    const client = await createTestClient()
+    const account = sponsoredAccountUrn(123)
+
+    const result = await client.adAccount(123).campaigns.create({
+      account,
+      campaignGroup: sponsoredCampaignGroupUrn(456),
+      name: "Awareness",
+      costType: "CPM",
+      locale: { country: "US", language: "en" },
+      offsiteDeliveryEnabled: false,
+      targetingCriteria: {
+        include: {
+          and: [{ or: { "urn:li:adTargetingFacet:locations": ["urn:li:geo:103644278"] } }],
+        },
+      },
+      type: "SPONSORED_UPDATES",
+      unitCost: { amount: "15", currencyCode: "USD" },
+      dailyBudget: { amount: "50", currencyCode: "USD" },
+      status: "ACTIVE",
+      politicalIntent: "NOT_POLITICAL",
+    })
+
+    const body = JSON.parse(calls[0]?.body ?? "{}")
+    expect(result.id).toBe("987")
+    expect(body.campaignGroup).toBe("urn:li:sponsoredCampaignGroup:456")
+    expect(body.politicalIntent).toBe("NOT_POLITICAL")
+    expect(body.targetingCriteria.include.and[0].or).toEqual({
+      "urn:li:adTargetingFacet:locations": ["urn:li:geo:103644278"],
+    })
+  })
+
+  test("updates and deletes campaigns with the documented wire methods", async () => {
+    const calls = recorder([empty(), empty()])
+    const client = await createTestClient()
+
+    await client.adAccount(123).campaigns.update(987, { status: "ARCHIVED" }, ["totalBudget"])
+    await client.adAccount(123).campaigns.deleteDraft(987)
+
+    expect(calls[0]?.headers.get("x-restli-method")).toBe("PARTIAL_UPDATE")
+    expect(JSON.parse(calls[0]?.body ?? "{}")).toEqual({
+      patch: { $set: { status: "ARCHIVED" }, $delete: ["totalBudget"] },
+    })
+    expect(calls[1]?.method).toBe("DELETE")
+  })
+
+  test("searches campaign URNs with Rest.li structural encoding", async () => {
+    const calls = recorder([json({ elements: [], metadata: {} })])
+    const client = await createTestClient()
+
+    await client.adAccount(123).campaigns.search({
+      ids: [sponsoredCampaignUrn(987)],
+      campaignGroups: [sponsoredCampaignGroupUrn(456)],
+    })
+
+    const search = new URL(calls[0]?.url ?? "").searchParams.get("search") ?? ""
+    expect(search).toContain("id:(values:List(urn:li:sponsoredCampaign:987))")
+    expect(search).toContain("campaignGroup:(values:List(urn:li:sponsoredCampaignGroup:456))")
+  })
+
+  test("rejects searches without the criteria required by LinkedIn", async () => {
+    const client = await createTestClient()
+    await expect(client.adAccount(123).campaigns.search({})).rejects.toThrow(
+      "requires at least one criterion"
+    )
+  })
+})

--- a/connectors/linkedin/tests/community-analytics.test.ts
+++ b/connectors/linkedin/tests/community-analytics.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { organizationUrn, shareUrn, ugcPostUrn } from "../src"
+import { createTestClient, json, recorder } from "./helpers"
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("linkedin community analytics", () => {
+  test("serializes organization follower, Page, share, and video analytics", async () => {
+    const organization = organizationUrn(123)
+    const share = shareUrn(456)
+    const ugcPost = ugcPostUrn(789)
+    const calls = recorder([
+      json({ elements: [{ organizationalEntity: organization, followerGains: {} }] }),
+      json({ elements: [{ organization, totalPageStatistics: {} }] }),
+      json({ elements: [{ organizationalEntity: organization, totalShareStatistics: {} }] }),
+      json({ elements: [{ entity: ugcPost, value: 100 }] }),
+    ])
+    const client = await createTestClient()
+
+    await client.organizationAnalytics.followers(organization, {
+      timeRange: { start: 1_700_000_000_000, end: 1_700_086_400_000 },
+      timeGranularityType: "DAY",
+    })
+    await client.organizationAnalytics.pages(organization)
+    await client.organizationAnalytics.shares(organization, { posts: [share, ugcPost] })
+    await client.organizationAnalytics.video({
+      entity: ugcPost,
+      type: "TIME_WATCHED_FOR_VIDEO_VIEWS",
+      aggregation: "DAY",
+      timeRange: { start: 1_700_000_000_000, end: 1_700_086_400_000 },
+    })
+
+    expect(new URL(calls[0]?.url ?? "").searchParams.get("timeIntervals")).toBe(
+      "(timeRange:(start:1700000000000,end:1700086400000),timeGranularityType:DAY)"
+    )
+    expect(new URL(calls[1]?.url ?? "").searchParams.get("q")).toBe("organization")
+    expect(new URL(calls[2]?.url ?? "").searchParams.get("shares")).toBe(`List(${share})`)
+    expect(new URL(calls[2]?.url ?? "").searchParams.get("ugcPosts[0]")).toBe(ugcPost)
+    expect(new URL(calls[3]?.url ?? "").searchParams.get("type")).toBe(
+      "TIME_WATCHED_FOR_VIDEO_VIEWS"
+    )
+    expect(new URL(calls[3]?.url ?? "").searchParams.get("timeRange")).toBe(
+      "(start:1700000000000,end:1700086400000)"
+    )
+  })
+
+  test("serializes authenticated-member follower, post, and video analytics", async () => {
+    const share = shareUrn(456)
+    const ugcPost = ugcPostUrn(789)
+    const calls = recorder([
+      json({ elements: [{ memberFollowersCount: 1_000 }] }),
+      json({ elements: [{ memberFollowersCount: 2 }] }),
+      json({ elements: [{ count: 5, metricType: "REACTION", targetEntity: { share } }] }),
+      json({ elements: [{ count: 100, metricType: "IMPRESSION" }] }),
+      json({ elements: [{ count: 30, metricType: "VIDEO_PLAY", targetEntity: { ugc: ugcPost } }] }),
+    ])
+    const client = await createTestClient()
+    const dateRange = {
+      start: { year: 2026, month: 8, day: 1 },
+      end: { year: 2026, month: 8, day: 3 },
+    } as const
+
+    await client.memberAnalytics.followers()
+    await client.memberAnalytics.followerHistory(dateRange)
+    await client.memberAnalytics.post({
+      entity: share,
+      queryType: "REACTION",
+      aggregation: "DAILY",
+      dateRange,
+    })
+    await client.memberAnalytics.posts({ queryType: "IMPRESSION", aggregation: "TOTAL" })
+    await client.memberAnalytics.video({
+      entity: ugcPost,
+      queryType: "VIDEO_PLAY",
+      aggregation: "DAILY",
+      dateRange,
+    })
+
+    expect(new URL(calls[0]?.url ?? "").searchParams.get("q")).toBe("me")
+    expect(new URL(calls[1]?.url ?? "").searchParams.get("q")).toBe("dateRange")
+    expect(new URL(calls[2]?.url ?? "").searchParams.get("entity")).toBe(`(share:${share})`)
+    expect(new URL(calls[2]?.url ?? "").searchParams.get("dateRange")).toBe(
+      "(start:(year:2026,month:8,day:1),end:(year:2026,month:8,day:3))"
+    )
+    expect(new URL(calls[3]?.url ?? "").searchParams.get("q")).toBe("me")
+    expect(new URL(calls[4]?.url ?? "").searchParams.get("entity")).toBe(`(ugc:${ugcPost})`)
+  })
+
+  test("rejects unsupported analytics combinations before making a request", async () => {
+    const client = await createTestClient()
+    const organization = organizationUrn(123)
+    const share = shareUrn(456)
+
+    expect(() =>
+      client.organizationAnalytics.pages(organization, {
+        timeRange: { start: 1, end: 2 },
+        timeGranularityType: "WEEK",
+      })
+    ).toThrow("DAY or MONTH")
+    await expect(
+      client.organizationAnalytics.shares(organization, {
+        timeIntervals: {
+          timeRange: { start: 1, end: 2 },
+          timeGranularityType: "DAY",
+        },
+        posts: [share],
+      })
+    ).rejects.toThrow("cannot be combined")
+    expect(() =>
+      client.memberAnalytics.post({
+        entity: share,
+        queryType: "IMPRESSION",
+        aggregation: "DAILY",
+      })
+    ).toThrow("does not support DAILY")
+  })
+})

--- a/connectors/linkedin/tests/community-media.test.ts
+++ b/connectors/linkedin/tests/community-media.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { createTestClient, json, recorder } from "./helpers"
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("linkedin community media", () => {
+  test("resolves image, video, and document download metadata from post URNs", async () => {
+    const image = "urn:li:image:C4E10AQImage" as const
+    const video = "urn:li:video:C4E10AQVideo" as const
+    const document = "urn:li:document:D5510AQDocument" as const
+    const owner = "urn:li:organization:123" as const
+    const calls = recorder([
+      json({ id: image, owner, status: "AVAILABLE", downloadUrl: "https://media/image" }),
+      json({
+        id: video,
+        owner,
+        status: "AVAILABLE",
+        downloadUrl: "https://media/video",
+        duration: 32_066,
+      }),
+      json({ id: document, owner, status: "AVAILABLE", downloadUrl: "https://media/document" }),
+    ])
+    const client = await createTestClient()
+
+    const resolvedImage = await client.images.get(image)
+    const resolvedVideo = await client.videos.get(video)
+    const resolvedDocument = await client.documents.get(document)
+
+    expect(resolvedImage.downloadUrl).toBe("https://media/image")
+    expect(resolvedVideo.duration).toBe(32_066)
+    expect(resolvedDocument.downloadUrl).toBe("https://media/document")
+    expect(decodeURIComponent(new URL(calls[0]?.url ?? "").pathname)).toContain(`/images/${image}`)
+    expect(decodeURIComponent(new URL(calls[1]?.url ?? "").pathname)).toContain(`/videos/${video}`)
+    expect(decodeURIComponent(new URL(calls[2]?.url ?? "").pathname)).toContain(
+      `/documents/${document}`
+    )
+  })
+})

--- a/connectors/linkedin/tests/community-pages.test.ts
+++ b/connectors/linkedin/tests/community-pages.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { organizationUrn } from "../src"
+import { collect, createTestClient, json, recorder } from "./helpers"
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("linkedin community organizations", () => {
+  test("discovers administered organizations through organization ACLs", async () => {
+    const organization = organizationUrn(123)
+    const calls = recorder([
+      json({
+        elements: [
+          {
+            role: "ADMINISTRATOR",
+            state: "APPROVED",
+            roleAssignee: "urn:li:person:member",
+            organizationTarget: organization,
+          },
+        ],
+        paging: { start: 0, count: 10, total: 1, links: [] },
+      }),
+      json({
+        elements: [],
+        paging: { start: 0, count: 10, total: 0, links: [] },
+      }),
+    ])
+    const client = await createTestClient()
+
+    const memberPage = await client.organizationAcls.listForAuthenticatedMember({
+      role: "ADMINISTRATOR",
+      state: "APPROVED",
+      count: 10,
+    })
+    await client.organizationAcls.listByOrganization(organization, {
+      state: "APPROVED",
+    })
+
+    const memberUrl = new URL(calls[0]?.url ?? "")
+    expect(memberUrl.searchParams.get("q")).toBe("roleAssignee")
+    expect(memberUrl.searchParams.get("role")).toBe("ADMINISTRATOR")
+    expect(memberPage.items[0]?.organizationTarget).toBe(organization)
+
+    const organizationUrl = new URL(calls[1]?.url ?? "")
+    expect(organizationUrl.searchParams.get("q")).toBe("organization")
+    expect(organizationUrl.searchParams.get("organization")).toBe(organization)
+  })
+
+  test("looks up organization details, children, and the current follower count", async () => {
+    const parent = organizationUrn(123)
+    const calls = recorder([
+      json({ id: 123, localizedName: "Acme" }),
+      json({ elements: [{ id: 123, localizedName: "Acme", vanityName: "acme" }] }),
+      json({
+        elements: [{ id: 456, localizedName: "Acme France" }],
+        paging: { start: 0, count: 1, total: 1, links: [] },
+      }),
+      json({ firstDegreeSize: 42_000 }),
+    ])
+    const client = await createTestClient()
+
+    const organization = await client.organizations.get(123)
+    const vanity = await client.organizations.findByVanityName("acme")
+    const children = await collect(client.organizations.listAllByParent(parent, { count: 1 }))
+    const followers = await client.organizations.followerCount(parent)
+
+    expect(organization.localizedName).toBe("Acme")
+    expect(vanity?.vanityName).toBe("acme")
+    expect(children[0]?.id).toBe(456)
+    expect(followers).toBe(42_000)
+    expect(new URL(calls[1]?.url ?? "").searchParams.get("q")).toBe("vanityName")
+    expect(new URL(calls[2]?.url ?? "").searchParams.get("parent")).toBe(parent)
+    expect(decodeURIComponent(new URL(calls[3]?.url ?? "").pathname)).toContain(
+      `/networkSizes/${parent}`
+    )
+  })
+})

--- a/connectors/linkedin/tests/community-posts.test.ts
+++ b/connectors/linkedin/tests/community-posts.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { organizationUrn, shareUrn, ugcPostUrn } from "../src"
+import { collect, createTestClient, empty, json, recorder } from "./helpers"
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("linkedin community posts and engagement", () => {
+  test("follows Posts next links even when LinkedIn returns a short page", async () => {
+    const author = organizationUrn(123)
+    const first = shareUrn(1)
+    const second = ugcPostUrn(2)
+    const calls = recorder([
+      json({
+        elements: [{ id: first, author, visibility: "PUBLIC", lifecycleState: "PUBLISHED" }],
+        paging: {
+          start: 0,
+          count: 100,
+          links: [{ rel: "next", href: "/rest/posts?q=author&start=100&count=100" }],
+        },
+      }),
+      json({
+        elements: [{ id: second, author, visibility: "PUBLIC", lifecycleState: "PUBLISHED" }],
+        paging: { start: 100, count: 100, links: [] },
+      }),
+    ])
+    const client = await createTestClient()
+
+    const posts = await collect(client.posts.listAllByAuthor(author))
+
+    expect(posts.map((post) => post.id)).toEqual([first, second])
+    expect(new URL(calls[0]?.url ?? "").searchParams.get("count")).toBe("100")
+    expect(new URL(calls[1]?.url ?? "").searchParams.get("start")).toBe("100")
+    expect(calls[0]?.headers.get("x-restli-method")).toBe("FINDER")
+  })
+
+  test("gets, creates, updates, and deletes Posts using encoded URN paths", async () => {
+    const author = organizationUrn(123)
+    const post = shareUrn(456)
+    const calls = recorder([
+      json({ id: post, author, visibility: "PUBLIC", lifecycleState: "PUBLISHED" }),
+      empty(201, { "x-restli-id": post }),
+      empty(),
+      empty(),
+    ])
+    const client = await createTestClient()
+
+    await client.posts.get(post, "AUTHOR")
+    const created = await client.posts.create({
+      author,
+      commentary: "Hello",
+      distribution: { feedDistribution: "MAIN_FEED" },
+      visibility: "PUBLIC",
+      lifecycleState: "PUBLISHED",
+    })
+    await client.posts.update(post, { commentary: "Updated" })
+    await client.posts.delete(post)
+
+    expect(created.id).toBe(post)
+    expect(new URL(calls[0]?.url ?? "").searchParams.get("viewContext")).toBe("AUTHOR")
+    expect(JSON.parse(calls[1]?.body ?? "{}").commentary).toBe("Hello")
+    expect(calls[2]?.headers.get("x-restli-method")).toBe("PARTIAL_UPDATE")
+    expect(JSON.parse(calls[2]?.body ?? "{}")).toEqual({
+      patch: { $set: { commentary: "Updated" } },
+    })
+    expect(calls[3]?.method).toBe("DELETE")
+    expect(decodeURIComponent(new URL(calls[3]?.url ?? "").pathname)).toContain(post)
+  })
+
+  test("reads social metadata and manages comments", async () => {
+    const organization = organizationUrn(123)
+    const post = shareUrn(456)
+    const calls = recorder([
+      json({
+        entity: post,
+        commentSummary: { count: 1, topLevelCount: 1 },
+        reactionSummaries: { LIKE: { count: 2 } },
+      }),
+      json({
+        elements: [{ id: "10", actor: organization, message: { text: "Nice" } }],
+        paging: { start: 0, count: 10, total: 1, links: [] },
+      }),
+      json(
+        { id: "11", actor: organization, object: post, message: { text: "Thanks" } },
+        { status: 201, headers: { "x-restli-id": "11" } }
+      ),
+      json({ id: "11", actor: organization, object: post, message: { text: "Thank you" } }),
+      empty(),
+      empty(202),
+    ])
+    const client = await createTestClient()
+
+    const metadata = await client.socialMetadata.get(post)
+    const comments = await client.comments.list(post, { count: 10 })
+    const created = await client.comments.create(post, {
+      actor: organization,
+      message: { text: "Thanks" },
+    })
+    await client.comments.update(post, 11, {
+      actor: organization,
+      message: { text: "Thank you" },
+    })
+    await client.comments.delete(post, 11, organization)
+    await client.socialMetadata.setCommentsState(post, organization, "OPEN")
+
+    expect(metadata.commentSummary?.count).toBe(1)
+    expect(comments.items[0]?.message.text).toBe("Nice")
+    expect(created.id).toBe("11")
+    expect(created.data.message.text).toBe("Thanks")
+    expect(JSON.parse(calls[2]?.body ?? "{}")).toEqual({
+      actor: organization,
+      message: { text: "Thanks" },
+      object: post,
+    })
+    expect(JSON.parse(calls[3]?.body ?? "{}")).toEqual({
+      patch: { message: { $set: { text: "Thank you" } } },
+    })
+    expect(new URL(calls[4]?.url ?? "").searchParams.get("actor")).toBe(organization)
+    expect(JSON.parse(calls[5]?.body ?? "{}")).toEqual({
+      patch: { $set: { commentsState: "OPEN" } },
+    })
+  })
+
+  test("reads, creates, and deletes reactions with Rest.li compound keys", async () => {
+    const organization = organizationUrn(123)
+    const post = shareUrn(456)
+    const calls = recorder([
+      json({ reactionType: "LIKE", root: post }),
+      json({
+        elements: [{ reactionType: "LIKE", root: post }],
+        paging: { start: 0, count: 10, total: 1, links: [] },
+      }),
+      json({ reactionType: "PRAISE", root: post }, { status: 201 }),
+      empty(),
+    ])
+    const client = await createTestClient()
+
+    await client.reactions.get(organization, post)
+    const reactions = await client.reactions.listByEntity(post, { count: 10 })
+    const created = await client.reactions.create({
+      actor: organization,
+      entity: post,
+      reactionType: "PRAISE",
+    })
+    await client.reactions.delete(organization, post)
+
+    expect(decodeURIComponent(new URL(calls[0]?.url ?? "").pathname)).toContain(
+      `(actor:${organization},entity:${post})`
+    )
+    expect(reactions.items[0]?.reactionType).toBe("LIKE")
+    expect(new URL(calls[1]?.url ?? "").searchParams.get("sort")).toBe(
+      "(value:REVERSE_CHRONOLOGICAL)"
+    )
+    expect(new URL(calls[2]?.url ?? "").searchParams.get("actor")).toBe(organization)
+    expect(JSON.parse(calls[2]?.body ?? "{}")).toEqual({
+      root: post,
+      reactionType: "PRAISE",
+    })
+    expect(created.reactionType).toBe("PRAISE")
+    expect(calls[3]?.method).toBe("DELETE")
+  })
+
+  test("rejects incomplete nested comments and the deprecated MAYBE reaction", async () => {
+    const client = await createTestClient()
+    const parent = "urn:li:comment:(urn:li:activity:123,456)" as const
+    const actor = organizationUrn(123)
+
+    await expect(
+      client.comments.create(parent, { actor, message: { text: "Nested" } })
+    ).rejects.toThrow("nested comments require both object and parentComment")
+    await expect(
+      client.reactions.create({ actor, entity: shareUrn(456), reactionType: "MAYBE" })
+    ).rejects.toThrow("MAYBE is deprecated")
+  })
+
+  test("validates documented poll constraints before sending the post", async () => {
+    const client = await createTestClient()
+    const author = organizationUrn(123)
+
+    await expect(
+      client.posts.create({
+        author,
+        commentary: "Choose",
+        content: {
+          poll: {
+            question: "Which option?",
+            options: [{ text: "Only one" }],
+            settings: { duration: "ONE_DAY" },
+          },
+        },
+        distribution: { feedDistribution: "MAIN_FEED" },
+        visibility: "PUBLIC",
+        lifecycleState: "PUBLISHED",
+      })
+    ).rejects.toThrow("between 2 and 4 options")
+
+    await expect(
+      client.posts.create({
+        author,
+        commentary: "Choose",
+        content: {
+          poll: {
+            question: "Which option?",
+            options: [{ text: "One" }, { text: "Two" }],
+            settings: { duration: "ONE_DAY", isVoterVisibleToAuthor: false },
+          },
+        },
+        distribution: { feedDistribution: "MAIN_FEED" },
+        visibility: "PUBLIC",
+        lifecycleState: "PUBLISHED",
+      })
+    ).rejects.toThrow("requires isVoterVisibleToAuthor to be true")
+  })
+})

--- a/connectors/linkedin/tests/creatives.test.ts
+++ b/connectors/linkedin/tests/creatives.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { sponsoredCampaignUrn, sponsoredCreativeUrn } from "../src"
+import { createTestClient, empty, json, recorder } from "./helpers"
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("linkedin creatives", () => {
+  test("encodes creative URNs as path segments", async () => {
+    const id = sponsoredCreativeUrn(120491345)
+    const calls = recorder([
+      json({ id, campaign: sponsoredCampaignUrn(1), intendedStatus: "DRAFT" }),
+    ])
+    const client = await createTestClient()
+
+    await client.adAccount(123).creatives.get(id)
+
+    expect(new URL(calls[0]?.url ?? "").pathname).toEndWith(
+      "/creatives/urn%3Ali%3AsponsoredCreative%3A120491345"
+    )
+  })
+
+  test("uses the criteria finder and creative cursor pagination", async () => {
+    const calls = recorder([
+      json({
+        elements: [],
+        metadata: { nextPageToken: "next", totalResultCount: 42 },
+      }),
+    ])
+    const client = await createTestClient()
+
+    const page = await client.adAccount(123).creatives.search({
+      campaigns: [sponsoredCampaignUrn(456)],
+      intendedStatuses: ["ACTIVE", "PAUSED"],
+      isTotalIncluded: true,
+      pageSize: 100,
+    })
+
+    const url = new URL(calls[0]?.url ?? "")
+    expect(calls[0]?.headers.get("x-restli-method")).toBe("FINDER")
+    expect(url.searchParams.get("campaigns")).toBe("List(urn:li:sponsoredCampaign:456)")
+    expect(url.searchParams.get("intendedStatuses")).toBe("List(ACTIVE,PAUSED)")
+    expect(url.searchParams.get("isTotalIncluded")).toBe("true")
+    expect(page.nextPageToken).toBe("next")
+    expect(page.totalCount).toBe(42)
+  })
+
+  test("creates and updates creatives without reshaping content", async () => {
+    const id = sponsoredCreativeUrn(789)
+    const calls = recorder([empty(201, { "x-restli-id": id }), empty()])
+    const client = await createTestClient()
+
+    const created = await client.adAccount(123).creatives.create({
+      campaign: sponsoredCampaignUrn(456),
+      intendedStatus: "DRAFT",
+      content: { reference: "urn:li:ugcPost:42" },
+    })
+    await client.adAccount(123).creatives.update(id, { intendedStatus: "ACTIVE" })
+
+    expect(created.id).toBe(id)
+    expect(JSON.parse(calls[0]?.body ?? "{}").content).toEqual({ reference: "urn:li:ugcPost:42" })
+    expect(calls[1]?.headers.get("x-restli-method")).toBe("PARTIAL_UPDATE")
+  })
+
+  test("enforces LinkedIn's creative page-size limit", async () => {
+    const client = await createTestClient()
+    await expect(client.adAccount(123).creatives.search({ pageSize: 101 })).rejects.toThrow(
+      "between 1 and 100"
+    )
+  })
+})

--- a/connectors/linkedin/tests/helpers.ts
+++ b/connectors/linkedin/tests/helpers.ts
@@ -1,0 +1,66 @@
+import type { LinkedinConnectorOptions } from "../src"
+import { linkedin } from "../src"
+
+export const CONTEXT = {
+  projectId: "demo",
+  connectorId: "linkedin",
+  signal: new AbortController().signal,
+}
+
+export const TOKEN = "linkedin-test-token"
+
+export function mockFetch(
+  implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+): void {
+  globalThis.fetch = implementation as typeof fetch
+}
+
+export function json(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  })
+}
+
+export function empty(status = 204, headers?: HeadersInit): Response {
+  return new Response(null, { status, headers })
+}
+
+export async function createTestClient(options: Partial<LinkedinConnectorOptions> = {}) {
+  return linkedin({ accessToken: TOKEN, ...options }).connect(CONTEXT)
+}
+
+export async function collect<T>(items: AsyncIterable<T>): Promise<T[]> {
+  const collected: T[] = []
+  for await (const item of items) collected.push(item)
+  return collected
+}
+
+export interface RecordedCall {
+  readonly url: string
+  readonly method: string
+  readonly headers: Headers
+  readonly body?: string
+}
+
+export function recorder(responses: readonly Response[] | ((call: RecordedCall) => Response)) {
+  const calls: RecordedCall[] = []
+  let index = 0
+
+  mockFetch(async (input, init) => {
+    const call: RecordedCall = {
+      url: String(input),
+      method: init?.method ?? "GET",
+      headers: new Headers(init?.headers),
+      body: typeof init?.body === "string" ? init.body : undefined,
+    }
+    calls.push(call)
+    if (typeof responses === "function") return responses(call)
+
+    const response = responses[index++]
+    if (!response) throw new Error(`Unexpected request: ${call.method} ${call.url}`)
+    return response
+  })
+
+  return calls
+}

--- a/connectors/linkedin/tests/helpers.ts
+++ b/connectors/linkedin/tests/helpers.ts
@@ -1,3 +1,4 @@
+import type { ConnectorTokenSource } from "@sixb/core"
 import type { LinkedinConnectorOptions } from "../src"
 import { linkedin } from "../src"
 
@@ -8,6 +9,13 @@ export const CONTEXT = {
 }
 
 export const TOKEN = "linkedin-test-token"
+
+export const DEFAULT_OPTIONS = {
+  clientId: "linkedin-client-id",
+  clientSecret: "linkedin-client-secret",
+  scopes: ["r_ads"],
+  accountType: "ad-account",
+} as const satisfies LinkedinConnectorOptions
 
 export function mockFetch(
   implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
@@ -26,8 +34,31 @@ export function empty(status = 204, headers?: HeadersInit): Response {
   return new Response(null, { status, headers })
 }
 
-export async function createTestClient(options: Partial<LinkedinConnectorOptions> = {}) {
-  return linkedin({ accessToken: TOKEN, ...options }).connect(CONTEXT)
+export async function createTestClient(
+  options: Partial<LinkedinConnectorOptions> = {},
+  tokenSource: ConnectorTokenSource = testTokenSource(() => TOKEN)
+) {
+  return linkedin({ ...DEFAULT_OPTIONS, ...options }).connect({
+    ...CONTEXT,
+    connectionId: "connection-1",
+    account: {
+      id: "urn:li:sponsoredAccount:123",
+      label: "Acme Ads",
+      description: "LinkedIn ad account",
+    },
+    tokenSource,
+  })
+}
+
+export function testTokenSource(
+  resolve: () => string | Promise<string>,
+  invalidate: () => void = () => undefined
+): ConnectorTokenSource {
+  return {
+    async get() {
+      return { accessToken: await resolve(), tokenType: "Bearer", invalidate }
+    },
+  }
 }
 
 export async function collect<T>(items: AsyncIterable<T>): Promise<T[]> {

--- a/connectors/linkedin/tests/linkedin.test.ts
+++ b/connectors/linkedin/tests/linkedin.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import {
+  DEFAULT_LINKEDIN_VERSION,
+  linkedin,
+  organizationUrn,
+  shareUrn,
+  sponsoredAccountUrn,
+  sponsoredCampaignGroupUrn,
+  sponsoredCampaignUrn,
+  sponsoredCreativeUrn,
+  ugcPostUrn,
+} from "../src"
+import { CONTEXT, createTestClient, json, recorder } from "./helpers"
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("linkedin connector", () => {
+  test("sends the required versioned Rest.li headers and resolves live tokens", async () => {
+    let tokenNumber = 0
+    const calls = recorder([json({ id: 1, name: "Acme", type: "BUSINESS" })])
+    const client = await createTestClient({ accessToken: () => `token-${++tokenNumber}` })
+
+    await client.adAccounts.get(1)
+
+    expect(calls[0]?.headers.get("authorization")).toBe("Bearer token-1")
+    expect(calls[0]?.headers.get("linkedin-version")).toBe(DEFAULT_LINKEDIN_VERSION)
+    expect(calls[0]?.headers.get("x-restli-protocol-version")).toBe("2.0.0")
+    expect(calls[0]?.headers.get("accept")).toBe("application/json")
+  })
+
+  test("accepts an explicit API version and normalizes a base URL override", async () => {
+    const calls = recorder([json({ id: 9, name: "Acme", type: "BUSINESS" })])
+    const client = await createTestClient({
+      version: "202607",
+      baseUrl: "https://example.test/rest",
+    })
+
+    await client.adAccounts.get(9)
+
+    expect(calls[0]?.url).toBe("https://example.test/rest/adAccounts/9")
+    expect(calls[0]?.headers.get("linkedin-version")).toBe("202607")
+  })
+
+  test("validates configuration and resource identifiers early", async () => {
+    expect(() => linkedin({ accessToken: " " })).toThrow("accessToken must not be empty")
+    expect(() => linkedin({ accessToken: "token", version: "v2" })).toThrow("YYYYMM")
+    expect(() => linkedin({ accessToken: "token", baseUrl: " " })).toThrow(
+      "baseUrl must not be empty"
+    )
+
+    const client = await createTestClient()
+    expect(() => client.adAccount("not-a-number")).toThrow("positive numeric ID")
+  })
+
+  test("builds typed advertising and community URNs", () => {
+    expect(organizationUrn(12)).toBe("urn:li:organization:12")
+    expect(shareUrn(34)).toBe("urn:li:share:34")
+    expect(ugcPostUrn(56)).toBe("urn:li:ugcPost:56")
+    expect(sponsoredAccountUrn(123)).toBe("urn:li:sponsoredAccount:123")
+    expect(sponsoredCampaignGroupUrn("456")).toBe("urn:li:sponsoredCampaignGroup:456")
+    expect(sponsoredCampaignUrn(789)).toBe("urn:li:sponsoredCampaign:789")
+    expect(sponsoredCreativeUrn(321)).toBe("urn:li:sponsoredCreative:321")
+  })
+
+  test("rejects an empty token returned by a live resolver", async () => {
+    let resolutions = 0
+    const client = await linkedin({
+      accessToken: () => {
+        resolutions++
+        return " "
+      },
+      retry: { maxRetries: 2, delayMs: () => 0 },
+    }).connect(CONTEXT)
+    await expect(client.adAccounts.get(1)).rejects.toThrow("accessToken must not be empty")
+    expect(resolutions).toBe(1)
+  })
+})

--- a/connectors/linkedin/tests/linkedin.test.ts
+++ b/connectors/linkedin/tests/linkedin.test.ts
@@ -10,7 +10,7 @@ import {
   sponsoredCreativeUrn,
   ugcPostUrn,
 } from "../src"
-import { CONTEXT, createTestClient, json, recorder } from "./helpers"
+import { createTestClient, DEFAULT_OPTIONS, json, recorder, testTokenSource } from "./helpers"
 
 const originalFetch = globalThis.fetch
 afterEach(() => {
@@ -21,7 +21,10 @@ describe("linkedin connector", () => {
   test("sends the required versioned Rest.li headers and resolves live tokens", async () => {
     let tokenNumber = 0
     const calls = recorder([json({ id: 1, name: "Acme", type: "BUSINESS" })])
-    const client = await createTestClient({ accessToken: () => `token-${++tokenNumber}` })
+    const client = await createTestClient(
+      {},
+      testTokenSource(() => `token-${++tokenNumber}`)
+    )
 
     await client.adAccounts.get(1)
 
@@ -45,13 +48,24 @@ describe("linkedin connector", () => {
   })
 
   test("validates configuration and resource identifiers early", async () => {
-    expect(() => linkedin({ accessToken: " " })).toThrow("accessToken must not be empty")
-    expect(() => linkedin({ accessToken: "token", version: "v2" })).toThrow("YYYYMM")
-    expect(() => linkedin({ accessToken: "token", baseUrl: " " })).toThrow(
+    expect(() => linkedin({ ...DEFAULT_OPTIONS, clientId: " " })).toThrow(
+      "clientId must not be empty"
+    )
+    expect(() => linkedin({ ...DEFAULT_OPTIONS, version: "v2" })).toThrow("YYYYMM")
+    expect(() => linkedin({ ...DEFAULT_OPTIONS, baseUrl: " " })).toThrow(
       "baseUrl must not be empty"
     )
+    expect(() =>
+      linkedin({ ...DEFAULT_OPTIONS, accountType: "organization", scopes: ["r_ads"] })
+    ).toThrow("requires rw_organization_admin")
 
     const client = await createTestClient()
+    expect(client.account).toEqual({
+      type: "ad-account",
+      id: "urn:li:sponsoredAccount:123",
+      label: "Acme Ads",
+      description: "LinkedIn ad account",
+    })
     expect(() => client.adAccount("not-a-number")).toThrow("positive numeric ID")
   })
 
@@ -65,16 +79,16 @@ describe("linkedin connector", () => {
     expect(sponsoredCreativeUrn(321)).toBe("urn:li:sponsoredCreative:321")
   })
 
-  test("rejects an empty token returned by a live resolver", async () => {
+  test("rejects an empty token returned by the managed token source", async () => {
     let resolutions = 0
-    const client = await linkedin({
-      accessToken: () => {
+    const client = await createTestClient(
+      { retry: { maxRetries: 2, delayMs: () => 0 } },
+      testTokenSource(() => {
         resolutions++
         return " "
-      },
-      retry: { maxRetries: 2, delayMs: () => 0 },
-    }).connect(CONTEXT)
-    await expect(client.adAccounts.get(1)).rejects.toThrow("accessToken must not be empty")
+      })
+    )
+    await expect(client.adAccounts.get(1)).rejects.toThrow("empty access token")
     expect(resolutions).toBe(1)
   })
 })

--- a/connectors/linkedin/tests/oauth.test.ts
+++ b/connectors/linkedin/tests/oauth.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { ConnectorOAuthError } from "@sixb/core"
+import { LINKEDIN_ACCESS_TOKEN_URL, LINKEDIN_AUTHORIZATION_URL, linkedin } from "../src"
+import { CONTEXT, DEFAULT_OPTIONS, json, mockFetch, type RecordedCall } from "./helpers"
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+const AUTHORIZATION_CONTEXT = {
+  ...CONTEXT,
+  redirectUri: "https://api.sixb.test/auth/connectors/callback",
+}
+
+describe("linkedin managed OAuth", () => {
+  test("builds the confidential web authorization URL with framework state", () => {
+    const connector = linkedin(DEFAULT_OPTIONS)
+    const authorizationUrl = connector.authentication.authorizationUrl(AUTHORIZATION_CONTEXT, {
+      state: "attempt.signed-state",
+      codeChallenge: "pkce-challenge",
+      codeChallengeMethod: "S256",
+    })
+    const url = new URL(String(authorizationUrl))
+
+    expect(url.origin + url.pathname).toBe(LINKEDIN_AUTHORIZATION_URL)
+    expect(url.searchParams.get("response_type")).toBe("code")
+    expect(url.searchParams.get("client_id")).toBe(DEFAULT_OPTIONS.clientId)
+    expect(url.searchParams.get("redirect_uri")).toBe(AUTHORIZATION_CONTEXT.redirectUri)
+    expect(url.searchParams.get("state")).toBe("attempt.signed-state")
+    expect(url.searchParams.get("scope")).toBe("r_ads")
+    expect(url.searchParams.get("code_challenge")).toBe("pkce-challenge")
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256")
+  })
+
+  test("exchanges an authorization code without sending the native-only PKCE verifier", async () => {
+    let call: RecordedCall | undefined
+    mockFetch(async (input, init) => {
+      call = {
+        url: String(input),
+        method: init?.method ?? "GET",
+        headers: new Headers(init?.headers),
+        body: typeof init?.body === "string" ? init.body : String(init?.body),
+      }
+      return json({
+        access_token: "access-1",
+        expires_in: 3600,
+        refresh_token: "refresh-1",
+        refresh_token_expires_in: 31_536_000,
+        scope: "r_ads%20r_ads_reporting",
+        token_type: "Bearer",
+      })
+    })
+
+    const before = Date.now()
+    const credentials = await linkedin(DEFAULT_OPTIONS).authentication.exchangeCode(
+      AUTHORIZATION_CONTEXT,
+      { code: "authorization-code", codeVerifier: "must-not-be-sent" }
+    )
+    const parameters = new URLSearchParams(call?.body)
+
+    expect(call?.url).toBe(LINKEDIN_ACCESS_TOKEN_URL)
+    expect(call?.method).toBe("POST")
+    expect(call?.headers.get("content-type")).toBe("application/x-www-form-urlencoded")
+    expect(parameters.get("grant_type")).toBe("authorization_code")
+    expect(parameters.get("code")).toBe("authorization-code")
+    expect(parameters.get("client_id")).toBe(DEFAULT_OPTIONS.clientId)
+    expect(parameters.get("client_secret")).toBe(DEFAULT_OPTIONS.clientSecret)
+    expect(parameters.get("redirect_uri")).toBe(AUTHORIZATION_CONTEXT.redirectUri)
+    expect(parameters.has("code_verifier")).toBe(false)
+    expect(credentials).toMatchObject({
+      accessToken: "access-1",
+      refreshToken: "refresh-1",
+      tokenType: "Bearer",
+      scopes: ["r_ads", "r_ads_reporting"],
+    })
+    expect(credentials.expiresAt?.getTime()).toBeGreaterThanOrEqual(before + 3_600_000)
+  })
+
+  test("refreshes programmatic tokens and classifies provider rejections", async () => {
+    const bodies: string[] = []
+    mockFetch(async (_input, init) => {
+      bodies.push(String(init?.body))
+      return bodies.length === 1
+        ? json({ access_token: "access-2", expires_in: 7200 })
+        : json({ error: "invalid_grant", error_description: "expired" }, { status: 400 })
+    })
+    const authentication = linkedin(DEFAULT_OPTIONS).authentication
+
+    const refreshed = await authentication.refresh(CONTEXT, {
+      accessToken: "access-1",
+      refreshToken: "refresh-1",
+    })
+    expect(refreshed.accessToken).toBe("access-2")
+    expect(new URLSearchParams(bodies[0]).get("refresh_token")).toBe("refresh-1")
+
+    try {
+      await authentication.refresh(CONTEXT, {
+        accessToken: "access-2",
+        refreshToken: "expired-refresh",
+      })
+      throw new Error("expected refresh to fail")
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConnectorOAuthError)
+      expect((error as ConnectorOAuthError).kind).toBe("terminal")
+      expect((error as Error).message).toContain("invalid_grant: expired")
+    }
+  })
+
+  test("requires reauthorization when LinkedIn did not issue a refresh token", async () => {
+    const authentication = linkedin(DEFAULT_OPTIONS).authentication
+    await expect(
+      authentication.refresh(CONTEXT, { accessToken: "access-1" })
+    ).rejects.toMatchObject({
+      kind: "terminal",
+    })
+  })
+})

--- a/connectors/linkedin/tests/reliability.test.ts
+++ b/connectors/linkedin/tests/reliability.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { LinkedinApiError } from "../src"
-import { collect, createTestClient, empty, json, mockFetch, recorder } from "./helpers"
+import {
+  collect,
+  createTestClient,
+  empty,
+  json,
+  mockFetch,
+  recorder,
+  testTokenSource,
+} from "./helpers"
 
 const originalFetch = globalThis.fetch
 afterEach(() => {
@@ -19,10 +27,10 @@ describe("linkedin reliability", () => {
           : json({ id: 1, name: "Acme", type: "BUSINESS" })
       )
     })
-    const client = await createTestClient({
-      accessToken: () => `token-${++tokenNumber}`,
-      retry: { maxRetries: 1, delayMs: () => 0 },
-    })
+    const client = await createTestClient(
+      { retry: { maxRetries: 1, delayMs: () => 0 } },
+      testTokenSource(() => `token-${++tokenNumber}`)
+    )
 
     await client.adAccounts.get(1)
     expect(authorizations).toEqual(["Bearer token-1", "Bearer token-2"])
@@ -36,6 +44,115 @@ describe("linkedin reliability", () => {
       client.adAccounts.create({ name: "Acme", type: "BUSINESS" })
     ).rejects.toBeInstanceOf(LinkedinApiError)
     expect(calls).toHaveLength(1)
+  })
+
+  test("invalidates and refreshes the exact token rejected by a read", async () => {
+    const authorizations: (string | null)[] = []
+    const invalidated: number[] = []
+    let tokenNumber = 0
+    mockFetch(async (_input, init) => {
+      authorizations.push(new Headers(init?.headers).get("authorization"))
+      return authorizations.length === 1
+        ? json({ message: "expired" }, { status: 401 })
+        : json({ id: 1, name: "Acme", type: "BUSINESS" })
+    })
+    const client = await createTestClient(
+      {},
+      {
+        async get() {
+          const revision = ++tokenNumber
+          return {
+            accessToken: `token-${revision}`,
+            invalidate: () => invalidated.push(revision),
+          }
+        },
+      }
+    )
+
+    await client.adAccounts.get(1)
+
+    expect(authorizations).toEqual(["Bearer token-1", "Bearer token-2"])
+    expect(invalidated).toEqual([1])
+  })
+
+  test("does not invalidate another in-flight request token", async () => {
+    const invalidated: number[] = []
+    let tokenNumber = 0
+    let releaseFirstRequest: (() => void) | undefined
+    const secondRequestStarted = new Promise<void>((resolve) => {
+      releaseFirstRequest = resolve
+    })
+    mockFetch(async (_input, init) => {
+      const authorization = new Headers(init?.headers).get("authorization")
+      if (authorization === "Bearer token-1") {
+        await secondRequestStarted
+        return json({ message: "expired" }, { status: 401 })
+      }
+      if (authorization === "Bearer token-2") {
+        releaseFirstRequest?.()
+      }
+      return json({ id: 1, name: "Acme", type: "BUSINESS" })
+    })
+    const client = await createTestClient(
+      {},
+      {
+        async get() {
+          const revision = ++tokenNumber
+          return {
+            accessToken: `token-${revision}`,
+            invalidate: () => invalidated.push(revision),
+          }
+        },
+      }
+    )
+
+    await Promise.all([client.adAccounts.get(1), client.adAccounts.get(2)])
+
+    expect(invalidated).toEqual([1])
+    expect(tokenNumber).toBe(3)
+  })
+
+  test("preserves logical GET replay safety when query tunneling is enabled", async () => {
+    const methods: string[] = []
+    let invalidations = 0
+    let attempts = 0
+    mockFetch(async (_input, init) => {
+      methods.push(init?.method ?? "GET")
+      attempts++
+      return attempts === 1
+        ? json({ message: "expired" }, { status: 401 })
+        : json({ elements: [], metadata: {} })
+    })
+    const client = await createTestClient(
+      { queryTunnelingThreshold: 0 },
+      testTokenSource(
+        () => `token-${attempts + 1}`,
+        () => invalidations++
+      )
+    )
+
+    await client.adAccounts.search({ statuses: ["ACTIVE"] })
+
+    expect(methods).toEqual(["POST", "POST"])
+    expect(invalidations).toBe(1)
+  })
+
+  test("never replays or invalidates a rejected write", async () => {
+    const calls = recorder([json({ message: "expired" }, { status: 401 })])
+    let invalidations = 0
+    const client = await createTestClient(
+      {},
+      testTokenSource(
+        () => "expired-token",
+        () => invalidations++
+      )
+    )
+
+    await expect(
+      client.adAccounts.create({ name: "Acme", type: "BUSINESS" })
+    ).rejects.toBeInstanceOf(LinkedinApiError)
+    expect(calls).toHaveLength(1)
+    expect(invalidations).toBe(0)
   })
 
   test("preserves structured API errors and response metadata", async () => {

--- a/connectors/linkedin/tests/reliability.test.ts
+++ b/connectors/linkedin/tests/reliability.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { LinkedinApiError } from "../src"
+import { collect, createTestClient, empty, json, mockFetch, recorder } from "./helpers"
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("linkedin reliability", () => {
+  test("retries transient GET responses with a fresh token", async () => {
+    const authorizations: (string | null)[] = []
+    let tokenNumber = 0
+    mockFetch((_input, init) => {
+      authorizations.push(new Headers(init?.headers).get("authorization"))
+      return Promise.resolve(
+        authorizations.length === 1
+          ? json({ message: "temporary" }, { status: 503 })
+          : json({ id: 1, name: "Acme", type: "BUSINESS" })
+      )
+    })
+    const client = await createTestClient({
+      accessToken: () => `token-${++tokenNumber}`,
+      retry: { maxRetries: 1, delayMs: () => 0 },
+    })
+
+    await client.adAccounts.get(1)
+    expect(authorizations).toEqual(["Bearer token-1", "Bearer token-2"])
+  })
+
+  test("does not retry writes by default", async () => {
+    const calls = recorder([json({ message: "temporary" }, { status: 503 })])
+    const client = await createTestClient({ retry: { maxRetries: 2, delayMs: () => 0 } })
+
+    await expect(
+      client.adAccounts.create({ name: "Acme", type: "BUSINESS" })
+    ).rejects.toBeInstanceOf(LinkedinApiError)
+    expect(calls).toHaveLength(1)
+  })
+
+  test("preserves structured API errors and response metadata", async () => {
+    recorder([
+      json(
+        { message: "Missing required field", serviceErrorCode: 100, status: 400 },
+        { status: 400, headers: { "x-li-uuid": "request-123" } }
+      ),
+    ])
+    const client = await createTestClient()
+
+    try {
+      await client.adAccounts.get(1)
+      throw new Error("expected request to fail")
+    } catch (error) {
+      expect(error).toBeInstanceOf(LinkedinApiError)
+      const apiError = error as LinkedinApiError
+      expect(apiError.status).toBe(400)
+      expect(apiError.serviceErrorCode).toBe(100)
+      expect(apiError.requestId).toBe("request-123")
+      expect(apiError.responseBody).toEqual({
+        message: "Missing required field",
+        serviceErrorCode: 100,
+        status: 400,
+      })
+    }
+  })
+
+  test("fails on repeated cursor tokens", async () => {
+    recorder([
+      json({
+        elements: [{ id: 1, name: "A", type: "BUSINESS" }],
+        metadata: { nextPageToken: "same" },
+      }),
+      json({
+        elements: [{ id: 2, name: "B", type: "BUSINESS" }],
+        metadata: { nextPageToken: "same" },
+      }),
+    ])
+    const client = await createTestClient()
+
+    await expect(
+      collect(client.adAccounts.searchAll({ statuses: ["ACTIVE"], pageToken: "initial" }))
+    ).rejects.toThrow("repeated nextPageToken")
+  })
+
+  test("rejects missing creation identifiers", async () => {
+    recorder([empty(201)])
+    const client = await createTestClient()
+    await expect(client.adAccounts.create({ name: "Acme", type: "BUSINESS" })).rejects.toThrow(
+      "missing the x-restli-id"
+    )
+  })
+})

--- a/connectors/linkedin/tsconfig.build.json
+++ b/connectors/linkedin/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "composite": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../packages/core/tsconfig.build.json"
+    },
+    {
+      "path": "../rest/tsconfig.build.json"
+    }
+  ]
+}

--- a/connectors/linkedin/tsconfig.json
+++ b/connectors/linkedin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/docs/data/connectors.md
+++ b/docs/data/connectors.md
@@ -406,6 +406,7 @@ to `defineConnector`, and most ship a matching webhook helper for the [Webhooks]
 | `@sixb/connector-github` | `github(...)` | GitHub REST API | `githubEventsWebhook` |
 | `@sixb/connector-google` | `google(...)` | Google APIs (Drive, Calendar, Gmail, Analytics) | — |
 | `@sixb/connector-google` | `googleAds(...)` | Google Ads manager-account reporting | — |
+| `@sixb/connector-linkedin` | `linkedin(...)` | LinkedIn advertising and organic Page management | — |
 | `@sixb/connector-meta` | `meta(...)` | Meta Graph API (Facebook/Instagram) | — |
 | `@sixb/connector-pipedrive` | `pipedrive(...)` | Pipedrive CRM | `pipedriveEventsWebhook` |
 | `@sixb/connector-stripe` | `stripe(...)` | Stripe customers, subscriptions, invoices, refunds, events | `stripeEventsWebhook` |

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -32,6 +32,9 @@
       "path": "connectors/imap/tsconfig.build.json"
     },
     {
+      "path": "connectors/linkedin/tsconfig.build.json"
+    },
+    {
       "path": "connectors/mercury/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
       "@sixb/connector-github": ["./connectors/github/src/index.ts"],
       "@sixb/connector-google": ["./connectors/google/src/index.ts"],
       "@sixb/connector-imap": ["./connectors/imap/src/index.ts"],
+      "@sixb/connector-linkedin": ["./connectors/linkedin/src/index.ts"],
       "@sixb/connector-mercury": ["./connectors/mercury/src/index.ts"],
       "@sixb/connector-meta": ["./connectors/meta/src/index.ts"],
       "@sixb/connector-pandadoc": ["./connectors/pandadoc/src/index.ts"],


### PR DESCRIPTION
## Summary

- Adds a typed LinkedIn connector for Advertising and Community Management APIs.
- Covers ad accounts, campaigns, creatives, reporting, Pages, organic content, engagement, media, and analytics.
- Integrates Sixb-managed OAuth, account discovery, token refresh, and reauthorization states.

## Linked issue

- Advances #384 by adopting the core managed OAuth lifecycle.

## Scope

| Area | Included |
| --- | --- |
| Advertising | Accounts and users, campaign groups, campaigns, creatives, analytics |
| Community | Page discovery, posts, comments, reactions, media, organization and member analytics |
| Reliability | Rest.li encoding, cursor pagination, query tunneling, rate limiting, typed errors |

## Validation

- 50 connector tests
- Connector build and typecheck
- Repository typecheck and Biome check
- Publish smoke test across 51 packages
- Live OAuth/API validation deferred until the LinkedIn application is approved

## Notes

- Advertising and Community connector definitions remain separate because LinkedIn initially requires distinct developer applications for these products.
- Wire payloads stay close to LinkedIn's schemas to keep API changes and reviews easy to trace.
- Reads may retry transient failures; writes do not retry by default because their upstream outcome can be ambiguous.
- The core-required PKCE challenge is preserved, while the token exchange follows LinkedIn's documented confidential-client contract.
