### PR TITLE
atlas: add workflow node execution debugging

### DIFF
--- a/packages/agent-ui/src/AgentExecutionTrace.tsx
+++ b/packages/agent-ui/src/AgentExecutionTrace.tsx
@@ -1,0 +1,316 @@
+import { Collapsible, CollapsibleContent, CollapsibleTrigger, Markdown } from "@sixb/ui/components"
+import { cn } from "@sixb/ui/lib/utils"
+import {
+  Brain,
+  Check,
+  CheckCircle2,
+  ChevronRight,
+  Copy,
+  FileText,
+  MessageSquareText,
+  Wrench,
+  XCircle,
+} from "lucide-react"
+import { type ReactElement, useEffect, useState } from "react"
+import { FileAttachmentCard } from "./components/FileAttachmentCard"
+import { AssistantBody } from "./components/MessageParts"
+import { type NormalizedPart, normalizeDurableParts } from "./parts"
+import type { AgentMessagePart } from "./types"
+
+export type AgentExecutionTraceVariant = "conversation" | "debug"
+
+export interface AgentExecutionTraceProps {
+  readonly parts: readonly AgentMessagePart[]
+  readonly variant?: AgentExecutionTraceVariant
+}
+
+/** Read-only durable agent work, without thread or composer chrome. */
+export function AgentExecutionTrace({ parts, variant = "conversation" }: AgentExecutionTraceProps) {
+  const normalized = normalizeDurableParts(parts)
+  return variant === "debug" ? (
+    <DebugTrace parts={normalized} />
+  ) : (
+    <AssistantBody parts={normalized} />
+  )
+}
+
+interface DebugStep {
+  readonly parts: readonly NormalizedPart[]
+}
+
+function DebugTrace({ parts }: { parts: readonly NormalizedPart[] }) {
+  const steps = splitIntoSteps(parts)
+  return (
+    <div className="space-y-3">
+      {steps.map((step, index) => (
+        <DebugStepCard
+          key={index}
+          step={step}
+          index={index}
+          finalStep={index === steps.length - 1}
+        />
+      ))}
+    </div>
+  )
+}
+
+function splitIntoSteps(parts: readonly NormalizedPart[]): readonly DebugStep[] {
+  const steps: DebugStep[] = []
+  let current: NormalizedPart[] = []
+
+  const flush = () => {
+    if (current.length === 0) return
+    steps.push({ parts: current })
+    current = []
+  }
+
+  for (const part of parts) {
+    if (part.kind === "step-start") {
+      flush()
+    } else {
+      current.push(part)
+    }
+  }
+  flush()
+  return steps
+}
+
+function DebugStepCard({
+  step,
+  index,
+  finalStep,
+}: {
+  step: DebugStep
+  index: number
+  finalStep: boolean
+}) {
+  const reasoning = step.parts
+    .filter(
+      (part): part is Extract<NormalizedPart, { kind: "reasoning" }> => part.kind === "reasoning"
+    )
+    .map((part) => part.text)
+    .filter(Boolean)
+    .join("\n\n")
+  const tools = step.parts.filter(
+    (part): part is Extract<NormalizedPart, { kind: "tool" }> => part.kind === "tool"
+  )
+  const files = step.parts.filter(
+    (part): part is Extract<NormalizedPart, { kind: "file" }> => part.kind === "file"
+  )
+  const text = step.parts
+    .filter((part): part is Extract<NormalizedPart, { kind: "text" }> => part.kind === "text")
+    .map((part) => part.text)
+    .join("")
+    .trim()
+  const failedTools = tools.filter((part) => part.tool.state === "output-error").length
+  const finalAnswer = finalStep && tools.length === 0 && text.length > 0
+  const detail = finalAnswer
+    ? "Final response"
+    : tools.length > 0
+      ? `${tools.length} ${tools.length === 1 ? "tool call" : "tool calls"}`
+      : "Model response"
+
+  return (
+    <section className="overflow-hidden rounded-lg border border-border/70 bg-background/40">
+      <div className="flex items-center justify-between gap-3 border-b border-border/60 bg-muted/20 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Step {index + 1}
+          </span>
+          <span className="truncate text-xs text-muted-foreground/70">{detail}</span>
+        </div>
+        {failedTools > 0 ? (
+          <span className="flex shrink-0 items-center gap-1 text-[10px] font-medium text-destructive">
+            <XCircle className="size-3.5" /> Failed
+          </span>
+        ) : (
+          <CheckCircle2 className="size-3.5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+        )}
+      </div>
+      <div className="space-y-3 px-3 py-3">
+        {reasoning ? <ReasoningDisclosure text={reasoning} /> : null}
+        {text ? (
+          finalAnswer ? (
+            <FinalAnswerDisclosure text={text} />
+          ) : (
+            <div className="space-y-1.5">
+              <DebugLabel icon={<MessageSquareText />} label="Agent message" />
+              <Markdown className="prose-chat text-sm">{text}</Markdown>
+            </div>
+          )
+        ) : null}
+        {tools.map((part, toolIndex) => (
+          <DebugToolCall key={`${part.tool.toolName}-${toolIndex}`} tool={part.tool} />
+        ))}
+        {files.map((part, fileIndex) => (
+          <div key={`${part.fileRef.blobId}-${fileIndex}`} className="space-y-1.5">
+            <DebugLabel icon={<FileText />} label="File" />
+            <FileAttachmentCard fileRef={part.fileRef} document={part.document} />
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function ReasoningDisclosure({ text }: { text: string }) {
+  return (
+    <Collapsible>
+      <CollapsibleTrigger className="group flex w-fit items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground">
+        <Brain className="size-3.5" />
+        Reasoning
+        <ChevronRight className="size-3.5 transition-transform group-data-[state=open]:rotate-90" />
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <p className="mt-2 border-l-2 border-border pl-3 text-xs leading-relaxed whitespace-pre-wrap text-muted-foreground">
+          {text}
+        </p>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+function FinalAnswerDisclosure({ text }: { text: string }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="group flex w-full items-center gap-2 text-left">
+        <MessageSquareText className="size-3.5 shrink-0 text-muted-foreground" />
+        <span className="text-xs font-medium text-foreground">Final answer</span>
+        <ChevronRight className="ml-auto size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+      </CollapsibleTrigger>
+      {open ? null : (
+        <p className="mt-2 line-clamp-2 text-xs leading-relaxed whitespace-pre-wrap text-muted-foreground">
+          {text}
+        </p>
+      )}
+      <CollapsibleContent>
+        <Markdown className="prose-chat mt-2 text-sm">{text}</Markdown>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+function DebugToolCall({ tool }: { tool: Extract<NormalizedPart, { kind: "tool" }>["tool"] }) {
+  const failed = tool.state === "output-error"
+  const running = tool.state === "input-streaming" || tool.state === "input-available"
+  const status = failed ? "Failed" : running ? "Running" : "Succeeded"
+  return (
+    <Collapsible defaultOpen={failed}>
+      <div
+        className={cn("overflow-hidden rounded-md", failed ? "bg-destructive/5" : "bg-muted/30")}
+      >
+        <CollapsibleTrigger className="group flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-muted/30">
+          <Wrench className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate font-mono text-xs font-medium text-foreground">
+            {tool.toolName}
+          </span>
+          <span
+            className={cn(
+              "shrink-0 text-[10px] font-medium",
+              failed
+                ? "text-destructive"
+                : running
+                  ? "text-amber-600 dark:text-amber-400"
+                  : "text-emerald-600 dark:text-emerald-400"
+            )}
+          >
+            {status}
+          </span>
+          <ChevronRight className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="space-y-3 border-t border-border/60 px-3 py-3">
+            {tool.input !== undefined || tool.inputText ? (
+              <DebugValue label="Input" value={tool.input ?? tool.inputText} />
+            ) : null}
+            {tool.state === "output-available" && tool.output !== undefined ? (
+              <DebugValue label="Output" value={tool.output} />
+            ) : null}
+            {failed ? (
+              <DebugValue label="Error" value={tool.errorText ?? "The tool call failed."} error />
+            ) : null}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  )
+}
+
+function DebugValue({
+  label,
+  value,
+  error = false,
+}: {
+  label: string
+  value: unknown
+  error?: boolean
+}) {
+  const formatted = formatValue(value)
+  return (
+    <div className="min-w-0">
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          {label}
+        </p>
+        <CopyValueButton value={formatted} label={`Copy tool ${label.toLowerCase()}`} />
+      </div>
+      <pre
+        className={cn(
+          "scrollbar-thin max-h-72 overflow-auto rounded-md p-2 font-mono text-[11px] leading-relaxed text-foreground",
+          error ? "bg-destructive/10" : "bg-background/60"
+        )}
+      >
+        {formatted}
+      </pre>
+    </div>
+  )
+}
+
+function DebugLabel({ icon, label }: { icon: ReactElement; label: string }) {
+  return (
+    <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+      <span className="[&_svg]:size-3.5">{icon}</span>
+      {label}
+    </div>
+  )
+}
+
+function CopyValueButton({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false)
+  useEffect(() => {
+    if (!copied) return
+    const timer = window.setTimeout(() => setCopied(false), 1500)
+    return () => window.clearTimeout(timer)
+  }, [copied])
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+    } catch {
+      // Clipboard access can be denied; the trace remains readable without it.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      aria-label={label}
+      title={label}
+      className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+    >
+      {copied ? <Check className="size-3.5 text-emerald-600" /> : <Copy className="size-3.5" />}
+    </button>
+  )
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === "string") return value
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}

--- a/packages/agent-ui/src/index.ts
+++ b/packages/agent-ui/src/index.ts
@@ -2,4 +2,9 @@ export {
   AgentContextProvider,
   useAgentContext,
 } from "./AgentContextProvider"
+export {
+  AgentExecutionTrace,
+  type AgentExecutionTraceProps,
+  type AgentExecutionTraceVariant,
+} from "./AgentExecutionTrace"
 export { AgentPanel, type AgentPanelProps } from "./AgentPanel"

--- a/packages/agent-ui/tests/activity.test.ts
+++ b/packages/agent-ui/tests/activity.test.ts
@@ -1,10 +1,102 @@
 import { describe, expect, test } from "bun:test"
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
+import { AgentExecutionTrace } from "../src/AgentExecutionTrace"
 import { AssistantBody } from "../src/components/MessageParts"
-import type { NormalizedPart } from "../src/parts"
+import { type NormalizedPart, normalizeDurableParts } from "../src/parts"
+import type { AgentMessagePart } from "../src/types"
 
 describe("assistant work dropdowns", () => {
+  test("renders a durable workflow trace through the shared agent presentation", () => {
+    const parts: AgentMessagePart[] = [
+      { type: "step-start" },
+      { type: "reasoning", text: "Checking policy." },
+      {
+        type: "tool-call",
+        toolCallId: "policy-call",
+        toolName: "lookup_policy",
+        state: "output-available",
+        input: { severity: "high" },
+        output: { responseWindowMinutes: 90 },
+      },
+      {
+        type: "tool-call",
+        toolCallId: "failed-call",
+        toolName: "lookup_history",
+        state: "output-error",
+        input: { caseNumber: "SC-1042" },
+        errorText: "History unavailable",
+      },
+      { type: "text", text: "Dispatch within 90 minutes." },
+    ]
+
+    const html = renderToStaticMarkup(createElement(AgentExecutionTrace, { parts }))
+
+    expect(html).toContain("Worked")
+    expect(html).toContain("2 steps")
+    expect(html).toContain("Dispatch within 90 minutes.")
+    expect(normalizeDurableParts(parts)).toContainEqual({
+      kind: "tool",
+      tool: {
+        toolName: "lookup_policy",
+        state: "output-available",
+        input: { severity: "high" },
+        output: { responseWindowMinutes: 90 },
+      },
+    })
+    expect(normalizeDurableParts(parts)).toContainEqual({
+      kind: "tool",
+      tool: {
+        toolName: "lookup_history",
+        state: "output-error",
+        input: { caseNumber: "SC-1042" },
+        errorText: "History unavailable",
+      },
+    })
+  })
+
+  test("renders workflow traces as explicit debugger steps", () => {
+    const parts: AgentMessagePart[] = [
+      { type: "step-start" },
+      { type: "reasoning", text: "Checking policy." },
+      { type: "text", text: "I will look up the response policy." },
+      {
+        type: "tool-call",
+        toolCallId: "policy-call",
+        toolName: "lookup_policy",
+        state: "output-available",
+        input: { severity: "high" },
+        output: { responseWindowMinutes: 90 },
+      },
+      {
+        type: "tool-call",
+        toolCallId: "history-call",
+        toolName: "lookup_history",
+        state: "output-error",
+        input: { caseNumber: "SC-1042" },
+        errorText: "History unavailable",
+      },
+      { type: "step-start" },
+      { type: "text", text: "Dispatch within 90 minutes." },
+    ]
+
+    const html = renderToStaticMarkup(
+      createElement(AgentExecutionTrace, { parts, variant: "debug" })
+    )
+
+    expect(html).toContain("Step 1")
+    expect(html).toContain("Step 2")
+    expect(html).toContain("2 tool calls")
+    expect(html).toContain("lookup_policy")
+    expect(html).toContain("Succeeded")
+    expect(html).not.toContain("responseWindowMinutes")
+    expect(html).toContain("lookup_history")
+    expect(html).toContain("Failed")
+    expect(html).toContain("History unavailable")
+    expect(html).toContain("Final answer")
+    expect(html).toContain("Dispatch within 90 minutes.")
+  })
+
   test("caps an expanded work group and scrolls its details independently", () => {
     const html = renderAssistant(
       [reasoning("Checking the available records."), tool("search", "input-available")],

--- a/packages/agent-worker/src/run-agent-loop.ts
+++ b/packages/agent-worker/src/run-agent-loop.ts
@@ -8,6 +8,7 @@ import {
   streamText,
   type ToolSet,
 } from "ai"
+import type { AiSdkTraceStep } from "./ai-sdk-adapters"
 import type { AiModelCallRecorder } from "./model-call-recorder"
 
 export const FINAL_AGENT_LOOP_STEP_INSTRUCTION = [
@@ -25,6 +26,7 @@ export interface RunAgentLoopInput {
   readonly usageRecorder: AiModelCallRecorder
   readonly abortSignal: AbortSignal
   readonly onError?: StreamTextOnErrorCallback
+  readonly onStepEnd?: (step: AiSdkTraceStep) => void | Promise<void>
 }
 
 /**
@@ -64,6 +66,7 @@ export function runAgentLoop(
     },
     onLanguageModelCallEnd: input.usageRecorder.onLanguageModelCallEnd,
     ...(input.onError === undefined ? {} : { onError: input.onError }),
+    ...(input.onStepEnd === undefined ? {} : { onStepEnd: input.onStepEnd }),
     abortSignal: input.abortSignal,
   })
 }

--- a/packages/agent-worker/src/run-workflow-agent-node.ts
+++ b/packages/agent-worker/src/run-workflow-agent-node.ts
@@ -11,7 +11,7 @@ import {
   validateWorkflowAgentStepOutput,
   type WorkflowIOSnapshot,
 } from "@sixb/core/internal/workflows"
-import { coerceAgentRunFinishReason } from "@sixb/core/storage"
+import { type AgentRunFinishReason, coerceAgentRunFinishReason } from "@sixb/core/storage"
 import { generateText, jsonSchema, type ModelMessage, NoObjectGeneratedError, Output } from "ai"
 import { type AiSdkTraceStep, agentTraceFromAiSdkSteps } from "./ai-sdk-adapters"
 import type { AiModelCallRecorder } from "./model-call-recorder"
@@ -45,16 +45,19 @@ export type WorkflowAgentFailurePhase = "agent-loop" | "structured-finalizer"
 /** Carries best-effort debug context across the workflow node's terminal error boundary. */
 export class WorkflowAgentNodeExecutionError extends Error {
   readonly phase: WorkflowAgentFailurePhase
+  readonly finishReason?: AgentRunFinishReason
   readonly trace: readonly AgentMessagePart[]
 
   constructor(input: {
     readonly phase: WorkflowAgentFailurePhase
+    readonly finishReason?: AgentRunFinishReason
     readonly trace: readonly AgentMessagePart[]
     readonly cause: unknown
   }) {
     super("Workflow agent node execution failed.", { cause: input.cause })
     this.name = "WorkflowAgentNodeExecutionError"
     this.phase = input.phase
+    this.finishReason = input.finishReason
     this.trace = input.trace
   }
 }
@@ -100,6 +103,7 @@ export async function runWorkflowAgentNode(
     nodeRunId: input.nodeRunId,
   }
   let phase: WorkflowAgentFailurePhase = "agent-loop"
+  let finishReason: AgentRunFinishReason | undefined
   try {
     let researchError: unknown
     const research = runAgentLoop({
@@ -131,7 +135,7 @@ export async function runWorkflowAgentNode(
     if (researchError !== undefined) throw researchError
 
     const researchText = await research.text
-    const researchFinishReason = await research.finishReason
+    finishReason = coerceAgentRunFinishReason(await research.finishReason) ?? "unknown"
     if (researchText.trim().length === 0) {
       throw createSixbError(
         "agent.execution_failed",
@@ -214,12 +218,13 @@ export async function runWorkflowAgentNode(
     return {
       output,
       modelId: input.agent.model.modelId,
-      finishReason: coerceAgentRunFinishReason(researchFinishReason) ?? "unknown",
+      finishReason,
       trace: agentTraceFromAiSdkSteps(completedSteps, traceDetails),
     }
   } catch (cause) {
     throw new WorkflowAgentNodeExecutionError({
       phase,
+      finishReason,
       trace: agentTraceFromAiSdkSteps(completedSteps, traceDetails),
       cause,
     })

--- a/packages/agent-worker/src/run-workflow-agent-node.ts
+++ b/packages/agent-worker/src/run-workflow-agent-node.ts
@@ -13,7 +13,7 @@ import {
 } from "@sixb/core/internal/workflows"
 import { coerceAgentRunFinishReason } from "@sixb/core/storage"
 import { generateText, jsonSchema, type ModelMessage, NoObjectGeneratedError, Output } from "ai"
-import { agentTraceFromAiSdkSteps } from "./ai-sdk-adapters"
+import { type AiSdkTraceStep, agentTraceFromAiSdkSteps } from "./ai-sdk-adapters"
 import type { AiModelCallRecorder } from "./model-call-recorder"
 import { runAgentLoop } from "./run-agent-loop"
 import type { AgentTurnContext } from "./types"
@@ -38,6 +38,25 @@ export interface WorkflowAgentNodeResult {
   readonly modelId: string
   readonly finishReason: NonNullable<ReturnType<typeof coerceAgentRunFinishReason>>
   readonly trace: readonly AgentMessagePart[]
+}
+
+export type WorkflowAgentFailurePhase = "agent-loop" | "structured-finalizer"
+
+/** Carries best-effort debug context across the workflow node's terminal error boundary. */
+export class WorkflowAgentNodeExecutionError extends Error {
+  readonly phase: WorkflowAgentFailurePhase
+  readonly trace: readonly AgentMessagePart[]
+
+  constructor(input: {
+    readonly phase: WorkflowAgentFailurePhase
+    readonly trace: readonly AgentMessagePart[]
+    readonly cause: unknown
+  }) {
+    super("Workflow agent node execution failed.", { cause: input.cause })
+    this.name = "WorkflowAgentNodeExecutionError"
+    this.phase = input.phase
+    this.trace = input.trace
+  }
 }
 
 export async function runWorkflowAgentNode(
@@ -73,6 +92,14 @@ export async function runWorkflowAgentNode(
   const timeout = new AbortController()
   const timer = setTimeout(() => timeout.abort(), input.context.turnTimeoutMs)
   const abortSignal = AbortSignal.any([input.signal, timeout.signal])
+  const completedSteps: AiSdkTraceStep[] = []
+  const traceDetails = {
+    agentId: input.agent.id,
+    workflowId: input.workflowId,
+    workflowRunId: input.workflowRunId,
+    nodeRunId: input.nodeRunId,
+  }
+  let phase: WorkflowAgentFailurePhase = "agent-loop"
   try {
     let researchError: unknown
     const research = runAgentLoop({
@@ -90,6 +117,9 @@ export async function runWorkflowAgentNode(
       onError: ({ error }) => {
         researchError ??= error
       },
+      onStepEnd: (step) => {
+        completedSteps.push(step)
+      },
     })
 
     await research.consumeStream({
@@ -100,24 +130,17 @@ export async function runWorkflowAgentNode(
     input.usageRecorder.assertHealthy()
     if (researchError !== undefined) throw researchError
 
-    const researchSteps = await research.steps
     const researchText = await research.text
     const researchFinishReason = await research.finishReason
     if (researchText.trim().length === 0) {
       throw createSixbError(
         "agent.execution_failed",
         `[SixbAgentWorker] Workflow agent '${input.agent.id}' produced no final answer to structure.`,
-        {
-          details: {
-            agentId: input.agent.id,
-            workflowId: input.workflowId,
-            workflowRunId: input.workflowRunId,
-            nodeRunId: input.nodeRunId,
-          },
-        }
+        { details: traceDetails }
       )
     }
 
+    phase = "structured-finalizer"
     let finalizerMessages: ModelMessage[] = [
       {
         role: "user",
@@ -178,14 +201,7 @@ export async function runWorkflowAgentNode(
       throw createSixbError(
         "internal.unexpected",
         `[SixbAgentWorker] Workflow output finalization for agent '${input.agent.id}' ended without a value.`,
-        {
-          details: {
-            agentId: input.agent.id,
-            workflowId: input.workflowId,
-            workflowRunId: input.workflowRunId,
-            nodeRunId: input.nodeRunId,
-          },
-        }
+        { details: traceDetails }
       )
     }
 
@@ -199,13 +215,14 @@ export async function runWorkflowAgentNode(
       output,
       modelId: input.agent.model.modelId,
       finishReason: coerceAgentRunFinishReason(researchFinishReason) ?? "unknown",
-      trace: agentTraceFromAiSdkSteps(researchSteps, {
-        agentId: input.agent.id,
-        workflowId: input.workflowId,
-        workflowRunId: input.workflowRunId,
-        nodeRunId: input.nodeRunId,
-      }),
+      trace: agentTraceFromAiSdkSteps(completedSteps, traceDetails),
     }
+  } catch (cause) {
+    throw new WorkflowAgentNodeExecutionError({
+      phase,
+      trace: agentTraceFromAiSdkSteps(completedSteps, traceDetails),
+      cause,
+    })
   } finally {
     clearTimeout(timer)
   }

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -1,10 +1,21 @@
-import type { AgentDefinition, SixbFailure, ValueType, WorkflowDefinition } from "@sixb/core"
+import type {
+  AgentDefinition,
+  AgentMessagePart,
+  SixbFailure,
+  ValueType,
+  WorkflowDefinition,
+} from "@sixb/core"
 import {
   createAgentRunExecutionToken,
   resolveAgentExecutionAuthorization,
 } from "@sixb/core/internal/agents"
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
-import { createSixbError, summarizeErrorMessage, toSixbFailure } from "@sixb/core/internal/errors"
+import {
+  createSixbError,
+  isSixbError,
+  summarizeErrorMessage,
+  toSixbFailure,
+} from "@sixb/core/internal/errors"
 import type { QueueDelivery } from "@sixb/core/internal/workers"
 import { QueueDeliveryLeaseLostError } from "@sixb/core/internal/workers"
 import type { WorkflowAgentNodeDefinition } from "@sixb/core/internal/workflows"
@@ -32,7 +43,11 @@ import {
   type AgentExecutionEnvironment,
   createWorkflowAgentNodeEnvironment,
 } from "./run-environment"
-import { runWorkflowAgentNode } from "./run-workflow-agent-node"
+import {
+  runWorkflowAgentNode,
+  type WorkflowAgentFailurePhase,
+  WorkflowAgentNodeExecutionError,
+} from "./run-workflow-agent-node"
 import type { AgentWorkerContext, AgentWorkerHost } from "./types"
 
 export interface ExecuteWorkflowAgentNodeInput {
@@ -173,13 +188,24 @@ export async function executeWorkflowAgentNode(
   } catch (error) {
     if (lostQueueDelivery(error, signal)) return
 
+    const debug =
+      error instanceof WorkflowAgentNodeExecutionError
+        ? {
+            cause: error.cause,
+            phase: error.phase,
+            trace: error.trace,
+          }
+        : undefined
+
     // Output parsing and tool handling can fail after the final provider callback. Accounting
     // failure takes precedence because AI SDK otherwise swallows the callback error.
-    let executionError = error
+    let executionError = debug?.cause ?? error
+    let failurePhase = debug?.phase
     try {
       usageRecorder.assertHealthy()
     } catch (recordingError) {
       executionError = recordingError
+      failurePhase = undefined
     }
 
     if (signal.aborted) throw executionError
@@ -201,6 +227,8 @@ export async function executeWorkflowAgentNode(
       executionToken,
       status,
       error: executionError,
+      trace: debug?.trace,
+      failurePhase,
     })
     if (status === "failed") {
       reportRunFailure(input.host, executionError, {
@@ -435,12 +463,22 @@ async function finishWorkflowAgentNodeFailed(input: {
   readonly executionToken: string
   readonly status: "failed" | "cancelled"
   readonly error: unknown
+  readonly trace?: readonly AgentMessagePart[]
+  readonly failurePhase?: WorkflowAgentFailurePhase
 }): Promise<{
   readonly node: WorkflowNodeRunRecord
   readonly run: WorkflowRunRecord
   readonly failure: SixbFailure<WorkflowRunFailureCode>
 }> {
   const at = new Date()
+  const agentErrorDetails = {
+    ...workflowAgentErrorDetails(input.agent.id, input.nodeRun),
+    ...(input.failurePhase === undefined ? {} : { failurePhase: input.failurePhase }),
+  }
+  const agentExecutionError =
+    input.failurePhase === undefined
+      ? input.error
+      : attachWorkflowAgentFailureDetails(input.error, input.status, agentErrorDetails)
   const workflowFailureError =
     input.status === "failed"
       ? createWorkflowNodeFailure(input.error, {
@@ -455,7 +493,7 @@ async function finishWorkflowAgentNodeFailed(input: {
           summarizeErrorMessage(input.error, "Agent workflow node execution failed."),
           {
             cause: input.error,
-            details: workflowAgentErrorDetails(input.agent.id, input.nodeRun),
+            details: agentErrorDetails,
           }
         )
   const workflowFailure = toSixbFailure(workflowFailureError, {
@@ -477,10 +515,11 @@ async function finishWorkflowAgentNodeFailed(input: {
       executionToken: input.executionToken,
       status: input.status,
       modelId: input.agent.model.modelId,
-      error: toAgentExecutionFailure(input.error, {
+      trace: input.trace,
+      error: toAgentExecutionFailure(agentExecutionError, {
         status: input.status,
         at,
-        details: workflowAgentErrorDetails(input.agent.id, input.nodeRun),
+        details: agentErrorDetails,
       }),
       completedAt: at,
     })
@@ -500,6 +539,27 @@ async function finishWorkflowAgentNodeFailed(input: {
     })
     return { node, run, failure: workflowFailure }
   })
+}
+
+function attachWorkflowAgentFailureDetails(
+  error: unknown,
+  status: "failed" | "cancelled",
+  details: Readonly<Record<string, string>>
+): unknown {
+  if (status === "cancelled") {
+    return createSixbError(
+      "runtime.cancelled",
+      summarizeErrorMessage(error, "Agent workflow node execution was cancelled."),
+      { cause: error, details }
+    )
+  }
+  if (
+    isSixbError(error) &&
+    (error.code === "internal.unexpected" || error.code === "agent.execution_failed")
+  ) {
+    return createSixbError(error.code, error.message, { cause: error, details })
+  }
+  return error
 }
 
 async function emitNodeSucceeded(

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -26,6 +26,7 @@ import type {
   AgentWorkflowNodeRequestedQueueJob,
 } from "@sixb/core/queues"
 import type {
+  AgentRunFinishReason,
   ExecutionRecord,
   WorkflowAgentNodeRunExecution,
   WorkflowAgentNodeRunRecord,
@@ -193,6 +194,7 @@ export async function executeWorkflowAgentNode(
         ? {
             cause: error.cause,
             phase: error.phase,
+            finishReason: error.finishReason,
             trace: error.trace,
           }
         : undefined
@@ -228,6 +230,7 @@ export async function executeWorkflowAgentNode(
       status,
       error: executionError,
       trace: debug?.trace,
+      finishReason: debug?.finishReason,
       failurePhase,
     })
     if (status === "failed") {
@@ -463,6 +466,7 @@ async function finishWorkflowAgentNodeFailed(input: {
   readonly executionToken: string
   readonly status: "failed" | "cancelled"
   readonly error: unknown
+  readonly finishReason?: AgentRunFinishReason
   readonly trace?: readonly AgentMessagePart[]
   readonly failurePhase?: WorkflowAgentFailurePhase
 }): Promise<{
@@ -515,6 +519,7 @@ async function finishWorkflowAgentNodeFailed(input: {
       executionToken: input.executionToken,
       status: input.status,
       modelId: input.agent.model.modelId,
+      finishReason: input.finishReason,
       trace: input.trace,
       error: toAgentExecutionFailure(agentExecutionError, {
         status: input.status,

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1858,6 +1858,7 @@ describe("AgentWorker", () => {
 
       expect(execution).toMatchObject({
         status: "failed",
+        finishReason: "stop",
         error: { details: { failurePhase: "structured-finalizer" } },
       })
       expect(execution.trace).toContainEqual(

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1856,7 +1856,13 @@ describe("AgentWorker", () => {
         { label: "workflow output validation failure" }
       )
 
-      expect(execution.status).toBe("failed")
+      expect(execution).toMatchObject({
+        status: "failed",
+        error: { details: { failurePhase: "structured-finalizer" } },
+      })
+      expect(execution.trace).toContainEqual(
+        expect.objectContaining({ type: "text", text: "Project Alpha is the best match." })
+      )
       await expect(
         aiUsageStorageOf(sixb).summarizeExecution({
           projectId: PROJECT_ID,
@@ -1949,7 +1955,18 @@ describe("AgentWorker", () => {
       )
 
       expect(toolCalls).toBe(1)
-      expect(execution.status).toBe("failed")
+      expect(execution).toMatchObject({
+        status: "failed",
+        error: { details: { failurePhase: "agent-loop" } },
+      })
+      expect(execution.trace).toContainEqual(
+        expect.objectContaining({
+          type: "tool-call",
+          toolName: "fail_lookup",
+          state: "output-error",
+          errorText: "An error occurred.",
+        })
+      )
       await expect(
         aiUsageStorageOf(sixb).summarizeExecution({
           projectId: PROJECT_ID,

--- a/packages/atlas/src/components/CopyButton.tsx
+++ b/packages/atlas/src/components/CopyButton.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@sixb/ui/components"
+import { Check, Copy } from "lucide-react"
+import { useEffect, useState } from "react"
+
+export function CopyButton({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    if (!copied) return
+    const timer = window.setTimeout(() => setCopied(false), 1500)
+    return () => window.clearTimeout(timer)
+  }, [copied])
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+    } catch {
+      // Clipboard access can be denied; fail silently.
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-xs"
+      onClick={onCopy}
+      aria-label={label}
+      title={label}
+      className="shrink-0 text-muted-foreground hover:text-foreground"
+    >
+      {copied ? <Check className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" /> : <Copy />}
+    </Button>
+  )
+}

--- a/packages/atlas/src/components/StructuredValue.tsx
+++ b/packages/atlas/src/components/StructuredValue.tsx
@@ -13,7 +13,7 @@ import {
   Minus,
   Type,
 } from "lucide-react"
-import { useEffect, useRef, useState } from "react"
+import { type ReactNode, useEffect, useRef, useState } from "react"
 import { fileMediaLabel, formatFileSize } from "../lib/files"
 
 export interface FileContentLinks {
@@ -23,27 +23,37 @@ export interface FileContentLinks {
 
 export type FileLinkForPath = (path: readonly string[]) => FileContentLinks | null
 
+export type StructuredValueVariant = "default" | "debug"
+
 export function StructuredValue({
   value,
   emptyLabel = "No data",
   fileLinkForPath,
   path = [],
+  variant = "default",
 }: {
   value: unknown
   emptyLabel?: string
   fileLinkForPath?: FileLinkForPath
   path?: readonly string[]
+  variant?: StructuredValueVariant
 }) {
   if (value === null || value === undefined) {
     return <p className="text-sm text-muted-foreground">{emptyLabel}</p>
   }
 
   if (isObjectRef(value)) {
-    return <ObjectRefChip objectTypeId={value.objectTypeId} primaryId={value.primaryId} />
+    return variant === "debug" ? (
+      <DebugObjectRef objectTypeId={value.objectTypeId} primaryId={value.primaryId} />
+    ) : (
+      <ObjectRefChip objectTypeId={value.objectTypeId} primaryId={value.primaryId} />
+    )
   }
 
   if (isFileRef(value)) {
-    return <FileRefValue fileRef={value} links={fileLinkForPath?.(path) ?? null} />
+    return (
+      <FileRefValue fileRef={value} links={fileLinkForPath?.(path) ?? null} variant={variant} />
+    )
   }
 
   if (Array.isArray(value)) {
@@ -57,6 +67,7 @@ export function StructuredValue({
               label={`${index + 1}`}
               path={[...path, String(index)]}
               fileLinkForPath={fileLinkForPath}
+              variant={variant}
             />
           </li>
         ))}
@@ -76,6 +87,7 @@ export function StructuredValue({
               label={name}
               path={[...path, name]}
               fileLinkForPath={fileLinkForPath}
+              variant={variant}
             />
           </li>
         ))}
@@ -83,7 +95,7 @@ export function StructuredValue({
     )
   }
 
-  return <RunValue value={value} path={path} fileLinkForPath={fileLinkForPath} />
+  return <RunValue value={value} path={path} fileLinkForPath={fileLinkForPath} variant={variant} />
 }
 
 function RunValue({
@@ -91,13 +103,22 @@ function RunValue({
   value,
   path,
   fileLinkForPath,
+  variant,
 }: {
   label?: string
   value: unknown
   path: readonly string[]
   fileLinkForPath?: FileLinkForPath
+  variant: StructuredValueVariant
 }) {
   if (isObjectRef(value)) {
+    if (variant === "debug") {
+      return (
+        <DebugField label={label}>
+          <DebugObjectRef objectTypeId={value.objectTypeId} primaryId={value.primaryId} />
+        </DebugField>
+      )
+    }
     return (
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
         {label ? <FieldLabel>{label}</FieldLabel> : null}
@@ -108,23 +129,33 @@ function RunValue({
 
   if (isFileRef(value)) {
     return (
-      <div className="space-y-2">
-        {label ? <FieldLabel>{label}</FieldLabel> : null}
-        <FileRefValue fileRef={value} links={fileLinkForPath?.(path) ?? null} />
-      </div>
+      <DebugField label={label} stacked={variant === "default"}>
+        <FileRefValue fileRef={value} links={fileLinkForPath?.(path) ?? null} variant={variant} />
+      </DebugField>
     )
   }
 
   if (Array.isArray(value)) {
     return (
       <div className="space-y-2">
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-          {label ? <FieldLabel>{label}</FieldLabel> : null}
-          <TypeChip icon="array" label="array" detail={`${value.length} items`} />
-        </div>
+        {variant === "debug" ? (
+          <DebugField label={label}>
+            <CollectionSummary type="array" count={value.length} />
+          </DebugField>
+        ) : (
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            {label ? <FieldLabel>{label}</FieldLabel> : null}
+            <TypeChip icon="array" label="array" detail={`${value.length} items`} />
+          </div>
+        )}
         {value.length > 0 ? (
           <div className="border-l border-border pl-3">
-            <StructuredValue value={value} path={path} fileLinkForPath={fileLinkForPath} />
+            <StructuredValue
+              value={value}
+              path={path}
+              fileLinkForPath={fileLinkForPath}
+              variant={variant}
+            />
           </div>
         ) : null}
       </div>
@@ -135,25 +166,43 @@ function RunValue({
     const entries = Object.entries(value)
     return (
       <div className="space-y-2">
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-          {label ? <FieldLabel>{label}</FieldLabel> : null}
-          <TypeChip icon="object" label="object" detail={`${entries.length} fields`} />
-        </div>
+        {variant === "debug" ? (
+          <DebugField label={label}>
+            <CollectionSummary type="object" count={entries.length} />
+          </DebugField>
+        ) : (
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            {label ? <FieldLabel>{label}</FieldLabel> : null}
+            <TypeChip icon="object" label="object" detail={`${entries.length} fields`} />
+          </div>
+        )}
         {entries.length > 0 ? (
           <div className="border-l border-border pl-3">
-            <StructuredValue value={value} path={path} fileLinkForPath={fileLinkForPath} />
+            <StructuredValue
+              value={value}
+              path={path}
+              fileLinkForPath={fileLinkForPath}
+              variant={variant}
+            />
           </div>
         ) : null}
       </div>
     )
   }
 
-  if (isLongString(value)) {
+  if (typeof value === "string" && (variant === "debug" || isLongString(value))) {
     return (
-      <div className="space-y-1.5">
-        {label ? <FieldLabel>{label}</FieldLabel> : null}
+      <DebugField label={label} stacked={variant === "default"}>
         <ExpandableText text={value} />
-      </div>
+      </DebugField>
+    )
+  }
+
+  if (variant === "debug") {
+    return (
+      <DebugField label={label}>
+        <DebugPrimitiveValue value={value} />
+      </DebugField>
     )
   }
 
@@ -166,7 +215,30 @@ function RunValue({
 }
 
 function FieldLabel({ children }: { children: string }) {
-  return <span className="min-w-0 font-medium text-foreground">{children}</span>
+  return <span className="min-w-0 break-words font-medium text-foreground">{children}</span>
+}
+
+function DebugField({
+  label,
+  children,
+  stacked = false,
+}: {
+  label?: string
+  children: ReactNode
+  stacked?: boolean
+}) {
+  if (!label) return <>{children}</>
+  return stacked ? (
+    <div className="space-y-1.5">
+      <FieldLabel>{label}</FieldLabel>
+      {children}
+    </div>
+  ) : (
+    <div className="grid min-w-0 grid-cols-[minmax(7rem,10rem)_minmax(0,1fr)] gap-3">
+      <FieldLabel>{label}</FieldLabel>
+      <div className="min-w-0">{children}</div>
+    </div>
+  )
 }
 
 function ObjectRefChip({ objectTypeId, primaryId }: { objectTypeId: string; primaryId: string }) {
@@ -182,18 +254,69 @@ function ObjectRefChip({ objectTypeId, primaryId }: { objectTypeId: string; prim
   )
 }
 
-function FileRefValue({ fileRef, links }: { fileRef: FileRef; links: FileContentLinks | null }) {
+function DebugObjectRef({ objectTypeId, primaryId }: { objectTypeId: string; primaryId: string }) {
+  return (
+    <span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-xs">
+      <Box className="size-3.5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+      <span className="font-medium text-foreground">{objectTypeId}</span>
+      <span className="text-muted-foreground">object</span>
+      <span aria-hidden="true" className="text-muted-foreground/60">
+        ·
+      </span>
+      <span className="min-w-[8rem] flex-1 break-all font-mono text-muted-foreground">
+        {primaryId}
+      </span>
+    </span>
+  )
+}
+
+function CollectionSummary({ type, count }: { type: "array" | "object"; count: number }) {
+  const Icon = type === "array" ? Brackets : Braces
+  const unit =
+    type === "array" ? (count === 1 ? "item" : "items") : count === 1 ? "field" : "fields"
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+      <Icon className="size-3.5" />
+      {type} · {count} {unit}
+    </span>
+  )
+}
+
+function FileRefValue({
+  fileRef,
+  links,
+  variant,
+}: {
+  fileRef: FileRef
+  links: FileContentLinks | null
+  variant: StructuredValueVariant
+}) {
   const fileName = fileNameFor(fileRef)
   const mediaLabel = fileMediaLabel(fileRef.mediaType, fileName)
 
   return (
-    <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2 rounded-md border border-border bg-background px-3 py-2.5 text-xs">
+    <div
+      className={cn(
+        "flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2 rounded-md text-xs",
+        variant === "debug"
+          ? "bg-muted/20 px-2.5 py-2"
+          : "border border-border bg-background px-3 py-2.5"
+      )}
+    >
       <span className="inline-flex min-w-0 flex-1 items-center gap-2.5">
         <FileIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        <span className="min-w-0 truncate font-medium text-foreground" title={fileName}>
+        <span
+          className={cn(
+            "min-w-0 font-medium text-foreground",
+            variant === "debug" ? "break-all" : "truncate"
+          )}
+          title={fileName}
+        >
           {fileName}
         </span>
-        <span className="shrink-0 text-muted-foreground">
+        <span
+          className={cn("text-muted-foreground", variant === "debug" ? "break-words" : "shrink-0")}
+        >
           {mediaLabel} · {formatFileSize(fileRef.sizeBytes)}
         </span>
       </span>
@@ -219,6 +342,24 @@ function FileRefValue({ fileRef, links }: { fileRef: FileRef; links: FileContent
         </span>
       ) : null}
     </div>
+  )
+}
+
+function DebugPrimitiveValue({ value }: { value: unknown }) {
+  const { Icon, text } =
+    typeof value === "number"
+      ? { Icon: Hash, text: String(value) }
+      : typeof value === "boolean"
+        ? { Icon: Check, text: value ? "true" : "false" }
+        : value === null || value === undefined
+          ? { Icon: Minus, text: "null" }
+          : { Icon: Braces, text: String(value) }
+
+  return (
+    <span className="flex min-w-0 items-start gap-1.5 text-xs text-foreground">
+      <Icon className="mt-0.5 size-3 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 break-all font-mono">{text}</span>
+    </span>
   )
 }
 

--- a/packages/atlas/src/features/workflows/components/runs/AgentExecutionPanel.tsx
+++ b/packages/atlas/src/features/workflows/components/runs/AgentExecutionPanel.tsx
@@ -1,0 +1,312 @@
+import { AgentExecutionTrace } from "@sixb/agent-ui"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@sixb/ui/components"
+import { cn } from "@sixb/ui/lib/utils"
+import { ScrollText } from "lucide-react"
+import type { ReactNode } from "react"
+import { SixbFailureSummary } from "../../../../components/SixbFailureSummary"
+import { type FileLinkForPath, StructuredValue } from "../../../../components/StructuredValue"
+import {
+  formatDate,
+  type WorkflowAgentNodeExecution,
+  type WorkflowRunNode,
+} from "../../utils/workflows"
+import { RunDebugSection, RunMetadataRows, stringifyRunDebugValue } from "./RunDebugSection"
+
+export function AgentExecutionPanel({
+  summary,
+  execution,
+  nodeInput,
+  nodeOutput,
+  nodeError,
+  inputFileLinkForPath,
+  outputFileLinkForPath,
+  loading,
+  failed,
+}: {
+  summary: WorkflowRunNode["agentExecution"]
+  execution: WorkflowAgentNodeExecution | undefined
+  nodeInput: WorkflowRunNode["input"]
+  nodeOutput: WorkflowRunNode["output"]
+  nodeError: WorkflowRunNode["error"]
+  inputFileLinkForPath: FileLinkForPath
+  outputFileLinkForPath: FileLinkForPath
+  loading: boolean
+  failed: boolean
+}) {
+  const data = execution ?? summary
+  const trace = execution?.trace ?? []
+  const stepMarkers = trace.filter((part) => part.type === "step-start").length
+  const stepCount = stepMarkers > 0 ? stepMarkers : trace.length > 0 ? 1 : 0
+  const tools = trace.filter((part) => part.type === "tool-call")
+  const failedTools = tools.filter((part) => part.state === "output-error").length
+  const failure = execution?.error ?? nodeError
+  const finalAnswer = finalAgentAnswer(trace)
+
+  if (!data) {
+    if (loading) return <p className="text-xs text-muted-foreground">Loading agent execution...</p>
+    if (failed) return <p className="text-xs text-destructive">Could not load agent execution.</p>
+    return <p className="text-xs text-muted-foreground">No agent execution record.</p>
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="min-w-0 space-y-2">
+        <div className="flex min-w-0 items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="break-words text-sm font-medium text-foreground">{data.agentId}</p>
+            <p className="mt-0.5 break-all font-mono text-[11px] text-muted-foreground">
+              {data.modelId ?? "Model not reported"} · Attempt {data.attempt}
+            </p>
+          </div>
+          <AgentExecutionStatus status={data.status} />
+        </div>
+        <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+          {data.usage?.totalTokens === undefined ? null : (
+            <span>{formatTokenCount(data.usage.totalTokens)} tokens</span>
+          )}
+          {execution ? (
+            <>
+              <span>{pluralCount(stepCount, "model step")}</span>
+              <span>{pluralCount(tools.length, "tool call")}</span>
+              {failedTools > 0 ? (
+                <span className="font-medium text-destructive">
+                  {pluralCount(failedTools, "tool error")}
+                </span>
+              ) : null}
+            </>
+          ) : loading ? (
+            <span>Loading trace…</span>
+          ) : null}
+        </div>
+      </div>
+
+      {failure ? (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+          <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-destructive">
+            {execution?.failurePhase === "structured-finalizer"
+              ? "Failed during structured output"
+              : execution?.failurePhase === "agent-loop"
+                ? "Failed during agent work"
+                : "Execution failed"}
+          </p>
+          <SixbFailureSummary failure={failure} className="text-sm" />
+        </div>
+      ) : null}
+
+      <Tabs defaultValue="trace" className="gap-3">
+        <TabsList variant="line" className="h-9 w-full border-b border-border/70">
+          <TabsTrigger value="trace">Trace</TabsTrigger>
+          <TabsTrigger value="io">Input & output</TabsTrigger>
+          <TabsTrigger value="details">Details</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="trace" className="mt-0">
+          {trace.length > 0 ? (
+            <AgentExecutionTrace parts={trace} variant="debug" />
+          ) : loading ? (
+            <AgentDebugEmpty>Loading completed agent steps...</AgentDebugEmpty>
+          ) : failed ? (
+            <AgentDebugEmpty error>Could not load the agent trace.</AgentDebugEmpty>
+          ) : (
+            <AgentDebugEmpty>
+              {data.status === "running"
+                ? "No completed steps yet."
+                : "No agent work was captured."}
+            </AgentDebugEmpty>
+          )}
+        </TabsContent>
+
+        <TabsContent value="io" className="mt-0 space-y-5">
+          <RunDebugSection label="Workflow input">
+            <StructuredValue
+              value={nodeInput}
+              emptyLabel="No input"
+              fileLinkForPath={inputFileLinkForPath}
+              variant="debug"
+            />
+          </RunDebugSection>
+          <RunDebugSection
+            label="Resolved prompt"
+            copyValue={execution?.prompt}
+            copyLabel="Copy resolved prompt"
+          >
+            {execution?.prompt ? (
+              <DebugTextValue value={execution.prompt} />
+            ) : (
+              <AgentDebugEmpty>Prompt not available.</AgentDebugEmpty>
+            )}
+          </RunDebugSection>
+          <RunDebugSection
+            label="Agent answer"
+            copyValue={finalAnswer}
+            copyLabel="Copy agent answer"
+          >
+            {finalAnswer ? (
+              <DebugTextValue value={finalAnswer} />
+            ) : (
+              <AgentDebugEmpty>No final agent answer was captured.</AgentDebugEmpty>
+            )}
+          </RunDebugSection>
+          <RunDebugSection label="Structured output">
+            <StructuredValue
+              value={nodeOutput ?? null}
+              emptyLabel="No structured output"
+              fileLinkForPath={outputFileLinkForPath}
+              variant="debug"
+            />
+          </RunDebugSection>
+        </TabsContent>
+
+        <TabsContent value="details" className="mt-0 space-y-5">
+          <AgentExecutionMetadata data={data} execution={execution} />
+          <AgentUsageDetails usage={data.usage} />
+          {execution?.diagnostics?.length ? (
+            <RunDebugSection label="Diagnostics">
+              <StructuredValue value={execution.diagnostics} variant="debug" />
+            </RunDebugSection>
+          ) : null}
+          {execution ? <RawExecutionRecord execution={execution} /> : null}
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+function AgentExecutionStatus({ status }: { status: WorkflowAgentNodeExecution["status"] }) {
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium capitalize",
+        status === "succeeded" &&
+          "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+        status === "failed" && "border-destructive/30 bg-destructive/10 text-destructive",
+        status === "cancelled" && "border-border bg-muted text-muted-foreground",
+        (status === "running" || status === "queued") &&
+          "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+      )}
+    >
+      {status}
+    </span>
+  )
+}
+
+function AgentDebugEmpty({ children, error = false }: { children: ReactNode; error?: boolean }) {
+  return (
+    <p className={cn("text-xs text-muted-foreground", error && "text-destructive")}>{children}</p>
+  )
+}
+
+function DebugTextValue({ value }: { value: string }) {
+  return (
+    <pre className="scrollbar-thin max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted/30 p-3 font-mono text-xs leading-relaxed text-foreground">
+      {value}
+    </pre>
+  )
+}
+
+function AgentExecutionMetadata({
+  data,
+  execution,
+}: {
+  data: NonNullable<WorkflowRunNode["agentExecution"]>
+  execution: WorkflowAgentNodeExecution | undefined
+}) {
+  const rows = [
+    ["Finish reason", execution?.finishReason ?? data.finishReason ?? "Not reported"],
+    ["Started", formatDate(data.startedAt)],
+    ["Completed", formatDate(data.completedAt)],
+    ["Node run ID", execution?.nodeRunId ?? "Not loaded"],
+  ] as const
+
+  return (
+    <RunDebugSection label="Execution">
+      <RunMetadataRows rows={rows} />
+    </RunDebugSection>
+  )
+}
+
+function AgentUsageDetails({
+  usage,
+}: {
+  usage: NonNullable<WorkflowRunNode["agentExecution"]>["usage"]
+}) {
+  if (!usage) {
+    return (
+      <RunDebugSection label="Token usage">
+        <AgentDebugEmpty>No token usage was reported.</AgentDebugEmpty>
+      </RunDebugSection>
+    )
+  }
+  const values = [
+    ["Total", usage.totalTokens],
+    ["Input", usage.inputTokens],
+    ["Output", usage.outputTokens],
+    ["Uncached input", usage.uncachedInputTokens],
+    ["Cache read", usage.cacheReadInputTokens],
+    ["Cache write", usage.cacheWriteInputTokens],
+    ["Text output", usage.textOutputTokens],
+    ["Reasoning output", usage.reasoningOutputTokens],
+  ] as const
+
+  return (
+    <RunDebugSection label="Token usage">
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3">
+        {values.map(([label, value]) => (
+          <div key={label} className="min-w-0">
+            <p className="text-[10px] text-muted-foreground">{label}</p>
+            <p className="mt-0.5 font-mono text-xs tabular-nums text-foreground">
+              {value === undefined ? "—" : formatTokenCount(value)}
+            </p>
+          </div>
+        ))}
+      </div>
+      <p className="mt-2 text-[10px] text-muted-foreground">
+        Reporting status:{" "}
+        <span className="font-medium text-foreground">{usage.reportingStatus}</span>
+      </p>
+    </RunDebugSection>
+  )
+}
+
+function RawExecutionRecord({ execution }: { execution: WorkflowAgentNodeExecution }) {
+  const raw = stringifyRunDebugValue(execution)
+  return (
+    <RunDebugSection label="Raw execution record" copyValue={raw} copyLabel="Copy raw execution">
+      <details>
+        <summary className="flex cursor-pointer list-none items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground">
+          <ScrollText className="size-3.5" /> View exact API response
+        </summary>
+        <pre className="scrollbar-thin mt-3 max-h-96 overflow-auto rounded-md bg-muted/30 p-3 font-mono text-[11px] leading-relaxed text-foreground">
+          {raw}
+        </pre>
+      </details>
+    </RunDebugSection>
+  )
+}
+
+function finalAgentAnswer(
+  trace: readonly NonNullable<WorkflowAgentNodeExecution["trace"]>[number][]
+) {
+  let finalStepStart = -1
+  for (let index = 0; index < trace.length; index += 1) {
+    if (trace[index]?.type === "step-start") finalStepStart = index
+  }
+  const finalStep = trace.slice(finalStepStart + 1)
+  if (finalStep.some((part) => part.type === "tool-call")) return undefined
+  const answer = finalStep
+    .filter(
+      (part): part is Extract<(typeof trace)[number], { type: "text" }> => part.type === "text"
+    )
+    .map((part) => part.text)
+    .join("")
+    .trim()
+  return answer || undefined
+}
+
+function formatTokenCount(value: number | undefined): string {
+  return value === undefined ? "—" : new Intl.NumberFormat().format(value)
+}
+
+function pluralCount(value: number, singular: string): string {
+  return `${value} ${value === 1 ? singular : `${singular}s`}`
+}

--- a/packages/atlas/src/features/workflows/components/runs/RunDebugSection.tsx
+++ b/packages/atlas/src/features/workflows/components/runs/RunDebugSection.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react"
+import { CopyButton } from "../../../../components/CopyButton"
+
+export function RunDebugSection({
+  label,
+  copyValue,
+  copyLabel = `Copy ${label.toLowerCase()}`,
+  children,
+}: {
+  label: string
+  copyValue?: string
+  copyLabel?: string
+  children: ReactNode
+}) {
+  return (
+    <section className="border-t border-border/60 pt-4 first:border-t-0 first:pt-0">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          {label}
+        </p>
+        {copyValue ? <CopyButton value={copyValue} label={copyLabel} /> : null}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+export function RunMetadataRows({
+  rows,
+}: {
+  rows: readonly (readonly [label: string, value: string])[]
+}) {
+  return (
+    <dl className="divide-y divide-border/60">
+      {rows.map(([label, value]) => (
+        <div
+          key={label}
+          className="grid grid-cols-[8rem_minmax(0,1fr)] gap-3 py-2 first:pt-0 last:pb-0"
+        >
+          <dt className="text-xs text-muted-foreground">{label}</dt>
+          <dd className="min-w-0 break-all text-right font-mono text-xs text-foreground">
+            {value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  )
+}
+
+export function stringifyRunDebugValue(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}

--- a/packages/atlas/src/features/workflows/components/runs/WorkflowNodeExecutionPanel.tsx
+++ b/packages/atlas/src/features/workflows/components/runs/WorkflowNodeExecutionPanel.tsx
@@ -1,0 +1,81 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@sixb/ui/components"
+import { ScrollText } from "lucide-react"
+import { SixbFailureSummary } from "../../../../components/SixbFailureSummary"
+import { type FileLinkForPath, StructuredValue } from "../../../../components/StructuredValue"
+import { formatDate, type WorkflowRunNode } from "../../utils/workflows"
+import { RunDebugSection, RunMetadataRows, stringifyRunDebugValue } from "./RunDebugSection"
+
+export function WorkflowNodeExecutionPanel({
+  node,
+  inputFileLinkForPath,
+  outputFileLinkForPath,
+}: {
+  node: WorkflowRunNode
+  inputFileLinkForPath: FileLinkForPath
+  outputFileLinkForPath: FileLinkForPath
+}) {
+  const outputLabel = node.nodeType === "intervention" ? "Response" : "Output"
+  const raw = stringifyRunDebugValue(node)
+  const metadata = [
+    ["Node type", node.nodeType],
+    ["Definition ID", node.nodeId],
+    ["Node run ID", node.id],
+    ["Started", formatDate(node.startedAt)],
+    ["Finished", formatDate(node.finishedAt)],
+  ] as const
+
+  return (
+    <div className="space-y-4">
+      {node.error ? (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+          <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-destructive">
+            Execution failed
+          </p>
+          <SixbFailureSummary failure={node.error} className="text-sm" />
+        </div>
+      ) : null}
+
+      <Tabs defaultValue={node.error ? "input" : "output"} className="gap-3">
+        <TabsList variant="line" className="h-9 w-full border-b border-border/70">
+          <TabsTrigger value="input">Input</TabsTrigger>
+          <TabsTrigger value="output">{outputLabel}</TabsTrigger>
+          <TabsTrigger value="details">Details</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="input" className="mt-0">
+          <StructuredValue
+            value={node.input}
+            emptyLabel="No input"
+            fileLinkForPath={inputFileLinkForPath}
+            variant="debug"
+          />
+        </TabsContent>
+
+        <TabsContent value="output" className="mt-0">
+          <StructuredValue
+            value={node.output ?? null}
+            emptyLabel={`No ${outputLabel.toLowerCase()}`}
+            fileLinkForPath={outputFileLinkForPath}
+            variant="debug"
+          />
+        </TabsContent>
+
+        <TabsContent value="details" className="mt-0 space-y-5">
+          <RunDebugSection label="Execution">
+            <RunMetadataRows rows={metadata} />
+          </RunDebugSection>
+          <RunDebugSection label="Raw execution record" copyValue={raw} copyLabel="Copy raw run">
+            <details>
+              <summary className="flex cursor-pointer list-none items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground">
+                <ScrollText className="size-3.5" /> View exact API response
+              </summary>
+              <pre className="scrollbar-thin mt-3 max-h-96 overflow-auto rounded-md bg-muted/30 p-3 font-mono text-[11px] leading-relaxed text-foreground">
+                {raw}
+              </pre>
+            </details>
+          </RunDebugSection>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/packages/atlas/src/features/workflows/hooks/useWorkflowLiveUpdates.ts
+++ b/packages/atlas/src/features/workflows/hooks/useWorkflowLiveUpdates.ts
@@ -1,5 +1,5 @@
 import { events, useInvalidateOnEvent } from "@sixb/client/hooks"
-import { type InvalidationKey, queryKey, queryKeyWithPath } from "../../../lib/liveUpdateKeys"
+import { workflowChangedKeys } from "../../../lib/liveUpdateKeys"
 
 const debounceMs = 100
 
@@ -13,15 +13,7 @@ export function useWorkflowLiveUpdates(
     (event) => {
       if (options.workflowId && event.payload.workflowId !== options.workflowId) return []
 
-      const keys: InvalidationKey[] = [
-        queryKey("listWorkflows"),
-        queryKey("listWorkflowRuns"),
-        queryKey("listWorkflowInterventions"),
-        queryKeyWithPath("getWorkflow", { workflowId: event.payload.workflowId }),
-        queryKeyWithPath("getWorkflowRun", { runId: event.payload.runId }),
-      ]
-
-      return keys
+      return workflowChangedKeys(event.payload.workflowId, event.payload.runId)
     },
     { enabled: options.enabled ?? true, debounceMs }
   )

--- a/packages/atlas/src/lib/liveUpdateKeys.ts
+++ b/packages/atlas/src/lib/liveUpdateKeys.ts
@@ -50,6 +50,17 @@ export function datasetChangedKeys(datasetId: string): InvalidationKey[] {
   ]
 }
 
+export function workflowChangedKeys(workflowId: string, runId: string): InvalidationKey[] {
+  return [
+    queryKey("listWorkflows"),
+    queryKey("listWorkflowRuns"),
+    queryKey("listWorkflowInterventions"),
+    queryKey("getWorkflowAgentNodeExecution"),
+    queryKeyWithPath("getWorkflow", { workflowId }),
+    queryKeyWithPath("getWorkflowRun", { runId }),
+  ]
+}
+
 export function sameObject(
   left: { readonly objectTypeId: string; readonly primaryId: string },
   right: { readonly objectTypeId: string; readonly primaryId: string }

--- a/packages/atlas/src/pages/WorkflowDetailPage.tsx
+++ b/packages/atlas/src/pages/WorkflowDetailPage.tsx
@@ -30,9 +30,7 @@ import {
   Bot,
   Box,
   CalendarClock,
-  Check,
   ChevronLeft,
-  Copy,
   Crosshair,
   GitBranch,
   History,
@@ -45,8 +43,9 @@ import {
   X,
   Zap,
 } from "lucide-react"
-import { type ReactNode, useEffect, useMemo, useState } from "react"
+import { type ReactNode, useEffect, useMemo } from "react"
 import { Navigate, useNavigate, useParams, useSearchParams } from "react-router-dom"
+import { CopyButton } from "../components/CopyButton"
 import { SixbFailureSummary } from "../components/SixbFailureSummary"
 import { StructuredValue } from "../components/StructuredValue"
 import {
@@ -56,12 +55,14 @@ import {
 import { SchemaShape } from "../features/workflows/components/nodes/SchemaShape"
 import { WorkflowInterventionPanel } from "../features/workflows/components/nodes/WorkflowInterventionPanel"
 import { RequestWorkflowRunDialog } from "../features/workflows/components/RequestWorkflowRunDialog"
+import { AgentExecutionPanel } from "../features/workflows/components/runs/AgentExecutionPanel"
 import { RunProgress } from "../features/workflows/components/runs/RunProgress"
 import {
   NodeStatusBadge,
   StatusBadge,
   WorkflowRunStatusIcon,
 } from "../features/workflows/components/runs/StatusBadge"
+import { WorkflowNodeExecutionPanel } from "../features/workflows/components/runs/WorkflowNodeExecutionPanel"
 import { useWorkflowLiveUpdates } from "../features/workflows/hooks/useWorkflowLiveUpdates"
 import {
   formatDate,
@@ -71,7 +72,6 @@ import {
   formatRunStartedDate,
   isActiveRunStatus,
   runTimeLabel,
-  type WorkflowAgentNodeExecution,
   type WorkflowDetail,
   type WorkflowNode,
   type WorkflowNodeStatus,
@@ -318,7 +318,9 @@ export function WorkflowDetailPage() {
           </div>
         </div>
 
-        <WorkflowSidePanel open={panelOpen}>{panelContent}</WorkflowSidePanel>
+        <WorkflowSidePanel open={panelOpen} wide={runNodesByFlowId.has(selectedNodeId ?? "")}>
+          {panelContent}
+        </WorkflowSidePanel>
       </ReactFlowProvider>
     </div>
   )
@@ -708,16 +710,26 @@ function WorkflowCanvas({
 // Side panel — shell + router
 // --------------------------------------------------------------------------
 
-function WorkflowSidePanel({ open, children }: { open: boolean; children: ReactNode }) {
+function WorkflowSidePanel({
+  open,
+  wide,
+  children,
+}: {
+  open: boolean
+  wide: boolean
+  children: ReactNode
+}) {
+  const width = wide ? "w-[36rem]" : "w-[22rem]"
   return (
     <aside
       className={cn(
         "h-full shrink-0 overflow-hidden border-l border-border bg-card transition-[width] duration-300 ease-out",
-        open ? "w-[22rem] max-w-[calc(100vw-1rem)]" : "w-0"
+        open ? width : "w-0",
+        "max-w-[calc(100vw-1rem)]"
       )}
       aria-hidden={!open}
     >
-      <div className="flex h-full w-[22rem] max-w-[calc(100vw-1rem)] flex-col">{children}</div>
+      <div className={cn("flex h-full max-w-[calc(100vw-1rem)] flex-col", width)}>{children}</div>
     </aside>
   )
 }
@@ -890,39 +902,6 @@ function PanelHeader({
         <X />
       </Button>
     </div>
-  )
-}
-
-function CopyButton({ value, label }: { value: string; label: string }) {
-  const [copied, setCopied] = useState(false)
-
-  useEffect(() => {
-    if (!copied) return
-    const timer = window.setTimeout(() => setCopied(false), 1500)
-    return () => window.clearTimeout(timer)
-  }, [copied])
-
-  const onCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(value)
-      setCopied(true)
-    } catch {
-      // Clipboard access can be denied; fail silently.
-    }
-  }
-
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon-xs"
-      onClick={onCopy}
-      aria-label={label}
-      title={label}
-      className="shrink-0 text-muted-foreground hover:text-foreground"
-    >
-      {copied ? <Check className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" /> : <Copy />}
-    </Button>
   )
 }
 
@@ -1471,6 +1450,11 @@ function RunNodePanel({
               <AgentExecutionPanel
                 summary={runNode.agentExecution}
                 execution={agentExecutionQuery.data}
+                nodeInput={runNode.input}
+                nodeOutput={runNode.output}
+                nodeError={runNode.error}
+                inputFileLinkForPath={fileLinkForRoot("input")}
+                outputFileLinkForPath={fileLinkForRoot("output")}
                 loading={agentExecutionQuery.isLoading}
                 failed={agentExecutionQuery.isError}
               />
@@ -1480,29 +1464,12 @@ function RunNodePanel({
               <WorkflowInterventionPanel node={runNode} />
             ) : null}
 
-            <PanelBlock label="Input" icon={<ArrowDownToLine className={SECTION_ICON} />}>
-              <StructuredValue
-                value={runNode.input}
-                emptyLabel="No input"
-                fileLinkForPath={fileLinkForRoot("input")}
+            {runNode.nodeType === "agent" ? null : (
+              <WorkflowNodeExecutionPanel
+                node={runNode}
+                inputFileLinkForPath={fileLinkForRoot("input")}
+                outputFileLinkForPath={fileLinkForRoot("output")}
               />
-            </PanelBlock>
-
-            {runNode.error ? (
-              <PanelBlock label="Error" icon={<X className={cn(SECTION_ICON, "text-red-500")} />}>
-                <SixbFailureSummary failure={runNode.error} className="text-sm" />
-              </PanelBlock>
-            ) : (
-              <PanelBlock
-                label={runNode.nodeType === "intervention" ? "Response" : "Output"}
-                icon={<ArrowUpFromLine className={SECTION_ICON} />}
-              >
-                <StructuredValue
-                  value={runNode.output ?? null}
-                  emptyLabel="No output"
-                  fileLinkForPath={fileLinkForRoot("output")}
-                />
-              </PanelBlock>
             )}
           </>
         ) : (
@@ -1518,63 +1485,5 @@ function RunNodePanel({
         )}
       </PanelScroll>
     </>
-  )
-}
-
-function AgentExecutionPanel({
-  summary,
-  execution,
-  loading,
-  failed,
-}: {
-  summary: WorkflowRunNode["agentExecution"]
-  execution: WorkflowAgentNodeExecution | undefined
-  loading: boolean
-  failed: boolean
-}) {
-  const data = execution ?? summary
-  return (
-    <PanelBlock label="Agent execution" icon={<Bot className={SECTION_ICON} />}>
-      {data ? (
-        <div className="space-y-3">
-          <div className="grid grid-cols-2 gap-2">
-            <RunStat label="Agent" value={data.agentId} />
-            <RunStat label="Attempt" value={String(data.attempt)} />
-            <RunStat label="Status" value={data.status} />
-            <RunStat label="Model" value={data.modelId ?? "—"} />
-          </div>
-          {data.usage ? (
-            <StructuredValue value={data.usage} emptyLabel="No token usage reported" />
-          ) : null}
-          {execution?.prompt ? (
-            <div>
-              <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                Prompt
-              </p>
-              <pre className="whitespace-pre-wrap break-words rounded-lg bg-muted/30 p-3 font-mono text-xs text-foreground">
-                {execution.prompt}
-              </pre>
-            </div>
-          ) : null}
-          {execution?.trace ? (
-            <div>
-              <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                Trace
-              </p>
-              <StructuredValue value={execution.trace} emptyLabel="No trace" />
-            </div>
-          ) : null}
-          {execution?.error ? (
-            <SixbFailureSummary failure={execution.error} className="text-sm" />
-          ) : null}
-        </div>
-      ) : loading ? (
-        <p className="text-xs text-muted-foreground">Loading agent execution...</p>
-      ) : failed ? (
-        <p className="text-xs text-destructive">Could not load agent execution.</p>
-      ) : (
-        <p className="text-xs text-muted-foreground">No agent execution record.</p>
-      )}
-    </PanelBlock>
   )
 }

--- a/packages/atlas/tests/live-update-keys.test.ts
+++ b/packages/atlas/tests/live-update-keys.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test"
+import { workflowChangedKeys } from "../src/lib/liveUpdateKeys"
+
+describe("workflowChangedKeys", () => {
+  test("invalidates the open workflow agent execution debugger", () => {
+    expect(workflowChangedKeys("triage", "run-1")).toContainEqual([
+      { _id: "getWorkflowAgentNodeExecution" },
+    ])
+  })
+})

--- a/packages/atlas/tests/structured-value.test.tsx
+++ b/packages/atlas/tests/structured-value.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { renderToStaticMarkup } from "react-dom/server"
+import { StructuredValue } from "../src/components/StructuredValue"
+
+describe("StructuredValue debug presentation", () => {
+  test("keeps short strings and object identifiers readable instead of truncating them", () => {
+    const title = "AHU-3 outside-air damper failed to track commanded position"
+    const primaryId = "equipment=broad-ahu-3/with/a/long/debug-identifier"
+    const markup = renderToStaticMarkup(
+      <StructuredValue
+        variant="debug"
+        value={{
+          equipment: { objectTypeId: "Equipment", primaryId },
+          title,
+        }}
+      />
+    )
+
+    expect(markup).toContain(title)
+    expect(markup).toContain(primaryId)
+    expect(markup).toContain("break-all")
+    expect(markup).not.toContain("truncate")
+    expect(markup).not.toContain("bg-muted/60")
+  })
+
+  test("preserves the compact chip presentation outside debugging surfaces", () => {
+    const markup = renderToStaticMarkup(<StructuredValue value={{ title: "A compact value" }} />)
+
+    expect(markup).toContain("truncate")
+    expect(markup).toContain("bg-muted/60")
+  })
+})

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -14561,11 +14561,463 @@
                     },
                     "trace": {
                       "type": "array",
-                      "items": {}
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": ["text"]
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "providerMetadata": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              }
+                            },
+                            "required": ["type", "text"],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": ["reasoning"]
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "providerMetadata": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              }
+                            },
+                            "required": ["type", "text"],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": ["step-start"]
+                              }
+                            },
+                            "required": ["type"],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": ["file"]
+                              },
+                              "fileRef": {
+                                "type": "object",
+                                "properties": {
+                                  "blobId": {
+                                    "type": "string"
+                                  },
+                                  "digest": {
+                                    "type": "string",
+                                    "pattern": "^sha256:[a-f0-9]{64}$"
+                                  },
+                                  "sizeBytes": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "fileName": {
+                                    "type": "string"
+                                  },
+                                  "mediaType": {
+                                    "type": "string"
+                                  },
+                                  "logicalPath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["blobId", "digest", "sizeBytes"],
+                                "additionalProperties": false
+                              },
+                              "providerMetadata": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              }
+                            },
+                            "required": ["type", "fileRef"],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "context": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "enum": ["object"]
+                                      },
+                                      "ref": {
+                                        "type": "object",
+                                        "properties": {
+                                          "objectTypeId": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "primaryId": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          }
+                                        },
+                                        "required": ["objectTypeId", "primaryId"],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": ["kind", "ref"],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "enum": ["app-state"]
+                                      },
+                                      "id": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "label": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "description": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "value": {
+                                        "description": "Any JSON-compatible value.",
+                                        "nullable": true,
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {}
+                                          },
+                                          {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": ["kind", "id", "label", "description", "value"],
+                                    "additionalProperties": false
+                                  }
+                                ]
+                              },
+                              "origin": {
+                                "type": "string",
+                                "enum": ["ambient", "explicit"]
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": ["context"]
+                              }
+                            },
+                            "required": ["context", "origin", "type"],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": ["tool-call"]
+                              },
+                              "toolCallId": {
+                                "type": "string"
+                              },
+                              "toolName": {
+                                "type": "string"
+                              },
+                              "dynamic": {
+                                "type": "boolean"
+                              },
+                              "providerExecuted": {
+                                "type": "boolean"
+                              },
+                              "input": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "providerMetadata": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "state": {
+                                "type": "string",
+                                "enum": ["output-available"]
+                              },
+                              "output": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "toolCallId",
+                              "toolName",
+                              "input",
+                              "state",
+                              "output"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": ["tool-call"]
+                              },
+                              "toolCallId": {
+                                "type": "string"
+                              },
+                              "toolName": {
+                                "type": "string"
+                              },
+                              "dynamic": {
+                                "type": "boolean"
+                              },
+                              "providerExecuted": {
+                                "type": "boolean"
+                              },
+                              "input": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "providerMetadata": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "state": {
+                                "type": "string",
+                                "enum": ["output-error"]
+                              },
+                              "errorText": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "toolCallId",
+                              "toolName",
+                              "input",
+                              "state",
+                              "errorText"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
                     },
                     "diagnostics": {
                       "type": "array",
-                      "items": {}
+                      "items": {
+                        "description": "Any JSON-compatible value.",
+                        "nullable": true,
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "array",
+                            "items": {}
+                          },
+                          {
+                            "type": "object",
+                            "additionalProperties": true
+                          }
+                        ]
+                      }
+                    },
+                    "failurePhase": {
+                      "type": "string",
+                      "enum": ["agent-loop", "structured-finalizer"]
                     },
                     "error": {
                       "type": "object",

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -5126,8 +5126,184 @@ export type GetWorkflowAgentNodeExecutionResponses = {
     completedAt?: string
     nodeRunId: string
     prompt: string
-    trace?: Array<unknown>
-    diagnostics?: Array<unknown>
+    trace?: Array<
+      | {
+          type: "text"
+          text: string
+          /**
+           * Any JSON-compatible value.
+           */
+          providerMetadata?:
+            | string
+            | number
+            | boolean
+            | Array<unknown>
+            | {
+                [key: string]: unknown
+              }
+            | null
+        }
+      | {
+          type: "reasoning"
+          text: string
+          /**
+           * Any JSON-compatible value.
+           */
+          providerMetadata?:
+            | string
+            | number
+            | boolean
+            | Array<unknown>
+            | {
+                [key: string]: unknown
+              }
+            | null
+        }
+      | {
+          type: "step-start"
+        }
+      | {
+          type: "file"
+          fileRef: {
+            blobId: string
+            digest: string
+            sizeBytes: number
+            fileName?: string
+            mediaType?: string
+            logicalPath?: string
+          }
+          /**
+           * Any JSON-compatible value.
+           */
+          providerMetadata?:
+            | string
+            | number
+            | boolean
+            | Array<unknown>
+            | {
+                [key: string]: unknown
+              }
+            | null
+        }
+      | {
+          context:
+            | {
+                kind: "object"
+                ref: {
+                  objectTypeId: string
+                  primaryId: string
+                }
+              }
+            | {
+                kind: "app-state"
+                id: string
+                label: string
+                description: string
+                /**
+                 * Any JSON-compatible value.
+                 */
+                value:
+                  | string
+                  | number
+                  | boolean
+                  | Array<unknown>
+                  | {
+                      [key: string]: unknown
+                    }
+                  | null
+              }
+          origin: "ambient" | "explicit"
+          type: "context"
+        }
+      | {
+          type: "tool-call"
+          toolCallId: string
+          toolName: string
+          dynamic?: boolean
+          providerExecuted?: boolean
+          /**
+           * Any JSON-compatible value.
+           */
+          input:
+            | string
+            | number
+            | boolean
+            | Array<unknown>
+            | {
+                [key: string]: unknown
+              }
+            | null
+          /**
+           * Any JSON-compatible value.
+           */
+          providerMetadata?:
+            | string
+            | number
+            | boolean
+            | Array<unknown>
+            | {
+                [key: string]: unknown
+              }
+            | null
+          state: "output-available"
+          /**
+           * Any JSON-compatible value.
+           */
+          output:
+            | string
+            | number
+            | boolean
+            | Array<unknown>
+            | {
+                [key: string]: unknown
+              }
+            | null
+        }
+      | {
+          type: "tool-call"
+          toolCallId: string
+          toolName: string
+          dynamic?: boolean
+          providerExecuted?: boolean
+          /**
+           * Any JSON-compatible value.
+           */
+          input:
+            | string
+            | number
+            | boolean
+            | Array<unknown>
+            | {
+                [key: string]: unknown
+              }
+            | null
+          /**
+           * Any JSON-compatible value.
+           */
+          providerMetadata?:
+            | string
+            | number
+            | boolean
+            | Array<unknown>
+            | {
+                [key: string]: unknown
+              }
+            | null
+          state: "output-error"
+          errorText: string
+        }
+    >
+    diagnostics?: Array<
+      | string
+      | number
+      | boolean
+      | Array<unknown>
+      | {
+          [key: string]: unknown
+        }
+      | null
+    >
+    failurePhase?: "agent-loop" | "structured-finalizer"
     error?: {
       code: "internal.unexpected" | "runtime.cancelled" | "agent.execution_failed"
       message: string

--- a/packages/server/src/routes/workflows.ts
+++ b/packages/server/src/routes/workflows.ts
@@ -157,9 +157,24 @@ function serializeWorkflowAgentExecution(execution: WorkflowAgentNodeRunView) {
     prompt: execution.prompt,
     trace: execution.trace,
     diagnostics: execution.diagnostics,
+    failurePhase: workflowAgentFailurePhase(execution),
     error: execution.error,
     createdAt: toIsoString(execution.createdAt),
   }
+}
+
+function workflowAgentFailurePhase(
+  execution: WorkflowAgentNodeRunView
+): "agent-loop" | "structured-finalizer" | undefined {
+  const details = execution.error?.details
+  if (!isRecord(details)) return undefined
+
+  const phase = details.failurePhase
+  return phase === "agent-loop" || phase === "structured-finalizer" ? phase : undefined
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
 }
 
 function principalForExecution(sixb: Sixb<readonly OntologySource[]>): Principal {

--- a/packages/server/src/schemas/workflows.ts
+++ b/packages/server/src/schemas/workflows.ts
@@ -4,7 +4,7 @@ import {
   type WorkflowRunFailureCode,
 } from "@sixb/core/storage"
 import { z } from "zod"
-import { AgentRunFailureSchema } from "./agents"
+import { AgentMessagePartSchema, AgentRunFailureSchema } from "./agents"
 import { AiUsageSummarySchema } from "./ai-usage"
 import { JsonValueSchema, sixbFailureSchema } from "./common"
 
@@ -152,11 +152,14 @@ export const WorkflowAgentNodeExecutionSummarySchema = z.object({
   completedAt: z.string().optional(),
 })
 
+export const WorkflowAgentFailurePhaseSchema = z.enum(["agent-loop", "structured-finalizer"])
+
 export const WorkflowAgentNodeExecutionSchema = WorkflowAgentNodeExecutionSummarySchema.extend({
   nodeRunId: z.string(),
   prompt: z.string(),
-  trace: z.array(z.unknown()).optional(),
-  diagnostics: z.array(z.unknown()).optional(),
+  trace: z.array(AgentMessagePartSchema).optional(),
+  diagnostics: z.array(JsonValueSchema).optional(),
+  failurePhase: WorkflowAgentFailurePhaseSchema.optional(),
   error: AgentRunFailureSchema.optional(),
   createdAt: z.string(),
 })

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -2163,6 +2163,111 @@ describe("SixbServer HTTP contract", () => {
     })
   })
 
+  test("returns a typed workflow agent trace and failure phase", async () => {
+    await withHttpContractServer(async ({ baseUrl, sixb }) => {
+      const runs = sixb.storage.workflowRuns!
+      const runId = "workflow-agent-failed-trace"
+      const nodeRunId = `${runId}:node:0`
+      const workflowExecutionId = await createTestWorkflowExecution(sixb.storage.executions, {
+        projectId: sixb.id,
+        workflowId: "review-device-health-workflow",
+        runId,
+      })
+      await runs.queue({
+        id: runId,
+        projectId: sixb.id,
+        executionId: workflowExecutionId,
+        workflowId: "review-device-health-workflow",
+        input: { deviceId: "fan-1" },
+        requesterGroupIds: [],
+      })
+      await runs.start({ id: runId, projectId: sixb.id })
+      await runs.nodes.start({
+        id: nodeRunId,
+        projectId: sixb.id,
+        workflowRunId: runId,
+        workflowId: "review-device-health-workflow",
+        nodeIndex: 0,
+        nodeType: "agent",
+        nodeId: "resolve-device",
+        nodeKey: "resolveDevice",
+        input: { deviceId: "fan-1" },
+      })
+      const agentExecutionId = await createTestAgentExecution(sixb.storage, {
+        projectId: sixb.id,
+        agentId: "device-resolver",
+        runId: nodeRunId,
+        sourceExecutionId: workflowExecutionId,
+      })
+      await runs.agentNodes.create({
+        projectId: sixb.id,
+        nodeRunId,
+        executionId: agentExecutionId,
+        agentId: "device-resolver",
+        prompt: "Resolve fan-1.",
+      })
+      await runs.nodes.wait({ projectId: sixb.id, id: nodeRunId })
+      await runs.wait({ projectId: sixb.id, id: runId })
+      await runs.agentNodes.start({
+        projectId: sixb.id,
+        nodeRunId,
+        modelId: "test-model",
+        execution: {
+          token: "failed-trace-token",
+          queueLeaseExpiresAt: new Date(Date.now() + 60_000),
+        },
+      })
+      await runs.agentNodes.finish({
+        projectId: sixb.id,
+        nodeRunId,
+        executionToken: "failed-trace-token",
+        status: "failed",
+        modelId: "test-model",
+        trace: [
+          { type: "step-start" },
+          {
+            type: "tool-call",
+            toolCallId: "policy-call",
+            toolName: "lookup_policy",
+            state: "output-available",
+            input: { severity: "high" },
+            output: { responseWindowMinutes: 90 },
+          },
+          { type: "text", text: "Dispatch within 90 minutes." },
+        ],
+        error: {
+          code: "agent.execution_failed",
+          message: "Structured output did not match the workflow contract.",
+          retryable: false,
+          at: "2026-07-02T12:01:00.000Z",
+          details: { failurePhase: "structured-finalizer" },
+        },
+        completedAt: new Date("2026-07-02T12:01:00.000Z"),
+      })
+
+      const response = await fetch(
+        `${baseUrl}/api/workflow-runs/${runId}/nodes/resolveDevice/agent-execution`
+      )
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toMatchObject({
+        status: "failed",
+        failurePhase: "structured-finalizer",
+        trace: [
+          { type: "step-start" },
+          {
+            type: "tool-call",
+            toolName: "lookup_policy",
+            state: "output-available",
+            input: { severity: "high" },
+            output: { responseWindowMinutes: 90 },
+          },
+          { type: "text", text: "Dispatch within 90 minutes." },
+        ],
+      })
+    })
+  })
+
   test("supports documented write endpoints", async () => {
     await withHttpContractServer(async ({ baseUrl, events, sixb }) => {
       const upsertObjectResponse = await fetch(`${baseUrl}/api/objects/device/fan-2`, {


### PR DESCRIPTION
## Context

Stacked on #457, which moves workflow agent steps onto the shared agent loop.

Workflow runs currently expose a node's input, output, and error, but agent steps do not expose the work that produced that result. This makes tool calls, model steps, resolved prompts, usage, and failure phases difficult to inspect from Atlas.

## What changed

- Persist the durable agent trace, resolved prompt, finish reason, usage, diagnostics, and failure phase on workflow agent executions.
- Add a typed API and generated client endpoint for reading an agent node execution by workflow run and node key.
- Add a shared read-only agent trace renderer for conversation and debugger surfaces.
- Add an Atlas agent debugger with `Trace`, `Input & output`, and `Details` views.
- Give regular workflow steps the same simple `Input`, `Output`, and `Details` debugging model.
- Flatten the drawer hierarchy, wrap long debug values, and keep exact execution records available as a copyable escape hatch.

## Flow

```text
workflow agent node
        |
        v
shared agent loop                 #457
        |
        +--> durable prompt + trace + usage
        |
        v
structured finalizer (if needed)
        |
        v
workflow node result
        |
        v
GET /workflows/:runId/nodes/:nodeKey/agent-execution
        |
        v
Atlas: Trace | Input & output | Details
```

## Review notes

- The structured finalizer remains a small post-loop step and does not receive reasoning or tool-call history.
- Agent failure phases distinguish the shared loop from structured finalization.
- The Atlas drawer uses one border depth; semantic failure callouts remain bordered.
- The Northline agent and regular workflow examples were exercised in the live Atlas UI.

##  Screenshots
<img width="580" height="871" alt="Screenshot 2026-08-26 at 7 44 11 PM" src="https://github.com/user-attachments/assets/671ff060-f851-49b9-8ee0-acc36cf37f67" />
<img width="550" height="1034" alt="Screenshot 2026-08-26 at 7 44 08 PM" src="https://github.com/user-attachments/assets/9672cca4-2826-4c6b-9e69-dbee7bddcf5a" />
<img width="581" height="693" alt="Screenshot 2026-08-26 at 7 44 03 PM" src="https://github.com/user-attachments/assets/54e1feac-b4b2-4c18-82ed-aa17c145a732" />
<img width="1056" height="796" alt="Screenshot 2026-08-26 at 7 43 50 PM" src="https://github.com/user-attachments/assets/607985dc-ab3d-4dce-a425-5e9ea50f182c" />



