### PR TITLE
server: accept trailing-slash OAuth callbacks

### DIFF
--- a/packages/server/src/auth/public-routes.ts
+++ b/packages/server/src/auth/public-routes.ts
@@ -1,6 +1,8 @@
 import { AGENT_API_GATEWAY_PREFIX } from "@sixb/core/internal/agents"
 import { isCsrfExemptMethod } from "@sixb/core/internal/auth"
 
+const CONNECTOR_OAUTH_CALLBACK_PATH = "/auth/connectors/callback"
+
 export type RouteAccessKind = "public" | "api" | "html" | "websocket"
 
 export interface RouteAccess {
@@ -84,8 +86,13 @@ export function isPublicRoute(pathname: string, method: string): boolean {
   }
 
   // The callback proves one-use OAuth state plus a dedicated HttpOnly browser binding. PKCE then
-  // binds the code exchange to the attempt created by the authorized initiating request.
-  if (pathname === "/auth/connectors/callback" && normalizedMethod === "GET") {
+  // binds the code exchange to the attempt created by the authorized initiating request. Elysia
+  // routes both trailing-slash variants; some providers require the slash in the registered URI.
+  if (
+    (pathname === CONNECTOR_OAUTH_CALLBACK_PATH ||
+      pathname === `${CONNECTOR_OAUTH_CALLBACK_PATH}/`) &&
+    normalizedMethod === "GET"
+  ) {
     return true
   }
 

--- a/packages/server/tests/connector-connections-routes.test.ts
+++ b/packages/server/tests/connector-connections-routes.test.ts
@@ -244,6 +244,24 @@ async function connectAccount(
 }
 
 describe("connector connection Headless API", () => {
+  test("accepts an OAuth callback whose registered URI ends in a slash", async () => {
+    const harness = await createHarness()
+    const started = await startRun(harness)
+    const callbackUrl = new URL("http://localhost/auth/connectors/callback/")
+    callbackUrl.searchParams.set("state", started.state)
+    callbackUrl.searchParams.set("code", "authorization-code")
+
+    const callback = await harness.app.handle(
+      new Request(callbackUrl, {
+        redirect: "manual",
+        headers: { cookie: started.callbackCookie },
+      })
+    )
+
+    expect(callback.status, await callback.clone().text()).toBe(302)
+    expect(harness.exchangeCount()).toBe(1)
+  })
+
   test("returns coded boundaries when a connector cannot have managed connections", async () => {
     const harness = await createStaticHarness()
 

--- a/packages/server/tests/route-classifier.test.ts
+++ b/packages/server/tests/route-classifier.test.ts
@@ -25,6 +25,11 @@ const PUBLIC: ReadonlyArray<readonly [string, string, string]> = [
   ["GET", "/auth/callback", "the emailed token IS the credential"],
   ["POST", "/auth/callback", "the emailed token IS the credential"],
   ["GET", "/auth/connectors/callback", "one-use state, browser binding and PKCE authenticate it"],
+  [
+    "GET",
+    "/auth/connectors/callback/",
+    "some OAuth providers require the registered redirect URI to end in a slash",
+  ],
 ]
 
 describe("classifyRoute", () => {


### PR DESCRIPTION
## Summary
- allow the connector OAuth callback with or without a trailing slash
- keep the public exception limited to GET
- cover the auth-enabled callback flow with an integration test

## Tests
- bun test packages/server/tests/route-classifier.test.ts packages/server/tests/connector-connections-routes.test.ts
- bun --filter @sixb/server typecheck
- bun run check