### PR TITLE
ci: prevent guard test process leaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,11 @@ job's `timeout-minutes` is only a backstop: a job that dies at its own wall cloc
 guard exists because a `Bun.build()` deadlock once cost five 15-minute runs before anyone found the
 one named failure buried in the log.
 
+Run `test:ci` outside restricted process sandboxes. Its self-tests exercise process inspection and
+signaling, and several suite fixtures require local process or network access. In Codex, request
+elevated sandbox permissions before the first full-suite run instead of rerunning after an expected
+restricted failure.
+
 `typecheck` uses the TypeScript project-reference graph: `bun run build:types` (`tsc -b
 tsconfig.build.json`) checks every package's `src` exactly once, `tsconfig.tests.json` checks
 test files against the emitted `.d.ts`, and the example/docs apps keep their own

--- a/scripts/ci-guard.ts
+++ b/scripts/ci-guard.ts
@@ -46,6 +46,12 @@ const USAGE_EXIT_CODE = 2
 /** How often progress is checked. Also the worst-case lateness of a stall report. */
 const POLL_MS = 1000
 
+/** A diagnostic must never become the reason the guard cannot reach process cleanup. */
+const PROCESS_TABLE_TIMEOUT_MS = 2000
+
+/** Signals relayed only after the guarded process group has been stopped. */
+const TERMINATION_SIGNALS = ["SIGHUP", "SIGINT", "SIGTERM"] as const
+
 if (import.meta.main) {
   try {
     process.exitCode = await main(process.argv.slice(2))
@@ -63,7 +69,35 @@ export async function main(argv: readonly string[]): Promise<number> {
     stdin: "inherit",
     stdout: "pipe",
     stderr: "pipe",
+    // A process group gives cleanup a reliable fallback when a restricted sandbox blocks `ps -A`.
+    // Pipes still keep the child attached; `detached` only establishes the group on POSIX.
+    detached: process.platform !== "win32",
   })
+
+  let stopChildPromise: Promise<void> | null = null
+  const stopChild = (): Promise<void> => {
+    stopChildPromise ??= killTree(child.pid)
+    return stopChildPromise
+  }
+
+  let relayingSignal = false
+  const signalHandlers = new Map<NodeJS.Signals, () => void>()
+  function removeSignalHandlers(): void {
+    for (const [signal, handler] of signalHandlers) process.off(signal, handler)
+  }
+  for (const signal of TERMINATION_SIGNALS) {
+    const handler = (): void => {
+      if (relayingSignal) return
+      relayingSignal = true
+      void stopChild().finally(() => {
+        removeSignalHandlers()
+        // Preserve the conventional signal exit status after giving descendants a chance to stop.
+        process.kill(process.pid, signal)
+      })
+    }
+    signalHandlers.set(signal, handler)
+    process.on(signal, handler)
+  }
 
   const tail: string[] = []
   let lastTestFile: string | null = null
@@ -87,6 +121,9 @@ export async function main(argv: readonly string[]): Promise<number> {
     forward(child.stdout, Bun.stdout, observe),
     forward(child.stderr, Bun.stderr, observe),
   ])
+  // The stall path does not await forwarding: if signaling is denied, waiting for pipe EOF would
+  // recreate the hang this guard exists to bound. Mark a broken downstream pipe as handled here.
+  void forwarding.catch(() => {})
 
   // The stall check runs on an interval that is cleared as soon as the race settles. A polling
   // loop built from awaited sleeps would instead leave a live timer behind and keep this process
@@ -112,32 +149,40 @@ export async function main(argv: readonly string[]): Promise<number> {
     }, POLL_MS)
   })
 
