### PR TITLE
projections: resolve source and edits by recency

### DIFF
--- a/docs/actions/overview.md
+++ b/docs/actions/overview.md
@@ -261,9 +261,10 @@ for a new one. Both return a handle with the rest of the edits:
 })
 ```
 
-When a [projection](../data/projections.md) also writes an object, values your actions set win
-over the projected ones. `reset(...)` drops the action's value for those properties so the projected
-value becomes visible again — use it to hand a field back to the projection.
+By default, when a [projection](../data/projections.md) also writes an object, values your actions set
+win over the projected ones. A projection configured with `mostRecent` can instead make a newer
+source value effective. `reset(...)` drops the action's value in either case so the projected value
+becomes visible again — use it to hand a field back to the projection.
 
 Repeated edits on one object stay in order, and a later `update(...)` sees what an earlier one wrote.
 An edit that ends up changing nothing emits no mutation event.

--- a/docs/data/projections.md
+++ b/docs/data/projections.md
@@ -44,6 +44,35 @@ export const customerProjection = defineProjection("customer-proj", Customer)
 
 The object property `id` reads from column `customer_id`, `name` from `contact_name`, and so on.
 
+### Source and Action conflict resolution
+
+By default, an Action edit to a projected property remains authoritative until application code
+resets that property. This `editsWin` policy is useful when Sixb owns the decision.
+
+When the source system remains authoritative, use `mostRecent` with a non-null timestamp column
+that contains the source system's own update time:
+
+```ts
+export const githubIssueProjection = defineProjection("github-issues", GitHubIssue)
+  .fromDataset(githubIssues)
+  .properties({
+    id: "id",
+    title: "title",
+    body: "body",
+    state: "state",
+  })
+  .resolveConflicts({
+    strategy: "mostRecent",
+    sourceTimestamp: "updated_at",
+  })
+```
+
+Resolution is per property. A source value wins when its timestamp is equal to or newer than that
+property's edit time; otherwise the Action edit wins. Editing one property does not refresh any
+other property's edit time. Unmapped properties remain edit-only. Use the source record's update
+time—not dataset ingestion or commit time—because those times do not establish when the source
+value changed.
+
 ## Links from foreign keys
 
 When a row carries a foreign key, turn it into an ontology link with `.withLinks(...)`. Each entry is

--- a/docs/data/projections.md
+++ b/docs/data/projections.md
@@ -44,10 +44,10 @@ export const customerProjection = defineProjection("customer-proj", Customer)
 
 The object property `id` reads from column `customer_id`, `name` from `contact_name`, and so on.
 
-### Source and Action conflict resolution
+### Source and managed-edit conflict resolution
 
-By default, an Action edit to a projected property remains authoritative until application code
-resets that property. This `editsWin` policy is useful when Sixb owns the decision.
+By default, an Action or runtime edit to a projected property remains authoritative until
+application code resets that property. This `editsWin` policy is useful when Sixb owns the decision.
 
 When the source system remains authoritative, use `mostRecent` with a non-null timestamp column
 that contains the source system's own update time:
@@ -68,10 +68,14 @@ export const githubIssueProjection = defineProjection("github-issues", GitHubIss
 ```
 
 Resolution is per property. A source value wins when its timestamp is equal to or newer than that
-property's edit time; otherwise the Action edit wins. Editing one property does not refresh any
-other property's edit time. Unmapped properties remain edit-only. Use the source record's update
-time—not dataset ingestion or commit time—because those times do not establish when the source
-value changed.
+property's Action or runtime edit time; otherwise the managed edit wins. Editing one property does
+not refresh any other property's edit time. Unmapped properties remain edit-only.
+
+Use the source record's own update time—not dataset ingestion or commit time—because those times do
+not establish when the source value changed. The timestamp must carry a time zone, progress
+monotonically for each record, and have enough precision to order source updates against managed
+edits. Sixb canonicalizes it to UTC, then compares it with the Sixb commit clock, so the source and
+Sixb clocks must be reasonably synchronized.
 
 ## Links from foreign keys
 

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -30820,6 +30820,35 @@
                               "additionalProperties": false
                             }
                           },
+                          "conflictResolution": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "strategy": {
+                                    "type": "string",
+                                    "enum": ["editsWin"]
+                                  }
+                                },
+                                "required": ["strategy"],
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "strategy": {
+                                    "type": "string",
+                                    "enum": ["mostRecent"]
+                                  },
+                                  "sourceTimestamp": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["strategy", "sourceTimestamp"],
+                                "additionalProperties": false
+                              }
+                            ]
+                          },
                           "latestRun": {
                             "anyOf": [
                               {
@@ -31364,6 +31393,7 @@
                           "datasetId",
                           "properties",
                           "links",
+                          "conflictResolution",
                           "latestRun"
                         ],
                         "additionalProperties": false
@@ -32611,6 +32641,35 @@
                             "additionalProperties": false
                           }
                         },
+                        "conflictResolution": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "strategy": {
+                                  "type": "string",
+                                  "enum": ["editsWin"]
+                                }
+                              },
+                              "required": ["strategy"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "strategy": {
+                                  "type": "string",
+                                  "enum": ["mostRecent"]
+                                },
+                                "sourceTimestamp": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["strategy", "sourceTimestamp"],
+                              "additionalProperties": false
+                            }
+                          ]
+                        },
                         "latestRun": {
                           "anyOf": [
                             {
@@ -33137,6 +33196,7 @@
                         "datasetId",
                         "properties",
                         "links",
+                        "conflictResolution",
                         "latestRun"
                       ],
                       "additionalProperties": false

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -10578,6 +10578,14 @@ export type ListProjectionsResponses = {
           targetObjectTypeId: string
         }
       }
+      conflictResolution:
+        | {
+            strategy: "editsWin"
+          }
+        | {
+            strategy: "mostRecent"
+            sourceTimestamp: string
+          }
       latestRun:
         | {
             id: string
@@ -11132,6 +11140,14 @@ export type GetProjectionResponses = {
             targetObjectTypeId: string
           }
         }
+        conflictResolution:
+          | {
+              strategy: "editsWin"
+            }
+          | {
+              strategy: "mostRecent"
+              sourceTimestamp: string
+            }
         latestRun:
           | {
               id: string

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1023,12 +1023,16 @@ export type {
   ForeignKeyDescriptor,
   LinkProjectionDefinition,
   LinkProjectionTarget,
+  ObjectProjectionBuilder,
+  ObjectProjectionConflictResolution,
   ObjectProjectionDefinition,
   ObjectProjectionTarget,
   ProjectionDefinition,
   ProjectionDefinitionCatalog,
+  ProjectionForeignKeyInput,
   ProjectionTarget,
   ProjectionTargetByKind,
+  SourceEditConflictResolution,
   TelemetryProjectionDefinition,
 } from "./projections"
 

--- a/packages/core/src/materialization/model.ts
+++ b/packages/core/src/materialization/model.ts
@@ -2,7 +2,11 @@ import type { SixbFailure } from "../errors/types"
 import type { EventOrigin } from "../events/envelope"
 import type { PropertyChange, PropertyChangeMap } from "../events/property-changes"
 import type { JsonValue } from "../json"
-import type { ProjectionProtocolIdentity, ProjectionRunFailureCode } from "../projections/types"
+import type {
+  ProjectionProtocolIdentity,
+  ProjectionRunFailureCode,
+  SourceEditConflictResolution,
+} from "../projections/types"
 
 export type { ProjectionProtocolIdentity } from "../projections/types"
 
@@ -152,6 +156,12 @@ export type ProjectionSourceAssertion =
       readonly kind: "object"
       readonly ref: OntologyObjectRef
       readonly properties: Readonly<Record<string, JsonValue>>
+      /** Canonical source-system update time supplied for `mostRecent` resolution. */
+      readonly sourceUpdatedAt?: string
+      /** Pinned by the materializer from the versioned projection definition. */
+      readonly conflictResolution?: SourceEditConflictResolution
+      /** Mapped properties, including properties absent from this row's value. */
+      readonly projectedPropertyIds?: readonly string[]
     }
   | {
       readonly kind: "link"

--- a/packages/core/src/materialization/model.ts
+++ b/packages/core/src/materialization/model.ts
@@ -2,11 +2,7 @@ import type { SixbFailure } from "../errors/types"
 import type { EventOrigin } from "../events/envelope"
 import type { PropertyChange, PropertyChangeMap } from "../events/property-changes"
 import type { JsonValue } from "../json"
-import type {
-  ProjectionProtocolIdentity,
-  ProjectionRunFailureCode,
-  SourceEditConflictResolution,
-} from "../projections/types"
+import type { ProjectionProtocolIdentity, ProjectionRunFailureCode } from "../projections/types"
 
 export type { ProjectionProtocolIdentity } from "../projections/types"
 
@@ -156,12 +152,10 @@ export type ProjectionSourceAssertion =
       readonly kind: "object"
       readonly ref: OntologyObjectRef
       readonly properties: Readonly<Record<string, JsonValue>>
-      /** Canonical source-system update time supplied for `mostRecent` resolution. */
+      /** Canonical source-system update time. Presence after validation pins `mostRecent`. */
       readonly sourceUpdatedAt?: string
-      /** Pinned by the materializer from the versioned projection definition. */
-      readonly conflictResolution?: SourceEditConflictResolution
-      /** Mapped properties, including properties absent from this row's value. */
-      readonly projectedPropertyIds?: readonly string[]
+      /** Projected properties represented by an absence candidate in this source row. */
+      readonly absentSourcePropertyIds?: readonly string[]
     }
   | {
       readonly kind: "link"

--- a/packages/core/src/materializer/edits/apply.ts
+++ b/packages/core/src/materializer/edits/apply.ts
@@ -25,6 +25,8 @@ interface ObjectEditInput {
   readonly operation: ObjectEditOperation
   readonly sourceProperties: Readonly<Record<string, JsonValue>> | null
   readonly authority: ObjectOverride | null
+  readonly editedAt: Readonly<Record<string, string>>
+  readonly committedAt: string
   readonly effectiveExists: boolean
   readonly normalizedProperties?: Readonly<Record<string, JsonValue>>
   readonly normalizedSet?: Readonly<Record<string, JsonValue>>
@@ -43,7 +45,11 @@ export interface AuthorityTransition<T> {
   readonly changed: boolean
 }
 
-export function applyObjectEdit(input: ObjectEditInput): AuthorityTransition<ObjectOverride> {
+export interface ObjectAuthorityTransition extends AuthorityTransition<ObjectOverride> {
+  readonly editedAt: Readonly<Record<string, string>>
+}
+
+export function applyObjectEdit(input: ObjectEditInput): ObjectAuthorityTransition {
   const current = input.authority
   let next: ObjectOverride | null
 
@@ -67,7 +73,54 @@ export function applyObjectEdit(input: ObjectEditInput): AuthorityTransition<Obj
       throw new MaterializationValidationError("Expected an object edit operation.")
   }
 
-  return transition(current, next)
+  const editedAt = applyObjectEditTimes(input, next)
+  const authority = transition(current, next)
+  return {
+    ...authority,
+    editedAt,
+    changed: authority.changed || !sameStringRecord(input.editedAt, editedAt),
+  }
+}
+
+function applyObjectEditTimes(
+  input: ObjectEditInput,
+  next: ObjectOverride | null
+): Readonly<Record<string, string>> {
+  if (!next || next.kind === "delete") return {}
+  const editedAt =
+    input.operation.kind === "object.create" || input.authority?.kind === "delete"
+      ? {}
+      : { ...input.editedAt }
+
+  switch (input.operation.kind) {
+    case "object.create":
+    case "object.upsert": {
+      const properties = input.normalizedProperties ?? input.operation.properties
+      for (const propertyId of Object.keys(properties)) editedAt[propertyId] = input.committedAt
+      break
+    }
+    case "object.patch":
+      for (const propertyId of input.operation.reset) delete editedAt[propertyId]
+      for (const propertyId of input.operation.unset) editedAt[propertyId] = input.committedAt
+      for (const propertyId of Object.keys(input.normalizedSet ?? input.operation.set)) {
+        editedAt[propertyId] = input.committedAt
+      }
+      break
+    case "object.delete":
+      return editedAt
+    case "object.restore":
+      break
+  }
+  return editedAt
+}
+
+function sameStringRecord(
+  left: Readonly<Record<string, string>>,
+  right: Readonly<Record<string, string>>
+): boolean {
+  const leftKeys = Object.keys(left)
+  if (leftKeys.length !== Object.keys(right).length) return false
+  return leftKeys.every((key) => left[key] === right[key])
 }
 
 function applyObjectCreate(

--- a/packages/core/src/materializer/edits/operations.ts
+++ b/packages/core/src/materializer/edits/operations.ts
@@ -93,11 +93,13 @@ function applyObjectOperation(
     operation,
     sourceProperties: working.source?.assertion.properties ?? null,
     authority: working.override,
+    editedAt: working.editedAt,
+    committedAt: identity.committedAt,
     effectiveExists: currentEffective !== null,
     ...normalized,
   })
 
-  applyObjectTransition(context, state, working, transition.next, journal)
+  applyObjectTransition(context, state, working, transition.next, transition.editedAt, journal)
 
   return objectOperationOutcome(operation, working, transition.changed, context, identity)
 }
@@ -146,21 +148,26 @@ function applyObjectTransition(
   state: EditWorkingState,
   working: WorkingObject,
   next: WorkingObject["override"],
+  nextEditedAt: Readonly<Record<string, string>>,
   journal?: EditUndoJournal
 ): void {
   const previous = working.override
+  const previousEditedAt = working.editedAt
   working.override = next
+  working.editedAt = { ...nextEditedAt }
   try {
     const resolved = resolveObject(context.ontology, working)
     if (resolved) validateEffectiveObject(context.ontology, resolved.ref, resolved.properties)
     validateWorkingCardinality(state.links.slots)
   } catch (error) {
     working.override = previous
+    working.editedAt = previousEditedAt
     throw error
   }
   journal?.push({
     restore: () => {
       working.override = previous
+      working.editedAt = previousEditedAt
     },
   })
 }

--- a/packages/core/src/materializer/edits/working-state.ts
+++ b/packages/core/src/materializer/edits/working-state.ts
@@ -25,6 +25,7 @@ import {
   resolveEffectiveLink,
   resolveEffectiveLinkSlot,
   resolveEffectiveObject,
+  storedObjectEditedAt,
   usableLinkSlotOverride,
 } from "../effective/resolve"
 import { linkCardinality } from "./read-set"
@@ -33,6 +34,8 @@ export interface WorkingObject {
   source: MaterializationObjectState["source"]
   originalOverride: StoredObjectOverride | null
   override: ObjectOverride | null
+  originalEditedAt: Readonly<Record<string, string>>
+  editedAt: Record<string, string>
   before: MaterializationObjectState["effective"]
   latestTelemetry: StoredTelemetryPoint[]
 }
@@ -112,11 +115,14 @@ function workingLinkSlotFromState(scope: MaterializationLinkScopeState): Working
 }
 
 export function workingObjectFromState(object: MaterializationObjectState): WorkingObject {
+  const editedAt = storedObjectEditedAt(object.override)
   return {
     ref: object.ref,
     source: object.source,
     originalOverride: object.override,
     override: object.override?.value ?? null,
+    originalEditedAt: editedAt,
+    editedAt: { ...editedAt },
     before: object.effective,
     latestTelemetry: [...object.latestTelemetry],
   }
@@ -141,6 +147,7 @@ export function resolveObject(
     primaryPropertyId: ontology.getPrimaryPropertyId(working.ref.objectTypeId),
     source: working.source,
     override: working.override,
+    editedAt: working.editedAt,
     latestTelemetry: working.latestTelemetry,
   })
 }

