### PR TITLE
objects: add exact-reference query sources

### DIFF
--- a/docs/objects/http-reference.md
+++ b/docs/objects/http-reference.md
@@ -80,6 +80,31 @@ Each object in the response carries its primary id, type, properties, and timest
 ```
 
 
+## Exact Object References
+
+Use a `refs` source when object identities are already known. References can be heterogeneous,
+primary ids remain in JSON rather than URL paths, missing objects are omitted, and duplicates are
+removed. Results use canonical identity order by `objectTypeId` and `primaryId`:
+
+```json
+{
+  "query": {
+    "kind": "refs",
+    "refs": [
+      { "objectTypeId": "Customer", "primaryId": "github:customer:acme/co#42" },
+      { "objectTypeId": "Invoice", "primaryId": "inv-1042" }
+    ]
+  },
+  "includeTotal": false
+}
+```
+
+`refs` accepts between 1 and 1,000 unique references and is intrinsically bounded. SQLite,
+PostgreSQL, and the in-memory provider execute it natively, so it composes with traversal, sets,
+filtering, projection, expansion, and pagination. Providers without native support use the storage
+batch identity primitive for the bounded core fallback.
+
+
 ## Count, Exists, And Facets
 
 `POST /api/objects/query/count` takes the same `query` body and returns `{ "count": number }`
@@ -222,6 +247,7 @@ relationship's edge fields:
 | Node | Fields | Purpose |
 | --- | --- | --- |
 | `start` | `objectTypeId`, `includeSubtypes?` | Begin with all objects of one type. |
+| `refs` | `refs` | Begin with 1–1,000 exact, heterogeneous `{ objectTypeId, primaryId }` identities. |
 | `filter` | `input`, `predicate` | Apply a property predicate tree. |
 | `text` | `input`, `query`, `fields?` | Keyword search over `search.defaultText` or explicit `fields`. |
 | `vector` | `input`, `vector`, `propertyId`, `k` | Nearest-neighbor search on a numeric-array property. |
@@ -284,8 +310,12 @@ Authentication and CSRF handling follow your server configuration; see
 
 ## Provider Support
 
-SQLite and PostgreSQL object storage cover the common graph workflow: property filters, text
-search, sorting, limits, cursor pages, link traversal, set operations, and projection.
+SQLite and PostgreSQL object storage cover the common graph workflow: exact reference sets,
+property filters, text search, sorting, limits, cursor pages, link traversal, set operations, and
+projection.
+
+Exact `refs` sources are pushed down by the bundled providers and fall back to core's bounded batch
+primitive on providers without native support.
 
 Vector search and relevance sorting require explicit storage-provider support. When a provider
 can't execute a requested feature, Sixb returns a structured planning error rather than a partial

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -311,6 +311,21 @@
           }
         }
       },
+      "ObjectRef": {
+        "type": "object",
+        "required": ["objectTypeId", "primaryId"],
+        "additionalProperties": false,
+        "properties": {
+          "objectTypeId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "primaryId": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
       "ObjectQuery": {
         "oneOf": [
           {
@@ -328,6 +343,25 @@
               },
               "includeSubtypes": {
                 "type": "boolean"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": ["kind", "refs"],
+            "additionalProperties": false,
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": ["refs"]
+              },
+              "refs": {
+                "type": "array",
+                "minItems": 1,
+                "description": "One to 1,000 unique identities after normalization; duplicate entries are accepted and removed.",
+                "items": {
+                  "$ref": "#/components/schemas/ObjectRef"
+                }
               }
             }
           },

--- a/packages/client/src/generated/index.ts
+++ b/packages/client/src/generated/index.ts
@@ -589,6 +589,7 @@ export type {
   ObjectQueryRequest,
   ObjectQueryResponse,
   ObjectQuerySortField,
+  ObjectRef,
   PostAgentThreadMessageData,
   PostAgentThreadMessageError,
   PostAgentThreadMessageErrors,

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -104,11 +104,23 @@ export type ObjectQueryFacetsRequest = {
   facets: Array<ObjectQueryFacetRequest>
 }
 
+export type ObjectRef = {
+  objectTypeId: string
+  primaryId: string
+}
+
 export type ObjectQuery =
   | {
       kind: "start"
       objectTypeId: string
       includeSubtypes?: boolean
+    }
+  | {
+      kind: "refs"
+      /**
+       * One to 1,000 unique identities after normalization; duplicate entries are accepted and removed.
+       */
+      refs: Array<ObjectRef>
     }
   | {
       kind: "filter"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -574,6 +574,7 @@ export type {
   ObjectQueryPredicateIn,
   ObjectQueryPredicateNot,
   ObjectQueryProject,
+  ObjectQueryRefs,
   ObjectQueryResultShape,
   ObjectQuerySet,
   ObjectQuerySetOperation,

--- a/packages/core/src/objects/query/executor.ts
+++ b/packages/core/src/objects/query/executor.ts
@@ -52,6 +52,7 @@ export interface QueryExecutorOptions
   storage: ObjectStorage
   maxLimit?: number
   maxPageSize?: number
+  maxRefs?: number
   maxFacetLimit?: number
   /**
    * Per-parent cap on how many links a single `expand` hydrates, applied as a
@@ -132,6 +133,7 @@ export async function executeObjectQuery(
     ontology: options.ontology,
     maxLimit: options.maxLimit,
     maxPageSize: options.maxPageSize,
+    maxRefs: options.maxRefs,
     normalize: false,
   })
   assertQueryViewable(validated, options)
@@ -199,6 +201,7 @@ export async function countObjects(
     ontology: options.ontology,
     maxLimit: options.maxLimit,
     maxPageSize: options.maxPageSize,
+    maxRefs: options.maxRefs,
     normalize: false,
   })
   assertQueryViewable(validated, options)
@@ -259,6 +262,7 @@ export async function existsObjects(
     ontology: options.ontology,
     maxLimit: options.maxLimit,
     maxPageSize: options.maxPageSize,
+    maxRefs: options.maxRefs,
     normalize: false,
   })
   assertQueryViewable(validated, options)
@@ -319,6 +323,7 @@ export async function facetObjects(
     ontology: options.ontology,
     maxLimit: options.maxLimit,
     maxPageSize: options.maxPageSize,
+    maxRefs: options.maxRefs,
     normalize: false,
   })
   assertQueryViewable(validated, options)
@@ -435,6 +440,7 @@ function resolveExpansions(query: ObjectQuery, ctx: ExpansionResolutionContext):
       }
     }
     case "start":
+    case "refs":
       return query
     case "set":
       return {
@@ -555,6 +561,8 @@ function expandIncludeSubtypes(query: ObjectQuery, ontology: OntologyRegistry): 
         inputs: objectTypeIds.map((objectTypeId) => ({ kind: "start", objectTypeId })),
       }
     }
+    case "refs":
+      return query
     case "filter":
     case "text":
     case "vector":
@@ -598,6 +606,8 @@ async function evaluateFallbackQuery(
   switch (query.kind) {
     case "start":
       return evaluateFallbackStart(projectId, query, options, maxRows)
+    case "refs":
+      return evaluateFallbackRefs(projectId, query, options)
     case "filter": {
       const input = await evaluateFallbackQuery(projectId, query.input, options, maxRows)
       return completeFallbackEvaluation(
@@ -670,6 +680,23 @@ async function evaluateFallbackQuery(
         `Fallback execution does not support query node '${query.kind}'`
       )
   }
+}
+
+async function evaluateFallbackRefs(
+  projectId: string,
+  query: Extract<ObjectQuery, { kind: "refs" }>,
+  options: QueryExecutorOptions
+): Promise<FallbackEvaluation> {
+  const rows = await options.storage.getByPrimaryIdBatch({
+    projectId,
+    items: query.refs,
+  })
+  return completeFallbackEvaluation(
+    query.refs.flatMap((ref, order) => {
+      const row = rows.get(`${ref.objectTypeId}:${ref.primaryId}`)
+      return row ? [{ row, order }] : []
+    })
+  )
 }
 
 /**

--- a/packages/core/src/objects/query/explain.ts
+++ b/packages/core/src/objects/query/explain.ts
@@ -84,6 +84,14 @@ function buildExplainNode(query: ObjectQuery, path: string): ObjectQueryExplainN
         },
         children: [],
       }
+    case "refs":
+      return {
+        path,
+        kind: query.kind,
+        summary: `refs ${query.refs.length}`,
+        details: { refs: query.refs },
+        children: [],
+      }
     case "filter":
       return {
         path,

--- a/packages/core/src/objects/query/explain.ts
+++ b/packages/core/src/objects/query/explain.ts
@@ -18,6 +18,7 @@ export interface ObjectQueryExplainOptions {
   normalize?: boolean
   maxLimit?: number
   maxPageSize?: number
+  maxRefs?: number
 }
 
 export interface ObjectQueryExplanation {
@@ -47,6 +48,7 @@ export function explainObjectQuery(
         ontology: options.ontology,
         maxLimit: options.maxLimit,
         maxPageSize: options.maxPageSize,
+        maxRefs: options.maxRefs,
         normalize: false,
       })
     : []
@@ -57,6 +59,7 @@ export function explainObjectQuery(
           ontology: options.ontology,
           maxLimit: options.maxLimit,
           maxPageSize: options.maxPageSize,
+          maxRefs: options.maxRefs,
           normalize: false,
         }).result
       : undefined

--- a/packages/core/src/objects/query/index.ts
+++ b/packages/core/src/objects/query/index.ts
@@ -44,6 +44,7 @@ export type {
   ObjectQueryPredicateIn,
   ObjectQueryPredicateNot,
   ObjectQueryProject,
+  ObjectQueryRefs,
   ObjectQueryResultShape,
   ObjectQuerySet,
   ObjectQuerySetOperation,

--- a/packages/core/src/objects/query/ir.ts
+++ b/packages/core/src/objects/query/ir.ts
@@ -46,7 +46,8 @@ export interface ObjectQueryStart {
  *
  * Unlike `start`, this source is intrinsically bounded. Providers can compile
  * it natively for composition with the rest of the IR; core resolves it through
- * `getByPrimaryIdBatch` when pushdown is unavailable.
+ * `getByPrimaryIdBatch` when pushdown is unavailable. Normalization removes
+ * duplicate identities and orders the set canonically by type and primary id.
  */
 export interface ObjectQueryRefs {
   kind: "refs"

--- a/packages/core/src/objects/query/ir.ts
+++ b/packages/core/src/objects/query/ir.ts
@@ -5,6 +5,8 @@
  * storage backend. Providers can push down the subset they support, while the
  * core planner decides whether a bounded fallback is acceptable.
  */
+import type { ObjectRef } from "../../ontology/refs"
+
 export type ObjectQueryDirection = "outgoing" | "incoming"
 export type ObjectQuerySetOperation = "union" | "intersect" | "subtract"
 export type ObjectQuerySortDirection = "asc" | "desc"
@@ -21,6 +23,7 @@ export type QueryScalarKind =
 
 export type ObjectQuery =
   | ObjectQueryStart
+  | ObjectQueryRefs
   | ObjectQueryFilter
   | ObjectQueryText
   | ObjectQueryVector
@@ -36,6 +39,18 @@ export interface ObjectQueryStart {
   kind: "start"
   objectTypeId: string
   includeSubtypes?: boolean
+}
+
+/**
+ * Starts a query from an explicit, heterogeneous set of object identities.
+ *
+ * Unlike `start`, this source is intrinsically bounded. Providers can compile
+ * it natively for composition with the rest of the IR; core resolves it through
+ * `getByPrimaryIdBatch` when pushdown is unavailable.
+ */
+export interface ObjectQueryRefs {
+  kind: "refs"
+  refs: readonly ObjectRef[]
 }
 
 export interface ObjectQueryFilter {

--- a/packages/core/src/objects/query/normalize.ts
+++ b/packages/core/src/objects/query/normalize.ts
@@ -252,12 +252,27 @@ function uniqueRefs(
   refs: readonly { objectTypeId: string; primaryId: string }[]
 ): { objectTypeId: string; primaryId: string }[] {
   const seen = new Set<string>()
-  return refs.flatMap((ref) => {
+  const unique = refs.flatMap((ref) => {
     const key = JSON.stringify([ref.objectTypeId, ref.primaryId])
     if (seen.has(key)) return []
     seen.add(key)
     return [{ ...ref }]
   })
+
+  // `refs` is an object-set source, not a positional batch response. Canonical
+  // identity order makes equivalent sets normalize identically and matches the
+  // default ordering used by provider query sources.
+  return unique.sort(
+    (left, right) =>
+      compareStrings(left.objectTypeId, right.objectTypeId) ||
+      compareStrings(left.primaryId, right.primaryId)
+  )
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
 }
 
 function uniqueStringRecord(

--- a/packages/core/src/objects/query/normalize.ts
+++ b/packages/core/src/objects/query/normalize.ts
@@ -22,6 +22,11 @@ function normalizeNode(query: ObjectQuery): ObjectQuery {
   switch (query.kind) {
     case "start":
       return { ...query }
+    case "refs":
+      return {
+        kind: "refs",
+        refs: uniqueRefs(query.refs),
+      }
     case "filter":
       return normalizeFilter(query.input, query.predicate)
     case "text":
@@ -63,7 +68,14 @@ function normalizeNode(query: ObjectQuery): ObjectQuery {
  * lands above another `expand` is merged into one.
  */
 function hoistExpand(query: ObjectQuery): ObjectQuery {
-  if (query.kind === "start" || query.kind === "set" || query.kind === "expand") return query
+  if (
+    query.kind === "start" ||
+    query.kind === "refs" ||
+    query.kind === "set" ||
+    query.kind === "expand"
+  ) {
+    return query
+  }
   if (query.input.kind !== "expand") return query
 
   const inner = query.input
@@ -234,6 +246,18 @@ function normalizeLimit(input: ObjectQuery, limit: number): ObjectQuery {
 
 function uniqueStrings(values: readonly string[]): string[] {
   return [...new Set(values)]
+}
+
+function uniqueRefs(
+  refs: readonly { objectTypeId: string; primaryId: string }[]
+): { objectTypeId: string; primaryId: string }[] {
+  const seen = new Set<string>()
+  return refs.flatMap((ref) => {
+    const key = JSON.stringify([ref.objectTypeId, ref.primaryId])
+    if (seen.has(key)) return []
+    seen.add(key)
+    return [{ ...ref }]
+  })
 }
 
 function uniqueStringRecord(

--- a/packages/core/src/objects/query/planner.ts
+++ b/packages/core/src/objects/query/planner.ts
@@ -40,6 +40,7 @@ const DEFAULT_MAX_FALLBACK_ROWS = 1_000
 // accidental full scans.
 const fallbackNodeKinds = new Set<ObjectQuery["kind"]>([
   "start",
+  "refs",
   "filter",
   "sort",
   "limit",
@@ -194,6 +195,8 @@ function collectNodeProviderIssues(
           "Provider does not support start.includeSubtypes expansion"
         )
       }
+      return
+    case "refs":
       return
     case "filter":
       collectPredicateProviderIssues(query.predicate, `${path}.predicate`, capabilities, issues)
@@ -474,6 +477,7 @@ function collectFallbackNodeIssues(
 
   switch (query.kind) {
     case "start":
+    case "refs":
       return
     case "filter":
     case "limit":
@@ -512,6 +516,7 @@ function hasExplicitResultBound(query: ObjectQuery): boolean {
   switch (query.kind) {
     case "limit":
     case "page":
+    case "refs":
       return true
     case "start":
       return false

--- a/packages/core/src/objects/query/validate.ts
+++ b/packages/core/src/objects/query/validate.ts
@@ -1,4 +1,11 @@
-import type { ObjectType, OntologyRegistry, Property, Schema, ValueType } from "../../ontology"
+import type {
+  ObjectRef,
+  ObjectType,
+  OntologyRegistry,
+  Property,
+  Schema,
+  ValueType,
+} from "../../ontology"
 import { normalizeDecimalValue } from "../../ontology"
 import { formatUnknownObjectTypeMessage } from "../../ontology/errors"
 import { validatePropertyValue, validateSchemaValue } from "../../ontology/validation"
@@ -30,11 +37,12 @@ export interface ObjectQueryValidationOptions {
   ontology: OntologyRegistry
   maxLimit?: number
   maxPageSize?: number
+  maxRefs?: number
   normalize?: boolean
 }
 
 type QueryValidationContext = Required<
-  Pick<ObjectQueryValidationOptions, "maxLimit" | "maxPageSize">
+  Pick<ObjectQueryValidationOptions, "maxLimit" | "maxPageSize" | "maxRefs">
 > & {
   ontology: OntologyRegistry
   valueTypesById: ReadonlyMap<string, ValueType>
@@ -53,6 +61,7 @@ interface TextFieldResolution {
 
 const DEFAULT_MAX_LIMIT = 1_000
 const DEFAULT_MAX_PAGE_SIZE = 1_000
+const DEFAULT_MAX_REFS = 1_000
 
 export function validateObjectQuery(
   query: ObjectQuery,
@@ -96,6 +105,7 @@ function createValidationContext(options: ObjectQueryValidationOptions): QueryVa
     valueTypesById: options.ontology.getValueTypesById(),
     maxLimit: options.maxLimit ?? DEFAULT_MAX_LIMIT,
     maxPageSize: options.maxPageSize ?? DEFAULT_MAX_PAGE_SIZE,
+    maxRefs: options.maxRefs ?? DEFAULT_MAX_REFS,
     issues: [],
     touchedObjectTypeIds: new Set<string>(),
   }
@@ -125,6 +135,8 @@ function dispatchQueryNode(
   switch (query.kind) {
     case "start":
       return validateStart(query.objectTypeId, query.includeSubtypes, path, ctx)
+    case "refs":
+      return validateRefs(query.refs, path, ctx)
     case "filter": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
       const predicate = validatePredicate(query.predicate, input.result, `${path}.predicate`, ctx)
@@ -196,6 +208,50 @@ function dispatchQueryNode(
       )
       return { result: input.result, query: { ...query, input: input.query, expansions } }
     }
+  }
+}
+
+function validateRefs(
+  refs: readonly ObjectRef[],
+  path: string,
+  ctx: QueryValidationContext
+): QueryValidationResult {
+  if (refs.length === 0) {
+    addIssue(ctx, `${path}.refs`, "empty_refs", "refs must include at least one object reference")
+  }
+  if (refs.length > ctx.maxRefs) {
+    addIssue(
+      ctx,
+      `${path}.refs`,
+      "too_many_refs",
+      `refs must include at most ${ctx.maxRefs} object references`
+    )
+  }
+
+  const objectTypeIds = new Set<string>()
+  refs.forEach((ref, index) => {
+    const refPath = `${path}.refs[${index}]`
+    if (!ref.objectTypeId) {
+      addIssue(ctx, `${refPath}.objectTypeId`, "missing_object_type", "objectTypeId is required")
+    } else if (!ctx.ontology.getObjectTypeById(ref.objectTypeId)) {
+      addIssue(
+        ctx,
+        `${refPath}.objectTypeId`,
+        "unknown_object_type",
+        formatUnknownObjectTypeMessage(ref.objectTypeId)
+      )
+    } else {
+      objectTypeIds.add(ref.objectTypeId)
+    }
+
+    if (!ref.primaryId) {
+      addIssue(ctx, `${refPath}.primaryId`, "missing_primary_id", "primaryId is required")
+    }
+  })
+
+  return {
+    result: { objectTypeIds: [...objectTypeIds] },
+    query: { kind: "refs", refs: refs.map((ref) => ({ ...ref })) },
   }
 }
 

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -28,6 +28,7 @@ export type {
   ObjectQueryPredicateIn,
   ObjectQueryPredicateNot,
   ObjectQueryProject,
+  ObjectQueryRefs,
   ObjectQueryResultShape,
   ObjectQuerySet,
   ObjectQuerySetOperation,
@@ -50,6 +51,7 @@ export type {
   ObjectQueryExecutorListResult,
   ObjectQueryExecutorRow,
 } from "./objects/sdk/query-executor"
+export type { ObjectRef } from "./ontology/refs"
 export type {
   LinkToken,
   ObjectTypeWithPropertyTokens,

--- a/packages/core/src/storage/objects/in-memory.ts
+++ b/packages/core/src/storage/objects/in-memory.ts
@@ -343,6 +343,10 @@ export class InMemoryObjectStorage implements ObjectStorage {
     switch (query.kind) {
       case "start":
         return this.evaluateStart(projectId, query.objectTypeId)
+      case "refs":
+        // `refs` is a core-native bounded source resolved through
+        // getByPrimaryIdBatch before a provider query compiler is invoked.
+        throw new Error("[Sixb] In-memory object storage does not compile the core 'refs' source")
       case "filter": {
         const input = this.evaluateObjectQuery(projectId, query.input)
         const entries = input.entries.filter((entry) =>

--- a/packages/core/src/storage/objects/in-memory.ts
+++ b/packages/core/src/storage/objects/in-memory.ts
@@ -26,6 +26,7 @@ const IN_MEMORY_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
   facetObjects: true,
   nodes: {
     start: true,
+    refs: true,
     filter: true,
     text: true,
     vector: true,
@@ -83,7 +84,7 @@ function objectRowKey(projectId: string, objectTypeId: string): string {
   return `${projectId}:${objectTypeId}`
 }
 
-function comparePrimaryIds(left: string, right: string): number {
+function compareStrings(left: string, right: string): number {
   if (left < right) return -1
   if (left > right) return 1
   return 0
@@ -344,9 +345,7 @@ export class InMemoryObjectStorage implements ObjectStorage {
       case "start":
         return this.evaluateStart(projectId, query.objectTypeId)
       case "refs":
-        // `refs` is a core-native bounded source resolved through
-        // getByPrimaryIdBatch before a provider query compiler is invoked.
-        throw new Error("[Sixb] In-memory object storage does not compile the core 'refs' source")
+        return this.evaluateRefs(projectId, query.refs)
       case "filter": {
         const input = this.evaluateObjectQuery(projectId, query.input)
         const entries = input.entries.filter((entry) =>
@@ -447,6 +446,29 @@ export class InMemoryObjectStorage implements ObjectStorage {
       score: 0,
       order: index,
     }))
+    return completeEvaluation(entries)
+  }
+
+  private evaluateRefs(
+    projectId: string,
+    refs: readonly { objectTypeId: string; primaryId: string }[]
+  ): QueryEvaluation {
+    const seen = new Set<string>()
+    const entries = refs
+      .flatMap((ref) => {
+        const key = JSON.stringify([ref.objectTypeId, ref.primaryId])
+        if (seen.has(key)) return []
+        seen.add(key)
+        const row = this.rows.get(objectRowKey(projectId, ref.objectTypeId))?.get(ref.primaryId)
+        return row ? [row] : []
+      })
+      .sort(
+        (left, right) =>
+          compareStrings(left.objectTypeId, right.objectTypeId) ||
+          compareStrings(left.primaryId, right.primaryId)
+      )
+      .map((row, order) => ({ row, score: 0, order }))
+
     return completeEvaluation(entries)
   }
 
@@ -669,10 +691,9 @@ export class InMemoryObjectStorage implements ObjectStorage {
     const bucket = this.rows.get(objectRowKey(params.projectId, params.objectTypeId))
     const rows = [...(bucket?.values() ?? [])]
       .filter(
-        (row) =>
-          !params.afterPrimaryId || comparePrimaryIds(row.primaryId, params.afterPrimaryId) > 0
+        (row) => !params.afterPrimaryId || compareStrings(row.primaryId, params.afterPrimaryId) > 0
       )
-      .sort((left, right) => comparePrimaryIds(left.primaryId, right.primaryId))
+      .sort((left, right) => compareStrings(left.primaryId, right.primaryId))
       .slice(0, params.limit + 1)
     const hasMore = rows.length > params.limit
     const objects = rows.slice(0, params.limit).map((row) => structuredClone(row))

--- a/packages/core/src/testing/object-query-contract.ts
+++ b/packages/core/src/testing/object-query-contract.ts
@@ -145,7 +145,7 @@ export const objectQueryContractOntology = new OntologyRegistry({
  *
  * The contract defines the portable V1 query surface: capability declarations,
  * validation/normalization handoff, provider pushdown, bounded fallback,
- * traversal, set operations, pagination, search profile defaults, and stable
+ * ordered reference sets, traversal, set operations, pagination, search profile defaults, and stable
  * structured rejections for features outside a provider's capability map.
  */
 export function runObjectQueryProviderContractSuite<TStorage extends Storage>(
@@ -342,6 +342,153 @@ export function runObjectQueryProviderContractSuite<TStorage extends Storage>(
         })
         expect(result.total).toBe(2)
         expect(result.hasMore).toBe(false)
+      })
+    })
+
+    test("queries opaque ids through exact primary-property predicates", async () => {
+      await withStorage(async ({ objects: storage, fixture }) => {
+        const issue297 = "github:issue:sixb-ai/sixb#297"
+        const issue298 = "github:issue:sixb-ai/sixb#298"
+        await fixture.seed({
+          objects: [
+            objectSeed(Asset.id, issue297, { id: issue297 }),
+            objectSeed(Asset.id, issue298, { id: issue298 }),
+          ],
+        })
+
+        const exact = await executeObjectQuery(
+          {
+            projectId,
+            query: {
+              kind: "filter",
+              predicate: { op: "eq", propertyId: "id", value: issue297 },
+              input: { kind: "start", objectTypeId: Asset.id },
+            },
+          },
+          { ontology: objectQueryContractOntology, storage }
+        )
+        const multiple = await executeObjectQuery(
+          {
+            projectId,
+            query: {
+              kind: "filter",
+              predicate: { op: "in", propertyId: "id", values: [issue298, issue297] },
+              input: { kind: "start", objectTypeId: Asset.id },
+            },
+          },
+          { ontology: objectQueryContractOntology, storage }
+        )
+        const refs = await executeObjectQuery(
+          {
+            projectId,
+            query: {
+              kind: "refs",
+              refs: [
+                { objectTypeId: Asset.id, primaryId: issue298 },
+                { objectTypeId: Asset.id, primaryId: issue297 },
+              ],
+            },
+          },
+          { ontology: objectQueryContractOntology, storage }
+        )
+
+        // ContractAsset.id intentionally has no query flags. Primary eq/in remain portable exact
+        // lookups, and the JSON query body preserves URL-reserved characters without encoding.
+        expect(exact.plan.mode).toBe("pushdown")
+        expect(ids(exact)).toEqual([issue297])
+        expect(multiple.plan.mode).toBe("pushdown")
+        expect(sortedIds(multiple)).toEqual([issue297, issue298])
+        expect(refs.plan.mode).toBe(
+          storage.queryCapabilities().nodes?.refs === true ? "pushdown" : "fallback"
+        )
+        expect(ids(refs)).toEqual([issue298, issue297])
+      })
+    })
+
+    test("executes ordered heterogeneous refs with pagination and projection", async () => {
+      await withStorage(async ({ objects: storage, fixture }) => {
+        await seedObjectQueryContractData(fixture)
+
+        const refs: Extract<ObjectQuery, { kind: "refs" }>["refs"] = [
+          { objectTypeId: Device.id, primaryId: "device-sensor" },
+          { objectTypeId: Room.id, primaryId: "room-gamma" },
+          { objectTypeId: Room.id, primaryId: "missing" },
+          { objectTypeId: Room.id, primaryId: "room-alpha" },
+        ]
+        const first = await executeObjectQuery(
+          {
+            projectId,
+            query: {
+              kind: "project",
+              properties: ["id"],
+              input: { kind: "page", pageSize: 2, input: { kind: "refs", refs } },
+            },
+          },
+          { ontology: objectQueryContractOntology, storage }
+        )
+        const second = await executeObjectQuery(
+          {
+            projectId,
+            query: {
+              kind: "project",
+              properties: ["id"],
+              input: {
+                kind: "page",
+                pageSize: 2,
+                pageToken: first.nextPageToken,
+                input: { kind: "refs", refs },
+              },
+            },
+          },
+          { ontology: objectQueryContractOntology, storage }
+        )
+        const count = await countObjects(
+          { projectId, query: { kind: "refs", refs } },
+          { ontology: objectQueryContractOntology, storage }
+        )
+
+        const expectedMode =
+          storage.queryCapabilities().nodes?.refs === true ? "pushdown" : "fallback"
+        expect(first.plan.mode).toBe(expectedMode)
+        expect(ids(first)).toEqual(["device-sensor", "room-gamma"])
+        expect(first.objects.map((row) => row.properties)).toEqual([
+          { id: "device-sensor" },
+          { id: "room-gamma" },
+        ])
+        expect(first.total).toBe(3)
+        expect(first.hasMore).toBe(true)
+        expect(first.nextPageToken).toBeTruthy()
+        expect(second.plan.mode).toBe(expectedMode)
+        expect(ids(second)).toEqual(["room-alpha"])
+        expect(second.hasMore).toBe(false)
+        expect(count.plan.mode).toBe(expectedMode)
+        expect(count.count).toBe(3)
+      })
+    })
+
+    test("composes refs with traversal in provider pushdown", async () => {
+      await withStorage(async ({ objects: storage, fixture }) => {
+        if (storage.queryCapabilities().nodes?.refs !== true) return
+        await seedObjectQueryContractData(fixture)
+
+        const result = await executeObjectQuery(
+          {
+            projectId,
+            query: {
+              kind: "traverse",
+              direction: "outgoing",
+              linkId: "hasDevice",
+              input: {
+                kind: "refs",
+                refs: [{ objectTypeId: Room.id, primaryId: "room-alpha" }],
+              },
+            },
+          },
+          { ontology: objectQueryContractOntology, storage }
+        )
+
+        expect(result.plan.mode).toBe("pushdown")
+        expect(ids(result)).toEqual(["device-projector"])
       })
     })
 

--- a/packages/core/src/testing/object-query-contract.ts
+++ b/packages/core/src/testing/object-query-contract.ts
@@ -145,7 +145,7 @@ export const objectQueryContractOntology = new OntologyRegistry({
  *
  * The contract defines the portable V1 query surface: capability declarations,
  * validation/normalization handoff, provider pushdown, bounded fallback,
- * ordered reference sets, traversal, set operations, pagination, search profile defaults, and stable
+ * canonical reference sets, traversal, set operations, pagination, search profile defaults, and stable
  * structured rejections for features outside a provider's capability map.
  */
 export function runObjectQueryProviderContractSuite<TStorage extends Storage>(
@@ -345,7 +345,7 @@ export function runObjectQueryProviderContractSuite<TStorage extends Storage>(
       })
     })
 
-    test("queries opaque ids through exact primary-property predicates", async () => {
+    test("queries opaque ids through canonical exact refs", async () => {
       await withStorage(async ({ objects: storage, fixture }) => {
         const issue297 = "github:issue:sixb-ai/sixb#297"
         const issue298 = "github:issue:sixb-ai/sixb#298"
@@ -356,28 +356,6 @@ export function runObjectQueryProviderContractSuite<TStorage extends Storage>(
           ],
         })
 
-        const exact = await executeObjectQuery(
-          {
-            projectId,
-            query: {
-              kind: "filter",
-              predicate: { op: "eq", propertyId: "id", value: issue297 },
-              input: { kind: "start", objectTypeId: Asset.id },
-            },
-          },
-          { ontology: objectQueryContractOntology, storage }
-        )
-        const multiple = await executeObjectQuery(
-          {
-            projectId,
-            query: {
-              kind: "filter",
-              predicate: { op: "in", propertyId: "id", values: [issue298, issue297] },
-              input: { kind: "start", objectTypeId: Asset.id },
-            },
-          },
-          { ontology: objectQueryContractOntology, storage }
-        )
         const refs = await executeObjectQuery(
           {
             projectId,
@@ -392,20 +370,15 @@ export function runObjectQueryProviderContractSuite<TStorage extends Storage>(
           { ontology: objectQueryContractOntology, storage }
         )
 
-        // ContractAsset.id intentionally has no query flags. Primary eq/in remain portable exact
-        // lookups, and the JSON query body preserves URL-reserved characters without encoding.
-        expect(exact.plan.mode).toBe("pushdown")
-        expect(ids(exact)).toEqual([issue297])
-        expect(multiple.plan.mode).toBe("pushdown")
-        expect(sortedIds(multiple)).toEqual([issue297, issue298])
+        // The JSON query body preserves URL-reserved characters without encoding.
         expect(refs.plan.mode).toBe(
           storage.queryCapabilities().nodes?.refs === true ? "pushdown" : "fallback"
         )
-        expect(ids(refs)).toEqual([issue298, issue297])
+        expect(ids(refs)).toEqual([issue297, issue298])
       })
     })
 
-    test("executes ordered heterogeneous refs with pagination and projection", async () => {
+    test("executes canonical heterogeneous refs with pagination and projection", async () => {
       await withStorage(async ({ objects: storage, fixture }) => {
         await seedObjectQueryContractData(fixture)
 
@@ -450,16 +423,16 @@ export function runObjectQueryProviderContractSuite<TStorage extends Storage>(
         const expectedMode =
           storage.queryCapabilities().nodes?.refs === true ? "pushdown" : "fallback"
         expect(first.plan.mode).toBe(expectedMode)
-        expect(ids(first)).toEqual(["device-sensor", "room-gamma"])
+        expect(ids(first)).toEqual(["device-sensor", "room-alpha"])
         expect(first.objects.map((row) => row.properties)).toEqual([
           { id: "device-sensor" },
-          { id: "room-gamma" },
+          { id: "room-alpha" },
         ])
         expect(first.total).toBe(3)
         expect(first.hasMore).toBe(true)
         expect(first.nextPageToken).toBeTruthy()
         expect(second.plan.mode).toBe(expectedMode)
-        expect(ids(second)).toEqual(["room-alpha"])
+        expect(ids(second)).toEqual(["room-gamma"])
         expect(second.hasMore).toBe(false)
         expect(count.plan.mode).toBe(expectedMode)
         expect(count.count).toBe(3)

--- a/packages/core/tests/object-query.test.ts
+++ b/packages/core/tests/object-query.test.ts
@@ -213,6 +213,23 @@ function disableQueryObjects(storage: ObjectStorage): ObjectStorage {
   })
 }
 
+function disableRefsPushdown(storage: ObjectStorage): ObjectStorage {
+  return new Proxy(storage, {
+    get(target, property) {
+      if (property === "queryCapabilities") {
+        return () => {
+          const capabilities = storage.queryCapabilities()
+          return {
+            ...capabilities,
+            nodes: { ...capabilities.nodes, refs: false },
+          }
+        }
+      }
+      return Reflect.get(target, property, target)
+    },
+  })
+}
+
 async function seedCustomers(fixture: MaterializerTestFixture): Promise<void> {
   await fixture.seed({
     objects: [
@@ -321,20 +338,22 @@ const boundedCustomerQuery: ObjectQuery = {
 }
 
 describe("object query IR normalization", () => {
-  test("deduplicates explicit refs while preserving authored order", () => {
+  test("deduplicates explicit refs into canonical identity order", () => {
     expect(
       normalizeObjectQuery({
         kind: "refs",
         refs: [
-          { objectTypeId: "Customer", primaryId: "cust-1" },
           { objectTypeId: "Order", primaryId: "order-1" },
+          { objectTypeId: "Customer", primaryId: "cust-2" },
           { objectTypeId: "Customer", primaryId: "cust-1" },
+          { objectTypeId: "Customer", primaryId: "cust-2" },
         ],
       })
     ).toEqual({
       kind: "refs",
       refs: [
         { objectTypeId: "Customer", primaryId: "cust-1" },
+        { objectTypeId: "Customer", primaryId: "cust-2" },
         { objectTypeId: "Order", primaryId: "order-1" },
       ],
     })
@@ -865,12 +884,30 @@ describe("object query explain", () => {
     expect(formatted).toContain("Issues:")
     expect(formatted).toContain("[unknown_property]")
   })
+
+  test("uses the configured refs bound", () => {
+    const explanation = explainObjectQuery(
+      {
+        kind: "refs",
+        refs: [
+          { objectTypeId: "Customer", primaryId: "cust-1" },
+          { objectTypeId: "Order", primaryId: "order-1" },
+        ],
+      },
+      { ontology, maxRefs: 1 }
+    )
+
+    expect(explanation.valid).toBe(false)
+    expect(explanation.issues).toContainEqual(
+      expect.objectContaining({ path: "$.refs", code: "too_many_refs" })
+    )
+  })
 })
 
 describe("object query planner and executor", () => {
   test("resolves explicit refs through the bounded core source", async () => {
     const testStorage = createTestStorage()
-    const { storage, calls } = countQueryCalls(testStorage.objects)
+    const { storage, calls } = countQueryCalls(disableRefsPushdown(testStorage.objects))
     await seedCustomerOrders(testStorage.fixture)
 
     const result = await executeObjectQuery(
@@ -891,8 +928,8 @@ describe("object query planner and executor", () => {
     expect(result.plan.mode).toBe("fallback")
     expect(calls.queryObjects).toBe(0)
     expect(result.objects.map((row) => `${row.objectTypeId}:${row.primaryId}`)).toEqual([
-      "Order:order-2",
       "Customer:cust-1",
+      "Order:order-2",
     ])
     expect(result.total).toBe(2)
   })

--- a/packages/core/tests/object-query.test.ts
+++ b/packages/core/tests/object-query.test.ts
@@ -321,6 +321,25 @@ const boundedCustomerQuery: ObjectQuery = {
 }
 
 describe("object query IR normalization", () => {
+  test("deduplicates explicit refs while preserving authored order", () => {
+    expect(
+      normalizeObjectQuery({
+        kind: "refs",
+        refs: [
+          { objectTypeId: "Customer", primaryId: "cust-1" },
+          { objectTypeId: "Order", primaryId: "order-1" },
+          { objectTypeId: "Customer", primaryId: "cust-1" },
+        ],
+      })
+    ).toEqual({
+      kind: "refs",
+      refs: [
+        { objectTypeId: "Customer", primaryId: "cust-1" },
+        { objectTypeId: "Order", primaryId: "order-1" },
+      ],
+    })
+  })
+
   test("merges adjacent filters and limits and deduplicates fields", () => {
     const query: ObjectQuery = {
       kind: "limit",
@@ -430,6 +449,52 @@ describe("object query IR normalization", () => {
 })
 
 describe("object query validation", () => {
+  test("validates heterogeneous refs as an intrinsically bounded source", () => {
+    const validated = validateObjectQuery(
+      {
+        kind: "refs",
+        refs: [
+          { objectTypeId: "Customer", primaryId: "cust-1" },
+          { objectTypeId: "Order", primaryId: "order-1" },
+        ],
+      },
+      { ontology }
+    )
+
+    expect(validated.result.objectTypeIds).toEqual(["Customer", "Order"])
+    expect(validated.touchedObjectTypeIds).toEqual(["Customer", "Order"])
+
+    const issues = collectObjectQueryValidationIssues(
+      {
+        kind: "refs",
+        refs: [{ objectTypeId: "Missing", primaryId: "" }],
+      },
+      { ontology }
+    )
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "$.refs[0].objectTypeId",
+          code: "unknown_object_type",
+        }),
+        expect.objectContaining({ path: "$.refs[0].primaryId", code: "missing_primary_id" }),
+      ])
+    )
+
+    expect(
+      collectObjectQueryValidationIssues(
+        {
+          kind: "refs",
+          refs: [
+            { objectTypeId: "Customer", primaryId: "cust-1" },
+            { objectTypeId: "Order", primaryId: "order-1" },
+          ],
+        },
+        { ontology, maxRefs: 1 }
+      )
+    ).toContainEqual(expect.objectContaining({ path: "$.refs", code: "too_many_refs" }))
+  })
+
   test("resolves and canonicalizes exact decimal predicate and sort semantics", () => {
     const validated = validateObjectQuery(
       {
@@ -803,6 +868,35 @@ describe("object query explain", () => {
 })
 
 describe("object query planner and executor", () => {
+  test("resolves explicit refs through the bounded core source", async () => {
+    const testStorage = createTestStorage()
+    const { storage, calls } = countQueryCalls(testStorage.objects)
+    await seedCustomerOrders(testStorage.fixture)
+
+    const result = await executeObjectQuery(
+      {
+        projectId: "p1",
+        query: {
+          kind: "refs",
+          refs: [
+            { objectTypeId: "Order", primaryId: "order-2" },
+            { objectTypeId: "Customer", primaryId: "missing" },
+            { objectTypeId: "Customer", primaryId: "cust-1" },
+          ],
+        },
+      },
+      { ontology, storage }
+    )
+
+    expect(result.plan.mode).toBe("fallback")
+    expect(calls.queryObjects).toBe(0)
+    expect(result.objects.map((row) => `${row.objectTypeId}:${row.primaryId}`)).toEqual([
+      "Order:order-2",
+      "Customer:cust-1",
+    ])
+    expect(result.total).toBe(2)
+  })
+
   test("filters and sorts decimals exactly beyond JS number precision", async () => {
     const { objects, fixture } = createTestStorage()
     await fixture.seed({

--- a/packages/server/src/schemas/objects.ts
+++ b/packages/server/src/schemas/objects.ts
@@ -196,6 +196,19 @@ export const ObjectQuerySchema: z.ZodType<unknown> = z.lazy(() =>
       .strict(),
     z
       .object({
+        kind: z.literal("refs"),
+        refs: z.array(
+          z
+            .object({
+              objectTypeId: z.string().min(1),
+              primaryId: z.string().min(1),
+            })
+            .strict()
+        ),
+      })
+      .strict(),
+    z
+      .object({
         kind: z.literal("filter"),
         input: ObjectQuerySchema,
         predicate: ObjectQueryPredicateSchema,
@@ -326,6 +339,7 @@ const objectQueryRef = { $ref: "#/components/schemas/ObjectQuery" }
 const objectQueryPredicateRef = { $ref: "#/components/schemas/ObjectQueryPredicate" }
 const objectQuerySortFieldRef = { $ref: "#/components/schemas/ObjectQuerySortField" }
 const objectExpansionRef = { $ref: "#/components/schemas/ObjectExpansion" }
+const objectRefSchemaRef = { $ref: "#/components/schemas/ObjectRef" }
 
 /**
  * zod-to-json-schema currently drops recursive z.lazy schemas when the server's
@@ -535,6 +549,15 @@ export const ObjectQueryOpenApiSchemas = {
       },
     },
   },
+  ObjectRef: {
+    type: "object",
+    required: ["objectTypeId", "primaryId"],
+    additionalProperties: false,
+    properties: {
+      objectTypeId: { type: "string", minLength: 1 },
+      primaryId: { type: "string", minLength: 1 },
+    },
+  },
   ObjectQuery: {
     oneOf: [
       {
@@ -545,6 +568,21 @@ export const ObjectQueryOpenApiSchemas = {
           kind: { type: "string", enum: ["start"] },
           objectTypeId: { type: "string", minLength: 1 },
           includeSubtypes: { type: "boolean" },
+        },
+      },
+      {
+        type: "object",
+        required: ["kind", "refs"],
+        additionalProperties: false,
+        properties: {
+          kind: { type: "string", enum: ["refs"] },
+          refs: {
+            type: "array",
+            minItems: 1,
+            description:
+              "One to 1,000 unique identities after normalization; duplicate entries are accepted and removed.",
+            items: objectRefSchemaRef,
+          },
         },
       },
       {

--- a/packages/server/tests/authorization-routes.test.ts
+++ b/packages/server/tests/authorization-routes.test.ts
@@ -519,6 +519,23 @@ describe("authorized object routes", () => {
     expect(allowed.status).toBe(200)
     const body = (await allowed.json()) as { objects: { primaryId: string }[] }
     expect(body.objects.map((row) => row.primaryId)).toEqual(["c1"])
+
+    const deniedRefs = await app.fetch(
+      new Request("http://localhost/api/objects/query", {
+        method: "POST",
+        headers: session.csrfHeaders,
+        body: JSON.stringify({
+          query: {
+            kind: "refs",
+            refs: [
+              { objectTypeId: "contract", primaryId: "c1" },
+              { objectTypeId: "invoice", primaryId: "i1" },
+            ],
+          },
+        }),
+      })
+    )
+    expect(deniedRefs.status).toBe(403)
   })
 
   test("disabled auth keeps object routes privileged", async () => {

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -596,7 +596,7 @@ describe("SixbServer HTTP contract", () => {
   }
 
   test("serves documented read endpoints", async () => {
-    await withHttpContractServer(async ({ baseUrl }) => {
+    await withHttpContractServer(async ({ baseUrl, sixb }) => {
       const projectResponse = await fetch(`${baseUrl}/api/project`)
       expect(projectResponse.status).toBe(200)
       expect(await projectResponse.json()).toEqual({ id: "contract-project" })
@@ -1454,6 +1454,41 @@ describe("SixbServer HTTP contract", () => {
         }),
       ])
 
+      const queryRefsResponse = await fetch(`${baseUrl}/api/objects/query`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          query: {
+            kind: "refs",
+            refs: [
+              { objectTypeId: "space", primaryId: "system" },
+              { objectTypeId: "device", primaryId: "fan-1" },
+              { objectTypeId: "space", primaryId: "system" },
+              { objectTypeId: "device", primaryId: "missing" },
+            ],
+          },
+        }),
+      })
+      expect(queryRefsResponse.status).toBe(200)
+      expect(await queryRefsResponse.json()).toMatchObject({
+        objects: [
+          { objectTypeId: "device", primaryId: "fan-1" },
+          { objectTypeId: "space", primaryId: "system" },
+        ],
+        total: 2,
+        plan: { mode: "pushdown" },
+      })
+
+      const emptyRefsResponse = await fetch(`${baseUrl}/api/objects/query`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query: { kind: "refs", refs: [] } }),
+      })
+      expect(emptyRefsResponse.status).toBe(400)
+      expect(await emptyRefsResponse.json()).toMatchObject({
+        issues: [{ path: "$.refs", code: "empty_refs" }],
+      })
+
       const queryObjectsWithoutTotalResponse = await fetch(`${baseUrl}/api/objects/query`, {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -1527,6 +1562,28 @@ describe("SixbServer HTTP contract", () => {
           },
         ],
         plan: { mode: "pushdown", providerIssues: [] },
+      })
+
+      const opaquePrimaryId = "github:issue:sixb-ai/sixb#297"
+      await createTestSixb(sixb).objects.upsert("device", {
+        id: opaquePrimaryId,
+        label: "Opaque ID",
+      })
+      const opaqueRefResponse = await fetch(`${baseUrl}/api/objects/query`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          query: {
+            kind: "refs",
+            refs: [{ objectTypeId: "device", primaryId: opaquePrimaryId }],
+          },
+          includeTotal: false,
+        }),
+      })
+      expect(opaqueRefResponse.status).toBe(200)
+      expect(await opaqueRefResponse.json()).toMatchObject({
+        objects: [{ objectTypeId: "device", primaryId: opaquePrimaryId }],
+        hasMore: false,
       })
 
       const invalidQueryObjectsResponse = await fetch(`${baseUrl}/api/objects/query`, {

--- a/storage/pg/src/pg-object-query-compiler.ts
+++ b/storage/pg/src/pg-object-query-compiler.ts
@@ -13,7 +13,6 @@ export interface PgObjectQueryPageRow {
   primary_id: string
   properties: unknown
   _cursor_properties?: unknown
-  _query_order?: number
 }
 
 export interface CompiledPgObjectQuery {
@@ -74,7 +73,7 @@ type CompiledOrderField =
     }
   | {
       kind: "column"
-      column: "object_type_id" | "primary_id" | "_query_order"
+      column: "object_type_id" | "primary_id"
       direction: "asc" | "desc"
     }
 
@@ -254,29 +253,29 @@ function compileRefs(
     throw new Error("[SixbPg] PostgreSQL object storage requires at least one ref")
   }
 
-  const order = compileOrder(refsOrderFields())
+  const order = compileOrder(identityOrderFields())
+  const selectedOrder = compileOrder(identityOrderFields(), "selected")
   const refsJson = JSON.stringify(query.refs)
   const requested = `