-  let verdict: { kind: "exited"; code: number } | { kind: "stalled"; reason: string }
   try {
-    verdict = await Promise.race([
-      child.exited.then((code) => ({ kind: "exited" as const, code })),
-      stalled,
-    ])
+    let verdict: { kind: "exited"; code: number } | { kind: "stalled"; reason: string }
+    try {
+      verdict = await Promise.race([
+        child.exited.then((code) => ({ kind: "exited" as const, code })),
+        stalled,
+      ])
+    } finally {
+      clearInterval(stallTimer)
+    }
+
+    if (verdict.kind === "exited") {
+      await forwarding
+      return verdict.code
+    }
+
+    // Snapshot the process state before killing anything, but stop the tree before writing the
+    // report: a closed parent pipe must not throw or SIGPIPE before cleanup gets its chance.
+    const report = await diagnose(child.pid, {
+      reason: verdict.reason,
+      elapsedSeconds: (performance.now() - started) / 1000,
+      silentSeconds: (performance.now() - lastOutputAt) / 1000,
+      lastTestFile,
+      tail,
+    })
+    await stopChild()
+    process.stderr.write(report)
+    return STALL_EXIT_CODE
+  } catch (error) {
+    await stopChild()
+    throw error
   } finally {
-    clearInterval(stallTimer)
+    removeSignalHandlers()
   }