--- a/packages/core/src/materializer/effective/resolve.ts
+++ b/packages/core/src/materializer/effective/resolve.ts
@@ -11,6 +11,7 @@ import type {
 import { linkRefKey } from "../../materialization/refs"
 import type {
   StoredLinkSlotOverride,
+  StoredObjectOverride,
   StoredSourceLinkAssertion,
   StoredSourceObjectAssertion,
   StoredTelemetryPoint,
@@ -46,9 +47,10 @@ export function resolveEffectiveObject(input: {
   readonly primaryPropertyId: string
   readonly source: StoredSourceObjectAssertion | null
   readonly override: ObjectOverride | null
+  readonly editedAt: Readonly<Record<string, string>>
   readonly latestTelemetry: readonly StoredTelemetryPoint[]
 }): ResolvedObjectValue | null {
-  const properties = resolveObjectAuthority(input.source, input.override)
+  const properties = resolveObjectAuthority(input.source, input.override, input.editedAt)
   if (!properties) return null
 
   properties[input.primaryPropertyId] = input.ref.primaryId
@@ -58,29 +60,97 @@ export function resolveEffectiveObject(input: {
 
 function resolveObjectAuthority(
   source: StoredSourceObjectAssertion | null,
-  override: ObjectOverride | null
+  override: ObjectOverride | null,
+  editedAt: Readonly<Record<string, string>>
 ): Record<string, JsonValue> | null {
   switch (override?.kind) {
     case "delete":
       return null
     case "create":
-      return { ...override.properties }
+      if (!source) return { ...override.properties }
+      return resolveSourceAndEdits(source, override, editedAt)
     case "patch":
       if (!source) return null
-      return applyObjectPatch(source.assertion.properties, override)
+      return resolveSourceAndEdits(source, override, editedAt)
     default:
       if (!source) return null
       return { ...source.assertion.properties }
   }
 }
 
-function applyObjectPatch(
-  sourceProperties: Readonly<Record<string, JsonValue>>,
-  override: Extract<ObjectOverride, { readonly kind: "patch" }>
+function resolveSourceAndEdits(
+  source: StoredSourceObjectAssertion,
+  override: Exclude<ObjectOverride, { readonly kind: "delete" }>,
+  editedAt: Readonly<Record<string, string>>
 ): Record<string, JsonValue> {
-  const properties = { ...sourceProperties, ...override.set }
-  for (const propertyId of override.unset) delete properties[propertyId]
+  const properties = { ...source.assertion.properties }
+  const policy = source.assertion.conflictResolution ?? { strategy: "editsWin" }
+  const projectedPropertyIds = new Set(
+    source.assertion.projectedPropertyIds ?? Object.keys(source.assertion.properties)
+  )
+
+  for (const propertyId of objectEditCandidateIds(override, editedAt)) {
+    const edit = objectEditCandidate(override, propertyId)
+    const editTimestamp = editedAt[propertyId]
+    const sourceWins =
+      projectedPropertyIds.has(propertyId) &&
+      policy.strategy === "mostRecent" &&
+      source.assertion.sourceUpdatedAt !== undefined &&
+      editTimestamp !== undefined &&
+      source.assertion.sourceUpdatedAt.localeCompare(editTimestamp) >= 0
+
+    if (!sourceWins) applyObjectEditCandidate(properties, propertyId, edit)
+  }
   return properties
+}
+
+interface ObjectPropertyCandidate {
+  readonly present: boolean
+  readonly value?: JsonValue
+}
+
+function objectEditCandidateIds(
+  override: Exclude<ObjectOverride, { readonly kind: "delete" }>,
+  editedAt: Readonly<Record<string, string>>
+): string[] {
+  const ids = new Set(Object.keys(editedAt))
+  if (override.kind === "create") {
+    for (const propertyId of Object.keys(override.properties)) ids.add(propertyId)
+  } else {
+    for (const propertyId of Object.keys(override.set)) ids.add(propertyId)
+    for (const propertyId of override.unset) ids.add(propertyId)
+  }
+  return [...ids]
+}
+
+function objectEditCandidate(
+  override: Exclude<ObjectOverride, { readonly kind: "delete" }>,
+  propertyId: string
+): ObjectPropertyCandidate {
+  const values = override.kind === "create" ? override.properties : override.set
+  return Object.hasOwn(values, propertyId)
+    ? { present: true, value: values[propertyId] }
+    : { present: false }
+}
+
+function applyObjectEditCandidate(
+  properties: Record<string, JsonValue>,
+  propertyId: string,
+  candidate: ObjectPropertyCandidate
+): void {
+  if (candidate.present) properties[propertyId] = candidate.value as JsonValue
+  else delete properties[propertyId]
+}
+
+export function storedObjectEditedAt(stored: StoredObjectOverride | null): Record<string, string> {
+  if (!stored || stored.value.kind === "delete") return {}
+  const editedAt = { ...(stored.editedAt ?? {}) }
+  const candidateIds =
+    stored.value.kind === "create"
+      ? Object.keys(stored.value.properties)
+      : [...Object.keys(stored.value.set), ...stored.value.unset]
+  for (const propertyId of candidateIds) editedAt[propertyId] ??= stored.updatedAt
+  return editedAt
 }
 
 function applyLatestTelemetry(

--- a/packages/core/src/materializer/effective/resolve.ts
+++ b/packages/core/src/materializer/effective/resolve.ts
@@ -84,17 +84,16 @@ function resolveSourceAndEdits(
   editedAt: Readonly<Record<string, string>>
 ): Record<string, JsonValue> {
   const properties = { ...source.assertion.properties }
-  const policy = source.assertion.conflictResolution ?? { strategy: "editsWin" }
-  const projectedPropertyIds = new Set(
-    source.assertion.projectedPropertyIds ?? Object.keys(source.assertion.properties)
-  )
+  const absentSourcePropertyIds = new Set(source.assertion.absentSourcePropertyIds ?? [])
 
   for (const propertyId of objectEditCandidateIds(override, editedAt)) {
     const edit = objectEditCandidate(override, propertyId)
     const editTimestamp = editedAt[propertyId]
+    const hasSourceCandidate =
+      Object.hasOwn(source.assertion.properties, propertyId) ||
+      absentSourcePropertyIds.has(propertyId)
     const sourceWins =
-      projectedPropertyIds.has(propertyId) &&
-      policy.strategy === "mostRecent" &&
+      hasSourceCandidate &&
       source.assertion.sourceUpdatedAt !== undefined &&
       editTimestamp !== undefined &&
       source.assertion.sourceUpdatedAt.localeCompare(editTimestamp) >= 0

--- a/packages/core/src/materializer/execution/work-records.ts
+++ b/packages/core/src/materializer/execution/work-records.ts
@@ -22,7 +22,8 @@ export function appendObjectOverrideWork(
 ): void {
   if (
     stableJsonStringify(working.originalOverride?.value ?? null) ===
-    stableJsonStringify(working.override)
+      stableJsonStringify(working.override) &&
+    stableJsonStringify(working.originalEditedAt) === stableJsonStringify(working.editedAt)
   ) {
     return
   }
@@ -32,6 +33,7 @@ export function appendObjectOverrideWork(
       value: {
         ref: working.ref,
         value: working.override,
+        editedAt: working.editedAt,
         expectedLastCommitId: working.originalOverride?.lastCommitId ?? null,
         lastCommitId: identity.commitId,
         updatedAt: identity.committedAt,

--- a/packages/core/src/materializer/projections/entry-validator.ts
+++ b/packages/core/src/materializer/projections/entry-validator.ts
@@ -119,21 +119,27 @@ function validateObjectAssertion(
     )
   }
   const conflictResolution = resolved.definition.conflictResolution ?? { strategy: "editsWin" }
-  if (conflictResolution.strategy === "mostRecent" && assertion.sourceUpdatedAt === undefined) {
+  if (conflictResolution.strategy !== "mostRecent") {
+    return { kind: "object", ref: assertion.ref, properties }
+  }
+  if (assertion.sourceUpdatedAt === undefined) {
     throw new MaterializationValidationError(
       `Projection '${resolved.projectionId}' requires source update timestamp ` +
         `'${conflictResolution.sourceTimestamp}' on every object assertion.`
     )
   }
+  const primaryPropertyId = ontology.getPrimaryPropertyId(assertion.ref.objectTypeId)
+  const absentSourcePropertyIds = [...owned]
+    .filter(
+      (propertyId) => propertyId !== primaryPropertyId && !Object.hasOwn(properties, propertyId)
+    )
+    .sort()
   return {
     kind: "object",
     ref: assertion.ref,
     properties,
-    conflictResolution: { ...conflictResolution },
-    projectedPropertyIds: [...owned].sort(),
-    ...(conflictResolution.strategy === "mostRecent"
-      ? { sourceUpdatedAt: assertion.sourceUpdatedAt }
-      : {}),
+    sourceUpdatedAt: assertion.sourceUpdatedAt,
+    ...(absentSourcePropertyIds.length === 0 ? {} : { absentSourcePropertyIds }),
   }
 }
 

--- a/packages/core/src/materializer/projections/entry-validator.ts
+++ b/packages/core/src/materializer/projections/entry-validator.ts
@@ -118,7 +118,23 @@ function validateObjectAssertion(
       `Projection '${resolved.projectionId}' asserted unowned property '${assertion.ref.objectTypeId}.${propertyId}'.`
     )
   }
-  return { ...assertion, properties }
+  const conflictResolution = resolved.definition.conflictResolution ?? { strategy: "editsWin" }
+  if (conflictResolution.strategy === "mostRecent" && assertion.sourceUpdatedAt === undefined) {
+    throw new MaterializationValidationError(
+      `Projection '${resolved.projectionId}' requires source update timestamp ` +
+        `'${conflictResolution.sourceTimestamp}' on every object assertion.`
+    )
+  }
+  return {
+    kind: "object",
+    ref: assertion.ref,
+    properties,
+    conflictResolution: { ...conflictResolution },
+    projectedPropertyIds: [...owned].sort(),
+    ...(conflictResolution.strategy === "mostRecent"
+      ? { sourceUpdatedAt: assertion.sourceUpdatedAt }
+      : {}),
+  }
 }
 
 function validateLinkAssertion(

--- a/packages/core/src/materializer/projections/replacement-plan.ts
+++ b/packages/core/src/materializer/projections/replacement-plan.ts
@@ -33,6 +33,7 @@ import {
   resolveEffectiveLink,
   resolveEffectiveLinkSlotMember,
   resolveEffectiveObject,
+  storedObjectEditedAt,
   usableLinkSlotOverride,
 } from "../effective/resolve"
 import { validateEffectiveObject } from "../effective/validate"
@@ -374,6 +375,7 @@ function resolveReplacementObject(
     primaryPropertyId: context.ontology.getPrimaryPropertyId(state.ref.objectTypeId),
     source: state.candidateSource,
     override: state.override?.value ?? null,
+    editedAt: storedObjectEditedAt(state.override),
     latestTelemetry: state.latestTelemetry,
   })
 }

--- a/packages/core/src/materializer/shared/normalize.ts
+++ b/packages/core/src/materializer/shared/normalize.ts
@@ -25,6 +25,7 @@ import {
   projectionEntityKey,
   telemetryPointKey,
 } from "../../materialization/refs"
+import { parseDatasetTimestamp } from "../../projections/timestamp"
 
 export function normalizeJsonProperties(
   properties: Readonly<Record<string, unknown>>,
@@ -65,6 +66,16 @@ function normalizeTimestamp(value: string, label: string): string {
     throw new MaterializationValidationError(`${label} must be a valid timestamp.`)
   }
   return new Date(milliseconds).toISOString()
+}
+
+function normalizeProjectionSourceTimestamp(value: string): string {
+  const timestamp = parseDatasetTimestamp(value)
+  if (!timestamp) {
+    throw new MaterializationValidationError(
+      "Projection source update timestamp must be a valid timestamp."
+    )
+  }
+  return timestamp.toISOString()
 }
 
 function normalizePropertyIds(values: readonly string[], label: string): readonly string[] {
@@ -347,6 +358,11 @@ function normalizeProjectionAssertion(
         kind: "object",
         ref: normalizeObjectRef(assertion.ref),
         properties: normalizeJsonProperties(assertion.properties),
+        ...(assertion.sourceUpdatedAt !== undefined
+          ? {
+              sourceUpdatedAt: normalizeProjectionSourceTimestamp(assertion.sourceUpdatedAt),
+            }
+          : {}),
       })
     : Object.freeze({
         kind: "link",

--- a/packages/core/src/projections/builders.ts
+++ b/packages/core/src/projections/builders.ts
@@ -5,6 +5,7 @@
  */
 
 import type {
+  DatasetColumnDefinitionOf,
   DatasetColumnNameOf,
   DatasetColumnType,
   DatasetColumnTypeOf,
@@ -21,6 +22,7 @@ import type {
   ObjectProjectionTarget,
   ProjectionDefinition,
   ProjectionTarget,
+  SourceEditConflictResolution,
   TelemetryProjectionDefinition,
 } from "./types"
 import {
@@ -153,6 +155,20 @@ type DateLikeDatasetColumnNameOf<TDataset extends DatasetDefinition> =
           : never
       }[DatasetColumnNameOf<TDataset>]
 
+type TimestampDatasetColumnNameOf<TDataset extends DatasetDefinition> =
+  string extends DatasetColumnNameOf<TDataset>
+    ? string
+    : {
+        [TColumnName in DatasetColumnNameOf<TDataset>]: DatasetColumnTypeOf<
+          TDataset,
+          TColumnName
+        > extends "timestamp"
+          ? DatasetColumnDefinitionOf<TDataset, TColumnName> extends { readonly nullable: true }
+            ? never
+            : TColumnName
+          : never
+      }[DatasetColumnNameOf<TDataset>]
+
 type ProjectionMappingFor<TObjectType extends ObjectType, TDataset extends DatasetDefinition> = {
   readonly [TPropertyId in PropertyIdOf<TObjectType>]?: DatasetColumnNameCompatibleWithSchema<
     TDataset,
@@ -239,7 +255,7 @@ type ProjectionForeignKeyTokenInput<
         )
     }
 
-type ProjectionForeignKeyInput<
+export type ProjectionForeignKeyInput<
   TObjectType extends ObjectType,
   TDataset extends DatasetDefinition,
   TLinkId extends LinkIdOf<TObjectType>,
@@ -280,16 +296,27 @@ interface ObjectProjectionMappingBuilder<
 > {
   properties<const TMapping extends ProjectionMappingFor<TObjectType, TDataset>>(
     mapping: ExactProjectionMapping<TObjectType, TMapping>
-  ): ObjectProjectionDefinition & ObjectProjectionLinkBuilder<TObjectType, TDataset>
+  ): ObjectProjectionBuilder<TObjectType, TDataset>
 }
 
-interface ObjectProjectionLinkBuilder<
+export type ObjectProjectionConflictResolution<TDataset extends DatasetDefinition> =
+  | { readonly strategy: "editsWin" }
+  | {
+      readonly strategy: "mostRecent"
+      readonly sourceTimestamp: TimestampDatasetColumnNameOf<TDataset>
+    }
+
+export interface ObjectProjectionBuilder<
   TObjectType extends ObjectType,
   TDataset extends DatasetDefinition,
-> {
+> extends ObjectProjectionDefinition {
+  readonly conflictResolution: SourceEditConflictResolution
   withLinks(
     mapping: { [K in LinkIdOf<TObjectType>]?: ProjectionForeignKeyInput<TObjectType, TDataset, K> }
-  ): ObjectProjectionDefinition
+  ): ObjectProjectionBuilder<TObjectType, TDataset>
+  resolveConflicts(
+    resolution: ObjectProjectionConflictResolution<TDataset>
+  ): ObjectProjectionBuilder<TObjectType, TDataset>
 }
 
 /**
@@ -352,46 +379,76 @@ function buildObjectProjection<const TObjectType extends ObjectType>(
       return {
         properties<const TMapping extends ProjectionMappingFor<TObjectType, TDataset>>(
           mapping: ExactProjectionMapping<TObjectType, TMapping>
-        ): ObjectProjectionDefinition & ObjectProjectionLinkBuilder<TObjectType, TDataset> {
+        ): ObjectProjectionBuilder<TObjectType, TDataset> {
           const propertyMapping = mapping as Record<string, string>
           validatePropertyMapping(objectType, propertyMapping)
 
-          const definition: ObjectProjectionDefinition = {
-            _tag: "ObjectProjectionDefinition",
+          return objectProjectionBuilder({
             id,
-            objectTypeId: objectType.id,
+            objectType,
             datasetId,
-            properties: { ...propertyMapping },
+            propertyMapping,
             links: {},
-          }
-
-          return Object.assign(definition, {
-            withLinks(
-              linkMapping: {
-                [K in LinkIdOf<TObjectType>]?: ProjectionForeignKeyInput<TObjectType, TDataset, K>
-              }
-            ): ObjectProjectionDefinition {
-              const loweredLinkMapping = lowerForeignKeyMapping(linkMapping)
-              const validatedLinks = validateAndLowerLinkMapping(
-                objectType,
-                loweredLinkMapping,
-                propertyMapping
-              )
-
-              return {
-                _tag: "ObjectProjectionDefinition",
-                id,
-                objectTypeId: objectType.id,
-                datasetId,
-                properties: { ...propertyMapping },
-                links: validatedLinks,
-              }
-            },
+            conflictResolution: { strategy: "editsWin" },
           })
         },
       }
     },
   }
+}
+
+function objectProjectionBuilder<
+  TObjectType extends ObjectType,
+  TDataset extends DatasetDefinition,
+>(input: {
+  readonly id: string
+  readonly objectType: TObjectType
+  readonly datasetId: string
+  readonly propertyMapping: Readonly<Record<string, string>>
+  readonly links: Readonly<Record<string, ForeignKeyDescriptor>>
+  readonly conflictResolution: SourceEditConflictResolution
+}): ObjectProjectionBuilder<TObjectType, TDataset> {
+  const definition: ObjectProjectionDefinition & {
+    readonly conflictResolution: SourceEditConflictResolution
+  } = {
+    _tag: "ObjectProjectionDefinition",
+    id: input.id,
+    objectTypeId: input.objectType.id,
+    datasetId: input.datasetId,
+    properties: { ...input.propertyMapping },
+    links: { ...input.links },
+    conflictResolution: { ...input.conflictResolution },
+  }
+
+  return Object.assign(definition, {
+    withLinks(
+      linkMapping: {
+        [K in LinkIdOf<TObjectType>]?: ProjectionForeignKeyInput<TObjectType, TDataset, K>
+      }
+    ): ObjectProjectionBuilder<TObjectType, TDataset> {
+      const loweredLinkMapping = lowerForeignKeyMapping(linkMapping)
+      const validatedLinks = validateAndLowerLinkMapping(
+        input.objectType,
+        loweredLinkMapping,
+        input.propertyMapping as Record<string, string>
+      )
+      return objectProjectionBuilder({ ...input, links: validatedLinks })
+    },
+    resolveConflicts(
+      resolution: ObjectProjectionConflictResolution<TDataset>
+    ): ObjectProjectionBuilder<TObjectType, TDataset> {
+      validateConflictResolution(resolution)
+      return objectProjectionBuilder({
+        ...input,
+        conflictResolution: resolution as SourceEditConflictResolution,
+      })
+    },
+  })
+}
+
+function validateConflictResolution(resolution: SourceEditConflictResolution): void {
+  if (resolution.strategy === "editsWin") return
+  assertNonEmpty(resolution.sourceTimestamp, "source timestamp field")
 }
 
 // ── Telemetry projection ────────────────────────────────────
@@ -672,8 +729,16 @@ export function isObjectProjectionDefinition(value: unknown): value is ObjectPro
     typeof value.objectTypeId === "string" &&
     typeof value.datasetId === "string" &&
     isRecord(value.properties) &&
-    isRecord(value.links)
+    isRecord(value.links) &&
+    isSourceEditConflictResolution(value.conflictResolution)
   )
+}
+
+function isSourceEditConflictResolution(value: unknown): boolean {
+  if (value === undefined) return true
+  if (!isRecord(value) || typeof value.strategy !== "string") return false
+  if (value.strategy === "editsWin") return value.sourceTimestamp === undefined
+  return value.strategy === "mostRecent" && typeof value.sourceTimestamp === "string"
 }
 
 /** Runtime type guard for {@link LinkProjectionDefinition}. */

--- a/packages/core/src/projections/index.ts
+++ b/packages/core/src/projections/index.ts
@@ -1,5 +1,10 @@
 // ── Builders ─────────────────────────────────────────────────
 
+export type {
+  ObjectProjectionBuilder,
+  ObjectProjectionConflictResolution,
+  ProjectionForeignKeyInput,
+} from "./builders"
 export {
   categorizeProjections,
   defineProjection,
@@ -24,6 +29,7 @@ export type {
   ProjectionKind,
   ProjectionTarget,
   ProjectionTargetByKind,
+  SourceEditConflictResolution,
   TelemetryProjectionDefinition,
 } from "./types"
 // ── Validation ───────────────────────────────────────────────

--- a/packages/core/src/projections/internal.ts
+++ b/packages/core/src/projections/internal.ts
@@ -7,7 +7,9 @@ import type { ProjectionDispatchDescriptor } from "./types"
  *
  * `projectionTargetOf` derives the object types a projection writes, to record them on the run.
  * `validateTelemetryProjectionFieldMapping` re-checks a telemetry mapping against the dataset schema
- * before writing. Both are plumbing, so they live here instead of on the `@sixb/core` root.
+ * before writing. `parseDatasetTimestamp` keeps worker timestamps aligned with the materializer's
+ * authoritative validation. These are plumbing, so they live here instead of on the
+ * `@sixb/core` root.
  */
 export { projectionTargetOf } from "./builders"
 export {
@@ -27,6 +29,7 @@ export {
   ProjectionRunDispatcher,
 } from "./run-dispatch"
 export { createProjectionRunId } from "./run-id"
+export { parseDatasetTimestamp } from "./timestamp"
 export { validateTelemetryProjectionFieldMapping } from "./validation"
 
 export type { ProjectionDispatchDescriptor, ProjectionMaterializationIdentity, ProjectionRegistry }

--- a/packages/core/src/projections/registry.ts
+++ b/packages/core/src/projections/registry.ts
@@ -241,6 +241,13 @@ function cloneObjectProjectionDefinition(
         },
       ])
     ),
+    conflictResolution:
+      projection.conflictResolution?.strategy === "mostRecent"
+        ? {
+            strategy: "mostRecent",
+            sourceTimestamp: projection.conflictResolution.sourceTimestamp,
+          }
+        : { strategy: "editsWin" },
   }
 }
 

--- a/packages/core/src/projections/revision.ts
+++ b/packages/core/src/projections/revision.ts
@@ -147,6 +147,7 @@ function normalizeProjectionDefinition(projection: ProjectionDefinition): JsonVa
             },
           ])
       ),
+      conflictResolution: projection.conflictResolution ?? { strategy: "editsWin" },
     }
   }
   if (projection._tag === "LinkProjectionDefinition") {
@@ -177,6 +178,9 @@ function projectionColumns(projection: ProjectionDefinition): Set<string> {
       ...Object.values(projection.links).flatMap((link) =>
         link.sourceField === undefined ? [] : [link.sourceField]
       ),
+      ...(projection.conflictResolution?.strategy === "mostRecent"
+        ? [projection.conflictResolution.sourceTimestamp]
+        : []),
     ])
   }
   if (projection._tag === "LinkProjectionDefinition") {

--- a/packages/core/src/projections/timestamp.ts
+++ b/packages/core/src/projections/timestamp.ts
@@ -1,0 +1,66 @@
+const DATASET_TIMESTAMP =
+  /^(\d{4})-(\d{1,2})-(\d{1,2})(?:[ T](\d{1,2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?)?([zZ]|[+-]\d{2}:?\d{2})?$/
+
+interface TimestampComponents {
+  readonly year: number
+  readonly month: number
+  readonly day: number
+  readonly hour: number
+  readonly minute: number
+  readonly second: number
+  readonly milliseconds: number
+}
+
+/** Parses a projection dataset timestamp, interpreting zone-less values as UTC. */
+export function parseDatasetTimestamp(value: unknown): Date | null {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value
+  if (typeof value !== "string") return null
+
+  const match = DATASET_TIMESTAMP.exec(value.trim())
+  if (!match) return null
+  const [, year, month, day, hour, minute, second, fraction, zone] = match
+  const offsetMinutes = parseZoneOffsetMinutes(zone)
+  if (offsetMinutes === null) return null
+
+  const components: TimestampComponents = {
+    year: Number(year),
+    month: Number(month),
+    day: Number(day),
+    hour: hour === undefined ? 0 : Number(hour),
+    minute: minute === undefined ? 0 : Number(minute),
+    second: second === undefined ? 0 : Number(second),
+    milliseconds: fraction === undefined ? 0 : Math.trunc(Number(`0.${fraction}`) * 1000),
+  }
+  const wallClock = Date.UTC(
+    components.year,
+    components.month - 1,
+    components.day,
+    components.hour,
+    components.minute,
+    components.second,
+    components.milliseconds
+  )
+  if (!wallClockMatchesComponents(wallClock, components)) return null
+  return new Date(wallClock - offsetMinutes * 60_000)
+}
+
+function parseZoneOffsetMinutes(zone: string | undefined): number | null {
+  if (zone === undefined || zone === "Z" || zone === "z") return 0
+  const digits = zone.slice(1).replace(":", "")
+  const hours = Number(digits.slice(0, 2))
+  const minutes = Number(digits.slice(2, 4))
+  if (hours > 23 || minutes > 59) return null
+  return (zone[0] === "-" ? -1 : 1) * (hours * 60 + minutes)
+}
+
+function wallClockMatchesComponents(wallClock: number, components: TimestampComponents): boolean {
+  const date = new Date(wallClock)
+  return (
+    date.getUTCFullYear() === components.year &&
+    date.getUTCMonth() === components.month - 1 &&
+    date.getUTCDate() === components.day &&
+    date.getUTCHours() === components.hour &&
+    date.getUTCMinutes() === components.minute &&
+    date.getUTCSeconds() === components.second
+  )
+}

--- a/packages/core/src/projections/types.ts
+++ b/packages/core/src/projections/types.ts
@@ -39,6 +39,11 @@ export interface ForeignKeyDescriptor {
   readonly targetObjectTypeId: string
 }
 
+/** Resolves competing source-projection and managed-edit values for projected properties. */
+export type SourceEditConflictResolution =
+  | { readonly strategy: "editsWin" }
+  | { readonly strategy: "mostRecent"; readonly sourceTimestamp: string }
+
 /**
  * Lowered, serializable definition for projecting a dataset into object instances.
  *
@@ -56,6 +61,8 @@ export interface ObjectProjectionDefinition {
   readonly properties: Readonly<Record<string, string>>
   /** Maps link id -> FK descriptor. Empty `{}` when no FK links are projected. */
   readonly links: Readonly<Record<string, ForeignKeyDescriptor>>
+  /** Defaults to `editsWin` when omitted by a legacy lowered definition. */
+  readonly conflictResolution?: SourceEditConflictResolution
 }
 
 /**

--- a/packages/core/src/projections/validation.ts
+++ b/packages/core/src/projections/validation.ts
@@ -315,6 +315,30 @@ export function validateProjectionsAtStartup(
     }
 
     const datasetColumnNames = new Set(dataset.schema.columns.map((column) => column.name))
+    const conflictResolution = projection.conflictResolution ?? { strategy: "editsWin" }
+    if (conflictResolution.strategy === "mostRecent") {
+      const sourceTimestamp = dataset.schema.columns.find(
+        (column) => column.name === conflictResolution.sourceTimestamp
+      )
+      if (!sourceTimestamp) {
+        throw new ProjectionValidationError(
+          `${prefix}: source timestamp "${conflictResolution.sourceTimestamp}" references unknown ` +
+            `dataset column on dataset "${projection.datasetId}"`
+        )
+      }
+      if (sourceTimestamp.type !== "timestamp") {
+        throw new ProjectionValidationError(
+          `${prefix}: source timestamp "${conflictResolution.sourceTimestamp}" must reference a ` +
+            `timestamp dataset column`
+        )
+      }
+      if (sourceTimestamp.nullable === true) {
+        throw new ProjectionValidationError(
+          `${prefix}: source timestamp "${conflictResolution.sourceTimestamp}" must reference a ` +
+            `non-null timestamp dataset column`
+        )
+      }
+    }
     const propertyIds = new Set(objectType.properties.map((p) => p.id))
     for (const [propId, columnName] of Object.entries(projection.properties)) {
       if (!propertyIds.has(propId)) {

--- a/packages/core/src/storage/ontology/in-memory/materializations.ts
+++ b/packages/core/src/storage/ontology/in-memory/materializations.ts
@@ -588,6 +588,7 @@ export class InMemoryOntologyMaterializationStorage implements OntologyMateriali
             projectId,
             ref: item.ref,
             value: item.value,
+            editedAt: { ...item.editedAt },
             lastCommitId: item.lastCommitId,
             updatedAt: item.updatedAt,
           })

--- a/packages/core/src/storage/ontology/materializations.ts
+++ b/packages/core/src/storage/ontology/materializations.ts
@@ -26,6 +26,8 @@ import type { StoredSourceLinkAssertion, StoredSourceObjectAssertion } from "./s
 export interface StoredObjectOverride {
   readonly ref: OntologyObjectRef
   readonly value: ObjectOverride
+  /** Per-property Action/runtime edit time. Legacy rows fall back to `updatedAt`. */
+  readonly editedAt?: Readonly<Record<string, string>>
   readonly lastCommitId: string
   readonly updatedAt: string
 }
@@ -160,6 +162,7 @@ export interface MaterializationPlanHeader {
 export interface ExactObjectOverrideWrite {
   readonly ref: OntologyObjectRef
   readonly value: ObjectOverride
+  readonly editedAt: Readonly<Record<string, string>>
   readonly expectedLastCommitId: string | null
   readonly lastCommitId: string
   readonly updatedAt: string

--- a/packages/core/src/testing/materializer-storage-contract.ts
+++ b/packages/core/src/testing/materializer-storage-contract.ts
@@ -55,6 +55,23 @@ const devices = defineDataset("storage_contract_devices", {
 const readings = defineDataset("storage_contract_readings", {
   schema: [col("device_id", "string"), col("at", "timestamp"), col("value", "float64")],
 })
+const ConflictDevice = defineObjectType({
+  id: "StorageContractConflictDevice",
+  name: "Conflict device",
+  properties: [
+    prop("id", "string", { primary: true, required: true }),
+    prop("name", "string", { required: true }),
+    prop("state", "string", { required: true }),
+  ],
+})
+const conflictDevices = defineDataset("storage_contract_conflict_devices", {
+  schema: [
+    col("id", "string"),
+    col("name", "string"),
+    col("state", "string"),
+    col("updated_at", "timestamp"),
+  ],
+})
 const deviceProjection = defineProjection("storage_contract_devices", Device)
   .fromDataset(devices)
   .properties({ id: "id", name: "name" })
@@ -71,14 +88,22 @@ const temperatureProjection = defineProjection(
 )
   .fromDataset(readings)
   .points({ objectId: "device_id", at: "at", value: "value" })
+const conflictDeviceProjection = defineProjection(
+  "storage_contract_conflict_devices",
+  ConflictDevice
+)
+  .fromDataset(conflictDevices)
+  .properties({ id: "id", name: "name", state: "state" })
+  .resolveConflicts({ strategy: "mostRecent", sourceTimestamp: "updated_at" })
 
-const ontology = new OntologyRegistry({ sources: [Device] })
+const ontology = new OntologyRegistry({ sources: [Device, ConflictDevice] })
 const projections = new ProjectionRegistry({
-  projections: [deviceProjection, temperatureProjection],
+  projections: [deviceProjection, temperatureProjection, conflictDeviceProjection],
   ontology,
   datasetsById: new Map<string, DatasetDefinition>([
     [devices.id, devices],
     [readings.id, readings],
+    [conflictDevices.id, conflictDevices],
   ]),
 })
 
@@ -334,6 +359,99 @@ export function runMaterializerStorageContractSuite<TStorage extends Storage>(
           propertyId: "temperature",
         })
       ).toMatchObject({ value: 21.5, lastCommitId: telemetry.commitId })
+    } finally {
+      await provider.cleanup?.(createdStorage)
+    }
+  })
+
+  test(`${name} persists per-property Action edit times`, async () => {
+    const createdStorage = await provider.createStorage()
+    const storage = requireContractStorage(createdStorage)
+    let materializationOrdinal = 0
+    let now = new Date("2026-02-01T00:00:10.000Z")
+    const materializer = createOntologyMaterializer({
+      projectId: "materializer-storage-contract",
+      ontology,
+      projections,
+      storage,
+      dependencies: {
+        batching: { sourceStageRows: 1, statePageRows: 1, planChunkRows: 1 },
+        clock: () => now,
+        materializationId: () => `conflict-contract-candidate-${++materializationOrdinal}`,
+      },
+    })
+    const runtimeMaterializer = materializer.withScope(runtimeScope())
+    const ref = { objectTypeId: ConflictDevice.id, primaryId: "one" }
+    const replace = async (
+      versionId: string,
+      sourceUpdatedAt: string,
+      name: string,
+      state: string
+    ) => {
+      const datasetVersion = {
+        datasetId: conflictDevices.id,
+        versionId,
+        createdAt: sourceUpdatedAt,
+      }
+      const execution = await claim(storage, {
+        runId: `conflict-${versionId}`,
+        projectionId: conflictDeviceProjection.id,
+        protocol: "replacement",
+        datasetVersion,
+      })
+      const projectionMaterializerForRun = await projectionMaterializer(
+        materializer,
+        storage,
+        conflictDeviceProjection.id,
+        `conflict-${versionId}`
+      )
+      await projectionMaterializerForRun.projections.replace({
+        source: { projectionId: conflictDeviceProjection.id },
+        datasetVersion,
+        execution,
+        entries: entries([
+          {
+            root: { kind: "object", ref },
+            assertions: [{ kind: "object", ref, properties: { name, state }, sourceUpdatedAt }],
+          },
+        ]),
+      })
+    }
+    const edit = (requestId: string, propertyId: "name" | "state", value: string) =>
+      runtimeMaterializer.edits.commit({
+        mode: "atomic",
+        source: { kind: "runtime", requestId },
+        operations: [
+          {
+            id: requestId,
+            kind: "object.patch",
+            ref,
+            set: { [propertyId]: value },
+            unset: [],
+            reset: [],
+          },
+        ],
+        expectedObjects: [],
+        expectedLinks: [],
+        expectedLinkScopes: [],
+      })
+
+    try {
+      await replace("v1", "2026-02-01T00:00:10.000Z", "Source A", "source-open")
+
+      now = new Date("2026-02-01T00:00:11.000Z")
+      await edit("conflict-name", "name", "Action B")
+      now = new Date("2026-02-01T00:00:13.000Z")
+      await edit("conflict-state", "state", "action-closed")
+
+      await replace("v2", "2026-02-01T00:00:12.000Z", "Source C", "source-changed")
+      expect(
+        await storage.objects.getByPrimaryId({
+          projectId: "materializer-storage-contract",
+          objectTypeId: ConflictDevice.id,
+          primaryId: "one",
+        })
+      ).toMatchObject({ properties: { id: "one", name: "Source C", state: "action-closed" } })
     } finally {
       await provider.cleanup?.(createdStorage)
     }

--- a/packages/core/tests/materializer-contracts.test.ts
+++ b/packages/core/tests/materializer-contracts.test.ts
@@ -287,6 +287,39 @@ describe("materializer canonical contracts", () => {
     ).toThrow("exactly its matching link assertion")
   })
 
+  test("strictly validates projection source update timestamps", () => {
+    // Regression proof: replacing the strict parser with Date.parse makes Bun roll February 30
+    // into March 2, so this assertion stops throwing.
+    expect(() =>
+      normalizeProjectionSourceEntry({
+        root: { kind: "object", ref: leftObject },
+        assertions: [
+          {
+            kind: "object",
+            ref: leftObject,
+            properties: {},
+            sourceUpdatedAt: "2026-02-30T03:04:05Z",
+          },
+        ],
+      })
+    ).toThrow("Projection source update timestamp must be a valid timestamp")
+
+    const normalized = normalizeProjectionSourceEntry({
+      root: { kind: "object", ref: leftObject },
+      assertions: [
+        {
+          kind: "object",
+          ref: leftObject,
+          properties: {},
+          sourceUpdatedAt: "2026-01-02 03:04:05-05:00",
+        },
+      ],
+    })
+    expect(normalized.assertions[0]).toMatchObject({
+      sourceUpdatedAt: "2026-01-02T08:04:05.000Z",
+    })
+  })
+
   test("collapses equal telemetry duplicates and rejects conflicting points", () => {
     const point = {
       series: { object: leftObject, propertyId: "temperature" },

--- a/packages/core/tests/materializer-edits.test.ts
+++ b/packages/core/tests/materializer-edits.test.ts
@@ -668,6 +668,31 @@ describe("ontology materializer edits", () => {
     )
     expect((await object())?.properties).toMatchObject({ name: "D", note: "source-note-4" })
     expect(tied.counts.objectsUpdated).toBe(1)
+
+    await materializer.projections.replace(
+      replacement("recent-v5", "2026-01-05T00:00:00Z", [
+        sourceEntryAt("one", "E", "2026-01-01T14:00:00Z"),
+      ])
+    )
+    const withoutSourceNote = await object()
+    expect(withoutSourceNote?.properties.name).toBe("E")
+    expect(withoutSourceNote?.properties).not.toHaveProperty("note")
+
+    const activeSource = [
+      ...getInMemoryOntologyStorageTestingAdapter(storage.ontology)
+        .snapshot()
+        .sourceMaterializations.values(),
+    ].find((source) => source.status === "active")
+    const activeObjectAssertion = [...(activeSource?.rowsByEntity.values() ?? [])].find(
+      (row) => row.assertion.kind === "object"
+    )?.assertion
+    expect(activeObjectAssertion).toEqual({
+      kind: "object",
+      ref: ref("one"),
+      properties: { name: "E" },
+      sourceUpdatedAt: "2026-01-01T14:00:00.000Z",
+      absentSourcePropertyIds: ["note"],
+    })
   })
 
   test("preserves a dormant edit timestamp when deleting an absent object", async () => {

--- a/packages/core/tests/materializer-edits.test.ts
+++ b/packages/core/tests/materializer-edits.test.ts
@@ -11,6 +11,7 @@ import {
   createMaterializerFixture,
   replacement,
   sourceEntry,
+  sourceEntryAt,
   sourceEntryWithParent,
 } from "./materializer-fixture"
 
@@ -584,6 +585,144 @@ describe("ontology materializer edits", () => {
         })
       )?.properties.name
     ).toBe("source")
+  })
+
+  test("resolves most-recent source and edit candidates independently per property", async () => {
+    let now = new Date("2026-01-01T10:00:00.000Z")
+    const { materializer, storage } = createMaterializerFixture({
+      conflictResolution: "mostRecent",
+      dependencies: { clock: () => now },
+    })
+    const object = async () =>
+      storage.objects.getByPrimaryId({
+        projectId: "project",
+        objectTypeId: "Device",
+        primaryId: "one",
+      })
+
+    await materializer.projections.replace(
+      replacement("recent-v1", "2026-01-01T00:00:00Z", [
+        sourceEntryAt("one", "A", "2026-01-01T10:00:00Z", "source-note-1"),
+      ])
+    )
+
+    now = new Date("2026-01-01T11:00:00.000Z")
+    const nameEdit = await materializer.edits.commit(
+      atomic("recent-edit-name", [
+        {
+          id: "name",
+          kind: "object.patch",
+          ref: ref("one"),
+          set: { name: "B" },
+          unset: [],
+          reset: [],
+        },
+      ])
+    )
+    const nameEditOutcome = nameEdit.outcomes[0]
+    expect(nameEditOutcome?.ok).toBe(true)
+    if (!nameEditOutcome?.ok) throw new Error("Expected the name edit to succeed.")
+    expect(nameEditOutcome.object).not.toHaveProperty("propertyConflicts")
+
+    await materializer.projections.replace(
+      replacement("recent-v2", "2026-01-02T00:00:00Z", [
+        sourceEntryAt("one", "source-still-old", "2026-01-01T10:00:00Z", "source-note-2"),
+      ])
+    )
+    expect((await object())?.properties).toMatchObject({ name: "B", note: "source-note-2" })
+
+    now = new Date("2026-01-01T13:00:00.000Z")
+    await materializer.edits.commit(
+      atomic("recent-edit-note", [
+        {
+          id: "note",
+          kind: "object.patch",
+          ref: ref("one"),
+          set: { note: "local-note" },
+          unset: [],
+          reset: [],
+        },
+      ])
+    )
+    const [storedOverride] = [
+      ...getInMemoryOntologyStorageTestingAdapter(storage.ontology)
+        .snapshot()
+        .objectOverrides.values(),
+    ]
+    expect(storedOverride?.editedAt).toEqual({
+      name: "2026-01-01T11:00:00.000Z",
+      note: "2026-01-01T13:00:00.000Z",
+    })
+
+    await materializer.projections.replace(
+      replacement("recent-v3", "2026-01-03T00:00:00Z", [
+        sourceEntryAt("one", "C", "2026-01-01T12:00:00Z", "source-note-3"),
+      ])
+    )
+    expect((await object())?.properties).toMatchObject({ name: "C", note: "local-note" })
+
+    const tied = await materializer.projections.replace(
+      replacement("recent-v4", "2026-01-04T00:00:00Z", [
+        sourceEntryAt("one", "D", "2026-01-01T13:00:00Z", "source-note-4"),
+      ])
+    )
+    expect((await object())?.properties).toMatchObject({ name: "D", note: "source-note-4" })
+    expect(tied.counts.objectsUpdated).toBe(1)
+  })
+
+  test("preserves a dormant edit timestamp when deleting an absent object", async () => {
+    let now = new Date("2026-01-01T10:00:00.000Z")
+    const { materializer, storage } = createMaterializerFixture({
+      conflictResolution: "mostRecent",
+      dependencies: { clock: () => now },
+    })
+
+    await materializer.projections.replace(
+      replacement("dormant-time-v1", "2026-01-01T00:00:00Z", [
+        sourceEntryAt("one", "source", "2026-01-01T10:00:00Z"),
+      ])
+    )
+    now = new Date("2026-01-01T11:00:00.000Z")
+    await materializer.edits.commit(
+      atomic("dormant-time-edit", [
+        {
+          id: "name",
+          kind: "object.patch",
+          ref: ref("one"),
+          set: { name: "edited" },
+          unset: [],
+          reset: [],
+        },
+      ])
+    )
+    await materializer.projections.replace(
+      replacement("dormant-time-v2", "2026-01-02T00:00:00Z", [])
+    )
+
+    now = new Date("2026-01-01T20:00:00.000Z")
+    await materializer.edits.commit(
+      atomic("dormant-time-delete", [{ id: "delete", kind: "object.delete", ref: ref("one") }])
+    )
+
+    const [storedOverride] = [
+      ...getInMemoryOntologyStorageTestingAdapter(storage.ontology)
+        .snapshot()
+        .objectOverrides.values(),
+    ]
+    expect(storedOverride?.editedAt).toEqual({ name: "2026-01-01T11:00:00.000Z" })
+
+    await materializer.projections.replace(
+      replacement("dormant-time-v3", "2026-01-03T00:00:00Z", [
+        sourceEntryAt("one", "newer source", "2026-01-01T12:00:00Z"),
+      ])
+    )
+    await expect(
+      storage.objects.getByPrimaryId({
+        projectId: "project",
+        objectTypeId: "Device",
+        primaryId: "one",
+      })
+    ).resolves.toMatchObject({ properties: { name: "newer source" } })
   })
 
   test("supports create-to-patch, tombstone, dormant patch, and restore semantics", async () => {

--- a/packages/core/tests/materializer-fixture.ts
+++ b/packages/core/tests/materializer-fixture.ts
@@ -42,6 +42,7 @@ const devices = defineDataset("devices", {
     col("name", "string"),
     col("note", "string", { nullable: true }),
     col("parent_id", "string", { nullable: true }),
+    col("updated_at", "timestamp"),
   ],
 })
 const readings = defineDataset("readings", {
@@ -57,6 +58,17 @@ const deviceProjection = defineProjection("devices", Device)
       target: Device,
     },
   })
+const mostRecentDeviceProjection = defineProjection("devices", Device)
+  .fromDataset(devices)
+  .properties({ id: "id", name: "name", note: "note" })
+  .withLinks({
+    parent: {
+      link: Device.l.parent,
+      sourceField: "parent_id",
+      target: Device,
+    },
+  })
+  .resolveConflicts({ strategy: "mostRecent", sourceTimestamp: "updated_at" })
 const temperatureProjection = defineProjection("temperatures", Device.p.temperature)
   .fromDataset(readings)
   .points({ objectId: "device_id", at: "at", value: "value" })
@@ -66,11 +78,15 @@ export function createMaterializerFixture(
     readonly dependencies?: OntologyMaterializerDependencies
     readonly storage?: InMemoryStorage
     readonly scope?: ExecutionScope
+    readonly conflictResolution?: "editsWin" | "mostRecent"
   } = {}
 ) {
   const ontology = new OntologyRegistry({ sources: [Device] })
   const projections = new ProjectionRegistry({
-    projections: [deviceProjection, temperatureProjection],
+    projections: [
+      input.conflictResolution === "mostRecent" ? mostRecentDeviceProjection : deviceProjection,
+      temperatureProjection,
+    ],
     ontology,
     datasetsById: new Map<string, DatasetDefinition>([
       [devices.id, devices],
@@ -219,6 +235,21 @@ export function sourceEntry(id: string, name: string, note?: string | null): Pro
         properties: { name, ...(note !== undefined ? { note } : {}) },
       },
     ],
+  }
+}
+
+export function sourceEntryAt(
+  id: string,
+  name: string,
+  sourceUpdatedAt: string,
+  note?: string | null
+): ProjectionSourceEntry {
+  const entry = sourceEntry(id, name, note)
+  return {
+    ...entry,
+    assertions: entry.assertions.map((assertion) =>
+      assertion.kind === "object" ? { ...assertion, sourceUpdatedAt } : assertion
+    ),
   }
 }
 

--- a/packages/core/tests/ontology-storage-in-memory.test.ts
+++ b/packages/core/tests/ontology-storage-in-memory.test.ts
@@ -1720,6 +1720,7 @@ describe("in-memory ontology storage", () => {
           value.overrides.objects.upserts.push({
             ref: objectA,
             value: { kind: "create", properties: { name: "a" } },
+            editedAt: { name: committedAt },
             expectedLastCommitId: null,
             lastCommitId: "wrong",
             updatedAt: committedAt,
@@ -1733,6 +1734,7 @@ describe("in-memory ontology storage", () => {
           value.overrides.objects.upserts.push({
             ref: objectA,
             value: { kind: "create", properties: { name: "a" } },
+            editedAt: { name: committedAt },
             expectedLastCommitId: "stale",
             lastCommitId: commitId,
             updatedAt: committedAt,

--- a/packages/core/tests/projection-registry.test.ts
+++ b/packages/core/tests/projection-registry.test.ts
@@ -41,7 +41,12 @@ const Room = defineObjectType({
   links: [link("hasSensor", Sensor, { cardinality: "one" })],
 })
 const rooms = defineDataset("rooms", {
-  schema: [col("room_name", "string"), col("room_id", "string"), col("sensor_id", "string")],
+  schema: [
+    col("room_name", "string"),
+    col("room_id", "string"),
+    col("sensor_id", "string"),
+    col("updated_at", "timestamp"),
+  ],
 })
 const roomSensors = defineDataset("room-sensors", {
   schema: [col("sensor_id", "string"), col("room_id", "string")],
@@ -333,6 +338,7 @@ describe("projection registry", () => {
       "datasetId",
       "properties",
       "links",
+      "conflictResolution",
     ])
     expect(Object.keys(resolvedObject.links.hasSensor)).toEqual([
       "linkId",
@@ -496,5 +502,48 @@ describe("projection registry", () => {
           datasetsById: new Map(),
         })
     ).toThrow("cannot be required")
+  })
+
+  test("requires mostRecent to reference a timestamp dataset column", () => {
+    const invalid = {
+      ...defineProjection("rooms", Room)
+        .fromDataset(rooms)
+        .properties({ id: "room_id", name: "room_name" }),
+      conflictResolution: { strategy: "mostRecent", sourceTimestamp: "room_name" } as const,
+    }
+
+    expect(
+      () =>
+        new ProjectionRegistry({
+          projections: [invalid],
+          ontology: registry(),
+          datasetsById: datasets(rooms),
+        })
+    ).toThrow("must reference a timestamp dataset column")
+  })
+
+  test("requires mostRecent to reference a non-null timestamp dataset column", () => {
+    const nullableRooms = defineDataset("nullable-rooms", {
+      schema: [
+        col("room_name", "string"),
+        col("room_id", "string"),
+        col("updated_at", "timestamp", { nullable: true }),
+      ],
+    })
+    const invalid = {
+      ...defineProjection("nullable-rooms", Room)
+        .fromDataset(nullableRooms)
+        .properties({ id: "room_id", name: "room_name" }),
+      conflictResolution: { strategy: "mostRecent", sourceTimestamp: "updated_at" } as const,
+    }
+
+    expect(
+      () =>
+        new ProjectionRegistry({
+          projections: [invalid],
+          ontology: registry(),
+          datasetsById: datasets(nullableRooms),
+        })
+    ).toThrow("must reference a non-null timestamp dataset column")
   })
 })

--- a/packages/core/tests/projection.test.ts
+++ b/packages/core/tests/projection.test.ts
@@ -45,6 +45,7 @@ const canonicalRoomsDataset = defineDataset("canonical.rooms", {
     col("room_name", "string"),
     col("building_id", "string"),
     col("building_ref", "string"),
+    col("updated_at", "timestamp"),
   ],
 })
 
@@ -93,6 +94,19 @@ describe("defineProjection", () => {
     expect(result.datasetId).toBe("canonical.rooms")
     expect(result.properties).toEqual({ id: "room_id", name: "room_name" })
     expect(result.links).toEqual({})
+    expect(result.conflictResolution).toEqual({ strategy: "editsWin" })
+  })
+
+  test("configures most-recent source/edit conflict resolution", () => {
+    const result = defineProjection("room-proj", Room)
+      .fromDataset(canonicalRoomsDataset)
+      .properties({ id: "room_id", name: "room_name" })
+      .resolveConflicts({ strategy: "mostRecent", sourceTimestamp: "updated_at" })
+
+    expect(result.conflictResolution).toEqual({
+      strategy: "mostRecent",
+      sourceTimestamp: "updated_at",
+    })
   })
 
   test("rejects empty id", () => {

--- a/packages/core/tests/projection.types.ts
+++ b/packages/core/tests/projection.types.ts
@@ -6,6 +6,9 @@ import {
   defineValueType,
   fromForeignKey,
   link,
+  type ObjectProjectionBuilder,
+  type ObjectProjectionConflictResolution,
+  type ProjectionForeignKeyInput,
   prop,
   stringEnum,
   valueTypeRef,
@@ -72,6 +75,7 @@ const roomDataset = defineDataset("canonical.rooms", {
     col("col_temperature", "float64"),
     col("col_opened_on", "date"),
     col("col_last_seen_at", "timestamp"),
+    col("col_nullable_updated_at", "timestamp", { nullable: true }),
     col("col_mode", "string"),
     col("col_metadata", "json"),
     col("col_reading", "decimal"),
@@ -98,6 +102,28 @@ const projection = defineProjection("test", _Room).fromDataset(roomDataset).prop
   reading: "col_reading",
 })
 type _projTag = Expect<Equal<typeof projection._tag, "ObjectProjectionDefinition">>
+type _projectionBuilder = Expect<
+  Equal<typeof projection, ObjectProjectionBuilder<typeof _Room, typeof roomDataset>>
+>
+type _projectionResolution = ObjectProjectionConflictResolution<typeof roomDataset>
+type _projectionForeignKey = ProjectionForeignKeyInput<
+  typeof _Room,
+  typeof roomDataset,
+  "inBuilding"
+>
+
+projection.resolveConflicts({ strategy: "editsWin" })
+projection.resolveConflicts({ strategy: "mostRecent", sourceTimestamp: "col_last_seen_at" })
+projection.resolveConflicts({
+  strategy: "mostRecent",
+  // @ts-expect-error — mostRecent requires a timestamp dataset column
+  sourceTimestamp: "col_name",
+})
+projection.resolveConflicts({
+  strategy: "mostRecent",
+  // @ts-expect-error — mostRecent requires a non-null timestamp dataset column
+  sourceTimestamp: "col_nullable_updated_at",
+})
 
 // 2. .fromDataset() accepts dataset definitions, not string ids
 // @ts-expect-error — string dataset ids are no longer accepted

--- a/packages/projection-worker/src/object-projection-plan.ts
+++ b/packages/projection-worker/src/object-projection-plan.ts
@@ -8,6 +8,7 @@ import {
   type Schema,
 } from "@sixb/core"
 import { createSixbError } from "@sixb/core/internal/errors"
+import { parseDatasetTimestamp } from "@sixb/core/internal/projections"
 import { resolveProjectionSchema } from "./projection-schema"
 import { normalizeProjectedValue } from "./projection-value-coercion"
 import { isPlainObject } from "./utils"
@@ -23,6 +24,7 @@ export interface ProjectedObjectRow {
   readonly properties: Record<string, unknown>
   readonly primaryValue: unknown
   readonly foreignKeyValues: Readonly<Record<string, unknown>>
+  readonly sourceUpdatedAt?: string
 }
 
 export type ProjectObjectRowResult =
@@ -81,7 +83,12 @@ export function projectObjectRow(plan: ObjectProjectionPlan, row: unknown): Proj
   const { projection, dataset, primaryPropertyId, propertyPlans } = plan
 
   const rowValidationError = getDatasetRowValidationError(row, dataset, {
-    columns: Object.values(projection.properties),
+    columns: [
+      ...Object.values(projection.properties),
+      ...(projection.conflictResolution?.strategy === "mostRecent"
+        ? [projection.conflictResolution.sourceTimestamp]
+        : []),
+    ],
   })
   if (rowValidationError) {
     return { ok: false, errorMessage: rowValidationError }
@@ -99,14 +106,43 @@ export function projectObjectRow(plan: ObjectProjectionPlan, row: unknown): Proj
     return collected
   }
 
+  const sourceUpdatedAt = projectSourceUpdatedAt(projection, row)
+  if (!sourceUpdatedAt.ok) return sourceUpdatedAt
+
   return {
     ok: true,
     row: {
       properties: collected.properties,
       primaryValue: collected.properties[primaryPropertyId],
       foreignKeyValues: collectForeignKeyValues(projection, row, collected.properties),
+      ...(sourceUpdatedAt.value === undefined ? {} : { sourceUpdatedAt: sourceUpdatedAt.value }),
     },
   }
+}
+
+function projectSourceUpdatedAt(
+  projection: ObjectProjectionDefinition,
+  row: DatasetRow
+):
+  | { readonly ok: true; readonly value?: string }
+  | { readonly ok: false; readonly errorMessage: string } {
+  const resolution = projection.conflictResolution ?? { strategy: "editsWin" }
+  if (resolution.strategy === "editsWin") return { ok: true }
+  const raw = row[resolution.sourceTimestamp]
+  if (raw === null || raw === undefined || raw === "") {
+    return {
+      ok: false,
+      errorMessage: `[SixbProjectionWorker] Projection '${projection.id}' source timestamp '${resolution.sourceTimestamp}' is required.`,
+    }
+  }
+  const parsed = parseDatasetTimestamp(raw)
+  if (!parsed) {
+    return {
+      ok: false,
+      errorMessage: `[SixbProjectionWorker] Projection '${projection.id}' source timestamp '${resolution.sourceTimestamp}' is invalid.`,
+    }
+  }
+  return { ok: true, value: parsed.toISOString() }
 }
 
 function buildProjectedPropertyPlans(input: {

--- a/packages/projection-worker/src/run-object-projection.ts
+++ b/packages/projection-worker/src/run-object-projection.ts
@@ -108,7 +108,15 @@ function toSourceEntry(
 
   return {
     root: { kind: "object", ref: objectRef },
-    assertions: [{ kind: "object", ref: objectRef, properties }, ...linkAssertions],
+    assertions: [
+      {
+        kind: "object",
+        ref: objectRef,
+        properties,
+        ...(row.sourceUpdatedAt === undefined ? {} : { sourceUpdatedAt: row.sourceUpdatedAt }),
+      },
+      ...linkAssertions,
+    ],
   }
 }
 
@@ -116,7 +124,15 @@ function objectProjectionReadColumns(projection: ObjectProjectionDefinition): re
   const linkSourceFields = Object.values(projection.links).flatMap((descriptor) =>
     descriptor.sourceField ? [descriptor.sourceField] : []
   )
-  return [...new Set([...Object.values(projection.properties), ...linkSourceFields])]
+  return [
+    ...new Set([
+      ...Object.values(projection.properties),
+      ...linkSourceFields,
+      ...(projection.conflictResolution?.strategy === "mostRecent"
+        ? [projection.conflictResolution.sourceTimestamp]
+        : []),
+    ]),
+  ]
 }
 
 function requireIdentity(value: unknown, projectionId: string, field: string): string {

--- a/packages/projection-worker/src/run-telemetry-projection.ts
+++ b/packages/projection-worker/src/run-telemetry-projection.ts
@@ -9,6 +9,7 @@ import {
 } from "@sixb/core"
 import { createSixbError } from "@sixb/core/internal/errors"
 import type { TelemetryPointWrite } from "@sixb/core/internal/materialization"
+import { parseDatasetTimestamp } from "@sixb/core/internal/projections"
 import { getOntologyMutationRuntime } from "@sixb/core/internal/runtime"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
 import { resolveProjectionSchema } from "./projection-schema"
@@ -342,68 +343,4 @@ function invalidIdentity(
   }
 }
 
-const TELEMETRY_TIMESTAMP =
-  /^(\d{4})-(\d{1,2})-(\d{1,2})(?:[ T](\d{1,2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?)?([zZ]|[+-]\d{2}:?\d{2})?$/
-
-interface TimestampComponents {
-  readonly year: number
-  readonly month: number
-  readonly day: number
-  readonly hour: number
-  readonly minute: number
-  readonly second: number
-  readonly milliseconds: number
-}
-
-export function parseTelemetryTimestamp(value: unknown): Date | null {
-  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value
-  if (typeof value !== "string") return null
-
-  const match = TELEMETRY_TIMESTAMP.exec(value.trim())
-  if (!match) return null
-  const [, year, month, day, hour, minute, second, fraction, zone] = match
-  const offsetMinutes = parseZoneOffsetMinutes(zone)
-  if (offsetMinutes === null) return null
-
-  const components: TimestampComponents = {
-    year: Number(year),
-    month: Number(month),
-    day: Number(day),
-    hour: hour === undefined ? 0 : Number(hour),
-    minute: minute === undefined ? 0 : Number(minute),
-    second: second === undefined ? 0 : Number(second),
-    milliseconds: fraction === undefined ? 0 : Math.trunc(Number(`0.${fraction}`) * 1000),
-  }
-  const wallClock = Date.UTC(
-    components.year,
-    components.month - 1,
-    components.day,
-    components.hour,
-    components.minute,
-    components.second,
-    components.milliseconds
-  )
-  if (!wallClockMatchesComponents(wallClock, components)) return null
-  return new Date(wallClock - offsetMinutes * 60_000)
-}
-
-function parseZoneOffsetMinutes(zone: string | undefined): number | null {
-  if (zone === undefined || zone === "Z" || zone === "z") return 0
-  const digits = zone.slice(1).replace(":", "")
-  const hours = Number(digits.slice(0, 2))
-  const minutes = Number(digits.slice(2, 4))
-  if (hours > 23 || minutes > 59) return null
-  return (zone[0] === "-" ? -1 : 1) * (hours * 60 + minutes)
-}
-
-function wallClockMatchesComponents(wallClock: number, components: TimestampComponents): boolean {
-  const date = new Date(wallClock)
-  return (
-    date.getUTCFullYear() === components.year &&
-    date.getUTCMonth() === components.month - 1 &&
-    date.getUTCDate() === components.day &&
-    date.getUTCHours() === components.hour &&
-    date.getUTCMinutes() === components.minute &&
-    date.getUTCSeconds() === components.second
-  )
-}
+export const parseTelemetryTimestamp = parseDatasetTimestamp

--- a/packages/projection-worker/src/schema-validation.ts
+++ b/packages/projection-worker/src/schema-validation.ts
@@ -36,6 +36,9 @@ function projectionDatasetColumns(projection: ProjectionDefinition): ReadonlySet
       ...Object.values(projection.links).flatMap((link) =>
         link.sourceField === undefined ? [] : [link.sourceField]
       ),
+      ...(projection.conflictResolution?.strategy === "mostRecent"
+        ? [projection.conflictResolution.sourceTimestamp]
+        : []),
     ])
   }
   if (projection._tag === "LinkProjectionDefinition") {
@@ -141,6 +144,26 @@ export function assertProjectionCompatibleWithDataset(input: {
             columnName: column.name,
             columnType: column.type,
           }
+        )
+      }
+    }
+
+    if (projection.conflictResolution?.strategy === "mostRecent") {
+      const column = requireColumn(
+        columnsByName,
+        projection.conflictResolution.sourceTimestamp,
+        context
+      )
+      if (column.type !== "timestamp") {
+        throw invalidProjectionDefinition(
+          `[SixbProjectionWorker] Projection '${projection.id}' source timestamp '${column.name}' must be a timestamp dataset column.`,
+          { ...context, columnName: column.name, columnType: column.type }
+        )
+      }
+      if (column.nullable === true) {
+        throw invalidProjectionDefinition(
+          `[SixbProjectionWorker] Projection '${projection.id}' source timestamp '${column.name}' must be a non-null timestamp dataset column.`,
+          { ...context, columnName: column.name, columnType: column.type, nullable: true }
         )
       }
     }

--- a/packages/projection-worker/tests/object-projection-plan.test.ts
+++ b/packages/projection-worker/tests/object-projection-plan.test.ts
@@ -4,10 +4,12 @@ import {
   defineDataset,
   defineObjectType,
   defineProjection,
+  type ObjectProjectionDefinition,
   OntologyRegistry,
   prop,
 } from "@sixb/core"
 import { buildObjectProjectionPlan, projectObjectRow } from "../src/object-projection-plan"
+import { assertProjectionCompatibleWithDataset } from "../src/schema-validation"
 
 describe("object projection plan", () => {
   test("preserves decimal precision from dataset row to object properties", () => {
@@ -73,6 +75,132 @@ describe("object projection plan", () => {
       errorMessage:
         "Dataset 'canonical.meter-readings' column 'reading' must match type 'float64'.",
     })
+  })
+
+  test("preserves a canonical source update timestamp for mostRecent resolution", () => {
+    const Issue = defineObjectType({
+      id: "Issue",
+      name: "Issue",
+      properties: [
+        prop("id", "string", { required: true, primary: true }),
+        prop("title", "string"),
+      ],
+    })
+    const issues = defineDataset("github.issues", {
+      schema: [col("id", "string"), col("title", "string"), col("updated_at", "timestamp")],
+    })
+    const projection = defineProjection("github-issues", Issue)
+      .fromDataset(issues)
+      .properties({ id: "id", title: "title" })
+      .resolveConflicts({ strategy: "mostRecent", sourceTimestamp: "updated_at" })
+    const ontology = new OntologyRegistry({ sources: [Issue] })
+    const plan = buildObjectProjectionPlan({
+      ontology,
+      projection,
+      dataset: issues,
+      primaryPropertyId: "id",
+    })
+
+    expect(
+      projectObjectRow(plan, {
+        id: "issue-1",
+        title: "First title",
+        updated_at: "2026-01-02T03:04:05Z",
+      })
+    ).toEqual({
+      ok: true,
+      row: {
+        properties: { id: "issue-1", title: "First title" },
+        primaryValue: "issue-1",
+        foreignKeyValues: {},
+        sourceUpdatedAt: "2026-01-02T03:04:05.000Z",
+      },
+    })
+  })
+
+  test("uses strict UTC parsing for source update timestamps", () => {
+    const Issue = defineObjectType({
+      id: "Issue",
+      name: "Issue",
+      properties: [
+        prop("id", "string", { required: true, primary: true }),
+        prop("title", "string"),
+      ],
+    })
+    const issues = defineDataset("github.issues", {
+      schema: [col("id", "string"), col("title", "string"), col("updated_at", "timestamp")],
+    })
+    const projection = defineProjection("github-issues", Issue)
+      .fromDataset(issues)
+      .properties({ id: "id", title: "title" })
+      .resolveConflicts({ strategy: "mostRecent", sourceTimestamp: "updated_at" })
+    const plan = buildObjectProjectionPlan({
+      ontology: new OntologyRegistry({ sources: [Issue] }),
+      projection,
+      dataset: issues,
+      primaryPropertyId: "id",
+    })
+
+    expect(
+      projectObjectRow(plan, {
+        id: "issue-1",
+        title: "Title",
+        updated_at: "2026-01-02 03:04:05",
+      })
+    ).toMatchObject({
+      ok: true,
+      row: { sourceUpdatedAt: "2026-01-02T03:04:05.000Z" },
+    })
+    expect(
+      projectObjectRow(plan, {
+        id: "issue-1",
+        title: "Title",
+        updated_at: "2026-02-30T03:04:05Z",
+      })
+    ).toEqual({
+      ok: false,
+      errorMessage:
+        "[SixbProjectionWorker] Projection 'github-issues' source timestamp 'updated_at' is invalid.",
+    })
+  })
+
+  test("rejects nullable source update timestamps before reading rows", () => {
+    const Issue = defineObjectType({
+      id: "Issue",
+      name: "Issue",
+      properties: [
+        prop("id", "string", { required: true, primary: true }),
+        prop("title", "string"),
+      ],
+    })
+    const issues = defineDataset("github.issues", {
+      schema: [
+        col("id", "string"),
+        col("title", "string"),
+        col("updated_at", "timestamp", { nullable: true }),
+      ],
+    })
+    const projection: ObjectProjectionDefinition = {
+      ...defineProjection("github-issues", Issue)
+        .fromDataset(issues)
+        .properties({ id: "id", title: "title" }),
+      conflictResolution: { strategy: "mostRecent", sourceTimestamp: "updated_at" },
+    }
+
+    expect(() =>
+      assertProjectionCompatibleWithDataset({
+        projection,
+        dataset: issues,
+        version: {
+          datasetId: issues.id,
+          versionId: "v1",
+          mode: "snapshot",
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          schema: issues.schema,
+        },
+        ontology: new OntologyRegistry({ sources: [Issue] }),
+      })
+    ).toThrow("must be a non-null timestamp dataset column")
   })
 
   test("codes an execution plan invariant with its projection correlation", () => {

--- a/packages/server/src/routes/projections.ts
+++ b/packages/server/src/routes/projections.ts
@@ -3,6 +3,7 @@ import type {
   ObjectProjectionDefinition,
   ProjectionDefinition,
   SixbHostView,
+  SourceEditConflictResolution,
   TelemetryProjectionDefinition,
 } from "@sixb/core"
 import type { ProjectionRunRecord } from "@sixb/core/storage"
@@ -81,14 +82,27 @@ function projectionCatalogIds(catalog: ViewableProjectionCatalog): string[] {
   ].map((projection) => projection.id)
 }
 
+type SerializedProjection<TProjection extends ProjectionDefinition> =
+  TProjection extends ObjectProjectionDefinition
+    ? Omit<TProjection, "conflictResolution"> & {
+        conflictResolution: SourceEditConflictResolution
+        latestRun: SerializedProjectionRun | null
+      }
+    : TProjection & { latestRun: SerializedProjectionRun | null }
+
 function serializeProjection<TProjection extends ProjectionDefinition>(
   projection: TProjection,
   latestRuns: ReadonlyMap<string, SerializedProjectionRun>
-): TProjection & { latestRun: SerializedProjectionRun | null } {
-  return {
-    ...projection,
-    latestRun: latestRuns.get(projection.id) ?? null,
+): SerializedProjection<TProjection> {
+  const latestRun = latestRuns.get(projection.id) ?? null
+  if (projection._tag === "ObjectProjectionDefinition") {
+    return {
+      ...projection,
+      conflictResolution: projection.conflictResolution ?? { strategy: "editsWin" },
+      latestRun,
+    } as SerializedProjection<TProjection>
   }
+  return { ...projection, latestRun } as SerializedProjection<TProjection>
 }
 
 function serializeProjectionCatalog(

--- a/packages/server/src/schemas/projections.ts
+++ b/packages/server/src/schemas/projections.ts
@@ -83,6 +83,11 @@ export const ForeignKeyDescriptorSchema = z.object({
   targetObjectTypeId: z.string(),
 })
 
+export const SourceEditConflictResolutionSchema = z.union([
+  z.object({ strategy: z.literal("editsWin") }),
+  z.object({ strategy: z.literal("mostRecent"), sourceTimestamp: z.string() }),
+])
+
 export const ObjectProjectionSchema = z.object({
   _tag: z.literal("ObjectProjectionDefinition"),
   id: z.string(),
@@ -90,6 +95,7 @@ export const ObjectProjectionSchema = z.object({
   datasetId: z.string(),
   properties: z.record(z.string()),
   links: z.record(ForeignKeyDescriptorSchema),
+  conflictResolution: SourceEditConflictResolutionSchema,
   latestRun: ProjectionRunSchema.nullable(),
 })
 

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -70,6 +70,9 @@ import aiCostAccountingSql from "./migrations/026-ai-cost-accounting.sql" with {
 import agentContextCheckpointsSql from "./migrations/027-agent-context-checkpoints.sql" with {
   type: "text",
 }
+import objectOverrideEditTimesSql from "./migrations/028-object-override-edit-times.sql" with {
+  type: "text",
+}
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -350,6 +353,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("025-connector-connections", connectorConnectionsSql),
     pgSql("026-ai-cost-accounting", aiCostAccountingSql),
     pgSql("027-agent-context-checkpoints", agentContextCheckpointsSql),
+    pgSql("028-object-override-edit-times", objectOverrideEditTimesSql),
   ],
 })
 

--- a/storage/pg/src/migrations/028-object-override-edit-times.sql
+++ b/storage/pg/src/migrations/028-object-override-edit-times.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ontology_object_overrides
+ADD COLUMN edited_at JSONB NOT NULL DEFAULT '{}'::jsonb
+CHECK (jsonb_typeof(edited_at) = 'object');

--- a/storage/pg/src/ontology-storage/materialization-state.ts
+++ b/storage/pg/src/ontology-storage/materialization-state.ts
@@ -98,6 +98,7 @@ interface LinkScopeRow extends EffectiveLinkRow {
 interface ObjectOverrideRow extends PgStoredOverrideRow {
   readonly object_type_id: string
   readonly primary_id: string
+  readonly edited_at: unknown
 }
 
 interface LinkOverrideRow extends PgStoredOverrideRow {
@@ -1060,6 +1061,7 @@ function storedObjectOverride(row: ObjectOverrideRow): StoredObjectOverride {
   return {
     ref,
     value: structuredClone(row.value) as StoredObjectOverride["value"],
+    editedAt: structuredClone(row.edited_at) as Readonly<Record<string, string>>,
     lastCommitId: row.last_commit_id,
     updatedAt: toIsoString(row.updated_at),
   }

--- a/storage/pg/src/ontology-storage/materialization-writer.ts
+++ b/storage/pg/src/ontology-storage/materialization-writer.ts
@@ -25,6 +25,7 @@ export class PgMaterializationWriter {
       objectTypeId: item.ref.objectTypeId,
       primaryId: item.ref.primaryId,
       value: item.value,
+      editedAt: item.editedAt,
       lastCommitId: item.lastCommitId,
       updatedAt: item.updatedAt,
       expectedLastCommitId: item.expectedLastCommitId,
@@ -36,10 +37,10 @@ export class PgMaterializationWriter {
           SELECT value FROM jsonb_array_elements(${jsonParameter(this.sql, objectInserts)}::jsonb)
         )
         INSERT INTO ontology_object_overrides (
-          project_id, object_type_id, primary_id, value, last_commit_id, updated_at
+          project_id, object_type_id, primary_id, value, edited_at, last_commit_id, updated_at
         )
         SELECT ${projectId}, value->>'objectTypeId', value->>'primaryId', value->'value',
-          value->>'lastCommitId',
+          value->'editedAt', value->>'lastCommitId',
           (value->>'updatedAt')::timestamptz
         FROM staged
         ON CONFLICT DO NOTHING
@@ -55,7 +56,8 @@ export class PgMaterializationWriter {
           SELECT value FROM jsonb_array_elements(${jsonParameter(this.sql, objectUpdates)}::jsonb)
         )
         UPDATE ontology_object_overrides AS overrides
-        SET value = staged.value->'value', last_commit_id = staged.value->>'lastCommitId',
+        SET value = staged.value->'value', edited_at = staged.value->'editedAt',
+          last_commit_id = staged.value->>'lastCommitId',
           updated_at = (staged.value->>'updatedAt')::timestamptz
         FROM staged
         WHERE overrides.project_id = ${projectId}

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -79,6 +79,7 @@ describe("Postgres storage migrations", () => {
             "025-connector-connections",
             "026-ai-cost-accounting",
             "027-agent-context-checkpoints",
+            "028-object-override-edit-times",
           ],
         },
       ])
@@ -271,6 +272,13 @@ describe("Postgres storage migrations", () => {
           id: "027-agent-context-checkpoints",
           status: "applied",
           version: 27,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "028-object-override-edit-times",
+          status: "applied",
+          version: 28,
         },
       ])
     })
@@ -1743,6 +1751,13 @@ describe("Postgres storage migrations", () => {
           id: "027-agent-context-checkpoints",
           status: "applied",
           version: 27,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "028-object-override-edit-times",
+          status: "applied",
+          version: 28,
         },
       ])
     } finally {

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -73,6 +73,9 @@ import aiCostAccountingSql from "./migrations/026-ai-cost-accounting.sql" with {
 import agentContextCheckpointsSql from "./migrations/027-agent-context-checkpoints.sql" with {
   type: "text",
 }
+import objectOverrideEditTimesSql from "./migrations/028-object-override-edit-times.sql" with {
+  type: "text",
+}
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -155,6 +158,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("025-connector-connections", connectorConnectionsSql),
     sqliteSql("026-ai-cost-accounting", aiCostAccountingSql),
     sqliteSql("027-agent-context-checkpoints", agentContextCheckpointsSql),
+    sqliteSql("028-object-override-edit-times", objectOverrideEditTimesSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/028-object-override-edit-times.sql
+++ b/storage/sqlite/src/migrations/028-object-override-edit-times.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ontology_object_overrides
+ADD COLUMN edited_at TEXT NOT NULL DEFAULT '{}'
+CHECK (json_valid(edited_at) AND json_type(edited_at) = 'object');

--- a/storage/sqlite/src/ontology-storage/materialization-state.ts
+++ b/storage/sqlite/src/ontology-storage/materialization-state.ts
@@ -86,6 +86,7 @@ interface LinkScopeRow extends EffectiveLinkRow {
 interface ObjectOverrideRow extends SqliteStoredOverrideRow {
   readonly object_type_id: string
   readonly primary_id: string
+  readonly edited_at: string
 }
 
 interface LinkOverrideRow extends SqliteStoredOverrideRow {
@@ -1028,6 +1029,7 @@ function storedObjectOverride(row: ObjectOverrideRow): StoredObjectOverride {
   return {
     ref,
     value: parseJson<StoredObjectOverride["value"]>(row.value),
+    editedAt: parseJson<Readonly<Record<string, string>>>(row.edited_at),
     lastCommitId: row.last_commit_id,
     updatedAt: row.updated_at,
   }

--- a/storage/sqlite/src/ontology-storage/materialization-writer.ts
+++ b/storage/sqlite/src/ontology-storage/materialization-writer.ts
@@ -41,14 +41,16 @@ export class SqliteMaterializationWriter {
           this.db
             .query(
               `INSERT INTO ontology_object_overrides (
-                 project_id, object_type_id, primary_id, value, last_commit_id, updated_at
-               ) VALUES (?, ?, ?, json(?), ?, ?)`
+                 project_id, object_type_id, primary_id, value, edited_at,
+                 last_commit_id, updated_at
+               ) VALUES (?, ?, ?, json(?), json(?), ?, ?)`
             )
             .run(
               projectId,
               item.ref.objectTypeId,
               item.ref.primaryId,
               canonicalJson(item.value),
+              canonicalJson(item.editedAt),
               item.lastCommitId,
               item.updatedAt
             )
@@ -64,12 +66,13 @@ export class SqliteMaterializationWriter {
         this.db
           .query(
             `UPDATE ontology_object_overrides
-             SET value = json(?), last_commit_id = ?, updated_at = ?
+             SET value = json(?), edited_at = json(?), last_commit_id = ?, updated_at = ?
              WHERE project_id = ? AND object_type_id = ? AND primary_id = ?
                AND last_commit_id = ?`
           )
           .run(
             canonicalJson(item.value),
+            canonicalJson(item.editedAt),
             item.lastCommitId,
             item.updatedAt,
             projectId,

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -217,6 +217,13 @@ const expectedStorageMigrationRows = [
     status: "applied",
     version: 27,
   },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "028-object-override-edit-times",
+    status: "applied",
+    version: 28,
+  },
 ]
 
 afterEach(async () => {
@@ -252,6 +259,35 @@ describe("SQLite storage migrations", () => {
       await expect(migrateStorage(storage)).resolves.toMatchObject({ status: "current" })
     } finally {
       storage.close()
+    }
+  })
+
+  test("adds empty per-property edit times to legacy object overrides", () => {
+    const db = new Database(":memory:")
+    try {
+      for (const migration of sqliteStorageMigrations.steps.slice(0, 27)) migration.up(db)
+      db.query(`
+        INSERT INTO ontology_object_overrides (
+          project_id, object_type_id, primary_id, value, last_commit_id, updated_at
+        ) VALUES (?, ?, ?, json(?), ?, ?)
+      `).run(
+        "project",
+        "Issue",
+        "issue-1",
+        JSON.stringify({ kind: "patch", set: { title: "edited" }, unset: [] }),
+        "legacy-commit",
+        "2026-01-01T11:00:00.000Z"
+      )
+
+      sqliteStorageMigrations.steps[27]?.up(db)
+
+      expect(
+        db
+          .query("SELECT edited_at FROM ontology_object_overrides WHERE primary_id = ?")
+          .get("issue-1")
+      ).toEqual({ edited_at: "{}" })
+    } finally {
+      db.close()
     }
   })
 


### PR DESCRIPTION
## Summary

Adds an opt-in `mostRecent` conflict policy for object projections so source-system values and
Action/runtime edits can be resolved by timestamp, independently for each projected property.

The existing behavior remains the default: with `editsWin`, an edit stays authoritative until the
property is explicitly reset. `mostRecent` is for integrations where the source system should be
able to reclaim authority after it records a newer update.

## Authoring API

```ts
export const githubIssueProjection = defineProjection("github-issues", GitHubIssue)
  .fromDataset(githubIssues)
  .properties({
    id: "id",
    title: "title",
    body: "body",
    state: "state",
  })
  .resolveConflicts({
    strategy: "mostRecent",
    sourceTimestamp: "updated_at",
  })
```

`sourceTimestamp` must reference an existing, non-null `timestamp` dataset column. The builder
enforces this for typed datasets, and startup/worker validation enforce it for lowered or dynamic
definitions.

The timestamp must be the source record's own update time. Ingestion time and dataset commit time do
not establish when the source value changed.

## Resolution semantics

Resolution happens per property, not per object.

| Source candidate | Edit candidate | Effective value |
| --- | --- | --- |
| Source timestamp is newer | Older edit timestamp | Source value |
| Source timestamp equals edit timestamp | Same-time edit | Source value |
| Source timestamp is older | Newer edit timestamp | Edited value |
| Property is reset | No edit candidate remains | Source value |
| Property is not projected | Any edit candidate | Edited value |

Mapped-but-absent source properties still participate as an absence candidate. Editing one property
does not refresh another property's timestamp. Existing object-existence, link, and telemetry
authority semantics are unchanged.

## How it works

### Projection definition and worker

- Adds `resolveConflicts(...)` to the immutable object projection builder.
- Includes the conflict policy and referenced timestamp column in projection revision calculation.
- Reads the source timestamp with the projected row and canonicalizes it to UTC.
- Uses one strict parser for object and telemetry projection timestamps. Impossible calendar values
  such as February 30 are rejected rather than rolled forward by `Date.parse`.
- Pins the resolved policy and complete mapped-property set onto each staged object assertion so
  later materialization does not depend on mutable runtime configuration.

### Materializer

- Tracks Action/runtime edit times per property alongside the existing object override.
- Updates only properties touched by each create, upsert, set, unset, or reset operation.
- Resolves source and edit candidates independently during both edit commits and source replacement.
- Preserves timestamp-only authority changes even when the effective object value does not change.
- Falls back safely for legacy source assertions and override records.

### Persistence and API

- Adds migration `028-object-override-edit-times` for PostgreSQL and SQLite.
- Stores edit times as a JSON object in `ontology_object_overrides.edited_at`.
- Existing rows receive `{}`; legacy override candidates fall back to the row's `updated_at` when
  loaded, then persist explicit per-property times on their next authority write.
- Returns a normalized `conflictResolution` field from projection API routes.
- Regenerates OpenAPI and typed client artifacts.
- Documents the new policy and source-timestamp guidance.

## Compatibility and rollout

- Definitions that omit `conflictResolution` normalize to `{ strategy: "editsWin" }`.
- Existing edit behavior is therefore preserved unless a projection opts into `mostRecent`.
- Object projection revisions now include the normalized conflict policy. Existing object
  projections will receive a new semantic revision once after upgrade; changing a policy or its
  timestamp column also produces a new run identity as intended.
- The database migration is additive and uses a non-null empty-object default.

## Suggested review path

1. `packages/core/src/projections/builders.ts` and `revision.ts` — public API and semantic identity.
2. `packages/projection-worker/src/object-projection-plan.ts` — row validation and timestamp capture.
3. `packages/core/src/materializer/effective/resolve.ts` — winner selection.
4. `packages/core/src/materializer/edits/apply.ts` — per-property edit-time transitions.
5. PostgreSQL/SQLite migration and writer changes — durable representation and legacy fallback.
6. Contract, materializer, worker, schema, and migration tests — end-to-end behavior.

## Validation

Passed:

- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test:publish`
- Core projection, registry, materializer edit, materializer contract, and in-memory storage tests
- Full projection-worker test suite, including strict timestamp and row-plan coverage
- Server projection route tests
- SQLite migration, ontology-storage, and materializer integration tests

PostgreSQL e2e tests were not run locally because they require the external test database. The
migration catalog assertions were updated, and CI will run the PostgreSQL e2e job.

## Linked issue

None.
