### PR TITLE
release: support passkey-authenticated publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,6 +236,17 @@ bun run release
 bun run release:publish -- --tag next
 ```
 
+For a passkey or security key, authenticate through the browser and keep the publisher interactive
+so every `bun publish` can expose its WebAuthn challenge:
+
+```bash
+bunx npm login --auth-type=web
+bun run release:publish -- --tag next --auth-type web
+```
+
+The publisher gives the child process direct terminal access in this mode. A failed or interrupted
+challenge is safe to resume: re-run the command and versions already on the registry are skipped.
+
 The tag changes how npm resolves an install, not the package version: consumers opt into previews
 with `bun add @sixb/core@next` or `bunx create-sixb@next my-app`. Publishing another preview moves
 `next` forward without making it the default install.

--- a/scripts/publish-options.ts
+++ b/scripts/publish-options.ts
@@ -1,0 +1,68 @@
+export type PublishAuthType = "legacy" | "web"
+
+export interface PublishOptions {
+  readonly authType?: PublishAuthType
+  readonly dryRun: boolean
+  readonly planOnly: boolean
+  readonly tag: string
+  readonly otp?: string
+  readonly registry?: string
+}
+
+const usage =
+  "bun scripts/publish.ts [--plan] [--dry-run] [--tag <tag>] " +
+  "[--auth-type <web|legacy>] [--otp <code>] [--registry <url>]"
+
+export function parsePublishOptions(argv: string[]): PublishOptions {
+  const values = new Map<string, string>()
+  let dryRun = false
+  let planOnly = false
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index]
+    if (arg === "--dry-run") {
+      dryRun = true
+      continue
+    }
+    if (arg === "--plan") {
+      planOnly = true
+      continue
+    }
+    if (arg === "--auth-type" || arg === "--tag" || arg === "--otp" || arg === "--registry") {
+      const value = argv[index + 1]
+      if (!value || value.startsWith("--")) {
+        throw new Error(`[SixbPublish] ${arg} needs a value.`)
+      }
+      values.set(arg, value)
+      index++
+      continue
+    }
+    throw new Error(`[SixbPublish] Unknown argument ${arg}. Usage: ${usage}`)
+  }
+
+  const authType = parseAuthType(values.get("--auth-type"))
+
+  const otp = values.get("--otp")
+  if (authType === "web" && otp) {
+    throw new Error(
+      "[SixbPublish] --auth-type web cannot be combined with --otp. " +
+        "Approve the browser challenge with your passkey instead."
+    )
+  }
+
+  const registry = values.get("--registry")
+  return {
+    dryRun,
+    planOnly,
+    tag: values.get("--tag") ?? "latest",
+    ...(authType ? { authType } : {}),
+    ...(otp ? { otp } : {}),
+    ...(registry ? { registry } : {}),
+  }
+}
+
+function parseAuthType(value: string | undefined): PublishAuthType | undefined {
+  if (!value) return undefined
+  if (value === "legacy" || value === "web") return value
+  throw new Error(`[SixbPublish] --auth-type must be "web" or "legacy" (received "${value}").`)
+}

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -4,6 +4,7 @@
  *   bun scripts/publish.ts --plan
  *   bun scripts/publish.ts --dry-run
  *   bun scripts/publish.ts --tag next
+ *   bun scripts/publish.ts --tag next --auth-type web  # passkey / browser challenge
  *   bun scripts/publish.ts --tag next --otp 123456
  *   bun scripts/publish.ts --tag next --registry http://localhost:4873  # local rehearsal
  *
@@ -19,6 +20,7 @@
  * whole thing with no credentials and no public side effects, point `--registry` at a local registry.
  */
 import { join } from "node:path"
+import { parsePublishOptions } from "./publish-options"
 import {
   discoverPublishablePackages,
   packageName,
@@ -34,7 +36,7 @@ import {
 import { assertReleaseTagAllowed, isPreviewRelease } from "./release-policy"
 
 const root = process.cwd()
-const options = parseOptions(process.argv.slice(2))
+const options = parsePublishOptions(process.argv.slice(2))
 const ordered = topologicalPublishOrder(await discoverPublishablePackages(root))
 const registryByName = new Map(
   await Promise.all(
@@ -108,8 +110,27 @@ if (options.tag !== "latest" && !options.dryRun && !options.planOnly) {
 async function publishPackage(release: PlannedPackageRelease): Promise<void> {
   const args = [process.execPath, "publish", "--tag", options.tag]
   if (options.dryRun) args.push("--dry-run")
+  if (options.authType) args.push("--auth-type", options.authType)
   if (options.otp) args.push("--otp", options.otp)
   if (options.registry) args.push("--registry", options.registry)
+
+  if (options.authType) {
+    const proc = Bun.spawn(args, {
+      cwd: join(root, release.packageInfo.dir),
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    })
+    const exitCode = await proc.exited
+
+    if (exitCode === 0) return
+
+    throw new Error(
+      `[SixbPublish] Failed to publish ${packageReleaseId(release)}; see the interactive output above.\n\n` +
+        `Published so far: ${published.length > 0 ? published.join(", ") : "nothing"}\n` +
+        "Fix the cause and re-run; packages already on the registry are skipped."
+    )
+  }
 
   const proc = Bun.spawn(args, {
     cwd: join(root, release.packageInfo.dir),
@@ -200,53 +221,4 @@ function dependencyRecord(value: unknown): Record<string, string> | undefined {
 
 function uniqueReleases(releases: readonly PlannedPackageRelease[]): PlannedPackageRelease[] {
   return [...new Map(releases.map((release) => [packageReleaseId(release), release])).values()]
-}
-
-interface PublishOptions {
-  readonly dryRun: boolean
-  readonly planOnly: boolean
-  readonly tag: string
-  readonly otp?: string
-  readonly registry?: string
-}
-
-function parseOptions(argv: string[]): PublishOptions {
-  const values = new Map<string, string>()
-  let dryRun = false
-  let planOnly = false
-
-  for (let index = 0; index < argv.length; index++) {
-    const arg = argv[index]
-    if (arg === "--dry-run") {
-      dryRun = true
-      continue
-    }
-    if (arg === "--plan") {
-      planOnly = true
-      continue
-    }
-    if (arg === "--tag" || arg === "--otp" || arg === "--registry") {
-      const value = argv[index + 1]
-      if (!value || value.startsWith("--")) {
-        throw new Error(`[SixbPublish] ${arg} needs a value.`)
-      }
-      values.set(arg, value)
-      index++
-      continue
-    }
-    throw new Error(
-      `[SixbPublish] Unknown argument ${arg}. Usage: bun scripts/publish.ts ` +
-        "[--plan] [--dry-run] [--tag <tag>] [--otp <code>] [--registry <url>]"
-    )
-  }
-
-  const otp = values.get("--otp")
-  const registry = values.get("--registry")
-  return {
-    dryRun,
-    planOnly,
-    tag: values.get("--tag") ?? "latest",
-    ...(otp ? { otp } : {}),
-    ...(registry ? { registry } : {}),
-  }
 }

--- a/scripts/tests/publish-options.test.ts
+++ b/scripts/tests/publish-options.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import { parsePublishOptions } from "../publish-options"
+
+describe("publish options", () => {
+  test("defaults to a latest publication", () => {
+    expect(parsePublishOptions([])).toEqual({
+      dryRun: false,
+      planOnly: false,
+      tag: "latest",
+    })
+  })
+
+  test("accepts an interactive web-authenticated release", () => {
+    expect(parsePublishOptions(["--tag", "next", "--auth-type", "web"])).toEqual({
+      authType: "web",
+      dryRun: false,
+      planOnly: false,
+      tag: "next",
+    })
+  })
+
+  test("keeps legacy OTP and registry options available", () => {
+    expect(
+      parsePublishOptions([
+        "--dry-run",
+        "--auth-type",
+        "legacy",
+        "--otp",
+        "123456",
+        "--registry",
+        "http://localhost:4873",
+      ])
+    ).toEqual({
+      authType: "legacy",
+      dryRun: true,
+      planOnly: false,
+      tag: "latest",
+      otp: "123456",
+      registry: "http://localhost:4873",
+    })
+  })
+
+  test("rejects unsupported authentication types", () => {
+    expect(() => parsePublishOptions(["--auth-type", "passkey"])).toThrow(
+      '--auth-type must be "web" or "legacy"'
+    )
+  })
+
+  test("does not silently turn web authentication into an OTP flow", () => {
+    expect(() => parsePublishOptions(["--auth-type", "web", "--otp", "123456"])).toThrow(
+      "--auth-type web cannot be combined with --otp"
+    )
+  })
+
+  test("reports missing values and the complete usage", () => {
+    expect(() => parsePublishOptions(["--auth-type"])).toThrow("--auth-type needs a value")
+    expect(() => parsePublishOptions(["--wat"])).toThrow("[--auth-type <web|legacy>]")
+  })
+})


### PR DESCRIPTION
## Summary

Add web authentication support to the release publisher so maintainers can complete npm WebAuthn challenges with a passkey or security key. Interactive authentication inherits the terminal, while the existing legacy and OTP flow remains available.

Document the macOS passkey workflow and validate incompatible authentication options early.

## Linked issue

None.

## Scope

Release tooling and contributor documentation only.

## Validation

- `bun test scripts/tests/publish-options.test.ts scripts/tests/release-plan.test.ts scripts/tests/release-policy.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run release`
- `bun run release:plan -- --tag next --auth-type web`
- Completed the npm publish flow using a macOS passkey

## Notes

A failed or interrupted browser challenge remains resumable because package versions already present on the registry are skipped.