-
-  if (verdict.kind === "exited") {
-    await forwarding
-    return verdict.code
-  }
-
-  // Snapshot the process state *before* killing anything, or the diagnosis dies with the process.
-  const report = await diagnose(child.pid, {
-    reason: verdict.reason,
-    elapsedSeconds: (performance.now() - started) / 1000,
-    silentSeconds: (performance.now() - lastOutputAt) / 1000,
-    lastTestFile,
-    tail,
-  })
-  process.stderr.write(report)
-  await killTree(child.pid)
-  return STALL_EXIT_CODE
 }
 
 async function forward(
@@ -239,12 +284,30 @@ interface ProcessEntry {
 
 /** `ps -A` with an explicit format: the one process listing that behaves the same on Linux and macOS. */
 async function processTable(): Promise<ProcessEntry[]> {
-  const proc = Bun.spawn(["ps", "-Ao", "pid=,ppid=,stat=,pcpu=,args="], {
-    stdout: "pipe",
-    stderr: "ignore",
-  })
-  const output = await new Response(proc.stdout).text()
-  await proc.exited
+  let proc: Bun.Subprocess<"ignore", "pipe", "ignore">
+  try {
+    proc = Bun.spawn(["ps", "-Ao", "pid=,ppid=,stat=,pcpu=,args="], {
+      stdout: "pipe",
+      stderr: "ignore",
+    })
+  } catch {
+    return []
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const output = await new Promise<string | null>((resolve) => {
+    timer = setTimeout(() => resolve(null), PROCESS_TABLE_TIMEOUT_MS)
+    void new Response(proc.stdout).text().then(resolve, () => resolve(null))
+  }).finally(() => clearTimeout(timer))
+
+  if (output === null) {
+    try {
+      proc.kill()
+    } catch {
+      // The process may already have failed under the same sandbox restriction as `ps -A`.
+    }
+    return []
+  }
 
   const entries: ProcessEntry[] = []
   for (const line of output.split("\n")) {
@@ -353,20 +416,46 @@ function read(path: string): string | null {
 }
 
 /**
- * Children first, then the root: killing the parent first can reparent a wedged grandchild to
- * init, which is exactly how an orphaned `bun` survives the job it belonged to.
+ * The guarded command owns a POSIX process group, so cleanup does not depend on `ps -A` being
+ * available. The discovered tree remains a second line of defence for descendants that create
+ * their own groups. Children are signaled before the root to avoid reparenting them mid-cleanup.
  */
 async function killTree(rootPid: number): Promise<void> {
-  const tree = descendants(await processTable(), rootPid)
-  for (const signal of ["SIGTERM", "SIGKILL"] as const) {
-    for (const entry of [...tree].reverse()) {
-      try {
-        process.kill(entry.pid, signal)
-      } catch {
-        // Already gone.
-      }
+  // Start discovery before signaling the root, while parent links still describe the whole tree.
+  const processes = processTable()
+
+  // The process group is the path that must not wait on `ps`: command runners commonly allow only
+  // a short grace before escalating their own SIGTERM to SIGKILL.
+  signalProcessGroup(rootPid, "SIGTERM")
+  signalProcesses([rootPid], "SIGTERM")
+  const forceGroup = Bun.sleep(TERM_GRACE_MS).then(() => {
+    signalProcessGroup(rootPid, "SIGKILL")
+    signalProcesses([rootPid], "SIGKILL")
+  })
+
+  const tree = descendants(await processes, rootPid)
+  const individualPids = [...new Set([...tree].reverse().map((entry) => entry.pid))]
+  signalProcesses(individualPids, "SIGTERM")
+  await forceGroup
+  signalProcesses(individualPids, "SIGKILL")
+}
+
+function signalProcessGroup(rootPid: number, signal: "SIGTERM" | "SIGKILL"): void {
+  if (process.platform === "win32") return
+  try {
+    process.kill(-rootPid, signal)
+  } catch {
+    // The group may already be gone, or a restricted host may only allow individual signals.
+  }
+}
+
+function signalProcesses(pids: readonly number[], signal: "SIGTERM" | "SIGKILL"): void {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal)
+    } catch {
+      // Already gone or not visible to this process sandbox.
     }
-    if (signal === "SIGTERM") await Bun.sleep(TERM_GRACE_MS)
   }
 }
 

--- a/scripts/tests/ci-guard.test.ts
+++ b/scripts/tests/ci-guard.test.ts
@@ -9,18 +9,42 @@ import { join } from "node:path"
  */
 const guardPath = join(import.meta.dir, "..", "ci-guard.ts")
 
+/**
+ * Intentional stall fixtures still need their own last-resort bound. They also watch their parent
+ * so a harness SIGKILL cannot leave them waiting for that bound after the guard disappears.
+ */
+function boundedFixture(body = "", delayMs = 100): string {
+  const iterations = Math.ceil(60_000 / delayMs)
+  const step = body ? `${body}; ` : ""
+  return [
+    "const fixtureParentPid = process.ppid",
+    `for (let i = 0; i < ${iterations} && process.ppid === fixtureParentPid; i++) { ${step}await Bun.sleep(${delayMs}) }`,
+  ].join("; ")
+}
+
 async function runGuard(
-  args: readonly string[]
+  args: readonly string[],
+  env: Readonly<Record<string, string | undefined>> = process.env
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   const proc = Bun.spawn([process.execPath, guardPath, ...args], {
     stdout: "pipe",
     stderr: "pipe",
+    env,
   })
   const [stdout, stderr] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
   ])
   return { exitCode: await proc.exited, stdout, stderr }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
 }
 
 describe("ci-guard", () => {
@@ -53,8 +77,8 @@ describe("ci-guard", () => {
   })
 
   test("kills a silent command and names the last test file it saw", async () => {
-    // Mirrors the real failure: output flows, a test file opens, then the process goes quiet
-    // forever. Without the guard this is the run that dies at the job's wall clock instead.
+    // Mirrors the real failure: output flows, a test file opens, then the process goes quiet past
+    // the guard's bound. The fixture itself is capped so an infrastructure failure cannot leak it.
     const result = await runGuard([
       "--stall",
       "1",
@@ -64,7 +88,8 @@ describe("ci-guard", () => {
       [
         'process.stderr.write("(pass) something\\n")',
         'process.stderr.write("::group::packages/atlas/tests/atlas-app.test.ts:\\n")',
-        "await new Promise(() => {})",
+        // A timer creates the required silence without making a leaked Bun fixture busy-spin.
+        boundedFixture(),
       ].join("; "),
     ])
 
@@ -79,8 +104,9 @@ describe("ci-guard", () => {
     // more than bun's 5s default per-test bound.
   }, 30_000)
 
-  test("bounds a command that keeps printing but never finishes", async () => {
-    // A stall bound alone cannot catch a loop that stays chatty, so `--max` covers wall clock.
+  test("bounds a command that keeps printing past the maximum", async () => {
+    // A stall bound alone cannot catch a loop that stays chatty, so `--max` covers wall clock. The
+    // fixture has its own generous cap so a broken guard still cannot leave it behind indefinitely.
     const result = await runGuard([
       "--stall",
       "30",
@@ -89,39 +115,42 @@ describe("ci-guard", () => {
       "--",
       process.execPath,
       "-e",
-      'setInterval(() => process.stdout.write("still here\\n"), 100)',
+      boundedFixture('process.stdout.write("still here\\n")'),
     ])
 
     expect(result.exitCode).toBe(124)
     expect(result.stderr).toContain("ran for")
   }, 30_000)
 
-  test("kills the whole tree so no child outlives the guard", async () => {
-    // The orphaned `bun` processes the runner had to reap came from exactly this gap: killing the
-    // command without killing what it spawned.
+  test("kills the whole process group when process listing is unavailable", async () => {
+    // The orphaned `bun` processes the runner had to reap came from exactly this gap: a restricted
+    // process sandbox denied `ps -A`, so the old implementation discovered an empty tree and
+    // signaled nothing. Reverting the process-group cleanup makes this test time out and leak.
     const scriptDir = await mkdtemp(join(tmpdir(), "sixb-ci-guard-"))
     const markerPath = join(scriptDir, "child-alive")
     const childPath = join(scriptDir, "child.ts")
     const parentPath = join(scriptDir, "parent.ts")
+    const fakePsPath = join(scriptDir, "ps")
 
     try {
+      await writeFile(fakePsPath, "#!/bin/sh\nexit 1\n", { mode: 0o755 })
       await writeFile(
         childPath,
-        [
-          `setInterval(() => { Bun.write(${JSON.stringify(markerPath)}, String(Date.now())) }, 50)`,
-          "await new Promise(() => {})",
-        ].join("\n")
+        boundedFixture(`await Bun.write(${JSON.stringify(markerPath)}, String(Date.now()))`, 50)
       )
       await writeFile(
         parentPath,
         [
           `Bun.spawn([process.execPath, ${JSON.stringify(childPath)}], { stdout: "ignore", stderr: "ignore" })`,
           'process.stdout.write("spawned\\n")',
-          "await new Promise(() => {})",
+          boundedFixture(),
         ].join("\n")
       )
 
-      const result = await runGuard(["--stall", "1", "--", process.execPath, parentPath])
+      const result = await runGuard(["--stall", "1", "--", process.execPath, parentPath], {
+        ...process.env,
+        PATH: scriptDir,
+      })
       expect(result.exitCode).toBe(124)
 
       // The grandchild keeps stamping the marker while it lives, so a marker that stops moving is
@@ -130,6 +159,107 @@ describe("ci-guard", () => {
       await Bun.sleep(500)
       expect(await Bun.file(markerPath).text()).toBe(afterKill)
     } finally {
+      await rm(scriptDir, { recursive: true, force: true })
+    }
+  }, 30_000)
+
+  test("stops the guarded process before relaying a termination signal", async () => {
+    // Local coding harnesses terminate their direct command on cancellation. The guard has to reap
+    // its own child before it accepts that signal or the fixture is reparented to PID 1.
+    const scriptDir = await mkdtemp(join(tmpdir(), "sixb-ci-guard-signal-"))
+    const pidPath = join(scriptDir, "child-pid")
+    const childPath = join(scriptDir, "child.ts")
+    const fakePsPath = join(scriptDir, "ps")
+    let childPid: number | null = null
+    let guard: Bun.Subprocess<"ignore", "ignore", "ignore"> | null = null
+
+    try {
+      await writeFile(
+        childPath,
+        `await Bun.write(${JSON.stringify(pidPath)}, String(process.pid))\n${boundedFixture()}\n`
+      )
+      // A stuck diagnostic must not delay the process-group signal until after the caller's grace.
+      await writeFile(fakePsPath, "#!/bin/sh\nexec /bin/sleep 60\n", { mode: 0o755 })
+      guard = Bun.spawn(
+        [process.execPath, guardPath, "--stall", "30", "--", process.execPath, childPath],
+        {
+          stdout: "ignore",
+          stderr: "ignore",
+          env: { ...process.env, PATH: scriptDir },
+        }
+      )
+
+      for (let attempt = 0; attempt < 100 && !(await Bun.file(pidPath).exists()); attempt++) {
+        await Bun.sleep(10)
+      }
+      childPid = Number(await Bun.file(pidPath).text())
+      expect(Number.isInteger(childPid)).toBeTrue()
+
+      guard.kill("SIGTERM")
+      await guard.exited
+      await Bun.sleep(100)
+      expect(isProcessAlive(childPid)).toBeFalse()
+    } finally {
+      try {
+        guard?.kill("SIGKILL")
+      } catch {
+        // Already stopped.
+      }
+      if (childPid !== null) {
+        try {
+          process.kill(childPid, "SIGKILL")
+        } catch {
+          // The assertion path already proved it was stopped.
+        }
+      }
+      await rm(scriptDir, { recursive: true, force: true })
+    }
+  }, 30_000)
+
+  test("bounds a fixture even when the guard is killed without cleanup", async () => {
+    // SIGKILL cannot be handled. The fixture itself watches its parent so the exact failure mode
+    // that produced the local PID-1 orphans still converges without waiting for its wall-clock cap.
+    const scriptDir = await mkdtemp(join(tmpdir(), "sixb-ci-guard-sigkill-"))
+    const pidPath = join(scriptDir, "child-pid")
+    const childPath = join(scriptDir, "child.ts")
+    let childPid: number | null = null
+    let guard: Bun.Subprocess<"ignore", "ignore", "ignore"> | null = null
+
+    try {
+      await writeFile(
+        childPath,
+        `await Bun.write(${JSON.stringify(pidPath)}, String(process.pid))\n${boundedFixture()}\n`
+      )
+      guard = Bun.spawn(
+        [process.execPath, guardPath, "--stall", "30", "--", process.execPath, childPath],
+        { stdout: "ignore", stderr: "ignore" }
+      )
+
+      for (let attempt = 0; attempt < 100 && !(await Bun.file(pidPath).exists()); attempt++) {
+        await Bun.sleep(10)
+      }
+      childPid = Number(await Bun.file(pidPath).text())
+      expect(Number.isInteger(childPid)).toBeTrue()
+
+      guard.kill("SIGKILL")
+      await guard.exited
+      for (let attempt = 0; attempt < 100 && isProcessAlive(childPid); attempt++) {
+        await Bun.sleep(10)
+      }
+      expect(isProcessAlive(childPid)).toBeFalse()
+    } finally {
+      try {
+        guard?.kill("SIGKILL")
+      } catch {
+        // Already stopped.
+      }
+      if (childPid !== null) {
+        try {
+          process.kill(childPid, "SIGKILL")
+        } catch {
+          // Already stopped.
+        }
+      }
       await rm(scriptDir, { recursive: true, force: true })
     }
   }, 30_000)


### PR DESCRIPTION
## Summary

- run guarded commands in a POSIX process group so cleanup does not depend on `ps -A`
- signal the group immediately, retain discovered-process fallback cleanup, and bound process-table diagnostics
- reap children before relaying `SIGHUP`, `SIGINT`, or `SIGTERM`, and clean up before writing a potentially broken output pipe
- make the intentional stall fixtures low-power, wall-clock bounded, and parent-aware so even an unhandleable `SIGKILL` cannot leave them behind
- document that the complete CI suite should be run outside restricted Codex process sandboxes

## What happened on the Mac

The repeated battery drain was not an application workload. Several Bun processes from `scripts/tests/ci-guard.test.ts` had been reparented to PID 1 and were still alive hours after their test runs ended. Three copies of the silent-command fixture were each consuming roughly 70–100% CPU, accompanied by orphaned CI-guard parent/child fixtures.

The process command lines and timestamps matched restricted Codex runs of `bun run test:ci`. In that sandbox, process inspection/signaling was unavailable and the three guard self-tests timed out. The old cleanup path derived every PID from `ps -A`; when that returned no usable tree, it signaled nothing. The outer test process then exited, leaving the intentional `await new Promise(() => {})` fixture behind. On Bun 1.3.14/macOS that unresolved top-level wait busy-spun a core. Later elevated reruns passed, but they could not clean processes leaked by earlier runs.

This change removes the `ps` dependency from the primary cleanup path and adds independent fixture safeguards for parent death and hard termination.

## Verification

- proved the regression with the pre-fix guard: with `ps` unavailable it remained hung after a 1-second stall bound
- `bun test --parallel=2 scripts/tests/ci-guard.test.ts`: 8 passed
- six guard suites run concurrently: 48 tests passed, zero surviving fixtures
- three forced outer-process-group `SIGTERM` cancellations: zero surviving fixtures
- explicit guard `SIGKILL` regression: fixture detected parent death and exited
- `bun run build:types`
- `bun run typecheck:tests`
- `bun run test:ci`: 4,355 passed, 2 skipped, 0 failed
- `bun run check` (one existing informational notice for the generated OpenAPI file size)
- final process scan: no CI-guard or Bun fixture processes remained