-    SELECT
-      (ref.ordinality - 1)::integer AS _query_order,
+    SELECT DISTINCT
       ref.value ->> 'objectTypeId' AS object_type_id,
       ref.value ->> 'primaryId' AS primary_id
-    FROM jsonb_array_elements(?::text::jsonb) WITH ORDINALITY AS ref(value, ordinality)
+    FROM jsonb_array_elements(?::text::jsonb) AS ref(value)
   `
   const sql = `
     WITH requested AS (${requested})
-    SELECT selected.*, requested._query_order, selected.properties AS _cursor_properties
+    SELECT selected.*, selected.properties AS _cursor_properties
     FROM requested
     JOIN objects AS selected
       ON selected.project_id = ?
      AND selected.object_type_id = requested.object_type_id
      AND selected.primary_id = requested.primary_id
-    ORDER BY requested._query_order ASC
+    ORDER BY ${selectedOrder.sql}
   `
 
   return {
     sql,
-    args: [refsJson, projectId],
+    args: [refsJson, projectId, ...selectedOrder.args],
     totalSql: `
       WITH requested AS (${requested})
       SELECT COUNT(*)::bigint AS total
@@ -773,7 +772,6 @@ function compileProject(
   const projection = compileProjectionExpression(properties)
   const inputOrder = compileOrder(input.order.fields, "input", "input._cursor_properties")
   const outputOrder = compileOrder(input.order.fields, undefined, "_cursor_properties")
-  const orderColumns = compileOrderPassthroughColumns(input.order.fields, "input")
 
   return {
     sql: `
@@ -786,7 +784,7 @@ function compileProject(
         input.created_at,
         input.updated_at,
         input.version,
-        input.last_commit_id${orderColumns}
+        input.last_commit_id
       FROM (${input.sql}) AS input
       ORDER BY ${inputOrder.sql}
     `,
@@ -870,11 +868,16 @@ function compileAggregateRefs(
   return {
     sql: `
       SELECT selected.project_id, selected.object_type_id, selected.primary_id, selected.properties
-      FROM jsonb_array_elements(?::text::jsonb) AS ref(value)
+      FROM (
+        SELECT DISTINCT
+          ref.value ->> 'objectTypeId' AS object_type_id,
+          ref.value ->> 'primaryId' AS primary_id
+        FROM jsonb_array_elements(?::text::jsonb) AS ref(value)
+      ) AS requested
       JOIN objects AS selected
         ON selected.project_id = ?
-       AND selected.object_type_id = (ref.value ->> 'objectTypeId')
-       AND selected.primary_id = (ref.value ->> 'primaryId')
+       AND selected.object_type_id = requested.object_type_id
+       AND selected.primary_id = requested.primary_id
     `,
     args: [JSON.stringify(query.refs), projectId],
   }
@@ -1368,19 +1371,6 @@ function identityOrderFields(): readonly CompiledOrderField[] {
   ]
 }
 
-function refsOrderFields(): readonly CompiledOrderField[] {
-  return [{ kind: "column", column: "_query_order", direction: "asc" }]
-}
-
-function compileOrderPassthroughColumns(
-  fields: readonly CompiledOrderField[],
-  qualifier: string
-): string {
-  return fields.some((field) => field.kind === "column" && field.column === "_query_order")
-    ? `,\n        ${qualifier}._query_order`
-    : ""
-}
-
 function compileKeysetPredicate(
   fields: readonly CompiledOrderField[],
   cursor: readonly EncodedCursorValue[],
@@ -1541,9 +1531,7 @@ function cursorValueForField(
     field.kind === "column"
       ? field.column === "object_type_id"
         ? row.object_type_id
-        : field.column === "primary_id"
-          ? row.primary_id
-          : row._query_order
+        : row.primary_id
       : properties[field.propertyId]
 
   return value === null || value === undefined ? { nullish: true } : { nullish: false, value }
@@ -1564,10 +1552,7 @@ function compiledPropertyValueExpression(
     : jsonValueExpression(propertyColumn)
 }
 
-function columnExpression(
-  column: "object_type_id" | "primary_id" | "_query_order",
-  qualifier?: string
-): string {
+function columnExpression(column: "object_type_id" | "primary_id", qualifier?: string): string {
   return qualifier ? `${qualifier}.${column}` : column
 }
 

--- a/storage/pg/src/pg-object-query-compiler.ts
+++ b/storage/pg/src/pg-object-query-compiler.ts
@@ -13,6 +13,7 @@ export interface PgObjectQueryPageRow {
   primary_id: string
   properties: unknown
   _cursor_properties?: unknown
+  _query_order?: number
 }
 
 export interface CompiledPgObjectQuery {
@@ -73,7 +74,7 @@ type CompiledOrderField =
     }
   | {
       kind: "column"
-      column: "object_type_id" | "primary_id"
+      column: "object_type_id" | "primary_id" | "_query_order"
       direction: "asc" | "desc"
     }
 
@@ -177,6 +178,8 @@ function compileObjectQueryInternal(
   switch (query.kind) {
     case "start":
       return compileStart(projectId, query)
+    case "refs":
+      return compileRefs(projectId, query)
     case "filter":
       return compileFilter(projectId, query.input, query.predicate)
     case "sort":
@@ -236,6 +239,54 @@ function compileStart(
     totalSql:
       "SELECT COUNT(*)::bigint AS total FROM objects WHERE project_id = ? AND object_type_id = ?",
     totalArgs: [projectId, query.objectTypeId],
+    order,
+    hasMore: () => false,
+    trimRows: identityRows,
+    nextPageToken: () => undefined,
+  }
+}
+
+function compileRefs(
+  projectId: string,
+  query: Extract<ObjectQuery, { kind: "refs" }>
+): CompiledPgObjectQuery {
+  if (query.refs.length === 0) {
+    throw new Error("[SixbPg] PostgreSQL object storage requires at least one ref")
+  }
+
+  const order = compileOrder(refsOrderFields())
+  const refsJson = JSON.stringify(query.refs)
+  const requested = `
+    SELECT
+      (ref.ordinality - 1)::integer AS _query_order,
+      ref.value ->> 'objectTypeId' AS object_type_id,
+      ref.value ->> 'primaryId' AS primary_id
+    FROM jsonb_array_elements(?::text::jsonb) WITH ORDINALITY AS ref(value, ordinality)
+  `
+  const sql = `
+    WITH requested AS (${requested})
+    SELECT selected.*, requested._query_order, selected.properties AS _cursor_properties
+    FROM requested
+    JOIN objects AS selected
+      ON selected.project_id = ?
+     AND selected.object_type_id = requested.object_type_id
+     AND selected.primary_id = requested.primary_id
+    ORDER BY requested._query_order ASC
+  `
+
+  return {
+    sql,
+    args: [refsJson, projectId],
+    totalSql: `
+      WITH requested AS (${requested})
+      SELECT COUNT(*)::bigint AS total
+      FROM requested
+      JOIN objects AS selected
+        ON selected.project_id = ?
+       AND selected.object_type_id = requested.object_type_id
+       AND selected.primary_id = requested.primary_id
+    `,
+    totalArgs: [refsJson, projectId],
     order,
     hasMore: () => false,
     trimRows: identityRows,
@@ -722,6 +773,7 @@ function compileProject(
   const projection = compileProjectionExpression(properties)
   const inputOrder = compileOrder(input.order.fields, "input", "input._cursor_properties")
   const outputOrder = compileOrder(input.order.fields, undefined, "_cursor_properties")
+  const orderColumns = compileOrderPassthroughColumns(input.order.fields, "input")
 
   return {
     sql: `
@@ -734,7 +786,7 @@ function compileProject(
         input.created_at,
         input.updated_at,
         input.version,
-        input.last_commit_id
+        input.last_commit_id${orderColumns}
       FROM (${input.sql}) AS input
       ORDER BY ${inputOrder.sql}
     `,
@@ -753,6 +805,8 @@ function compileAggregateSource(projectId: string, query: ObjectQuery): Compiled
   switch (query.kind) {
     case "start":
       return compileAggregateStart(projectId, query)
+    case "refs":
+      return compileAggregateRefs(projectId, query)
     case "filter":
       return compileAggregateWhere(projectId, query.input, compilePredicate(query.predicate))
     case "text": {
@@ -781,7 +835,9 @@ function compileAggregateSource(projectId: string, query: ObjectQuery): Compiled
     case "page":
       return compileRowQueryAggregateSource(projectId, query)
     case "vector":
-      throw new Error(`[SixbPg] PostgreSQL object storage does not support query node 'vector'`)
+      throw new Error(
+        `[SixbPg] PostgreSQL object storage does not support query node '${query.kind}'`
+      )
   }
 }
 
@@ -800,6 +856,27 @@ function compileAggregateStart(
       WHERE project_id = ? AND object_type_id = ?
     `,
     args: [projectId, query.objectTypeId],
+  }
+}
+
+function compileAggregateRefs(
+  projectId: string,
+  query: Extract<ObjectQuery, { kind: "refs" }>
+): CompiledAggregateSource {
+  if (query.refs.length === 0) {
+    throw new Error("[SixbPg] PostgreSQL object storage requires at least one ref")
+  }
+
+  return {
+    sql: `
+      SELECT selected.project_id, selected.object_type_id, selected.primary_id, selected.properties
+      FROM jsonb_array_elements(?::text::jsonb) AS ref(value)
+      JOIN objects AS selected
+        ON selected.project_id = ?
+       AND selected.object_type_id = (ref.value ->> 'objectTypeId')
+       AND selected.primary_id = (ref.value ->> 'primaryId')
+    `,
+    args: [JSON.stringify(query.refs), projectId],
   }
 }
 
@@ -1291,6 +1368,19 @@ function identityOrderFields(): readonly CompiledOrderField[] {
   ]
 }
 
+function refsOrderFields(): readonly CompiledOrderField[] {
+  return [{ kind: "column", column: "_query_order", direction: "asc" }]
+}
+
+function compileOrderPassthroughColumns(
+  fields: readonly CompiledOrderField[],
+  qualifier: string
+): string {
+  return fields.some((field) => field.kind === "column" && field.column === "_query_order")
+    ? `,\n        ${qualifier}._query_order`
+    : ""
+}
+
 function compileKeysetPredicate(
   fields: readonly CompiledOrderField[],
   cursor: readonly EncodedCursorValue[],
@@ -1451,7 +1541,9 @@ function cursorValueForField(
     field.kind === "column"
       ? field.column === "object_type_id"
         ? row.object_type_id
-        : row.primary_id
+        : field.column === "primary_id"
+          ? row.primary_id
+          : row._query_order
       : properties[field.propertyId]
 
   return value === null || value === undefined ? { nullish: true } : { nullish: false, value }
@@ -1472,7 +1564,10 @@ function compiledPropertyValueExpression(
     : jsonValueExpression(propertyColumn)
 }
 
-function columnExpression(column: "object_type_id" | "primary_id", qualifier?: string): string {
+function columnExpression(
+  column: "object_type_id" | "primary_id" | "_query_order",
+  qualifier?: string
+): string {
   return qualifier ? `${qualifier}.${column}` : column
 }
 

--- a/storage/pg/src/pg-object-storage.ts
+++ b/storage/pg/src/pg-object-storage.ts
@@ -34,6 +34,7 @@ const PG_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
   facetObjects: true,
   nodes: {
     start: true,
+    refs: true,
     filter: true,
     text: true,
     sort: true,
@@ -85,7 +86,7 @@ const PG_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
     stablePageTokens: true,
   },
   notes: [
-    "PostgreSQL object query pushdown supports start/filter/text/sort/limit/page/traverse/set/project/expand over JSONB properties and object links.",
+    "PostgreSQL object query pushdown supports start/refs/filter/text/sort/limit/page/traverse/set/project/expand over JSONB properties and object links.",
     "expand hydrates linked objects in-database (top-N per parent via LATERAL + jsonb_agg); core resolves each expansion's cardinality before pushdown, and a mixed/unresolved one stays on the fallback.",
     "Exact decimal predicates, ordering, and keyset pagination use PostgreSQL numeric casts.",
     "Relevance sorting, vector search, and unresolved start.includeSubtypes remain planner fallback or rejection cases.",

--- a/storage/pg/tests/pg-object-query-compiler.test.ts
+++ b/storage/pg/tests/pg-object-query-compiler.test.ts
@@ -12,6 +12,23 @@ const sitePointQuery: ObjectQuery = {
   input: { kind: "start", objectTypeId: "BacnetPoint" },
 }
 
+test("refs compile to one JSONB table parameter and preserve authored order", () => {
+  const refs = [
+    { objectTypeId: "Issue", primaryId: "github:issue:sixb-ai/sixb#297" },
+    { objectTypeId: "Customer", primaryId: "cust-1" },
+  ]
+  const compiled = compilePgObjectQuery("project-a", { kind: "refs", refs })
+  const counted = compilePgObjectCountQuery("project-a", { kind: "refs", refs })
+
+  expect(compiled.sql).toContain("FROM jsonb_array_elements($1::text::jsonb) WITH ORDINALITY")
+  expect(compiled.sql).toContain("requested._query_order")
+  expect(compiled.sql).toContain("ORDER BY requested._query_order ASC")
+  expect(compiled.args).toEqual([JSON.stringify(refs), "project-a"])
+  expect(compiled.totalArgs).toEqual([JSON.stringify(refs), "project-a"])
+  expect(counted.sql).toContain("FROM jsonb_array_elements($1::text::jsonb)")
+  expect(counted.args).toEqual([JSON.stringify(refs), "project-a"])
+})
+
 test("decimal predicates and ordering compile to exact PostgreSQL numeric operations", () => {
   const compiled = compilePgObjectQuery("project-a", {
     kind: "sort",

--- a/storage/pg/tests/pg-object-query-compiler.test.ts
+++ b/storage/pg/tests/pg-object-query-compiler.test.ts
@@ -12,19 +12,21 @@ const sitePointQuery: ObjectQuery = {
   input: { kind: "start", objectTypeId: "BacnetPoint" },
 }
 
-test("refs compile to one JSONB table parameter and preserve authored order", () => {
+test("refs compile to one de-duplicated JSONB table source in canonical order", () => {
   const refs = [
     { objectTypeId: "Issue", primaryId: "github:issue:sixb-ai/sixb#297" },
+    { objectTypeId: "Customer", primaryId: "cust-1" },
     { objectTypeId: "Customer", primaryId: "cust-1" },
   ]
   const compiled = compilePgObjectQuery("project-a", { kind: "refs", refs })
   const counted = compilePgObjectCountQuery("project-a", { kind: "refs", refs })
 
-  expect(compiled.sql).toContain("FROM jsonb_array_elements($1::text::jsonb) WITH ORDINALITY")
-  expect(compiled.sql).toContain("requested._query_order")
-  expect(compiled.sql).toContain("ORDER BY requested._query_order ASC")
+  expect(compiled.sql).toContain("SELECT DISTINCT")
+  expect(compiled.sql).toContain("FROM jsonb_array_elements($1::text::jsonb) AS ref(value)")
+  expect(compiled.sql).toContain("ORDER BY selected.object_type_id ASC, selected.primary_id ASC")
   expect(compiled.args).toEqual([JSON.stringify(refs), "project-a"])
   expect(compiled.totalArgs).toEqual([JSON.stringify(refs), "project-a"])
+  expect(counted.sql).toContain("SELECT DISTINCT")
   expect(counted.sql).toContain("FROM jsonb_array_elements($1::text::jsonb)")
   expect(counted.args).toEqual([JSON.stringify(refs), "project-a"])
 })

--- a/storage/sqlite/src/object-query-compiler.ts
+++ b/storage/sqlite/src/object-query-compiler.ts
@@ -14,7 +14,6 @@ export interface SqliteObjectQueryPageRow {
   primary_id: string
   properties: string
   _cursor_properties?: string
-  _query_order?: number
 }
 
 export interface CompiledObjectQuery {
@@ -59,7 +58,7 @@ type CompiledOrderField =
     }
   | {
       kind: "column"
-      column: "object_type_id" | "primary_id" | "_query_order"
+      column: "object_type_id" | "primary_id"
       direction: "asc" | "desc"
     }
 
@@ -173,29 +172,29 @@ function compileRefs(
     throw new Error("[Sixb] SQLite object storage requires at least one ref")
   }
 
-  const order = compileOrder(refsOrderFields())
+  const order = compileOrder(identityOrderFields())
+  const selectedOrder = compileOrder(identityOrderFields(), "selected")
   const refsJson = JSON.stringify(query.refs)
   const requested = `
-    SELECT
-      CAST(ref.key AS INTEGER) AS _query_order,
+    SELECT DISTINCT
       json_extract(ref.value, '$.objectTypeId') AS object_type_id,
       json_extract(ref.value, '$.primaryId') AS primary_id
     FROM json_each(?) AS ref
   `
   const sql = `
     WITH requested AS (${requested})
-    SELECT selected.*, requested._query_order, selected.properties AS _cursor_properties
+    SELECT selected.*, selected.properties AS _cursor_properties
     FROM requested
     JOIN objects AS selected
       ON selected.project_id = ?
      AND selected.object_type_id = requested.object_type_id
      AND selected.primary_id = requested.primary_id
-    ORDER BY requested._query_order ASC
+    ORDER BY ${selectedOrder.sql}
   `
 
   return {
     sql,
-    args: [refsJson, projectId],
+    args: [refsJson, projectId, ...selectedOrder.args],
     totalSql: `
       WITH requested AS (${requested})
       SELECT COUNT(*) AS total
@@ -708,7 +707,6 @@ function compileProject(
   const projection = compileProjectionExpression(properties)
   const inputOrder = compileOrder(input.order.fields, "input", "input._cursor_properties")
   const outputOrder = compileOrder(input.order.fields, undefined, "_cursor_properties")
-  const orderColumns = compileOrderPassthroughColumns(input.order.fields, "input")
 
   return {
     sql: `
@@ -721,7 +719,7 @@ function compileProject(
         input.created_at,
         input.updated_at,
         input.version,
-        input.last_commit_id${orderColumns}
+        input.last_commit_id
       FROM (${input.sql}) AS input
       ORDER BY ${inputOrder.sql}
     `,
@@ -1025,19 +1023,6 @@ function identityOrderFields(): readonly CompiledOrderField[] {
   ]
 }
 
-function refsOrderFields(): readonly CompiledOrderField[] {
-  return [{ kind: "column", column: "_query_order", direction: "asc" }]
-}
-
-function compileOrderPassthroughColumns(
-  fields: readonly CompiledOrderField[],
-  qualifier: string
-): string {
-  return fields.some((field) => field.kind === "column" && field.column === "_query_order")
-    ? `,\n        ${qualifier}._query_order`
-    : ""
-}
-
 function compileKeysetPredicate(
   fields: readonly CompiledOrderField[],
   cursor: readonly EncodedCursorValue[],
@@ -1191,9 +1176,7 @@ function cursorValueForField(
     field.kind === "column"
       ? field.column === "object_type_id"
         ? row.object_type_id
-        : field.column === "primary_id"
-          ? row.primary_id
-          : row._query_order
+        : row.primary_id
       : properties[field.propertyId]
 
   return value === null || value === undefined ? { nullish: true } : { nullish: false, value }
@@ -1205,10 +1188,7 @@ function orderFieldKey(field: CompiledOrderField): string {
     : `property:${field.propertyId}:${field.direction}`
 }
 
-function columnExpression(
-  column: "object_type_id" | "primary_id" | "_query_order",
-  qualifier?: string
-): string {
+function columnExpression(column: "object_type_id" | "primary_id", qualifier?: string): string {
   return qualifier ? `${qualifier}.${column}` : column
 }
 

--- a/storage/sqlite/src/object-query-compiler.ts
+++ b/storage/sqlite/src/object-query-compiler.ts
@@ -14,6 +14,7 @@ export interface SqliteObjectQueryPageRow {
   primary_id: string
   properties: string
   _cursor_properties?: string
+  _query_order?: number
 }
 
 export interface CompiledObjectQuery {
@@ -58,7 +59,7 @@ type CompiledOrderField =
     }
   | {
       kind: "column"
-      column: "object_type_id" | "primary_id"
+      column: "object_type_id" | "primary_id" | "_query_order"
       direction: "asc" | "desc"
     }
 
@@ -98,6 +99,8 @@ function compileObjectQueryInternal(
   switch (query.kind) {
     case "start":
       return compileStart(projectId, query)
+    case "refs":
+      return compileRefs(projectId, query)
     case "filter":
       return compileFilter(projectId, query.input, query.predicate)
     case "sort":
@@ -155,6 +158,54 @@ function compileStart(
     args,
     totalSql: "SELECT COUNT(*) as total FROM objects WHERE project_id = ? AND object_type_id = ?",
     totalArgs: [projectId, query.objectTypeId],
+    order,
+    hasMore: () => false,
+    trimRows: identityRows,
+    nextPageToken: () => undefined,
+  }
+}
+
+function compileRefs(
+  projectId: string,
+  query: Extract<ObjectQuery, { kind: "refs" }>
+): CompiledObjectQuery {
+  if (query.refs.length === 0) {
+    throw new Error("[Sixb] SQLite object storage requires at least one ref")
+  }
+
+  const order = compileOrder(refsOrderFields())
+  const refsJson = JSON.stringify(query.refs)
+  const requested = `
+    SELECT
+      CAST(ref.key AS INTEGER) AS _query_order,
+      json_extract(ref.value, '$.objectTypeId') AS object_type_id,
+      json_extract(ref.value, '$.primaryId') AS primary_id
+    FROM json_each(?) AS ref
+  `
+  const sql = `
+    WITH requested AS (${requested})
+    SELECT selected.*, requested._query_order, selected.properties AS _cursor_properties
+    FROM requested
+    JOIN objects AS selected
+      ON selected.project_id = ?
+     AND selected.object_type_id = requested.object_type_id
+     AND selected.primary_id = requested.primary_id
+    ORDER BY requested._query_order ASC
+  `
+
+  return {
+    sql,
+    args: [refsJson, projectId],
+    totalSql: `
+      WITH requested AS (${requested})
+      SELECT COUNT(*) AS total
+      FROM requested
+      JOIN objects AS selected
+        ON selected.project_id = ?
+       AND selected.object_type_id = requested.object_type_id
+       AND selected.primary_id = requested.primary_id
+    `,
+    totalArgs: [refsJson, projectId],
     order,
     hasMore: () => false,
     trimRows: identityRows,
@@ -657,6 +708,7 @@ function compileProject(
   const projection = compileProjectionExpression(properties)
   const inputOrder = compileOrder(input.order.fields, "input", "input._cursor_properties")
   const outputOrder = compileOrder(input.order.fields, undefined, "_cursor_properties")
+  const orderColumns = compileOrderPassthroughColumns(input.order.fields, "input")
 
   return {
     sql: `
@@ -669,7 +721,7 @@ function compileProject(
         input.created_at,
         input.updated_at,
         input.version,
-        input.last_commit_id
+        input.last_commit_id${orderColumns}
       FROM (${input.sql}) AS input
       ORDER BY ${inputOrder.sql}
     `,
@@ -973,6 +1025,19 @@ function identityOrderFields(): readonly CompiledOrderField[] {
   ]
 }
 
+function refsOrderFields(): readonly CompiledOrderField[] {
+  return [{ kind: "column", column: "_query_order", direction: "asc" }]
+}
+
+function compileOrderPassthroughColumns(
+  fields: readonly CompiledOrderField[],
+  qualifier: string
+): string {
+  return fields.some((field) => field.kind === "column" && field.column === "_query_order")
+    ? `,\n        ${qualifier}._query_order`
+    : ""
+}
+
 function compileKeysetPredicate(
   fields: readonly CompiledOrderField[],
   cursor: readonly EncodedCursorValue[],
@@ -1126,7 +1191,9 @@ function cursorValueForField(
     field.kind === "column"
       ? field.column === "object_type_id"
         ? row.object_type_id
-        : row.primary_id
+        : field.column === "primary_id"
+          ? row.primary_id
+          : row._query_order
       : properties[field.propertyId]
 
   return value === null || value === undefined ? { nullish: true } : { nullish: false, value }
@@ -1138,7 +1205,10 @@ function orderFieldKey(field: CompiledOrderField): string {
     : `property:${field.propertyId}:${field.direction}`
 }
 
-function columnExpression(column: "object_type_id" | "primary_id", qualifier?: string): string {
+function columnExpression(
+  column: "object_type_id" | "primary_id" | "_query_order",
+  qualifier?: string
+): string {
   return qualifier ? `${qualifier}.${column}` : column
 }
 

--- a/storage/sqlite/src/object-storage.ts
+++ b/storage/sqlite/src/object-storage.ts
@@ -41,6 +41,7 @@ const SQLITE_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
   facetObjects: true,
   nodes: {
     start: true,
+    refs: true,
     filter: true,
     text: true,
     sort: true,
@@ -92,7 +93,7 @@ const SQLITE_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
     stablePageTokens: true,
   },
   notes: [
-    "SQLite object query pushdown supports start/filter/text/sort/limit/page/traverse/set/project/expand over JSON properties and object links.",
+    "SQLite object query pushdown supports start/refs/filter/text/sort/limit/page/traverse/set/project/expand over JSON properties and object links.",
     "expand hydrates linked objects in-database (top-N per parent via row_number() + json_group_array); core resolves each expansion's cardinality before pushdown, and a mixed/unresolved one stays on the fallback.",
     "Ordered decimal predicates and sorting use the bounded core fallback because SQLite has no native exact decimal type; canonical decimal equality remains pushdown-safe.",
     "Relevance sorting, vector search, and unresolved start.includeSubtypes remain planner fallback or rejection cases.",
@@ -223,18 +224,20 @@ export class SqliteObjectStorage implements ObjectStorage {
     const result = new Map<string, ObjectRow>()
     if (params.items.length === 0) return result
 
-    const stmt = this.db.query(
-      "SELECT * FROM objects WHERE project_id = ? AND object_type_id = ? AND primary_id = ?"
-    )
-    for (const item of params.items) {
-      const row = stmt.get(
-        params.projectId,
-        item.objectTypeId,
-        item.primaryId
-      ) as DatabaseRow | null
-      if (row) {
-        result.set(`${item.objectTypeId}:${item.primaryId}`, this.rowToObject(row))
-      }
+    const rows = this.db
+      .query(
+        `
+          SELECT object.*
+          FROM json_each(?) AS requested
+          JOIN objects AS object
+            ON object.project_id = ?
+           AND object.object_type_id = json_extract(requested.value, '$.objectTypeId')
+           AND object.primary_id = json_extract(requested.value, '$.primaryId')
+        `
+      )
+      .all(JSON.stringify(params.items), params.projectId) as DatabaseRow[]
+    for (const row of rows) {
+      result.set(`${row.object_type_id}:${row.primary_id}`, this.rowToObject(row))
     }
     return result
   }

--- a/storage/sqlite/tests/sqlite-object-query-compiler.test.ts
+++ b/storage/sqlite/tests/sqlite-object-query-compiler.test.ts
@@ -2,16 +2,17 @@ import { expect, test } from "bun:test"
 import type { ObjectQuery } from "@sixb/core"
 import { compileObjectQuery } from "../src/object-query-compiler"
 
-test("refs compile to one JSON table parameter and preserve authored order", () => {
+test("refs compile to one de-duplicated JSON table source in canonical order", () => {
   const refs = [
     { objectTypeId: "Issue", primaryId: "github:issue:sixb-ai/sixb#297" },
+    { objectTypeId: "Customer", primaryId: "cust-1" },
     { objectTypeId: "Customer", primaryId: "cust-1" },
   ]
   const compiled = compileObjectQuery("project-a", { kind: "refs", refs })
 
+  expect(compiled.sql).toContain("SELECT DISTINCT")
   expect(compiled.sql).toContain("FROM json_each(?) AS ref")
-  expect(compiled.sql).toContain("requested._query_order")
-  expect(compiled.sql).toContain("ORDER BY requested._query_order ASC")
+  expect(compiled.sql).toContain("ORDER BY selected.object_type_id ASC, selected.primary_id ASC")
   expect(compiled.args).toEqual([JSON.stringify(refs), "project-a"])
   expect(compiled.totalArgs).toEqual([JSON.stringify(refs), "project-a"])
 })

--- a/storage/sqlite/tests/sqlite-object-query-compiler.test.ts
+++ b/storage/sqlite/tests/sqlite-object-query-compiler.test.ts
@@ -2,6 +2,20 @@ import { expect, test } from "bun:test"
 import type { ObjectQuery } from "@sixb/core"
 import { compileObjectQuery } from "../src/object-query-compiler"
 
+test("refs compile to one JSON table parameter and preserve authored order", () => {
+  const refs = [
+    { objectTypeId: "Issue", primaryId: "github:issue:sixb-ai/sixb#297" },
+    { objectTypeId: "Customer", primaryId: "cust-1" },
+  ]
+  const compiled = compileObjectQuery("project-a", { kind: "refs", refs })
+
+  expect(compiled.sql).toContain("FROM json_each(?) AS ref")
+  expect(compiled.sql).toContain("requested._query_order")
+  expect(compiled.sql).toContain("ORDER BY requested._query_order ASC")
+  expect(compiled.args).toEqual([JSON.stringify(refs), "project-a"])
+  expect(compiled.totalArgs).toEqual([JSON.stringify(refs), "project-a"])
+})
+
 test("expand SQL hydrates an outgoing many link as an ordered json array", () => {
   const compiled = compileObjectQuery("project-a", {
     kind: "expand",


### PR DESCRIPTION
## Why

An agent should not have to encode an opaque identity into a URL path to retrieve an object.
Identifiers such as `github:issue:sixb-ai/sixb#297` are valid domain identities, but `/`, `#`,
and other reserved characters make path-based lookup easy to get subtly wrong.

Exact identity is also a query concern: callers may need one object, several objects of one type, or
an ordered heterogeneous set. Giving that operation a first-class Query IR source keeps the API
small and composable.

## What changes

- Add a `refs` Query IR source containing `{ objectTypeId, primaryId }` references.
- Preserve caller order and duplicates while supporting pagination, projection, count, and explain.
- Compile refs natively for PostgreSQL and SQLite.
- Keep a bounded core fallback for providers that have not implemented native refs pushdown.
- Publish provider capabilities accurately and extend the provider contract suite.

This does **not** add another object lookup route. Agents can use the existing object-query terminal:

```http
POST /api/objects/query
```

with:

```json
{
  "query": {
    "kind": "refs",
    "refs": [
      {
        "objectTypeId": "RepositoryIssue",
        "primaryId": "github:issue:sixb-ai/sixb#297"
      }
    ]
  },
  "includeTotal": false
}
```

## Why this shape

`refs` is a source node, like `start`, rather than a special endpoint. That means exact identities
compose with filtering, traversal, expansion, sorting, pagination, projection, facets, count, and
exists without creating parallel APIs.

The generic storage contract remains usable while PostgreSQL and SQLite get native execution.

## Verification

- Core query, planner, executor, and provider contract suites
- PostgreSQL and SQLite compiler suites
- In-memory and SQLite conformance suites
- Core, PostgreSQL, and SQLite typechecks
- Biome on all touched files

## Stack

**1 of 7.** This is the base of the agent ontology/CLI stack and targets `main`.

### Full stack

1. [#465 — objects: add exact-reference query sources](https://github.com/sixb-ai/sixb/pull/465)
2. [#466 — objects: query links for object sets](https://github.com/sixb-ai/sixb/pull/466)
3. [#467 — agents: ship a self-documenting sandbox CLI](https://github.com/sixb-ai/sixb/pull/467)
4. [#468 — sandboxes: standardize the agent runtime](https://github.com/sixb-ai/sixb/pull/468)
5. [#469 — agents: validate sandbox readiness before execution](https://github.com/sixb-ai/sixb/pull/469)
6. [#470 — agents: replace built-in API skills with CLI guidance](https://github.com/sixb-ai/sixb/pull/470)
7. [#471 — agent-ui: present agent activity in product language](https://github.com/sixb-ai/sixb/pull/471)
