### PR TITLE
tiktok: add organic and ads connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Sixb packages are versioned independently. Each release entry names the packages that shipped.
 
+## 2026-08-26
+
+### TikTok connector
+
+- `@sixb/connector-tiktok` `0.1.0`: add separate managed OAuth grants for organic TikTok accounts
+  and Ads accounts, with typed read clients for profiles, posts, comments, campaign entities, and
+  integrated Ads reports.
+
 ## 2026-08-14
 
 ### Redis subscription recovery

--- a/bun.lock
+++ b/bun.lock
@@ -336,6 +336,21 @@
         "@sixb/core": "workspace:^",
       },
     },
+    "connectors/tiktok": {
+      "name": "@sixb/connector-tiktok",
+      "version": "0.1.0",
+      "dependencies": {
+        "@sixb/connector-rest": "workspace:^",
+      },
+      "devDependencies": {
+        "@sixb/core": "workspace:*",
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+      "peerDependencies": {
+        "@sixb/core": "workspace:^",
+      },
+    },
     "connectors/unipile": {
       "name": "@sixb/connector-unipile",
       "version": "0.1.0",
@@ -1439,6 +1454,8 @@
     "@sixb/connector-stripe": ["@sixb/connector-stripe@workspace:connectors/stripe"],
 
     "@sixb/connector-teamleader": ["@sixb/connector-teamleader@workspace:connectors/teamleader"],
+
+    "@sixb/connector-tiktok": ["@sixb/connector-tiktok@workspace:connectors/tiktok"],
 
     "@sixb/connector-unipile": ["@sixb/connector-unipile@workspace:connectors/unipile"],
 

--- a/connectors/tiktok/LICENSE
+++ b/connectors/tiktok/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sixb contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/connectors/tiktok/README.md
+++ b/connectors/tiktok/README.md
@@ -1,0 +1,98 @@
+# @sixb/connector-tiktok
+
+Read-only TikTok API for Business v1.3 connector for organic account data and Ads reporting.
+TikTok uses two separate OAuth grants, so register one connector definition per surface.
+
+## Register
+
+```ts
+import { defineConnector } from "@sixb/core"
+import { tiktok } from "@sixb/connector-tiktok"
+
+export const tiktokOrganic = defineConnector(
+  "tiktok-organic",
+  tiktok({
+    accountType: "organic-account",
+    clientId: process.env.TIKTOK_CLIENT_ID!,
+    clientSecret: process.env.TIKTOK_CLIENT_SECRET!,
+    authorizationUrl: process.env.TIKTOK_ACCOUNT_AUTHORIZATION_URL!,
+  })
+)
+
+export const tiktokAds = defineConnector(
+  "tiktok-ads",
+  tiktok({
+    accountType: "ad-account",
+    appId: process.env.TIKTOK_APP_ID!,
+    secret: process.env.TIKTOK_APP_SECRET!,
+  })
+)
+```
+
+For the organic grant, copy the complete account-holder authorization URL from the TikTok app
+portal. Register Sixb's callback URL with a trailing slash; TikTok requires an exact HTTPS redirect
+URI ending in `/`. The Ads grant uses TikTok's Marketing API authorization page and a long-lived,
+non-refreshable access token.
+
+TikTok does not document PKCE for either flow. Sixb still sends its required `code_challenge` on
+the authorization request, but the connector does not send an undocumented `code_verifier` to the
+token endpoints. Sixb's one-use state and callback browser binding remain enforced.
+
+## Client API
+
+Organic account:
+
+| Client method | Endpoint |
+| --- | --- |
+| `client.profile.get(...)` | `GET /business/get/` |
+| `client.posts.list(...)` / `.listAll(...)` | `GET /business/video/list/` |
+| `client.comments.list(...)` / `.listAll(...)` | `GET /business/comment/list/` |
+| `client.comments.replies.list(...)` / `.listAll(...)` | `GET /business/comment/reply/list/` |
+
+Ads account:
+
+| Client method | Endpoint |
+| --- | --- |
+| `client.adAccount.get(...)` | `GET /advertiser/info/` |
+| `client.campaigns.list(...)` / `.listAll(...)` | `GET /campaign/get/` |
+| `client.adGroups.list(...)` / `.listAll(...)` | `GET /adgroup/get/` |
+| `client.ads.list(...)` / `.listAll(...)` | `GET /ad/get/` |
+| `client.reports.run(...)` / `.runAll(...)` | `GET /report/integrated/get/` |
+
+Every resource is scoped to the account selected during the Sixb connection flow. Wire objects
+retain TikTok's field names and values; list helpers only normalize pagination envelopes.
+
+```ts
+for await (const post of organic.posts.listAll({
+  fields: ["item_id", "caption", "create_time", "video_views", "likes"],
+  maxCount: 20,
+})) {
+  // persist or transform the TikTok wire object
+}
+
+for await (const row of ads.reports.runAll({
+  serviceType: "AUCTION",
+  reportType: "BASIC",
+  dataLevel: "AUCTION_AD",
+  dimensions: ["ad_id", "stat_time_day"],
+  metrics: ["spend", "impressions", "clicks"],
+  startDate: "2026-08-01",
+  endDate: "2026-08-25",
+  pageSize: 1000,
+})) {
+  // TikTok report metrics remain strings
+}
+```
+
+## Operational notes
+
+- Organic access tokens expire after one day and are refreshed automatically. TikTok refresh
+  tokens expire after one year, after which the account must be reauthorized. Sixb's current OAuth
+  credential contract does not store a separate refresh-token expiry timestamp, so expiry is
+  detected from TikTok's terminal refresh response rather than scheduled in advance.
+- Ads access tokens are long-lived and have no refresh endpoint. A rejected Ads token therefore
+  produces a terminal reauthorization error.
+- Profile insight windows are limited to 60 days; post statistics stop updating after 365 days.
+- Reporting is passed through without a metric taxonomy. TikTok limits synchronous requests by
+  dimensions and date range; split larger syncs at the project layer.
+- `onResponse` exposes `requestId`, `X-Tt-Logid`, and raw `X-Tt-Ads-Throttle` metadata.

--- a/connectors/tiktok/README.md
+++ b/connectors/tiktok/README.md
@@ -1,7 +1,8 @@
 # @sixb/connector-tiktok
 
 Read-only TikTok API for Business v1.3 connector for organic account data and Ads reporting.
-TikTok uses two separate OAuth grants, so register one connector definition per surface.
+TikTok uses separate Organic API and Marketing API OAuth grants, so register one connector
+definition per API.
 
 ## Register
 
@@ -12,7 +13,7 @@ import { tiktok } from "@sixb/connector-tiktok"
 export const tiktokOrganic = defineConnector(
   "tiktok-organic",
   tiktok({
-    accountType: "organic-account",
+    api: "organic",
     clientId: process.env.TIKTOK_CLIENT_ID!,
     clientSecret: process.env.TIKTOK_CLIENT_SECRET!,
     authorizationUrl: process.env.TIKTOK_ACCOUNT_AUTHORIZATION_URL!,
@@ -22,7 +23,7 @@ export const tiktokOrganic = defineConnector(
 export const tiktokAds = defineConnector(
   "tiktok-ads",
   tiktok({
-    accountType: "ad-account",
+    api: "marketing",
     appId: process.env.TIKTOK_APP_ID!,
     secret: process.env.TIKTOK_APP_SECRET!,
   })
@@ -31,8 +32,7 @@ export const tiktokAds = defineConnector(
 
 For the organic grant, copy the complete account-holder authorization URL from the TikTok app
 portal. Register Sixb's callback URL with a trailing slash; TikTok requires an exact HTTPS redirect
-URI ending in `/`. The Ads grant uses TikTok's Marketing API authorization page and a long-lived,
-non-refreshable access token.
+URI ending in `/`. The Marketing API grant uses a long-lived, non-refreshable access token.
 
 TikTok does not document PKCE for either flow. Sixb still sends its required `code_challenge` on
 the authorization request, but the connector does not send an undocumented `code_verifier` to the
@@ -90,8 +90,8 @@ for await (const row of ads.reports.runAll({
   tokens expire after one year, after which the account must be reauthorized. Sixb's current OAuth
   credential contract does not store a separate refresh-token expiry timestamp, so expiry is
   detected from TikTok's terminal refresh response rather than scheduled in advance.
-- Ads access tokens are long-lived and have no refresh endpoint. A rejected Ads token therefore
-  produces a terminal reauthorization error.
+- Marketing API access tokens are long-lived and have no refresh endpoint. A rejected token
+  therefore produces a terminal reauthorization error.
 - Profile insight windows are limited to 60 days; post statistics stop updating after 365 days.
 - Reporting is passed through without a metric taxonomy. TikTok limits synchronous requests by
   dimensions and date range; split larger syncs at the project layer.

--- a/connectors/tiktok/package.json
+++ b/connectors/tiktok/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@sixb/connector-tiktok",
+  "version": "0.1.0",
+  "description": "TikTok organic account and Ads reporting connector for Sixb",
+  "keywords": [
+    "sixb",
+    "bun",
+    "connector",
+    "integration",
+    "tiktok",
+    "ads"
+  ],
+  "homepage": "https://sixb.ai",
+  "bugs": {
+    "url": "https://github.com/sixb-ai/sixb/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sixb-ai/sixb.git",
+    "directory": "connectors/tiktok"
+  },
+  "author": "Sixb contributors",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "bun": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "bun ../../scripts/build-package.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "prepack": "bun run build"
+  },
+  "dependencies": {
+    "@sixb/connector-rest": "workspace:^"
+  },
+  "peerDependencies": {
+    "@sixb/core": "workspace:^"
+  },
+  "devDependencies": {
+    "@sixb/core": "workspace:*",
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "engines": {
+    "bun": ">=1.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE"
+  ]
+}

--- a/connectors/tiktok/src/ads/client.ts
+++ b/connectors/tiktok/src/ads/client.ts
@@ -1,0 +1,24 @@
+import type { TiktokHttp } from "../http"
+import type { TiktokAdsClient } from "../types/client"
+import type { TiktokConnectedAccount } from "../types/common"
+import {
+  createAdAccountApi,
+  createAdGroupsApi,
+  createAdsApi,
+  createCampaignsApi,
+  createReportsApi,
+} from "./resources"
+
+export function createAdsClient(
+  http: TiktokHttp,
+  account: TiktokConnectedAccount<"ad-account">
+): TiktokAdsClient {
+  return {
+    account,
+    adAccount: createAdAccountApi(http, account.id),
+    campaigns: createCampaignsApi(http, account.id),
+    adGroups: createAdGroupsApi(http, account.id),
+    ads: createAdsApi(http, account.id),
+    reports: createReportsApi(http, account.id),
+  }
+}

--- a/connectors/tiktok/src/ads/resources.ts
+++ b/connectors/tiktok/src/ads/resources.ts
@@ -1,0 +1,160 @@
+import { assertNonEmpty, assertPositiveIntegerInRange, type TiktokHttp } from "../http"
+import { paginateNumbered } from "../pagination"
+import type {
+  TiktokAd,
+  TiktokAdAccountApi,
+  TiktokAdGroup,
+  TiktokAdGroupsApi,
+  TiktokAdGroupsListQuery,
+  TiktokAdsApi,
+  TiktokAdsListQuery,
+  TiktokAdvertiser,
+  TiktokAdvertiserField,
+  TiktokCampaign,
+  TiktokCampaignsApi,
+  TiktokCampaignsListQuery,
+  TiktokReportPage,
+  TiktokReportQuery,
+  TiktokReportRow,
+  TiktokReportsApi,
+} from "../types/ads"
+import type { TiktokNumberedPage, TiktokPageInfo } from "../types/common"
+
+interface ListData<T> {
+  readonly list?: readonly T[]
+  readonly page_info: TiktokPageInfo
+}
+
+interface ReportData extends ListData<TiktokReportRow> {
+  readonly total_metrics?: TiktokReportPage["totalMetrics"]
+}
+
+export function createAdAccountApi(http: TiktokHttp, advertiserId: string): TiktokAdAccountApi {
+  return {
+    async get(fields?: readonly TiktokAdvertiserField[]) {
+      const result = await http.get<{ readonly list?: readonly TiktokAdvertiser[] }>(
+        "advertiser/info/",
+        {
+          advertiser_ids: [advertiserId],
+          fields,
+        }
+      )
+      const advertiser = result.data.list?.find((item) => item.advertiser_id === advertiserId)
+      if (!advertiser) {
+        throw new Error(`[SixbTikTok] Advertiser '${advertiserId}' was not returned by TikTok.`)
+      }
+      return advertiser
+    },
+  }
+}
+
+export function createCampaignsApi(http: TiktokHttp, advertiserId: string): TiktokCampaignsApi {
+  const list = (query: TiktokCampaignsListQuery | undefined, page = query?.page ?? 1) =>
+    listEntities<TiktokCampaign>(http, "campaign/get/", advertiserId, query, page)
+  return {
+    list,
+    listAll(query) {
+      return paginateNumbered((page) => list(query, page), query?.page)
+    },
+  }
+}
+
+export function createAdGroupsApi(http: TiktokHttp, advertiserId: string): TiktokAdGroupsApi {
+  const list = (query: TiktokAdGroupsListQuery | undefined, page = query?.page ?? 1) =>
+    listEntities<TiktokAdGroup>(http, "adgroup/get/", advertiserId, query, page)
+  return {
+    list,
+    listAll(query) {
+      return paginateNumbered((page) => list(query, page), query?.page)
+    },
+  }
+}
+
+export function createAdsApi(http: TiktokHttp, advertiserId: string): TiktokAdsApi {
+  const list = (query: TiktokAdsListQuery | undefined, page = query?.page ?? 1) =>
+    listEntities<TiktokAd>(http, "ad/get/", advertiserId, query, page)
+  return {
+    list,
+    listAll(query) {
+      return paginateNumbered((page) => list(query, page), query?.page)
+    },
+  }
+}
+
+export function createReportsApi(http: TiktokHttp, advertiserId: string): TiktokReportsApi {
+  const run = (query: TiktokReportQuery, page = query.page ?? 1) =>
+    runReport(http, advertiserId, query, page)
+  return {
+    run,
+    runAll(query) {
+      return paginateNumbered((page) => run(query, page), query.page)
+    },
+  }
+}
+
+async function listEntities<T>(
+  http: TiktokHttp,
+  path: string,
+  advertiserId: string,
+  query: TiktokCampaignsListQuery | TiktokAdGroupsListQuery | TiktokAdsListQuery | undefined,
+  page: number
+): Promise<TiktokNumberedPage<T>> {
+  validateNumberedPage(page, query?.pageSize)
+  const result = await http.get<ListData<T>>(path, {
+    advertiser_id: advertiserId,
+    fields: query?.fields,
+    exclude_field_types_in_response: query?.excludeFieldTypesInResponse,
+    filtering: query?.filtering ? { ...query.filtering } : undefined,
+    page,
+    page_size: query?.pageSize,
+  })
+  return {
+    items: result.data.list ?? [],
+    pageInfo: result.data.page_info,
+    requestId: result.requestId,
+  }
+}
+
+async function runReport(
+  http: TiktokHttp,
+  advertiserId: string,
+  query: TiktokReportQuery,
+  page: number
+): Promise<TiktokReportPage> {
+  assertNonEmpty(query.dataLevel, "dataLevel")
+  if (query.dimensions.length === 0) {
+    throw new Error("[SixbTikTok] dimensions must contain at least one report dimension.")
+  }
+  validateNumberedPage(page, query.pageSize)
+
+  const result = await http.get<ReportData>("report/integrated/get/", {
+    advertiser_id: advertiserId,
+    service_type: query.serviceType,
+    report_type: query.reportType,
+    data_level: query.dataLevel,
+    dimensions: query.dimensions,
+    metrics: query.metrics,
+    enable_total_metrics: query.enableTotalMetrics,
+    start_date: query.startDate,
+    end_date: query.endDate,
+    query_lifetime: query.queryLifetime,
+    order_field: query.orderField,
+    order_type: query.orderType,
+    filtering: query.filtering,
+    page,
+    page_size: query.pageSize,
+  })
+  return {
+    items: result.data.list ?? [],
+    pageInfo: result.data.page_info,
+    totalMetrics: result.data.total_metrics,
+    requestId: result.requestId,
+  }
+}
+
+function validateNumberedPage(page: number, pageSize: number | undefined): void {
+  if (!Number.isInteger(page) || page < 1) {
+    throw new Error("[SixbTikTok] page must be a positive integer.")
+  }
+  assertPositiveIntegerInRange(pageSize, "pageSize", 1000)
+}

--- a/connectors/tiktok/src/http.ts
+++ b/connectors/tiktok/src/http.ts
@@ -1,0 +1,260 @@
+import { type RestClient, rest } from "@sixb/connector-rest"
+import type { ConnectorContext, ConnectorTokenSource } from "@sixb/core"
+import type { TiktokResponseMetadata } from "./types/common"
+import type { TiktokConnectorOptions } from "./types/options"
+
+export const TIKTOK_API_BASE_URL = "https://business-api.tiktok.com/open_api/v1.3/"
+
+export interface TiktokApiResult<T> {
+  readonly data: T
+  readonly requestId?: string
+}
+
+interface TiktokEnvelope<T> {
+  readonly code: number
+  readonly message: string
+  readonly request_id?: string
+  readonly data: T
+}
+
+/** Raised for a valid TikTok response whose HTTP status or API envelope reports a failure. */
+export class TiktokApiError extends Error {
+  readonly name = "TiktokApiError"
+
+  constructor(
+    readonly status: number,
+    readonly code: number | undefined,
+    readonly providerMessage: string | undefined,
+    readonly requestId: string | undefined,
+    readonly rawBody: string,
+    readonly headers: Headers
+  ) {
+    super(formatApiError(status, code, providerMessage, requestId))
+  }
+}
+
+export class TiktokHttp {
+  constructor(
+    private readonly http: RestClient,
+    private readonly tokenSource: ConnectorTokenSource,
+    private readonly onResponse?: (metadata: TiktokResponseMetadata) => Promise<void> | void
+  ) {}
+
+  get<T>(path: string, query: TiktokQuery = {}): Promise<TiktokApiResult<T>> {
+    return this.request<T>("GET", withTiktokQuery(path, query), undefined, true)
+  }
+
+  post<T>(
+    path: string,
+    body: unknown,
+    options: { readonly authenticated?: boolean } = {}
+  ): Promise<TiktokApiResult<T>> {
+    return this.request<T>("POST", path, body, options.authenticated ?? true)
+  }
+
+  private async request<T>(
+    method: "GET" | "POST",
+    path: string,
+    body: unknown,
+    authenticated: boolean
+  ): Promise<TiktokApiResult<T>> {
+    for (let authorizationAttempt = 0; ; authorizationAttempt += 1) {
+      const token = authenticated ? await this.tokenSource.get() : undefined
+      const response =
+        method === "GET"
+          ? await this.http.get(path, {
+              headers: token ? { "Access-Token": token.accessToken } : undefined,
+            })
+          : await this.http.post(
+              path,
+              body,
+              { headers: token ? { "Access-Token": token.accessToken } : undefined },
+              { idempotent: true }
+            )
+
+      const parsed = await readTiktokResponse<T>(response)
+      await this.onResponse?.(responseMetadata(response, path, method, parsed.requestId))
+
+      if (parsed.error && token && authorizationAttempt === 0 && isTokenFailure(parsed.error)) {
+        token.invalidate()
+        continue
+      }
+      if (parsed.error) throw parsed.error
+      return { data: parsed.data as T, requestId: parsed.requestId }
+    }
+  }
+}
+
+export async function createTiktokHttp(
+  context: ConnectorContext,
+  options: TiktokConnectorOptions,
+  tokenSource: ConnectorTokenSource
+): Promise<TiktokHttp> {
+  const maxRetries = options.retry?.maxRetries ?? 2
+  assertNonNegativeInteger(maxRetries, "retry.maxRetries")
+
+  const connector = rest({
+    baseUrl: normalizeBaseUrl(options.baseUrl ?? TIKTOK_API_BASE_URL),
+    headers: { Accept: "application/json" },
+    retry: { maxRetries },
+    timeoutMs: options.timeoutMs,
+  })
+
+  return new TiktokHttp(await connector.connect(context), tokenSource, options.onResponse)
+}
+
+export type TiktokQueryValue =
+  | string
+  | number
+  | boolean
+  | readonly unknown[]
+  | Readonly<Record<string, unknown>>
+  | null
+  | undefined
+
+export type TiktokQuery = Readonly<Record<string, TiktokQueryValue>>
+
+export function withTiktokQuery(path: string, query: TiktokQuery): string {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null) continue
+    params.set(
+      key,
+      typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+        ? String(value)
+        : JSON.stringify(value)
+    )
+  }
+  const search = params.toString()
+  return search ? `${path}?${search}` : path
+}
+
+export function assertNonEmpty(value: string, field: string): void {
+  if (!value?.trim()) {
+    throw new Error(`[SixbTikTok] ${field} must not be empty.`)
+  }
+}
+
+export function assertPositiveIntegerInRange(
+  value: number | undefined,
+  field: string,
+  maximum: number
+): void {
+  if (value === undefined) return
+  if (!Number.isInteger(value) || value < 1 || value > maximum) {
+    throw new Error(`[SixbTikTok] ${field} must be an integer between 1 and ${maximum}.`)
+  }
+}
+
+export function assertNonNegativeInteger(value: number, field: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`[SixbTikTok] ${field} must be a non-negative integer.`)
+  }
+}
+
+export function fixedTokenSource(accessToken: string): ConnectorTokenSource {
+  assertNonEmpty(accessToken, "accessToken")
+  return {
+    async get() {
+      return { accessToken, invalidate() {} }
+    },
+  }
+}
+
+function normalizeBaseUrl(value: string): string {
+  assertNonEmpty(value, "baseUrl")
+  return value.endsWith("/") ? value : `${value}/`
+}
+
+async function readTiktokResponse<T>(response: Response): Promise<{
+  readonly data?: T
+  readonly requestId?: string
+  readonly error?: TiktokApiError
+}> {
+  const rawBody = response.status === 204 ? "" : await response.text()
+  const body = parseJson(rawBody)
+  const envelope = parseEnvelope<T>(body)
+  const requestId = envelope?.request_id
+
+  if (!response.ok || !envelope || envelope.code !== 0) {
+    return {
+      requestId,
+      error: new TiktokApiError(
+        response.status,
+        envelope?.code,
+        envelope?.message,
+        requestId,
+        rawBody,
+        response.headers
+      ),
+    }
+  }
+
+  return { data: envelope.data, requestId }
+}
+
+function parseEnvelope<T>(value: unknown): TiktokEnvelope<T> | undefined {
+  if (!isRecord(value)) return undefined
+  if (typeof value.code !== "number" || typeof value.message !== "string" || !("data" in value)) {
+    return undefined
+  }
+  return {
+    code: value.code,
+    message: value.message,
+    request_id: typeof value.request_id === "string" ? value.request_id : undefined,
+    data: value.data as T,
+  }
+}
+
+function responseMetadata(
+  response: Response,
+  path: string,
+  method: "GET" | "POST",
+  requestId: string | undefined
+): TiktokResponseMetadata {
+  return {
+    path: new URL(path, "https://sixb.invalid/").pathname,
+    method,
+    status: response.status,
+    requestId,
+    logId: response.headers.get("x-tt-logid") ?? undefined,
+    adsThrottle: response.headers.get("x-tt-ads-throttle") ?? undefined,
+  }
+}
+
+function isTokenFailure(error: TiktokApiError): boolean {
+  return (
+    error.status === 401 ||
+    /access[ _-]?token.*(?:invalid|expired)|(?:invalid|expired).*access[ _-]?token/i.test(
+      error.providerMessage ?? ""
+    )
+  )
+}
+
+function parseJson(rawBody: string): unknown {
+  if (!rawBody) return undefined
+  try {
+    return JSON.parse(rawBody)
+  } catch {
+    return rawBody
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function formatApiError(
+  status: number,
+  code: number | undefined,
+  providerMessage: string | undefined,
+  requestId: string | undefined
+): string {
+  const details = [
+    `HTTP ${status}`,
+    code === undefined ? undefined : `code ${code}`,
+    providerMessage || undefined,
+    requestId ? `request ${requestId}` : undefined,
+  ].filter(Boolean)
+  return `[SixbTikTok] TikTok API request failed (${details.join(", ")}).`
+}

--- a/connectors/tiktok/src/index.ts
+++ b/connectors/tiktok/src/index.ts
@@ -1,0 +1,8 @@
+export { TiktokApiError } from "./http"
+export type {
+  TiktokAdsConnector,
+  TiktokConnector,
+  TiktokOrganicConnector,
+} from "./tiktok"
+export { tiktok } from "./tiktok"
+export type * from "./types/index"

--- a/connectors/tiktok/src/oauth.ts
+++ b/connectors/tiktok/src/oauth.ts
@@ -1,0 +1,336 @@
+import {
+  type ConnectorContext,
+  type ConnectorOAuth2Authentication,
+  type ConnectorOAuthCredentials,
+  ConnectorOAuthError,
+} from "@sixb/core"
+import { assertNonEmpty, TIKTOK_API_BASE_URL } from "./http"
+import type {
+  TiktokAdsConnectorOptions,
+  TiktokConnectorOptions,
+  TiktokOrganicConnectorOptions,
+} from "./types/options"
+
+const ADS_AUTHORIZATION_URL = "https://ads.tiktok.com/marketing_api/auth"
+
+interface OAuthEnvelope {
+  readonly code: number
+  readonly message: string
+  readonly request_id?: string
+  readonly data: unknown
+}
+
+type OAuthOperation = "exchange" | "refresh" | "revoke"
+
+export function createTiktokAuthentication(
+  options: TiktokConnectorOptions
+): ConnectorOAuth2Authentication {
+  return options.accountType === "organic-account"
+    ? createOrganicAuthentication(options)
+    : createAdsAuthentication(options)
+}
+
+export function organicRedirectUri(redirectUri: string): string {
+  const url = new URL(redirectUri)
+  if (url.protocol !== "https:" || url.port || url.search || url.hash) {
+    throw new Error(
+      "[SixbTikTok] The organic redirect URI must use HTTPS without a port, query, or fragment."
+    )
+  }
+  if (!url.pathname.endsWith("/")) url.pathname += "/"
+  const normalized = url.toString()
+  if (normalized.length < 10 || normalized.length > 512) {
+    throw new Error("[SixbTikTok] The organic redirect URI must be between 10 and 512 characters.")
+  }
+  return normalized
+}
+
+function createOrganicAuthentication(
+  options: TiktokOrganicConnectorOptions
+): ConnectorOAuth2Authentication {
+  return {
+    type: "oauth2",
+    authorizationUrl(context, input) {
+      const url = new URL(options.authorizationUrl)
+      if (url.protocol !== "https:") {
+        throw new Error("[SixbTikTok] authorizationUrl must use HTTPS.")
+      }
+      url.searchParams.set("redirect_uri", organicRedirectUri(context.redirectUri))
+      url.searchParams.set("state", input.state)
+      addFrameworkPkce(url, input.codeChallenge, input.codeChallengeMethod)
+      if (options.disableAutoAuth) url.searchParams.set("disable_auto_auth", "1")
+      return url
+    },
+    async exchangeCode(context, input) {
+      const data = await oauthRequest(
+        context,
+        options,
+        "tt_user/oauth2/token/",
+        {
+          client_id: options.clientId,
+          client_secret: options.clientSecret,
+          grant_type: "authorization_code",
+          auth_code: input.code,
+          redirect_uri: organicRedirectUri(context.redirectUri),
+        },
+        "exchange"
+      )
+      return organicCredentials(data)
+    },
+    async refresh(context, credentials) {
+      if (!credentials.refreshToken) {
+        throw new ConnectorOAuthError(
+          "terminal",
+          "[SixbTikTok] The TikTok organic grant has no refresh token; reauthorization is required."
+        )
+      }
+      const data = await oauthRequest(
+        context,
+        options,
+        "tt_user/oauth2/refresh_token/",
+        {
+          client_id: options.clientId,
+          client_secret: options.clientSecret,
+          grant_type: "refresh_token",
+          refresh_token: credentials.refreshToken,
+        },
+        "refresh"
+      )
+      return organicCredentials(data)
+    },
+    async revoke(context, credentials) {
+      await revokeGrant(context, options, "tt_user/oauth2/revoke/", {
+        client_id: options.clientId,
+        client_secret: options.clientSecret,
+        access_token: credentials.accessToken,
+      })
+    },
+  }
+}
+
+function createAdsAuthentication(
+  options: TiktokAdsConnectorOptions
+): ConnectorOAuth2Authentication {
+  return {
+    type: "oauth2",
+    authorizationUrl(context, input) {
+      const url = new URL(ADS_AUTHORIZATION_URL)
+      url.searchParams.set("app_id", options.appId)
+      url.searchParams.set("state", input.state)
+      url.searchParams.set("redirect_uri", context.redirectUri)
+      if (options.scope) url.searchParams.set("scope", options.scope)
+      addFrameworkPkce(url, input.codeChallenge, input.codeChallengeMethod)
+      return url
+    },
+    async exchangeCode(context, input) {
+      const data = await oauthRequest(
+        context,
+        options,
+        "oauth2/access_token/",
+        {
+          app_id: options.appId,
+          secret: options.secret,
+          auth_code: input.code,
+          return_advertiser_ids: true,
+        },
+        "exchange"
+      )
+      return adsCredentials(data, options.scope)
+    },
+    refresh() {
+      throw new ConnectorOAuthError(
+        "terminal",
+        "[SixbTikTok] TikTok Ads access tokens do not expire or refresh; reauthorization is required."
+      )
+    },
+    async revoke(context, credentials) {
+      await revokeGrant(
+        context,
+        options,
+        "oauth2/revoke_token/",
+        {
+          app_id: options.appId,
+          secret: options.secret,
+          access_token: credentials.accessToken,
+        },
+        { "Access-Token": credentials.accessToken }
+      )
+    },
+  }
+}
+
+function addFrameworkPkce(url: URL, challenge: string, method: "S256"): void {
+  // TikTok does not document PKCE for either Business API flow. Sixb still requires a challenge
+  // on the authorization request; the verifier is deliberately not sent to TikTok's token APIs.
+  url.searchParams.set("code_challenge", challenge)
+  url.searchParams.set("code_challenge_method", method)
+}
+
+function organicCredentials(data: unknown): ConnectorOAuthCredentials {
+  if (!isRecord(data)) throw malformedTokenResponse("data")
+  const accessToken = requiredString(data.access_token, "access_token")
+  const refreshToken = requiredString(data.refresh_token, "refresh_token")
+  const expiresIn = requiredPositiveNumber(data.expires_in, "expires_in")
+  requiredPositiveNumber(data.refresh_token_expires_in, "refresh_token_expires_in")
+  const scope = requiredString(data.scope, "scope")
+  const tokenType = requiredString(data.token_type, "token_type")
+  return {
+    accessToken,
+    refreshToken,
+    tokenType,
+    scopes: splitScopes(scope),
+    expiresAt: new Date(Date.now() + expiresIn * 1000),
+  }
+}
+
+function adsCredentials(data: unknown, scope: string | undefined): ConnectorOAuthCredentials {
+  if (!isRecord(data)) throw malformedTokenResponse("data")
+  const accessToken = requiredString(data.access_token, "access_token")
+  return {
+    accessToken,
+    tokenType: "Bearer",
+    // TikTok returns numeric permission IDs, including values beyond Number.MAX_SAFE_INTEGER.
+    // Preserve only the exact caller-provided scope string in Sixb's normalized credentials.
+    scopes: scope ? [scope] : undefined,
+  }
+}
+
+async function revokeGrant(
+  context: ConnectorContext,
+  options: TiktokConnectorOptions,
+  path: string,
+  body: unknown,
+  headers?: HeadersInit
+): Promise<void> {
+  try {
+    await oauthRequest(context, options, path, body, "revoke", headers)
+  } catch (error) {
+    if (error instanceof ConnectorOAuthError && isAlreadyRevoked(error.message)) return
+    throw error
+  }
+}
+
+async function oauthRequest(
+  context: ConnectorContext,
+  options: TiktokConnectorOptions,
+  path: string,
+  body: unknown,
+  operation: OAuthOperation,
+  extraHeaders?: HeadersInit
+): Promise<unknown> {
+  let response: Response
+  try {
+    const signal = options.timeoutMs
+      ? AbortSignal.any([context.signal, AbortSignal.timeout(options.timeoutMs)])
+      : context.signal
+    response = await fetch(new URL(path, normalizedBaseUrl(options.baseUrl)), {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        ...Object.fromEntries(new Headers(extraHeaders)),
+      },
+      body: JSON.stringify(body),
+      signal,
+    })
+  } catch (error) {
+    throw new ConnectorOAuthError(
+      "ambiguous",
+      `[SixbTikTok] TikTok OAuth ${operation} ended without a provider response.`,
+      { cause: error }
+    )
+  }
+
+  let rawBody: string
+  try {
+    rawBody = await response.text()
+  } catch (error) {
+    throw new ConnectorOAuthError(
+      "ambiguous",
+      `[SixbTikTok] TikTok OAuth ${operation} response could not be read.`,
+      { cause: error }
+    )
+  }
+  const envelope = parseOAuthEnvelope(rawBody)
+  if (!response.ok || (envelope && envelope.code !== 0)) {
+    const detail = envelope?.message || `HTTP ${response.status}`
+    const request = envelope?.request_id ? ` (request ${envelope.request_id})` : ""
+    throw new ConnectorOAuthError(
+      response.status === 429 || response.status >= 500 ? "retryable" : "terminal",
+      `[SixbTikTok] TikTok OAuth ${operation} failed: ${detail}${request}.`
+    )
+  }
+  if (!envelope) {
+    throw new ConnectorOAuthError(
+      "ambiguous",
+      `[SixbTikTok] TikTok OAuth ${operation} returned a malformed success response.`
+    )
+  }
+  return envelope.data
+}
+
+function parseOAuthEnvelope(rawBody: string): OAuthEnvelope | undefined {
+  let value: unknown
+  try {
+    value = JSON.parse(rawBody)
+  } catch {
+    return undefined
+  }
+  if (
+    !isRecord(value) ||
+    typeof value.code !== "number" ||
+    typeof value.message !== "string" ||
+    !("data" in value)
+  ) {
+    return undefined
+  }
+  return {
+    code: value.code,
+    message: value.message,
+    request_id: typeof value.request_id === "string" ? value.request_id : undefined,
+    data: value.data,
+  }
+}
+
+function normalizedBaseUrl(baseUrl: string | undefined): string {
+  const value = baseUrl ?? TIKTOK_API_BASE_URL
+  assertNonEmpty(value, "baseUrl")
+  return value.endsWith("/") ? value : `${value}/`
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || !value.trim()) throw malformedTokenResponse(field)
+  return value
+}
+
+function requiredPositiveNumber(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw malformedTokenResponse(field)
+  }
+  return value
+}
+
+function malformedTokenResponse(field: string): ConnectorOAuthError {
+  return new ConnectorOAuthError(
+    "ambiguous",
+    `[SixbTikTok] TikTok returned an invalid OAuth token field '${field}'.`
+  )
+}
+
+function splitScopes(value: string): readonly string[] | undefined {
+  const scopes = value
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter(Boolean)
+  return scopes.length ? scopes : undefined
+}
+
+function isAlreadyRevoked(message: string): boolean {
+  return /(?:already revoked|invalid|expired|not exist).*token|token.*(?:already revoked|invalid|expired|not exist)/i.test(
+    message
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/connectors/tiktok/src/oauth.ts
+++ b/connectors/tiktok/src/oauth.ts
@@ -11,7 +11,7 @@ import type {
   TiktokOrganicConnectorOptions,
 } from "./types/options"
 
-const ADS_AUTHORIZATION_URL = "https://ads.tiktok.com/marketing_api/auth"
+const MARKETING_AUTHORIZATION_URL = "https://ads.tiktok.com/marketing_api/auth"
 
 interface OAuthEnvelope {
   readonly code: number
@@ -25,9 +25,9 @@ type OAuthOperation = "exchange" | "refresh" | "revoke"
 export function createTiktokAuthentication(
   options: TiktokConnectorOptions
 ): ConnectorOAuth2Authentication {
-  return options.accountType === "organic-account"
+  return options.api === "organic"
     ? createOrganicAuthentication(options)
-    : createAdsAuthentication(options)
+    : createMarketingAuthentication(options)
 }
 
 export function organicRedirectUri(redirectUri: string): string {
@@ -108,13 +108,13 @@ function createOrganicAuthentication(
   }
 }
 
-function createAdsAuthentication(
+function createMarketingAuthentication(
   options: TiktokAdsConnectorOptions
 ): ConnectorOAuth2Authentication {
   return {
     type: "oauth2",
     authorizationUrl(context, input) {
-      const url = new URL(ADS_AUTHORIZATION_URL)
+      const url = new URL(MARKETING_AUTHORIZATION_URL)
       url.searchParams.set("app_id", options.appId)
       url.searchParams.set("state", input.state)
       url.searchParams.set("redirect_uri", context.redirectUri)
@@ -135,12 +135,12 @@ function createAdsAuthentication(
         },
         "exchange"
       )
-      return adsCredentials(data, options.scope)
+      return marketingCredentials(data, options.scope)
     },
     refresh() {
       throw new ConnectorOAuthError(
         "terminal",
-        "[SixbTikTok] TikTok Ads access tokens do not expire or refresh; reauthorization is required."
+        "[SixbTikTok] TikTok Marketing API access tokens do not refresh; reauthorization is required."
       )
     },
     async revoke(context, credentials) {
@@ -183,7 +183,7 @@ function organicCredentials(data: unknown): ConnectorOAuthCredentials {
   }
 }
 
-function adsCredentials(data: unknown, scope: string | undefined): ConnectorOAuthCredentials {
+function marketingCredentials(data: unknown, scope: string | undefined): ConnectorOAuthCredentials {
   if (!isRecord(data)) throw malformedTokenResponse("data")
   const accessToken = requiredString(data.access_token, "access_token")
   return {

--- a/connectors/tiktok/src/organic/client.ts
+++ b/connectors/tiktok/src/organic/client.ts
@@ -1,0 +1,20 @@
+import type { TiktokHttp } from "../http"
+import type { TiktokOrganicClient } from "../types/client"
+import type { TiktokConnectedAccount } from "../types/common"
+import {
+  createOrganicCommentsApi,
+  createOrganicPostsApi,
+  createOrganicProfileApi,
+} from "./resources"
+
+export function createOrganicClient(
+  http: TiktokHttp,
+  account: TiktokConnectedAccount<"organic-account">
+): TiktokOrganicClient {
+  return {
+    account,
+    profile: createOrganicProfileApi(http, account.id),
+    posts: createOrganicPostsApi(http, account.id),
+    comments: createOrganicCommentsApi(http, account.id),
+  }
+}

--- a/connectors/tiktok/src/organic/client.ts
+++ b/connectors/tiktok/src/organic/client.ts
@@ -9,7 +9,7 @@ import {
 
 export function createOrganicClient(
   http: TiktokHttp,
-  account: TiktokConnectedAccount<"organic-account">
+  account: TiktokConnectedAccount<"tiktok-account">
 ): TiktokOrganicClient {
   return {
     account,

--- a/connectors/tiktok/src/organic/resources.ts
+++ b/connectors/tiktok/src/organic/resources.ts
@@ -1,0 +1,203 @@
+import { assertNonEmpty, assertPositiveIntegerInRange, type TiktokHttp } from "../http"
+import { paginateCursor } from "../pagination"
+import type { TiktokCursorPage } from "../types/common"
+import type {
+  TiktokOrganicComment,
+  TiktokOrganicCommentsApi,
+  TiktokOrganicCommentsListQuery,
+  TiktokOrganicPost,
+  TiktokOrganicPostsApi,
+  TiktokOrganicPostsListQuery,
+  TiktokOrganicProfile,
+  TiktokOrganicProfileApi,
+  TiktokOrganicProfileQuery,
+  TiktokOrganicRepliesApi,
+  TiktokOrganicRepliesListQuery,
+} from "../types/organic"
+
+interface VideoListData {
+  readonly videos?: readonly TiktokOrganicPost[]
+  readonly cursor?: number
+  readonly has_more?: boolean
+}
+
+interface CommentListData {
+  readonly comments?: readonly TiktokOrganicComment[]
+  readonly cursor?: number
+  readonly has_more?: boolean
+}
+
+export function createOrganicProfileApi(
+  http: TiktokHttp,
+  businessId: string
+): TiktokOrganicProfileApi {
+  return {
+    async get(query) {
+      validateProfileDates(query)
+      const result = await http.get<TiktokOrganicProfile>("business/get/", {
+        business_id: businessId,
+        start_date: query?.startDate,
+        end_date: query?.endDate,
+        fields: query?.fields,
+      })
+      return result.data
+    },
+  }
+}
+
+export function createOrganicPostsApi(http: TiktokHttp, businessId: string): TiktokOrganicPostsApi {
+  const list = (
+    query: TiktokOrganicPostsListQuery | undefined,
+    cursor = query?.cursor
+  ): Promise<TiktokCursorPage<TiktokOrganicPost>> => listPosts(http, businessId, query, cursor)
+
+  return {
+    list,
+    listAll(query) {
+      return paginateCursor((cursor) => list(query, cursor), query?.cursor)
+    },
+  }
+}
+
+export function createOrganicCommentsApi(
+  http: TiktokHttp,
+  businessId: string
+): TiktokOrganicCommentsApi {
+  return {
+    replies: createOrganicRepliesApi(http, businessId),
+    list(query) {
+      return listComments(http, businessId, query, query.cursor)
+    },
+    listAll(query) {
+      return paginateCursor((cursor) => listComments(http, businessId, query, cursor), query.cursor)
+    },
+  }
+}
+
+function createOrganicRepliesApi(http: TiktokHttp, businessId: string): TiktokOrganicRepliesApi {
+  return {
+    list(query) {
+      return listReplies(http, businessId, query, query.cursor)
+    },
+    listAll(query) {
+      return paginateCursor((cursor) => listReplies(http, businessId, query, cursor), query.cursor)
+    },
+  }
+}
+
+async function listPosts(
+  http: TiktokHttp,
+  businessId: string,
+  query: TiktokOrganicPostsListQuery | undefined,
+  cursor: number | undefined
+): Promise<TiktokCursorPage<TiktokOrganicPost>> {
+  assertPositiveIntegerInRange(query?.maxCount, "maxCount", 20)
+  const filters =
+    query?.videoIds !== undefined || query?.adPostOnly !== undefined
+      ? { video_ids: query.videoIds, ad_post_only: query.adPostOnly }
+      : undefined
+  const result = await http.get<VideoListData>("business/video/list/", {
+    business_id: businessId,
+    fields: query?.fields,
+    filters,
+    cursor,
+    max_count: query?.maxCount,
+  })
+  return {
+    items: result.data.videos ?? [],
+    hasMore: result.data.has_more ?? false,
+    nextCursor: result.data.cursor,
+    requestId: result.requestId,
+  }
+}
+
+async function listComments(
+  http: TiktokHttp,
+  businessId: string,
+  query: TiktokOrganicCommentsListQuery,
+  cursor: number | undefined
+): Promise<TiktokCursorPage<TiktokOrganicComment>> {
+  validateCommentQuery(query)
+  if (query.commentIds && query.commentIds.length > 30) {
+    throw new Error("[SixbTikTok] commentIds cannot contain more than 30 IDs.")
+  }
+  const result = await http.get<CommentListData>("business/comment/list/", {
+    business_id: businessId,
+    video_id: query.videoId,
+    comment_ids: query.commentIds,
+    include_replies: query.includeReplies,
+    status: query.status,
+    sort_field: query.sortField,
+    sort_order: query.sortOrder,
+    cursor,
+    max_count: query.maxCount,
+  })
+  return commentPage(result)
+}
+
+async function listReplies(
+  http: TiktokHttp,
+  businessId: string,
+  query: TiktokOrganicRepliesListQuery,
+  cursor: number | undefined
+): Promise<TiktokCursorPage<TiktokOrganicComment>> {
+  validateCommentQuery(query)
+  assertNonEmpty(query.commentId, "commentId")
+  const result = await http.get<CommentListData>("business/comment/reply/list/", {
+    business_id: businessId,
+    video_id: query.videoId,
+    comment_id: query.commentId,
+    status: query.status,
+    sort_field: query.sortField,
+    sort_order: query.sortOrder,
+    cursor,
+    max_count: query.maxCount,
+  })
+  return commentPage(result)
+}
+
+function commentPage(result: {
+  readonly data: CommentListData
+  readonly requestId?: string
+}): TiktokCursorPage<TiktokOrganicComment> {
+  return {
+    items: result.data.comments ?? [],
+    hasMore: result.data.has_more ?? false,
+    nextCursor: result.data.cursor,
+    requestId: result.requestId,
+  }
+}
+
+function validateCommentQuery(query: {
+  readonly videoId: string
+  readonly maxCount?: number
+}): void {
+  assertNonEmpty(query.videoId, "videoId")
+  assertPositiveIntegerInRange(query.maxCount, "maxCount", 30)
+}
+
+function validateProfileDates(query: TiktokOrganicProfileQuery | undefined): void {
+  if (query?.startDate) assertDate(query.startDate, "startDate")
+  if (query?.endDate) assertDate(query.endDate, "endDate")
+  if (!query?.startDate || !query.endDate) return
+
+  const start = Date.parse(`${query.startDate}T00:00:00Z`)
+  const end = Date.parse(`${query.endDate}T00:00:00Z`)
+  if (start > end) {
+    throw new Error("[SixbTikTok] startDate must not be after endDate.")
+  }
+  if ((end - start) / 86_400_000 > 59) {
+    throw new Error("[SixbTikTok] profile insights cannot span more than 60 calendar days.")
+  }
+}
+
+function assertDate(value: string, field: string): void {
+  const parsed = new Date(`${value}T00:00:00Z`)
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/.test(value) ||
+    Number.isNaN(parsed.getTime()) ||
+    parsed.toISOString().slice(0, 10) !== value
+  ) {
+    throw new Error(`[SixbTikTok] ${field} must use YYYY-MM-DD.`)
+  }
+}

--- a/connectors/tiktok/src/pagination.ts
+++ b/connectors/tiktok/src/pagination.ts
@@ -1,0 +1,48 @@
+import type { TiktokCursorPage, TiktokNumberedPage } from "./types/common"
+
+export async function* paginateCursor<T>(
+  fetchPage: (cursor: number | undefined) => Promise<TiktokCursorPage<T>>,
+  initialCursor?: number
+): AsyncIterable<T> {
+  let cursor = initialCursor
+  const seen = new Set<number>()
+
+  for (;;) {
+    const page = await fetchPage(cursor)
+    for (const item of page.items) yield item
+    if (!page.hasMore) return
+    if (page.nextCursor === undefined || page.nextCursor === cursor || seen.has(page.nextCursor)) {
+      throw new Error("[SixbTikTok] TikTok returned a repeated or missing pagination cursor.")
+    }
+    seen.add(page.nextCursor)
+    cursor = page.nextCursor
+  }
+}
+
+export async function* paginateNumbered<T>(
+  fetchPage: (page: number) => Promise<TiktokNumberedPage<T>>,
+  initialPage = 1
+): AsyncIterable<T> {
+  let pageNumber = initialPage
+  const seen = new Set<number>()
+
+  for (;;) {
+    if (seen.has(pageNumber)) {
+      throw new Error("[SixbTikTok] TikTok returned a repeated page number.")
+    }
+    seen.add(pageNumber)
+
+    const page = await fetchPage(pageNumber)
+    for (const item of page.items) yield item
+
+    const {
+      page: current,
+      page_size: pageSize,
+      total_number: total,
+      total_page: totalPages,
+    } = page.pageInfo
+    const lastPage = totalPages ?? Math.ceil(total / Math.max(pageSize, 1))
+    if (page.items.length === 0 || current >= lastPage) return
+    pageNumber = current + 1
+  }
+}

--- a/connectors/tiktok/src/tiktok.ts
+++ b/connectors/tiktok/src/tiktok.ts
@@ -1,0 +1,137 @@
+import type {
+  ConnectorAccountCandidate,
+  ConnectorContext,
+  ConnectorOAuthCredentials,
+  OAuthConnectorAdapter,
+} from "@sixb/core"
+import { createAdsClient } from "./ads/client"
+import { assertNonEmpty, createTiktokHttp, fixedTokenSource } from "./http"
+import { createTiktokAuthentication } from "./oauth"
+import { createOrganicClient } from "./organic/client"
+import type { TiktokAdsClient, TiktokOrganicClient } from "./types/client"
+import type {
+  TiktokAdsConnectorOptions,
+  TiktokConnectorOptions,
+  TiktokOrganicConnectorOptions,
+} from "./types/options"
+import type { TiktokOrganicProfile } from "./types/organic"
+
+export type TiktokOrganicConnector = OAuthConnectorAdapter<"tiktok", TiktokOrganicClient>
+export type TiktokAdsConnector = OAuthConnectorAdapter<"tiktok", TiktokAdsClient>
+export type TiktokConnector = TiktokOrganicConnector | TiktokAdsConnector
+
+interface OrganicTokenInfo {
+  readonly app_id?: string
+  readonly scope?: string
+  readonly creator_id: string
+}
+
+interface AdvertiserListData {
+  readonly list?: readonly {
+    readonly advertiser_id: string
+    readonly advertiser_name?: string
+  }[]
+}
+
+/** Create a managed TikTok connector for one of TikTok's two distinct OAuth grants. */
+export function tiktok(options: TiktokOrganicConnectorOptions): TiktokOrganicConnector
+export function tiktok(options: TiktokAdsConnectorOptions): TiktokAdsConnector
+export function tiktok(options: TiktokConnectorOptions): TiktokConnector {
+  validateOptions(options)
+  const authentication = createTiktokAuthentication(options)
+
+  if (options.accountType === "organic-account") {
+    return {
+      type: "tiktok",
+      authentication,
+      discoverAccounts: (context, credentials) =>
+        discoverOrganicAccount(context, options, credentials),
+      async connect(context) {
+        const http = await createTiktokHttp(context, options, context.tokenSource)
+        return createOrganicClient(http, {
+          type: "organic-account",
+          ...context.account,
+        })
+      },
+    }
+  }
+
+  return {
+    type: "tiktok",
+    authentication,
+    discoverAccounts: (context, credentials) => discoverAdvertisers(context, options, credentials),
+    async connect(context) {
+      const http = await createTiktokHttp(context, options, context.tokenSource)
+      return createAdsClient(http, {
+        type: "ad-account",
+        ...context.account,
+      })
+    },
+  }
+}
+
+async function discoverOrganicAccount(
+  context: ConnectorContext,
+  options: TiktokOrganicConnectorOptions,
+  credentials: ConnectorOAuthCredentials
+): Promise<readonly ConnectorAccountCandidate[]> {
+  const http = await createTiktokHttp(context, options, fixedTokenSource(credentials.accessToken))
+  const tokenInfo = await http.post<OrganicTokenInfo>(
+    "tt_user/token_info/get/",
+    { app_id: options.clientId, access_token: credentials.accessToken },
+    { authenticated: false }
+  )
+  assertNonEmpty(tokenInfo.data.creator_id, "creator_id")
+
+  const profile = await http.get<TiktokOrganicProfile>("business/get/", {
+    business_id: tokenInfo.data.creator_id,
+    fields: ["display_name", "username", "profile_image", "bio_description"],
+  })
+  const label = profile.data.display_name || profile.data.username || tokenInfo.data.creator_id
+  return [
+    {
+      id: tokenInfo.data.creator_id,
+      label,
+      description: profile.data.username
+        ? `@${profile.data.username}`
+        : profile.data.bio_description,
+      avatarUrl: profile.data.profile_image,
+    },
+  ]
+}
+
+async function discoverAdvertisers(
+  context: ConnectorContext,
+  options: TiktokAdsConnectorOptions,
+  credentials: ConnectorOAuthCredentials
+): Promise<readonly ConnectorAccountCandidate[]> {
+  const http = await createTiktokHttp(context, options, fixedTokenSource(credentials.accessToken))
+  const result = await http.get<AdvertiserListData>("oauth2/advertiser/get/", {
+    app_id: options.appId,
+    secret: options.secret,
+  })
+  return (result.data.list ?? []).map((advertiser) => ({
+    id: advertiser.advertiser_id,
+    label: advertiser.advertiser_name || advertiser.advertiser_id,
+  }))
+}
+
+function validateOptions(options: TiktokConnectorOptions): void {
+  if (
+    options.timeoutMs !== undefined &&
+    (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0)
+  ) {
+    throw new Error("[SixbTikTok] timeoutMs must be a positive number.")
+  }
+
+  if (options.accountType === "organic-account") {
+    assertNonEmpty(options.clientId, "clientId")
+    assertNonEmpty(options.clientSecret, "clientSecret")
+    assertNonEmpty(options.authorizationUrl, "authorizationUrl")
+    return
+  }
+
+  assertNonEmpty(options.appId, "appId")
+  assertNonEmpty(options.secret, "secret")
+  if (options.scope !== undefined) assertNonEmpty(options.scope, "scope")
+}

--- a/connectors/tiktok/src/tiktok.ts
+++ b/connectors/tiktok/src/tiktok.ts
@@ -40,7 +40,7 @@ export function tiktok(options: TiktokConnectorOptions): TiktokConnector {
   validateOptions(options)
   const authentication = createTiktokAuthentication(options)
 
-  if (options.accountType === "organic-account") {
+  if (options.api === "organic") {
     return {
       type: "tiktok",
       authentication,
@@ -49,7 +49,7 @@ export function tiktok(options: TiktokConnectorOptions): TiktokConnector {
       async connect(context) {
         const http = await createTiktokHttp(context, options, context.tokenSource)
         return createOrganicClient(http, {
-          type: "organic-account",
+          type: "tiktok-account",
           ...context.account,
         })
       },
@@ -124,7 +124,7 @@ function validateOptions(options: TiktokConnectorOptions): void {
     throw new Error("[SixbTikTok] timeoutMs must be a positive number.")
   }
 
-  if (options.accountType === "organic-account") {
+  if (options.api === "organic") {
     assertNonEmpty(options.clientId, "clientId")
     assertNonEmpty(options.clientSecret, "clientSecret")
     assertNonEmpty(options.authorizationUrl, "authorizationUrl")

--- a/connectors/tiktok/src/types/ads.ts
+++ b/connectors/tiktok/src/types/ads.ts
@@ -1,0 +1,302 @@
+import type { TiktokExtensible, TiktokNumberedPage } from "./common"
+
+export type TiktokAdvertiserField =
+  | "advertiser_id"
+  | "can_use_custom_identity"
+  | "ads_only_mode"
+  | "owner_bc_id"
+  | "status"
+  | "role"
+  | "rejection_reason"
+  | "name"
+  | "timezone"
+  | "display_timezone"
+  | "company"
+  | "company_name_editable"
+  | "industry"
+  | "address"
+  | "country"
+  | "advertiser_account_type"
+  | "currency"
+  | "contacter"
+  | "email"
+  | "cellphone_number"
+  | "telephone_number"
+  | "language"
+  | "license_no"
+  | "license_url"
+  | "description"
+  | "balance"
+  | "create_time"
+
+export interface TiktokAdvertiser {
+  readonly advertiser_id: string
+  readonly can_use_custom_identity?: boolean
+  readonly ads_only_mode?: boolean
+  readonly owner_bc_id?: string
+  readonly status?: string
+  readonly role?: string
+  readonly rejection_reason?: string
+  readonly name?: string
+  readonly timezone?: string
+  readonly display_timezone?: string
+  readonly company?: string
+  readonly company_name_editable?: boolean
+  readonly industry?: string
+  readonly address?: string | null
+  readonly country?: string
+  readonly advertiser_account_type?: TiktokExtensible<"RESERVATION" | "AUCTION">
+  readonly currency?: string
+  readonly contacter?: string | null
+  readonly email?: string | null
+  readonly cellphone_number?: string | null
+  readonly telephone_number?: string | null
+  readonly language?: string
+  readonly license_no?: string
+  readonly license_url?: string
+  readonly description?: string
+  readonly balance?: number
+  readonly create_time?: number
+  readonly [field: string]: unknown
+}
+
+export type TiktokAdsField = string
+export type TiktokAdsExcludeFieldType = TiktokExtensible<"NULL_FIELD">
+
+interface TiktokAdsListQueryBase<TFilter> {
+  readonly fields?: readonly TiktokAdsField[]
+  readonly excludeFieldTypesInResponse?: readonly TiktokAdsExcludeFieldType[]
+  readonly filtering?: TFilter
+  readonly page?: number
+  /** 1-1000. */
+  readonly pageSize?: number
+}
+
+export interface TiktokCampaignFilter {
+  readonly campaign_automation_type?: string
+  readonly campaign_ids?: readonly string[]
+  readonly campaign_name?: string
+  readonly campaign_system_origins?: readonly string[]
+  readonly primary_status?: string
+  readonly secondary_status?: string
+  readonly objective_type?: string
+  readonly sales_destination?: string
+  readonly buying_types?: readonly string[]
+  readonly is_smart_performance_campaign?: boolean
+  readonly creative_campaign_type?: string
+  readonly split_test_enabled?: boolean
+  readonly campaign_product_source?: string
+  readonly optimization_goal?: string
+  readonly campaign_type?: string
+  readonly creation_filter_start_time?: string
+  readonly creation_filter_end_time?: string
+}
+
+export interface TiktokCampaign {
+  readonly advertiser_id: string
+  readonly campaign_id: string
+  readonly campaign_name?: string
+  readonly create_time?: string
+  readonly modify_time?: string
+  readonly objective_type?: string
+  readonly app_promotion_type?: string
+  readonly virtual_objective_type?: string
+  readonly sales_destination?: string
+  readonly is_search_campaign?: boolean
+  readonly campaign_automation_type?: string
+  readonly is_smart_performance_campaign?: boolean
+  readonly campaign_type?: string
+  readonly app_id?: string
+  readonly is_advanced_dedicated_campaign?: boolean
+  readonly disable_skan_campaign?: boolean
+  readonly bid_align_type?: string
+  readonly campaign_app_profile_page_state?: string
+  readonly rf_campaign_type?: string
+  readonly campaign_product_source?: string
+  readonly catalog_enabled?: boolean
+  readonly special_industries?: readonly string[]
+  readonly budget_optimize_on?: boolean
+  readonly bid_type?: string
+  readonly deep_bid_type?: string
+  readonly roas_bid?: number
+  readonly optimization_goal?: string
+  readonly budget_mode?: string
+  readonly budget?: number
+  readonly rta_id?: string
+  readonly rta_bid_enabled?: boolean
+  readonly rta_product_selection_enabled?: boolean
+  readonly operation_status?: string
+  readonly secondary_status?: string
+  readonly postback_window_mode?: string
+  readonly is_new_structure?: boolean
+  readonly objective?: string
+  readonly po_number?: string
+  readonly [field: string]: unknown
+}
+
+export type TiktokCampaignsListQuery = TiktokAdsListQueryBase<TiktokCampaignFilter>
+
+export interface TiktokAdGroupFilter {
+  readonly campaign_automation_type?: string
+  readonly campaign_ids?: readonly string[]
+  readonly campaign_system_origins?: readonly string[]
+  readonly adgroup_ids?: readonly string[]
+  readonly adgroup_name?: string
+  readonly primary_status?: string
+  readonly secondary_status?: string
+  readonly objective_type?: string
+  readonly buying_types?: readonly string[]
+  readonly optimization_goal?: string
+  readonly promotion_type?: string
+  readonly bid_strategy?: string
+  readonly creative_material_mode?: string
+  readonly billing_events?: readonly string[]
+  readonly creation_filter_start_time?: string
+  readonly creation_filter_end_time?: string
+  readonly split_test_enabled?: boolean
+}
+
+export interface TiktokAdGroup {
+  readonly advertiser_id: string
+  readonly campaign_id: string
+  readonly campaign_name?: string
+  readonly campaign_system_origin?: string
+  readonly adgroup_id: string
+  readonly adgroup_name?: string
+  readonly create_time?: string
+  readonly modify_time?: string
+  readonly operation_status?: string
+  readonly secondary_status?: string
+  readonly budget?: number
+  readonly budget_mode?: string
+  readonly schedule_type?: string
+  readonly schedule_start_time?: string
+  readonly schedule_end_time?: string
+  readonly optimization_goal?: string
+  readonly promotion_type?: string
+  readonly billing_event?: string
+  readonly bid_price?: number
+  readonly conversion_bid_price?: number
+  readonly campaign_automation_type?: string
+  readonly [field: string]: unknown
+}
+
+export type TiktokAdGroupsListQuery = TiktokAdsListQueryBase<TiktokAdGroupFilter>
+
+export interface TiktokAdFilter {
+  readonly campaign_automation_type?: string
+  readonly ad_ids_v2?: readonly string[]
+  readonly campaign_ids?: readonly string[]
+  readonly campaign_system_origins?: readonly string[]
+  readonly adgroup_ids?: readonly string[]
+  readonly ad_ids?: readonly string[]
+  readonly primary_status?: string
+  readonly secondary_status?: string
+  readonly objective_type?: string
+  readonly buying_types?: readonly string[]
+  readonly optimization_goal?: string
+  readonly creative_material_mode?: string
+  readonly destination?: string
+  readonly creation_filter_start_time?: string
+  readonly creation_filter_end_time?: string
+  readonly modified_after?: string
+}
+
+export interface TiktokAd {
+  readonly advertiser_id: string
+  readonly campaign_id: string
+  readonly campaign_name?: string
+  readonly campaign_automation_type?: string
+  readonly campaign_system_origin?: string
+  readonly adgroup_id: string
+  readonly adgroup_name?: string
+  readonly smart_plus_ad_id?: string
+  readonly ad_id: string
+  readonly ad_id_v2?: string
+  readonly ad_name?: string
+  readonly create_time?: string
+  readonly modify_time?: string
+  readonly identity_id?: string
+  readonly identity_type?: string
+  readonly operation_status?: string
+  readonly secondary_status?: string
+  readonly [field: string]: unknown
+}
+
+export type TiktokAdsListQuery = TiktokAdsListQueryBase<TiktokAdFilter>
+
+export type TiktokReportServiceType = "AUCTION" | "RESERVATION"
+export type TiktokReportType = TiktokExtensible<
+  "BASIC" | "AUDIENCE" | "PLAYABLE_MATERIAL" | "CATALOG" | "BC" | "TT_SHOP"
+>
+export type TiktokReportFilterType =
+  | "IN"
+  | "CONTAIN_ANY_OF"
+  | "MATCH"
+  | "NOT_IN"
+  | "GREATER_EQUAL"
+  | "GREATER_THAN"
+  | "LOWER_EQUAL"
+  | "LOWER_THAN"
+  | "BETWEEN"
+
+export interface TiktokReportFilter {
+  readonly field_name: string
+  readonly filter_type: TiktokReportFilterType
+  /** TikTok expects the filter value to be JSON-encoded inside this string. */
+  readonly filter_value: string
+}
+
+export interface TiktokReportQuery {
+  readonly serviceType: TiktokReportServiceType
+  readonly reportType: TiktokReportType
+  readonly dataLevel: string
+  readonly dimensions: readonly string[]
+  readonly metrics?: readonly string[]
+  readonly enableTotalMetrics?: boolean
+  readonly startDate?: string
+  readonly endDate?: string
+  readonly queryLifetime?: boolean
+  readonly orderField?: string
+  readonly orderType?: "ASC" | "DESC"
+  readonly filtering?: readonly TiktokReportFilter[]
+  readonly page?: number
+  /** 1-1000. */
+  readonly pageSize?: number
+}
+
+export type TiktokReportMetricValue = string | readonly string[]
+
+export interface TiktokReportRow {
+  readonly dimensions: Readonly<Record<string, string>>
+  readonly metrics: Readonly<Record<string, TiktokReportMetricValue>>
+}
+
+export interface TiktokReportPage extends TiktokNumberedPage<TiktokReportRow> {
+  readonly totalMetrics?: Readonly<Record<string, TiktokReportMetricValue>>
+}
+
+export interface TiktokAdAccountApi {
+  /** TikTok defaults to all ordinary advertiser fields when `fields` is omitted. */
+  get(fields?: readonly TiktokAdvertiserField[]): Promise<TiktokAdvertiser>
+}
+
+export interface TiktokCampaignsApi {
+  list(query?: TiktokCampaignsListQuery): Promise<TiktokNumberedPage<TiktokCampaign>>
+  listAll(query?: TiktokCampaignsListQuery): AsyncIterable<TiktokCampaign>
+}
+
+export interface TiktokAdGroupsApi {
+  list(query?: TiktokAdGroupsListQuery): Promise<TiktokNumberedPage<TiktokAdGroup>>
+  listAll(query?: TiktokAdGroupsListQuery): AsyncIterable<TiktokAdGroup>
+}
+
+export interface TiktokAdsApi {
+  list(query?: TiktokAdsListQuery): Promise<TiktokNumberedPage<TiktokAd>>
+  listAll(query?: TiktokAdsListQuery): AsyncIterable<TiktokAd>
+}
+
+export interface TiktokReportsApi {
+  run(query: TiktokReportQuery): Promise<TiktokReportPage>
+  runAll(query: TiktokReportQuery): AsyncIterable<TiktokReportRow>
+}

--- a/connectors/tiktok/src/types/client.ts
+++ b/connectors/tiktok/src/types/client.ts
@@ -1,0 +1,31 @@
+import type {
+  TiktokAdAccountApi,
+  TiktokAdGroupsApi,
+  TiktokAdsApi,
+  TiktokCampaignsApi,
+  TiktokReportsApi,
+} from "./ads"
+import type { TiktokConnectedAccount } from "./common"
+import type {
+  TiktokOrganicCommentsApi,
+  TiktokOrganicPostsApi,
+  TiktokOrganicProfileApi,
+} from "./organic"
+
+export interface TiktokOrganicClient {
+  readonly account: TiktokConnectedAccount<"organic-account">
+  readonly profile: TiktokOrganicProfileApi
+  readonly posts: TiktokOrganicPostsApi
+  readonly comments: TiktokOrganicCommentsApi
+}
+
+export interface TiktokAdsClient {
+  readonly account: TiktokConnectedAccount<"ad-account">
+  readonly adAccount: TiktokAdAccountApi
+  readonly campaigns: TiktokCampaignsApi
+  readonly adGroups: TiktokAdGroupsApi
+  readonly ads: TiktokAdsApi
+  readonly reports: TiktokReportsApi
+}
+
+export type TiktokClient = TiktokOrganicClient | TiktokAdsClient

--- a/connectors/tiktok/src/types/client.ts
+++ b/connectors/tiktok/src/types/client.ts
@@ -13,7 +13,7 @@ import type {
 } from "./organic"
 
 export interface TiktokOrganicClient {
-  readonly account: TiktokConnectedAccount<"organic-account">
+  readonly account: TiktokConnectedAccount<"tiktok-account">
   readonly profile: TiktokOrganicProfileApi
   readonly posts: TiktokOrganicPostsApi
   readonly comments: TiktokOrganicCommentsApi

--- a/connectors/tiktok/src/types/common.ts
+++ b/connectors/tiktok/src/types/common.ts
@@ -1,0 +1,48 @@
+export type TiktokAccountType = "organic-account" | "ad-account"
+
+export interface TiktokConnectedAccount<TType extends TiktokAccountType> {
+  readonly type: TType
+  readonly id: string
+  readonly label: string
+  readonly description?: string
+  readonly avatarUrl?: string
+}
+
+export interface TiktokResponseMetadata {
+  readonly path: string
+  readonly method: "GET" | "POST"
+  readonly status: number
+  readonly requestId?: string
+  readonly logId?: string
+  /** Raw `X-Tt-Ads-Throttle` value returned by the Ads API. */
+  readonly adsThrottle?: string
+}
+
+export interface TiktokRetryOptions {
+  /** Number of retries for network errors, HTTP 429, and HTTP 5xx responses. Defaults to 2. */
+  readonly maxRetries?: number
+}
+
+export interface TiktokCursorPage<T> {
+  readonly items: readonly T[]
+  readonly hasMore: boolean
+  readonly nextCursor?: number
+  readonly requestId?: string
+}
+
+export interface TiktokPageInfo {
+  readonly page: number
+  readonly page_size: number
+  readonly total_number: number
+  readonly total_page?: number
+}
+
+export interface TiktokNumberedPage<T> {
+  readonly items: readonly T[]
+  readonly pageInfo: TiktokPageInfo
+  readonly requestId?: string
+}
+
+export type TiktokSortOrder = "asc" | "desc"
+
+export type TiktokExtensible<T extends string> = T | (string & {})

--- a/connectors/tiktok/src/types/common.ts
+++ b/connectors/tiktok/src/types/common.ts
@@ -1,4 +1,6 @@
-export type TiktokAccountType = "organic-account" | "ad-account"
+export type TiktokApi = "organic" | "marketing"
+
+export type TiktokAccountType = "tiktok-account" | "ad-account"
 
 export interface TiktokConnectedAccount<TType extends TiktokAccountType> {
   readonly type: TType

--- a/connectors/tiktok/src/types/index.ts
+++ b/connectors/tiktok/src/types/index.ts
@@ -1,0 +1,5 @@
+export type * from "./ads"
+export type * from "./client"
+export type * from "./common"
+export type * from "./options"
+export type * from "./organic"

--- a/connectors/tiktok/src/types/options.ts
+++ b/connectors/tiktok/src/types/options.ts
@@ -1,0 +1,30 @@
+import type { TiktokResponseMetadata, TiktokRetryOptions } from "./common"
+
+interface TiktokConnectorOptionsBase {
+  /** TikTok Business API base URL. Override only for compatible proxies and tests. */
+  readonly baseUrl?: string
+  readonly timeoutMs?: number
+  readonly retry?: TiktokRetryOptions
+  readonly onResponse?: (metadata: TiktokResponseMetadata) => Promise<void> | void
+}
+
+export interface TiktokOrganicConnectorOptions extends TiktokConnectorOptionsBase {
+  readonly accountType: "organic-account"
+  /** Client ID from the TikTok for Business app. */
+  readonly clientId: string
+  readonly clientSecret: string
+  /** Full TikTok account-holder authorization URL copied from the app portal. */
+  readonly authorizationUrl: string
+  /** Add `disable_auto_auth=1` to force the account chooser. */
+  readonly disableAutoAuth?: boolean
+}
+
+export interface TiktokAdsConnectorOptions extends TiktokConnectorOptionsBase {
+  readonly accountType: "ad-account"
+  readonly appId: string
+  readonly secret: string
+  /** Optional Ads authorization scope string. Omit to request the app's current permissions. */
+  readonly scope?: string
+}
+
+export type TiktokConnectorOptions = TiktokOrganicConnectorOptions | TiktokAdsConnectorOptions

--- a/connectors/tiktok/src/types/options.ts
+++ b/connectors/tiktok/src/types/options.ts
@@ -9,7 +9,7 @@ interface TiktokConnectorOptionsBase {
 }
 
 export interface TiktokOrganicConnectorOptions extends TiktokConnectorOptionsBase {
-  readonly accountType: "organic-account"
+  readonly api: "organic"
   /** Client ID from the TikTok for Business app. */
   readonly clientId: string
   readonly clientSecret: string
@@ -20,10 +20,10 @@ export interface TiktokOrganicConnectorOptions extends TiktokConnectorOptionsBas
 }
 
 export interface TiktokAdsConnectorOptions extends TiktokConnectorOptionsBase {
-  readonly accountType: "ad-account"
+  readonly api: "marketing"
   readonly appId: string
   readonly secret: string
-  /** Optional Ads authorization scope string. Omit to request the app's current permissions. */
+  /** Optional Marketing API authorization scope. Omit to request the app's current permissions. */
   readonly scope?: string
 }
 

--- a/connectors/tiktok/src/types/organic.ts
+++ b/connectors/tiktok/src/types/organic.ts
@@ -1,0 +1,277 @@
+import type { TiktokCursorPage, TiktokExtensible, TiktokSortOrder } from "./common"
+
+export type TiktokOrganicProfileField =
+  | "is_business_account"
+  | "profile_image"
+  | "username"
+  | "profile_deep_link"
+  | "display_name"
+  | "bio_description"
+  | "is_verified"
+  | "following_count"
+  | "followers_count"
+  | "total_likes"
+  | "videos_count"
+  | "video_views"
+  | "unique_video_views"
+  | "profile_views"
+  | "likes"
+  | "comments"
+  | "shares"
+  | "phone_number_clicks"
+  | "lead_submissions"
+  | "app_download_clicks"
+  | "bio_link_clicks"
+  | "email_clicks"
+  | "address_clicks"
+  | "daily_total_followers"
+  | "daily_new_followers"
+  | "daily_lost_followers"
+  | "audience_activity"
+  | "engaged_audience"
+  | "audience_ages"
+  | "audience_genders"
+  | "audience_countries"
+  | "audience_cities"
+
+export interface TiktokAudienceActivity {
+  readonly hour: string
+  readonly count: number
+}
+
+export interface TiktokAudienceAge {
+  readonly age: TiktokExtensible<"18-24" | "25-34" | "35-44" | "45-54" | "55+">
+  readonly percentage: number
+}
+
+export interface TiktokAudienceGender {
+  readonly gender: TiktokExtensible<"Female" | "Male" | "Other">
+  readonly percentage: number
+}
+
+export interface TiktokAudienceCountry {
+  readonly country: string
+  readonly percentage: number
+}
+
+export interface TiktokAudienceCity {
+  readonly city_name: string
+  readonly percentage: number
+}
+
+export interface TiktokOrganicProfileMetric {
+  readonly date: string
+  readonly video_views?: number
+  readonly unique_video_views?: number
+  readonly profile_views?: number
+  readonly likes?: number
+  readonly comments?: number
+  readonly shares?: number
+  readonly phone_number_clicks?: number
+  readonly lead_submissions?: number
+  readonly app_download_clicks?: number
+  readonly bio_link_clicks?: number
+  readonly email_clicks?: number
+  readonly address_clicks?: number
+  readonly daily_total_followers?: number
+  readonly daily_new_followers?: number
+  readonly daily_lost_followers?: number
+  readonly audience_activity?: readonly TiktokAudienceActivity[]
+  readonly engaged_audience?: number
+  readonly audience_ages?: readonly TiktokAudienceAge[]
+  readonly audience_genders?: readonly TiktokAudienceGender[]
+  readonly audience_countries?: readonly TiktokAudienceCountry[]
+  readonly audience_cities?: readonly TiktokAudienceCity[]
+  readonly [field: string]: unknown
+}
+
+export interface TiktokOrganicProfile {
+  readonly business_id?: string
+  readonly is_business_account?: boolean
+  readonly profile_image?: string
+  readonly username?: string
+  readonly profile_deep_link?: string
+  readonly display_name?: string
+  readonly bio_description?: string
+  readonly is_verified?: boolean
+  readonly following_count?: number
+  readonly followers_count?: number
+  readonly total_likes?: number
+  readonly videos_count?: number
+  readonly metrics?: readonly TiktokOrganicProfileMetric[]
+  readonly [field: string]: unknown
+}
+
+export interface TiktokOrganicProfileQuery {
+  /** UTC date in `YYYY-MM-DD` format. TikTok accepts at most a 60-day window. */
+  readonly startDate?: string
+  /** UTC date in `YYYY-MM-DD` format. */
+  readonly endDate?: string
+  /** Omit to use TikTok's default `display_name` and `profile_image` fields. */
+  readonly fields?: readonly TiktokOrganicProfileField[]
+}
+
+export type TiktokOrganicPostField =
+  | "item_id"
+  | "media_type"
+  | "is_ad"
+  | "thumbnail_url"
+  | "share_url"
+  | "embed_url"
+  | "caption"
+  | "video_duration"
+  | "likes"
+  | "comments"
+  | "shares"
+  | "favorites"
+  | "create_time"
+  | "reach"
+  | "video_views"
+  | "total_time_watched"
+  | "average_time_watched"
+  | "full_video_watched_rate"
+  | "new_followers"
+  | "profile_views"
+  | "website_clicks"
+  | "phone_number_clicks"
+  | "lead_submissions"
+  | "app_download_clicks"
+  | "email_clicks"
+  | "address_clicks"
+  | "video_view_retention"
+  | "impression_sources"
+  | "audience_genders"
+  | "audience_countries"
+  | "audience_cities"
+  | "audience_types"
+  | "engagement_likes"
+
+export interface TiktokPercentageAtSecond {
+  readonly second: number
+  readonly percentage: number
+}
+
+export interface TiktokPercentageBySource {
+  readonly impression_source: string
+  readonly percentage: number
+}
+
+export interface TiktokAudienceType {
+  readonly type: TiktokExtensible<
+    "NEW_VIEWER" | "RETURN_VIEWER" | "FOLLOWER_PERCENT" | "NON_FOLLOWER_PERCENT"
+  >
+  readonly percentage: number
+}
+
+export interface TiktokOrganicPost {
+  readonly item_id: string
+  readonly media_type?: TiktokExtensible<"VIDEO" | "PHOTO">
+  readonly is_ad?: boolean
+  readonly thumbnail_url?: string
+  readonly share_url?: string
+  readonly embed_url?: string
+  readonly caption?: string
+  readonly video_duration?: number
+  readonly likes?: number
+  readonly comments?: number
+  readonly shares?: number
+  readonly favorites?: number
+  /** Unix timestamp returned as a string by TikTok. */
+  readonly create_time?: string
+  readonly reach?: number
+  readonly video_views?: number
+  readonly total_time_watched?: number
+  readonly average_time_watched?: number
+  readonly full_video_watched_rate?: number
+  readonly new_followers?: number
+  readonly profile_views?: number
+  readonly website_clicks?: number
+  readonly phone_number_clicks?: number
+  readonly lead_submissions?: number
+  readonly app_download_clicks?: number
+  readonly email_clicks?: number
+  readonly address_clicks?: number
+  readonly video_view_retention?: readonly TiktokPercentageAtSecond[]
+  readonly impression_sources?: readonly TiktokPercentageBySource[]
+  readonly audience_genders?: readonly TiktokAudienceGender[]
+  readonly audience_countries?: readonly TiktokAudienceCountry[]
+  readonly audience_cities?: readonly TiktokAudienceCity[]
+  readonly audience_types?: readonly TiktokAudienceType[]
+  readonly engagement_likes?: readonly TiktokPercentageAtSecond[]
+  readonly [field: string]: unknown
+}
+
+export interface TiktokOrganicPostsListQuery {
+  /** Omit to request only TikTok's default `item_id` field. */
+  readonly fields?: readonly TiktokOrganicPostField[]
+  readonly videoIds?: readonly string[]
+  readonly adPostOnly?: boolean
+  /** Cursor from `nextCursor`, expressed as Unix time in milliseconds. */
+  readonly cursor?: number
+  /** 1-20. Defaults to TikTok's page size. */
+  readonly maxCount?: number
+}
+
+export type TiktokCommentStatus = "PUBLIC" | "ALL"
+export type TiktokCommentSortField = "likes" | "replies" | "create_time"
+
+export interface TiktokOrganicComment {
+  readonly comment_id: string
+  readonly video_id: string
+  readonly user_id?: string
+  readonly unique_identifier?: string
+  readonly create_time?: number
+  readonly text?: string
+  readonly likes?: number
+  readonly replies?: number
+  readonly owner?: boolean
+  readonly liked?: boolean
+  readonly pinned?: boolean
+  readonly status?: TiktokExtensible<"HIDDEN" | "PUBLIC">
+  readonly username?: string
+  readonly display_name?: string
+  readonly profile_image?: string
+  readonly parent_comment_id?: string
+  readonly reply_list?: readonly TiktokOrganicComment[]
+  readonly image_url?: string
+  readonly [field: string]: unknown
+}
+
+interface TiktokCommentsListQueryBase {
+  readonly videoId: string
+  readonly status?: TiktokCommentStatus
+  readonly sortField?: TiktokCommentSortField
+  readonly sortOrder?: TiktokSortOrder
+  readonly cursor?: number
+  /** 1-30. Defaults to TikTok's page size. */
+  readonly maxCount?: number
+}
+
+export interface TiktokOrganicCommentsListQuery extends TiktokCommentsListQueryBase {
+  readonly commentIds?: readonly string[]
+  readonly includeReplies?: boolean
+}
+
+export interface TiktokOrganicRepliesListQuery extends TiktokCommentsListQueryBase {
+  readonly commentId: string
+}
+
+export interface TiktokOrganicProfileApi {
+  get(query?: TiktokOrganicProfileQuery): Promise<TiktokOrganicProfile>
+}
+
+export interface TiktokOrganicPostsApi {
+  list(query?: TiktokOrganicPostsListQuery): Promise<TiktokCursorPage<TiktokOrganicPost>>
+  listAll(query?: TiktokOrganicPostsListQuery): AsyncIterable<TiktokOrganicPost>
+}
+
+export interface TiktokOrganicRepliesApi {
+  list(query: TiktokOrganicRepliesListQuery): Promise<TiktokCursorPage<TiktokOrganicComment>>
+  listAll(query: TiktokOrganicRepliesListQuery): AsyncIterable<TiktokOrganicComment>
+}
+
+export interface TiktokOrganicCommentsApi {
+  readonly replies: TiktokOrganicRepliesApi
+  list(query: TiktokOrganicCommentsListQuery): Promise<TiktokCursorPage<TiktokOrganicComment>>
+  listAll(query: TiktokOrganicCommentsListQuery): AsyncIterable<TiktokOrganicComment>
+}

--- a/connectors/tiktok/tests/tiktok.test.ts
+++ b/connectors/tiktok/tests/tiktok.test.ts
@@ -1,0 +1,629 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { ConnectorOAuthError } from "@sixb/core"
+import { TiktokApiError, tiktok } from "../src"
+
+const originalFetch = globalThis.fetch
+const signal = new AbortController().signal
+const context = { projectId: "demo", connectorId: "tiktok", signal }
+const authorizationContext = {
+  ...context,
+  redirectUri: "https://api.example.com/auth/connectors/callback",
+}
+const authorizationInput = {
+  state: "signed-state",
+  codeChallenge: "pkce-challenge",
+  codeChallengeMethod: "S256" as const,
+}
+
+beforeEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("TikTok OAuth", () => {
+  test("builds the organic account-holder URL with its exact trailing-slash redirect", () => {
+    const adapter = organicAdapter()
+    const url = new URL(
+      adapter.authentication.authorizationUrl(authorizationContext, authorizationInput).toString()
+    )
+
+    expect(url.origin).toBe("https://www.tiktok.com")
+    expect(url.searchParams.get("client_key")).toBe("portal-client")
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://api.example.com/auth/connectors/callback/"
+    )
+    expect(url.searchParams.get("state")).toBe("signed-state")
+    expect(url.searchParams.get("code_challenge")).toBe("pkce-challenge")
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256")
+    expect(url.searchParams.get("disable_auto_auth")).toBe("1")
+  })
+
+  test("exchanges and refreshes organic tokens without sending an undocumented verifier", async () => {
+    const requests: CapturedRequest[] = []
+    mockFetch(async (input, init) => {
+      requests.push({ input, init })
+      const path = new URL(String(input)).pathname
+      if (path.endsWith("/refresh_token/")) {
+        return json({
+          code: 0,
+          message: "OK",
+          data: organicToken("access-2", "refresh-2"),
+        })
+      }
+      return json({
+        code: 0,
+        message: "OK",
+        request_id: "request-1",
+        data: organicToken("access-1", "refresh-1"),
+      })
+    })
+
+    const adapter = organicAdapter()
+    const exchanged = await adapter.authentication.exchangeCode(authorizationContext, {
+      code: "provider-code",
+      codeVerifier: "must-not-leave-sixb",
+    })
+    const refreshed = await adapter.authentication.refresh(context, exchanged)
+
+    expect(exchanged.accessToken).toBe("access-1")
+    expect(exchanged.refreshToken).toBe("refresh-1")
+    expect(exchanged.scopes).toEqual(["user.info.basic", "video.list"])
+    expect(exchanged.expiresAt?.getTime()).toBeGreaterThan(Date.now())
+    expect(refreshed.accessToken).toBe("access-2")
+    expect(requestBody(requests[0])).toEqual({
+      client_id: "client-id",
+      client_secret: "client-secret",
+      grant_type: "authorization_code",
+      auth_code: "provider-code",
+      redirect_uri: "https://api.example.com/auth/connectors/callback/",
+    })
+    expect(JSON.stringify(requestBody(requests[0]))).not.toContain("must-not-leave-sixb")
+    expect(requestBody(requests[1])).toEqual({
+      client_id: "client-id",
+      client_secret: "client-secret",
+      grant_type: "refresh_token",
+      refresh_token: "refresh-1",
+    })
+  })
+
+  test("builds and exchanges the distinct Ads grant", async () => {
+    const requests: CapturedRequest[] = []
+    mockFetch(async (input, init) => {
+      requests.push({ input, init })
+      return new Response(
+        '{"code":0,"message":"OK","data":{"access_token":"ads-token","advertiser_ids":["adv-1"],"scope":[9007199254740993]}}',
+        { headers: { "content-type": "application/json" } }
+      )
+    })
+
+    const adapter = adsAdapter()
+    const url = new URL(
+      adapter.authentication.authorizationUrl(authorizationContext, authorizationInput).toString()
+    )
+    const credentials = await adapter.authentication.exchangeCode(authorizationContext, {
+      code: "ads-code",
+      codeVerifier: "must-not-leave-sixb",
+    })
+
+    expect(url.toString()).toStartWith("https://ads.tiktok.com/marketing_api/auth?")
+    expect(url.searchParams.get("app_id")).toBe("app-id")
+    expect(url.searchParams.get("redirect_uri")).toBe(authorizationContext.redirectUri)
+    expect(url.searchParams.get("scope")).toBe("ads.read")
+    expect(credentials).toEqual({
+      accessToken: "ads-token",
+      tokenType: "Bearer",
+      scopes: ["ads.read"],
+    })
+    expect(requestBody(requests[0])).toEqual({
+      app_id: "app-id",
+      secret: "app-secret",
+      auth_code: "ads-code",
+      return_advertiser_ids: true,
+    })
+  })
+
+  test("marks Ads refresh as terminal because TikTok has no refresh endpoint", () => {
+    const adapter = adsAdapter()
+    expect(() => adapter.authentication.refresh(context, { accessToken: "ads-token" })).toThrow(
+      ConnectorOAuthError
+    )
+    try {
+      adapter.authentication.refresh(context, { accessToken: "ads-token" })
+    } catch (error) {
+      expect((error as ConnectorOAuthError).kind).toBe("terminal")
+    }
+  })
+
+  test("revokes each grant through its own endpoint and authentication shape", async () => {
+    const requests: CapturedRequest[] = []
+    mockFetch(async (input, init) => {
+      requests.push({ input, init })
+      return json({ code: 0, message: "OK", data: {} })
+    })
+
+    await organicAdapter().authentication.revoke?.(context, { accessToken: "organic-token" })
+    await adsAdapter().authentication.revoke?.(context, { accessToken: "ads-token" })
+
+    expect(requests.map((request) => new URL(String(request.input)).pathname)).toEqual([
+      "/open_api/v1.3/tt_user/oauth2/revoke/",
+      "/open_api/v1.3/oauth2/revoke_token/",
+    ])
+    expect(requestBody(requests[0])).toEqual({
+      client_id: "client-id",
+      client_secret: "client-secret",
+      access_token: "organic-token",
+    })
+    expect(requestBody(requests[1])).toEqual({
+      app_id: "app-id",
+      secret: "app-secret",
+      access_token: "ads-token",
+    })
+    expect(new Headers(requests[1]?.init?.headers).get("access-token")).toBe("ads-token")
+  })
+
+  test("classifies a malformed successful token response as ambiguous", async () => {
+    mockFetch(async () => json({ code: 0, message: "OK", data: { access_token: "partial" } }))
+
+    try {
+      await organicAdapter().authentication.exchangeCode(authorizationContext, {
+        code: "provider-code",
+        codeVerifier: "verifier",
+      })
+      throw new Error("expected exchange to fail")
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConnectorOAuthError)
+      expect((error as ConnectorOAuthError).kind).toBe("ambiguous")
+    }
+  })
+})
+
+describe("TikTok organic resources", () => {
+  test("discovers the creator account through the token inspector", async () => {
+    const requests: CapturedRequest[] = []
+    mockFetch(async (input, init) => {
+      requests.push({ input, init })
+      const path = new URL(String(input)).pathname
+      return path.endsWith("/tt_user/token_info/get/")
+        ? json({ code: 0, message: "OK", data: { creator_id: "creator-1" } })
+        : json({
+            code: 0,
+            message: "OK",
+            data: {
+              display_name: "Acme TikTok",
+              username: "acme",
+              profile_image: "https://cdn.example.com/avatar.jpg",
+            },
+          })
+    })
+
+    const accounts = await organicAdapter().discoverAccounts(context, {
+      accessToken: "organic-token",
+    })
+
+    expect(accounts).toEqual([
+      {
+        id: "creator-1",
+        label: "Acme TikTok",
+        description: "@acme",
+        avatarUrl: "https://cdn.example.com/avatar.jpg",
+      },
+    ])
+    expect(requestBody(requests[0])).toEqual({
+      app_id: "client-id",
+      access_token: "organic-token",
+    })
+    expect(new Headers(requests[0]?.init?.headers).get("access-token")).toBeNull()
+    expect(new Headers(requests[1]?.init?.headers).get("access-token")).toBe("organic-token")
+  })
+
+  test("paginates posts and serializes TikTok fields and filters as JSON", async () => {
+    const requests: CapturedRequest[] = []
+    mockFetch(async (input, init) => {
+      requests.push({ input, init })
+      const cursor = new URL(String(input)).searchParams.get("cursor")
+      return cursor
+        ? json({
+            code: 0,
+            message: "OK",
+            data: { videos: [{ item_id: "post-2" }], cursor: 200, has_more: false },
+          })
+        : json({
+            code: 0,
+            message: "OK",
+            data: { videos: [{ item_id: "post-1" }], cursor: 100, has_more: true },
+          })
+    })
+
+    const client = await organicClient()
+    const posts = await collect(
+      client.posts.listAll({
+        fields: ["item_id", "video_views"],
+        videoIds: ["post-1", "post-2"],
+        adPostOnly: false,
+        maxCount: 20,
+      })
+    )
+
+    expect(posts.map((post) => post.item_id)).toEqual(["post-1", "post-2"])
+    const first = new URL(String(requests[0]?.input))
+    const second = new URL(String(requests[1]?.input))
+    expect(JSON.parse(first.searchParams.get("fields") ?? "null")).toEqual([
+      "item_id",
+      "video_views",
+    ])
+    expect(JSON.parse(first.searchParams.get("filters") ?? "null")).toEqual({
+      video_ids: ["post-1", "post-2"],
+      ad_post_only: false,
+    })
+    expect(second.searchParams.get("cursor")).toBe("100")
+    expect(first.searchParams.get("business_id")).toBe("creator-1")
+  })
+
+  test("lists replies with the selected account and comment identifiers", async () => {
+    let requested = ""
+    mockFetch(async (input) => {
+      requested = String(input)
+      return json({
+        code: 0,
+        message: "OK",
+        data: { comments: [{ comment_id: "reply-1", video_id: "video-1" }], has_more: false },
+      })
+    })
+
+    const client = await organicClient()
+    const page = await client.comments.replies.list({
+      videoId: "video-1",
+      commentId: "comment-1",
+      status: "PUBLIC",
+      maxCount: 30,
+    })
+
+    expect(page.items[0]?.comment_id).toBe("reply-1")
+    const url = new URL(requested)
+    expect(url.pathname).toEndWith("/business/comment/reply/list/")
+    expect(url.searchParams.get("business_id")).toBe("creator-1")
+    expect(url.searchParams.get("comment_id")).toBe("comment-1")
+  })
+
+  test("requests profile insights and top-level comments with documented parameters", async () => {
+    const requests: string[] = []
+    mockFetch(async (input) => {
+      requests.push(String(input))
+      const path = new URL(String(input)).pathname
+      return path.endsWith("/business/get/")
+        ? json({
+            code: 0,
+            message: "OK",
+            data: { display_name: "Acme", metrics: [{ date: "2026-08-01", video_views: 12 }] },
+          })
+        : json({
+            code: 0,
+            message: "OK",
+            data: { comments: [{ comment_id: "comment-1", video_id: "video-1" }], has_more: false },
+          })
+    })
+
+    const client = await organicClient()
+    const profile = await client.profile.get({
+      startDate: "2026-08-01",
+      endDate: "2026-08-02",
+      fields: ["display_name", "video_views"],
+    })
+    const comments = await client.comments.list({
+      videoId: "video-1",
+      includeReplies: true,
+      sortField: "create_time",
+      sortOrder: "desc",
+    })
+
+    expect(profile.metrics?.[0]?.video_views).toBe(12)
+    expect(comments.items[0]?.comment_id).toBe("comment-1")
+    const profileUrl = new URL(requests[0] ?? "")
+    const commentsUrl = new URL(requests[1] ?? "")
+    expect(profileUrl.searchParams.get("start_date")).toBe("2026-08-01")
+    expect(profileUrl.searchParams.get("end_date")).toBe("2026-08-02")
+    expect(commentsUrl.searchParams.get("include_replies")).toBe("true")
+    expect(commentsUrl.searchParams.get("sort_order")).toBe("desc")
+  })
+})
+
+describe("TikTok Ads resources", () => {
+  test("discovers authorized advertiser accounts", async () => {
+    let requested = ""
+    mockFetch(async (input, init) => {
+      requested = String(input)
+      expect(new Headers(init?.headers).get("access-token")).toBe("ads-token")
+      return json({
+        code: 0,
+        message: "OK",
+        data: { list: [{ advertiser_id: "adv-1", advertiser_name: "Acme Ads" }] },
+      })
+    })
+
+    const accounts = await adsAdapter().discoverAccounts(context, { accessToken: "ads-token" })
+
+    expect(accounts).toEqual([{ id: "adv-1", label: "Acme Ads" }])
+    const url = new URL(requested)
+    expect(url.pathname).toEndWith("/oauth2/advertiser/get/")
+    expect(url.searchParams.get("app_id")).toBe("app-id")
+    expect(url.searchParams.get("secret")).toBe("app-secret")
+  })
+
+  test("scopes campaign pagination to the selected advertiser", async () => {
+    const requests: string[] = []
+    mockFetch(async (input) => {
+      requests.push(String(input))
+      const page = Number(new URL(String(input)).searchParams.get("page"))
+      return json({
+        code: 0,
+        message: "OK",
+        data: {
+          list: [{ advertiser_id: "adv-1", campaign_id: `campaign-${page}` }],
+          page_info: { page, page_size: 1, total_number: 2, total_page: 2 },
+        },
+      })
+    })
+
+    const client = await adsClient()
+    const campaigns = await collect(
+      client.campaigns.listAll({
+        fields: ["campaign_id", "campaign_name"],
+        filtering: { campaign_ids: ["campaign-1"] },
+        pageSize: 1,
+      })
+    )
+
+    expect(campaigns.map((campaign) => campaign.campaign_id)).toEqual(["campaign-1", "campaign-2"])
+    expect(requests.map((request) => new URL(request).searchParams.get("advertiser_id"))).toEqual([
+      "adv-1",
+      "adv-1",
+    ])
+    expect(JSON.parse(new URL(requests[0] ?? "").searchParams.get("filtering") ?? "null")).toEqual({
+      campaign_ids: ["campaign-1"],
+    })
+  })
+
+  test("runs paginated reports and exposes Ads throttle metadata", async () => {
+    const observed: string[] = []
+    const requests: string[] = []
+    mockFetch(async (input) => {
+      requests.push(String(input))
+      const page = Number(new URL(String(input)).searchParams.get("page"))
+      return json(
+        {
+          code: 0,
+          message: "OK",
+          request_id: `request-${page}`,
+          data: {
+            list: [{ dimensions: { ad_id: `ad-${page}` }, metrics: { spend: "1.20" } }],
+            page_info: { page, page_size: 1, total_number: 2, total_page: 2 },
+          },
+        },
+        { headers: { "x-tt-ads-throttle": `quota-${page}` } }
+      )
+    })
+
+    const client = await adsClient((metadata) => {
+      if (metadata.adsThrottle) observed.push(metadata.adsThrottle)
+    })
+    const rows = await collect(
+      client.reports.runAll({
+        serviceType: "AUCTION",
+        reportType: "BASIC",
+        dataLevel: "AUCTION_AD",
+        dimensions: ["ad_id"],
+        metrics: ["spend"],
+        startDate: "2026-08-01",
+        endDate: "2026-08-02",
+        pageSize: 1,
+      })
+    )
+
+    expect(rows.map((row) => row.metrics.spend)).toEqual(["1.20", "1.20"])
+    expect(observed).toEqual(["quota-1", "quota-2"])
+    const url = new URL(requests[0] ?? "")
+    expect(url.searchParams.get("advertiser_id")).toBe("adv-1")
+    expect(JSON.parse(url.searchParams.get("dimensions") ?? "null")).toEqual(["ad_id"])
+    expect(JSON.parse(url.searchParams.get("metrics") ?? "null")).toEqual(["spend"])
+  })
+
+  test("reads advertiser, ad-group, and ad resources from their documented endpoints", async () => {
+    const requests: string[] = []
+    mockFetch(async (input) => {
+      requests.push(String(input))
+      const path = new URL(String(input)).pathname
+      if (path.endsWith("/advertiser/info/")) {
+        return json({
+          code: 0,
+          message: "OK",
+          data: { list: [{ advertiser_id: "adv-1", name: "Acme Ads", currency: "USD" }] },
+        })
+      }
+      const list = path.endsWith("/adgroup/get/")
+        ? [{ advertiser_id: "adv-1", campaign_id: "campaign-1", adgroup_id: "group-1" }]
+        : [
+            {
+              advertiser_id: "adv-1",
+              campaign_id: "campaign-1",
+              adgroup_id: "group-1",
+              ad_id: "ad-1",
+            },
+          ]
+      return json({
+        code: 0,
+        message: "OK",
+        data: { list, page_info: { page: 1, page_size: 100, total_number: 1 } },
+      })
+    })
+
+    const client = await adsClient()
+    const advertiser = await client.adAccount.get(["advertiser_id", "name", "currency"])
+    const adGroups = await client.adGroups.list({ pageSize: 100 })
+    const ads = await client.ads.list({ pageSize: 100 })
+
+    expect(advertiser.currency).toBe("USD")
+    expect(adGroups.items[0]?.adgroup_id).toBe("group-1")
+    expect(ads.items[0]?.ad_id).toBe("ad-1")
+    expect(requests.map((request) => new URL(request).pathname)).toEqual([
+      "/open_api/v1.3/advertiser/info/",
+      "/open_api/v1.3/adgroup/get/",
+      "/open_api/v1.3/ad/get/",
+    ])
+    for (const request of requests) {
+      const url = new URL(request)
+      const advertiserIds = url.searchParams.get("advertiser_ids")
+      expect(url.searchParams.get("advertiser_id") ?? advertiserIds).toContain("adv-1")
+    }
+  })
+
+  test("invalidates a rejected token and retries once with the refreshed value", async () => {
+    const usedTokens: string[] = []
+    mockFetch(async (_input, init) => {
+      const token = new Headers(init?.headers).get("access-token") ?? ""
+      usedTokens.push(token)
+      return token === "old-token"
+        ? json({ code: 40100, message: "Access token is invalid", data: {} }, { status: 401 })
+        : json({
+            code: 0,
+            message: "OK",
+            data: {
+              list: [{ advertiser_id: "adv-1", name: "Acme" }],
+            },
+          })
+    })
+
+    let invalidated = false
+    const adapter = adsAdapter()
+    const client = await adapter.connect({
+      ...context,
+      connectionId: "connection-1",
+      account: { id: "adv-1", label: "Acme" },
+      tokenSource: {
+        async get() {
+          const accessToken = invalidated ? "new-token" : "old-token"
+          return { accessToken, invalidate: () => (invalidated = true) }
+        },
+      },
+    })
+
+    expect((await client.adAccount.get()).name).toBe("Acme")
+    expect(usedTokens).toEqual(["old-token", "new-token"])
+  })
+
+  test("preserves structured API failures", async () => {
+    mockFetch(async () =>
+      json({ code: 40002, message: "Invalid advertiser", request_id: "req-bad", data: {} })
+    )
+    const client = await adsClient()
+
+    try {
+      await client.ads.list()
+      throw new Error("expected request to fail")
+    } catch (error) {
+      expect(error).toBeInstanceOf(TiktokApiError)
+      expect((error as TiktokApiError).code).toBe(40002)
+      expect((error as TiktokApiError).requestId).toBe("req-bad")
+    }
+  })
+})
+
+function organicAdapter() {
+  return tiktok({
+    accountType: "organic-account",
+    clientId: "client-id",
+    clientSecret: "client-secret",
+    authorizationUrl:
+      "https://www.tiktok.com/v2/auth/authorize/?client_key=portal-client&response_type=code",
+    disableAutoAuth: true,
+    baseUrl: "https://business-api.example.com/open_api/v1.3/",
+    retry: { maxRetries: 0 },
+  })
+}
+
+function adsAdapter(onResponse?: Parameters<typeof tiktok>[0]["onResponse"]) {
+  return tiktok({
+    accountType: "ad-account",
+    appId: "app-id",
+    secret: "app-secret",
+    scope: "ads.read",
+    baseUrl: "https://business-api.example.com/open_api/v1.3/",
+    retry: { maxRetries: 0 },
+    onResponse,
+  })
+}
+
+async function organicClient() {
+  return organicAdapter().connect({
+    ...context,
+    connectionId: "connection-1",
+    account: { id: "creator-1", label: "Acme TikTok" },
+    tokenSource: staticToken("organic-token"),
+  })
+}
+
+async function adsClient(onResponse?: Parameters<typeof tiktok>[0]["onResponse"]) {
+  const adapter = tiktok({
+    accountType: "ad-account",
+    appId: "app-id",
+    secret: "app-secret",
+    baseUrl: "https://business-api.example.com/open_api/v1.3/",
+    retry: { maxRetries: 0 },
+    onResponse,
+  })
+  return adapter.connect({
+    ...context,
+    connectionId: "connection-1",
+    account: { id: "adv-1", label: "Acme Ads" },
+    tokenSource: staticToken("ads-token"),
+  })
+}
+
+function staticToken(accessToken: string) {
+  return {
+    async get() {
+      return { accessToken, invalidate() {} }
+    },
+  }
+}
+
+function organicToken(accessToken: string, refreshToken: string) {
+  return {
+    access_token: accessToken,
+    expires_in: 86_400,
+    refresh_token: refreshToken,
+    refresh_token_expires_in: 31_536_000,
+    scope: "user.info.basic,video.list",
+    token_type: "Bearer",
+  }
+}
+
+type CapturedRequest = {
+  readonly input: RequestInfo | URL
+  readonly init?: RequestInit
+}
+
+function mockFetch(
+  implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+): void {
+  globalThis.fetch = implementation as typeof fetch
+}
+
+function json(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  })
+}
+
+function requestBody(request: CapturedRequest | undefined): unknown {
+  return JSON.parse(String(request?.init?.body))
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const items: T[] = []
+  for await (const item of iterable) items.push(item)
+  return items
+}

--- a/connectors/tiktok/tests/tiktok.test.ts
+++ b/connectors/tiktok/tests/tiktok.test.ts
@@ -89,7 +89,7 @@ describe("TikTok OAuth", () => {
     })
   })
 
-  test("builds and exchanges the distinct Ads grant", async () => {
+  test("builds and exchanges the distinct Marketing API grant", async () => {
     const requests: CapturedRequest[] = []
     mockFetch(async (input, init) => {
       requests.push({ input, init })
@@ -125,7 +125,7 @@ describe("TikTok OAuth", () => {
     })
   })
 
-  test("marks Ads refresh as terminal because TikTok has no refresh endpoint", () => {
+  test("marks Marketing API refresh as terminal because TikTok has no refresh endpoint", () => {
     const adapter = adsAdapter()
     expect(() => adapter.authentication.refresh(context, { accessToken: "ads-token" })).toThrow(
       ConnectorOAuthError
@@ -532,7 +532,7 @@ describe("TikTok Ads resources", () => {
 
 function organicAdapter() {
   return tiktok({
-    accountType: "organic-account",
+    api: "organic",
     clientId: "client-id",
     clientSecret: "client-secret",
     authorizationUrl:
@@ -545,7 +545,7 @@ function organicAdapter() {
 
 function adsAdapter(onResponse?: Parameters<typeof tiktok>[0]["onResponse"]) {
   return tiktok({
-    accountType: "ad-account",
+    api: "marketing",
     appId: "app-id",
     secret: "app-secret",
     scope: "ads.read",
@@ -566,7 +566,7 @@ async function organicClient() {
 
 async function adsClient(onResponse?: Parameters<typeof tiktok>[0]["onResponse"]) {
   const adapter = tiktok({
-    accountType: "ad-account",
+    api: "marketing",
     appId: "app-id",
     secret: "app-secret",
     baseUrl: "https://business-api.example.com/open_api/v1.3/",

--- a/connectors/tiktok/tsconfig.build.json
+++ b/connectors/tiktok/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "composite": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../packages/core/tsconfig.build.json"
+    },
+    {
+      "path": "../rest/tsconfig.build.json"
+    }
+  ]
+}

--- a/connectors/tiktok/tsconfig.json
+++ b/connectors/tiktok/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/docs/data/connectors.md
+++ b/docs/data/connectors.md
@@ -411,6 +411,7 @@ to `defineConnector`, and most ship a matching webhook helper for the [Webhooks]
 | `@sixb/connector-pipedrive` | `pipedrive(...)` | Pipedrive CRM | `pipedriveEventsWebhook` |
 | `@sixb/connector-stripe` | `stripe(...)` | Stripe customers, subscriptions, invoices, refunds, events | `stripeEventsWebhook` |
 | `@sixb/connector-teamleader` | `teamleader(...)` | Teamleader CRM, invoicing, quotations | `defineTeamleaderWebhook` |
+| `@sixb/connector-tiktok` | `tiktok(...)` | TikTok organic accounts and Ads reporting | — |
 | `@sixb/connector-pandadoc` | `pandadoc(...)` | PandaDoc documents and e-signatures | `pandaDocEventsWebhook` |
 | `@sixb/connector-companycam` | `companycam(...)` | CompanyCam jobsite photos | `companyCamEventsWebhook` |
 | `@sixb/connector-pennylane` | `pennylane(...)` | Pennylane quotes, products, customers | — |

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -65,6 +65,9 @@
       "path": "connectors/teamleader/tsconfig.build.json"
     },
     {
+      "path": "connectors/tiktok/tsconfig.build.json"
+    },
+    {
       "path": "connectors/unipile/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
       "@sixb/connector-sql": ["./connectors/sql/src/index.ts"],
       "@sixb/connector-stripe": ["./connectors/stripe/src/index.ts"],
       "@sixb/connector-teamleader": ["./connectors/teamleader/src/index.ts"],
+      "@sixb/connector-tiktok": ["./connectors/tiktok/src/index.ts"],
       "@sixb/connector-unipile": ["./connectors/unipile/src/index.ts"],
       "@sixb/core": ["./packages/core/src/index.ts"],
       "@sixb/core/actions/worker": ["./packages/core/src/actions/worker.ts"],


### PR DESCRIPTION
## What this adds

| TikTok API | OAuth identity | Read resources |
| --- | --- | --- |
| Organic API | TikTok account holder | Profile, posts, comments, replies |
| Marketing API | TikTok for Business user | Ad account, campaigns, ad groups, ads, reports |

- New public package: `@sixb/connector-tiktok`
- OAuth selected explicitly with `api: "organic" | "marketing"`
- Connected entities typed as `tiktok-account | ad-account`
- Typed v1.3 wire objects, filters, pagination helpers, retries, and structured errors
- README, tests, workspace registration, changelog, and publish configuration

## Why this shape

- **Two API families:** each uses distinct authorization, token, refresh, and revoke contracts.
- **One account per connection:** requests always inject the selected creator or advertiser ID.
- **Faithful wire data:** TikTok field names and report metric strings remain unchanged.
- **Read-only scope:** focused on organic and advertising data ingestion.

## Authentication choices

- Organic redirect URIs are normalized to TikTok's required trailing slash.
- Organic tokens refresh automatically; Marketing API tokens require reauthorization when rejected.
- TikTok does not document PKCE: the required challenge is sent, but no undocumented verifier reaches token endpoints.
- Depends on #455 for the TikTok `auth_code` callback parameter.

## Validation

- Connector tests: **16 passed**
- Repository tests: **4,219 passed**, **7 skipped**
- `typecheck`, `check`, `build`, and `test:publish` passed
