### PR TITLE
server: accept TikTok OAuth authorization codes

### DIFF
--- a/packages/server/src/schemas/connectors.ts
+++ b/packages/server/src/schemas/connectors.ts
@@ -165,11 +165,13 @@ export const ConnectorOAuthCallbackQuerySchema = z
   .object({
     state: z.string().min(1),
     code: z.string().min(1).optional(),
+    auth_code: z.string().min(1).optional(),
     error: z.string().min(1).optional(),
   })
-  .refine((query) => (query.code === undefined) !== (query.error === undefined), {
-    message: "OAuth callback must contain exactly one of code or error.",
+  .refine((query) => [query.code, query.auth_code, query.error].filter(Boolean).length === 1, {
+    message: "OAuth callback must contain exactly one of code, auth_code, or error.",
   })
+  .transform(({ auth_code, ...query }) => ({ ...query, code: query.code ?? auth_code }))
 
 function connectorRouteErrorResponseSchema<
   const TCodes extends readonly [ConnectorHttpErrorCode, ...ConnectorHttpErrorCode[]],

--- a/packages/server/tests/connector-connections-routes.test.ts
+++ b/packages/server/tests/connector-connections-routes.test.ts
@@ -244,12 +244,12 @@ async function connectAccount(
 }
 
 describe("connector connection Headless API", () => {
-  test("accepts an OAuth callback whose registered URI ends in a slash", async () => {
+  test("accepts TikTok's auth_code on a callback URI ending in a slash", async () => {
     const harness = await createHarness()
     const started = await startRun(harness)
     const callbackUrl = new URL("http://localhost/auth/connectors/callback/")
     callbackUrl.searchParams.set("state", started.state)
-    callbackUrl.searchParams.set("code", "authorization-code")
+    callbackUrl.searchParams.set("auth_code", "authorization-code")
 
     const callback = await harness.app.handle(
       new Request(callbackUrl, {


### PR DESCRIPTION
## Summary
- accept TikTok's `auth_code` callback parameter as a strict alias for OAuth `code`
- keep exactly-one-of validation across `code`, `auth_code`, and `error`
- exercise `auth_code` through the real trailing-slash callback route

## Tests
- `bun test packages/server/tests/connector-connections-routes.test.ts packages/server/tests/route-classifier.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run test:ci`