### PR TITLE
agents: validate sandbox readiness before execution

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -530,6 +530,7 @@
         "@ai-sdk/provider": "^4.0.0",
         "@sixb/connector-exa": "workspace:*",
         "@sixb/core": "workspace:*",
+        "@sixb/sandboxes-local": "workspace:*",
         "@types/bun": "latest",
         "typescript": "^5.7.0",
       },

--- a/docs/sandboxes/local.md
+++ b/docs/sandboxes/local.md
@@ -16,7 +16,9 @@ implements.
 
 The built-in agent tools use the host's `PATH`. For agent use, the host needs Bash, the standard
 file utilities used by reads and output collection, CA certificates, and either Bun 1.3+ or Node
-22+. The local provider does not install or modify host tools. `curl` and `jq` are not required.
+22+. The agent worker validates the environment immediately after provisioning and reports the
+failed behavior when a dependency is missing. The local provider does not install or modify host
+tools. `curl` and `jq` are not required.
 
 ## Isolation backends
 

--- a/docs/sandboxes/overview.md
+++ b/docs/sandboxes/overview.md
@@ -74,21 +74,26 @@ command is data, not an exception:
 `CreateSandboxOptions` sets the per-run defaults at `create()` time: `workingDirectory`, `env`,
 `timeout`, and `network`.
 
-### Agent runtime expectations
+### Agent runtime profile
 
-The generic `Sandbox` contract remains command-agnostic. Images and hosts used by the agent worker
-must still provide the behavior its installed CLI and file tools use:
+The generic `Sandbox` contract remains command-agnostic. The agent worker separately validates the
+concrete provisioned environment against `sixb-agent-runtime/v1` before any model-issued sandbox
+command can run. The profile requires behavior, not an `agentReady` provider flag:
 
 - Bash must load the worker's `BASH_ENV` bootstrap.
 - Standard file utilities must support bounded reads and output collection, including `realpath`,
   `tail`, `head`, `base64`, `find`, `wc`, and `tr`.
 - Bun 1.3+ or Node 22+ must execute the portable `sixb` CLI.
 - CA certificates must allow the CLI to reach an HTTPS API gateway.
+- The installed CLI, file modes, `PATH`, and run environment must be correct.
+- The CLI must reach and identify the run-scoped API gateway.
 
-These are agent-environment expectations, not additional `Sandbox` interface fields. `curl` and
-`jq` are not required because the production CLI uses the JavaScript runtime's native fetch and
-JSON support. Bake shared dependencies into versioned images or snapshots; never install packages
-during an individual run.
+`curl` and `jq` are not runtime-profile dependencies because the production CLI uses the JavaScript
+runtime's native fetch and JSON support. The worker performs one network-free behavioral probe
+after materializing its files, then verifies the project identity through the gateway. An
+incompatible environment cannot execute a sandbox command. Its failure records the provider,
+profile, and failed check without recording the gateway capability URL. Bake shared dependencies
+into versioned images or snapshots; never install packages during an individual run.
 
 ## Wiring
 

--- a/docs/sandboxes/overview.md
+++ b/docs/sandboxes/overview.md
@@ -90,10 +90,11 @@ command can run. The profile requires behavior, not an `agentReady` provider fla
 
 `curl` and `jq` are not runtime-profile dependencies because the production CLI uses the JavaScript
 runtime's native fetch and JSON support. The worker performs one network-free behavioral probe
-after materializing its files, then verifies the project identity through the gateway. An
-incompatible environment cannot execute a sandbox command. Its failure records the provider,
-profile, and failed check without recording the gateway capability URL. Bake shared dependencies
-into versioned images or snapshots; never install packages during an individual run.
+after materializing its files, then runs `sixb doctor` to verify the installed CLI contract and
+project identity through the gateway. An incompatible environment cannot execute a sandbox
+command. Its failure records the provider, profile, failed check, and safe failure classification
+without recording raw command output or the gateway capability URL. Bake shared dependencies into
+versioned images or snapshots; never install packages during an individual run.
 
 ## Wiring
 

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -62,6 +62,7 @@
     "@ai-sdk/provider": "^4.0.0",
     "@sixb/connector-exa": "workspace:*",
     "@sixb/core": "workspace:*",
+    "@sixb/sandboxes-local": "workspace:*",
     "@types/bun": "latest",
     "typescript": "^5.7.0"
   },

--- a/packages/agent-worker/src/agent-cli/commands/system.ts
+++ b/packages/agent-worker/src/agent-cli/commands/system.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises"
+import { AGENT_RUNTIME_PROFILE } from "../../agent-runtime/profile"
 import { ApiClient } from "../api-client"
 import { isHelp, requireExact } from "../arguments"
 import { AGENT_CLI_VERSION, fail, writeJson, writeText } from "../output"
@@ -12,7 +13,9 @@ export async function doctor(args: string[]): Promise<void> {
   writeJson({
     ok: true,
     cliVersion: AGENT_CLI_VERSION,
+    runtimeProfile: AGENT_RUNTIME_PROFILE,
     runtime: runtimeInfo(),
+    dependencies: { fetch: true, json: true },
     project: await api.get("/api/project"),
   })
 }

--- a/packages/agent-worker/src/agent-cli/commands/system.ts
+++ b/packages/agent-worker/src/agent-cli/commands/system.ts
@@ -1,23 +1,29 @@
 import { readFile } from "node:fs/promises"
-import { AGENT_RUNTIME_PROFILE } from "../../agent-runtime/profile"
+import { AGENT_RUNTIME_PROFILE, type AgentDoctorReport } from "../../agent-runtime/profile"
 import { ApiClient } from "../api-client"
 import { isHelp, requireExact } from "../arguments"
-import { AGENT_CLI_VERSION, fail, writeJson, writeText } from "../output"
+import { AGENT_CLI_VERSION, CliError, EXIT_API, fail, writeJson, writeText } from "../output"
 import { GROUP_HELP } from "./metadata"
-import { isFileError } from "./shared"
+import { asRecord, isFileError } from "./shared"
 
 export async function doctor(args: string[]): Promise<void> {
   if (isHelp(args[0])) return writeText(GROUP_HELP.doctor)
   requireExact(args, 0, "doctor accepts no arguments.")
-  const api = new ApiClient()
-  writeJson({
+  const project = asRecord(await new ApiClient().get("/api/project"))
+  if (typeof project.id !== "string" || project.id.length === 0) {
+    throw new CliError(
+      { code: "invalid_api_response", message: "The Sixb API returned an invalid project." },
+      EXIT_API
+    )
+  }
+  const report: AgentDoctorReport = {
     ok: true,
-    cliVersion: AGENT_CLI_VERSION,
-    runtimeProfile: AGENT_RUNTIME_PROFILE,
-    runtime: runtimeInfo(),
-    dependencies: { fetch: true, json: true },
-    project: await api.get("/api/project"),
-  })
+    profile: AGENT_RUNTIME_PROFILE,
+    cli: { version: AGENT_CLI_VERSION },
+    javascript: javascriptRuntime(),
+    project: { id: project.id },
+  }
+  writeJson(report)
 }
 
 export async function context(args: string[]): Promise<void> {
@@ -48,7 +54,7 @@ export async function project(args: string[]): Promise<void> {
   writeJson(await new ApiClient().get("/api/project"))
 }
 
-function runtimeInfo(): { readonly name: "bun" | "node"; readonly version: string } {
+function javascriptRuntime(): AgentDoctorReport["javascript"] {
   if (typeof globalThis.Bun === "object") {
     return { name: "bun", version: globalThis.Bun.version }
   }

--- a/packages/agent-worker/src/agent-cli/generated/sixb.mjs
+++ b/packages/agent-worker/src/agent-cli/generated/sixb.mjs
@@ -1174,15 +1174,18 @@ async function doctor(args) {
   if (isHelp(args[0]))
     return writeText(GROUP_HELP.doctor);
   requireExact(args, 0, "doctor accepts no arguments.");
-  const api = new ApiClient;
-  writeJson({
+  const project = asRecord2(await new ApiClient().get("/api/project"));
+  if (typeof project.id !== "string" || project.id.length === 0) {
+    throw new CliError({ code: "invalid_api_response", message: "The Sixb API returned an invalid project." }, EXIT_API);
+  }
+  const report = {
     ok: true,
-    cliVersion: AGENT_CLI_VERSION,
-    runtimeProfile: AGENT_RUNTIME_PROFILE,
-    runtime: runtimeInfo(),
-    dependencies: { fetch: true, json: true },
-    project: await api.get("/api/project")
-  });
+    profile: AGENT_RUNTIME_PROFILE,
+    cli: { version: AGENT_CLI_VERSION },
+    javascript: javascriptRuntime(),
+    project: { id: project.id }
+  };
+  writeJson(report);
 }
 async function context(args) {
   if (isHelp(args[0]))
@@ -1214,7 +1217,7 @@ async function project(args) {
   requireExact(args, 1, "project show accepts no arguments.");
   writeJson(await new ApiClient().get("/api/project"));
 }
-function runtimeInfo() {
+function javascriptRuntime() {
   if (typeof globalThis.Bun === "object") {
     return { name: "bun", version: globalThis.Bun.version };
   }

--- a/packages/agent-worker/src/agent-cli/generated/sixb.mjs
+++ b/packages/agent-worker/src/agent-cli/generated/sixb.mjs
@@ -1165,6 +1165,11 @@ async function runs(kind, args) {
 
 // src/agent-cli/commands/system.ts
 import { readFile as readFile3 } from "node:fs/promises";
+
+// src/agent-runtime/profile.ts
+var AGENT_RUNTIME_PROFILE = "sixb-agent-runtime/v1";
+
+// src/agent-cli/commands/system.ts
 async function doctor(args) {
   if (isHelp(args[0]))
     return writeText(GROUP_HELP.doctor);
@@ -1173,7 +1178,9 @@ async function doctor(args) {
   writeJson({
     ok: true,
     cliVersion: AGENT_CLI_VERSION,
+    runtimeProfile: AGENT_RUNTIME_PROFILE,
     runtime: runtimeInfo(),
+    dependencies: { fetch: true, json: true },
     project: await api.get("/api/project")
   });
 }

--- a/packages/agent-worker/src/agent-runtime/errors.ts
+++ b/packages/agent-worker/src/agent-runtime/errors.ts
@@ -1,0 +1,34 @@
+import { AGENT_RUNTIME_PROFILE, type AgentRuntimeProfileCheck } from "./profile"
+
+/** A provisioned sandbox does not satisfy the worker's versioned agent-runtime contract. */
+export class AgentRuntimeProfileError extends Error {
+  override readonly name = "AgentRuntimeProfileError"
+  readonly profile = AGENT_RUNTIME_PROFILE
+  readonly remediation: string
+
+  constructor(
+    readonly provider: string,
+    readonly check: AgentRuntimeProfileCheck
+  ) {
+    const remediation = remediationFor(provider)
+    super(
+      `[SixbAgentWorker] Sandbox provider '${provider}' failed '${AGENT_RUNTIME_PROFILE}' check '${check}'. ${remediation}`
+    )
+    this.remediation = remediation
+  }
+}
+
+function remediationFor(provider: string): string {
+  switch (provider) {
+    case "local":
+      return "Install Bash, the required POSIX read utilities, and Bun 1.3+ or Node 22+ in the worker environment."
+    case "smolvm":
+      return "Rebuild the managed smolvm agent image with 'bun run agent:image', or configure a compatible runtime-v1 image."
+    case "apple-container":
+      return "Use the pinned Sixb Node image or configure an image that satisfies sixb-agent-runtime/v1."
+    case "vercel":
+      return "Use the explicit node24 runtime, or configure a compatible Vercel image or snapshot."
+    default:
+      return `Configure provider '${provider}' with an image or runtime that satisfies sixb-agent-runtime/v1.`
+  }
+}

--- a/packages/agent-worker/src/agent-runtime/errors.ts
+++ b/packages/agent-worker/src/agent-runtime/errors.ts
@@ -1,4 +1,8 @@
-import { AGENT_RUNTIME_PROFILE, type AgentRuntimeProfileCheck } from "./profile"
+import {
+  AGENT_RUNTIME_PROFILE,
+  type AgentRuntimeFailureReason,
+  type AgentRuntimeProfileCheck,
+} from "./profile"
 
 /** A provisioned sandbox does not satisfy the worker's versioned agent-runtime contract. */
 export class AgentRuntimeProfileError extends Error {
@@ -8,27 +12,36 @@ export class AgentRuntimeProfileError extends Error {
 
   constructor(
     readonly provider: string,
-    readonly check: AgentRuntimeProfileCheck
+    readonly check: AgentRuntimeProfileCheck,
+    readonly reason: AgentRuntimeFailureReason,
+    readonly exitCode?: number
   ) {
-    const remediation = remediationFor(provider)
+    const remediation = remediationFor(check)
+    const failure = exitCode === undefined ? reason : `${reason} (exit ${exitCode})`
     super(
-      `[SixbAgentWorker] Sandbox provider '${provider}' failed '${AGENT_RUNTIME_PROFILE}' check '${check}'. ${remediation}`
+      `[SixbAgentWorker] Sandbox provider '${provider}' failed '${AGENT_RUNTIME_PROFILE}' check '${check}': ${failure}. ${remediation}`
     )
     this.remediation = remediation
   }
 }
 
-function remediationFor(provider: string): string {
-  switch (provider) {
-    case "local":
-      return "Install Bash, the required POSIX read utilities, and Bun 1.3+ or Node 22+ in the worker environment."
-    case "smolvm":
-      return "Rebuild the managed smolvm agent image with 'bun run agent:image', or configure a compatible runtime-v1 image."
-    case "apple-container":
-      return "Use the pinned Sixb Node image or configure an image that satisfies sixb-agent-runtime/v1."
-    case "vercel":
-      return "Use the explicit node24 runtime, or configure a compatible Vercel image or snapshot."
-    default:
-      return `Configure provider '${provider}' with an image or runtime that satisfies sixb-agent-runtime/v1.`
+function remediationFor(check: AgentRuntimeProfileCheck): string {
+  switch (check) {
+    case "bash":
+      return "Provide Bash in the configured sandbox host or image."
+    case "environment-bootstrap":
+      return "Ensure sandbox commands preserve the worker-provided environment and load BASH_ENV."
+    case "path-bootstrap":
+      return "Ensure BASH_ENV can prepend the worker-installed Sixb CLI directory to PATH."
+    case "cli-installation":
+      return "Ensure sandbox file materialization preserves the Sixb CLI bytes and executable mode."
+    case "file-tools":
+      return "Provide compatible realpath, tail, head, base64, find, wc, and tr utilities in the sandbox."
+    case "javascript-runtime":
+      return "Provide Bun 1.3+ or Node 22+ in the configured sandbox host or image."
+    case "cli-execution":
+      return "Ensure the worker-installed Sixb CLI artifact can execute without modifying it."
+    case "gateway-connectivity":
+      return "Ensure the run-scoped Sixb API gateway is reachable from the sandbox and identifies the current project."
   }
 }

--- a/packages/agent-worker/src/agent-runtime/preflight.ts
+++ b/packages/agent-worker/src/agent-runtime/preflight.ts
@@ -1,0 +1,190 @@
+import type { CommandResult, Sandbox } from "@sixb/core"
+import { AGENT_CLI_VERSION } from "../agent-cli/output"
+import { AgentRuntimeProfileError } from "./errors"
+import {
+  AGENT_RUNTIME_MINIMUM_VERSIONS,
+  AGENT_RUNTIME_PROFILE,
+  type AgentJavascriptRuntime,
+  type AgentRuntimeInfo,
+  type AgentRuntimeProfileCheck,
+} from "./profile"
+
+const PREFLIGHT_TIMEOUT_MS = 15_000
+
+const CHECK_BY_EXIT_CODE: Readonly<Record<number, AgentRuntimeProfileCheck>> = {
+  20: "environment-bootstrap",
+  21: "environment-bootstrap",
+  22: "path-bootstrap",
+  23: "cli-installation",
+  24: "cli-installation",
+  25: "read-tool",
+  26: "read-tool",
+  27: "read-tool",
+  28: "read-tool",
+  29: "javascript-runtime",
+  30: "read-tool",
+  31: "cli-execution",
+}
+
+export interface AssertAgentRuntimeProfileInput {
+  readonly sandbox: Sandbox
+  readonly env: Readonly<Record<string, string>>
+  readonly projectId: string
+}
+
+/**
+ * Validate the concrete provisioned environment before a model can use its sandbox tools.
+ *
+ * The first command is deterministic and network-free. The second deliberately travels through
+ * the installed CLI and run-scoped gateway, proving the launcher, JavaScript fetch stack, gateway
+ * capability, DNS, and TLS/CA path (when the configured gateway uses HTTPS) together.
+ */
+export async function assertAgentRuntimeProfile(
+  input: AssertAgentRuntimeProfileInput
+): Promise<AgentRuntimeInfo> {
+  const local = await runProbe(input.sandbox, LOCAL_BEHAVIOR_PROBE, input.env, "bash")
+  if (local.exitCode !== 0) {
+    throw profileError(input.sandbox, CHECK_BY_EXIT_CODE[local.exitCode] ?? "bash")
+  }
+
+  const runtime = parseLocalProbe(input.sandbox, local.stdout)
+  assertSupportedRuntime(input.sandbox, runtime.name, runtime.version)
+  if (runtime.cliVersion !== AGENT_CLI_VERSION) {
+    throw profileError(input.sandbox, "cli-execution")
+  }
+
+  const gateway = await runProbe(
+    input.sandbox,
+    "sixb project show",
+    input.env,
+    "gateway-connectivity"
+  )
+  if (gateway.exitCode !== 0) {
+    throw profileError(input.sandbox, "gateway-connectivity")
+  }
+  assertGatewayProject(input.sandbox, gateway.stdout, input.projectId)
+
+  return {
+    profile: AGENT_RUNTIME_PROFILE,
+    provider: input.sandbox.provider,
+    javascript: { name: runtime.name, version: runtime.version },
+    cliVersion: runtime.cliVersion,
+  }
+}
+
+async function runProbe(
+  sandbox: Sandbox,
+  script: string,
+  env: Readonly<Record<string, string>>,
+  failureCheck: AgentRuntimeProfileCheck
+): Promise<CommandResult> {
+  try {
+    const result = await sandbox.runCommand("bash", ["-lc", script], {
+      env,
+      timeout: PREFLIGHT_TIMEOUT_MS,
+    })
+    if (result.timedOut) throw profileError(sandbox, failureCheck)
+    return result
+  } catch (error) {
+    if (error instanceof AgentRuntimeProfileError) throw error
+    throw profileError(sandbox, failureCheck)
+  }
+}
+
+function parseLocalProbe(
+  sandbox: Sandbox,
+  stdout: string
+): {
+  readonly name: AgentJavascriptRuntime
+  readonly version: string
+  readonly cliVersion: string
+} {
+  const fields = stdout.trim().split("\t")
+  if (fields.length !== 3) throw profileError(sandbox, "cli-execution")
+  const [name, version, cliOutput] = fields
+  if ((name !== "bun" && name !== "node") || !version || !cliOutput) {
+    throw profileError(sandbox, "cli-execution")
+  }
+  const prefix = "sixb agent CLI "
+  if (!cliOutput.startsWith(prefix)) throw profileError(sandbox, "cli-execution")
+  return { name, version, cliVersion: cliOutput.slice(prefix.length) }
+}
+
+function assertSupportedRuntime(
+  sandbox: Sandbox,
+  name: AgentJavascriptRuntime,
+  version: string
+): void {
+  const parsed = parseVersion(version)
+  const minimum = AGENT_RUNTIME_MINIMUM_VERSIONS[name]
+  if (
+    !parsed ||
+    parsed.major < minimum.major ||
+    (parsed.major === minimum.major && parsed.minor < minimum.minor)
+  ) {
+    throw profileError(sandbox, "javascript-runtime")
+  }
+}
+
+function parseVersion(version: string): { readonly major: number; readonly minor: number } | null {
+  const match = /^v?(\d+)\.(\d+)(?:\.|$)/.exec(version.trim())
+  if (!match) return null
+  return { major: Number(match[1]), minor: Number(match[2]) }
+}
+
+function assertGatewayProject(sandbox: Sandbox, stdout: string, projectId: string): void {
+  try {
+    const value: unknown = JSON.parse(stdout)
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      Array.isArray(value) ||
+      !("id" in value) ||
+      value.id !== projectId
+    ) {
+      throw profileError(sandbox, "gateway-connectivity")
+    }
+  } catch (error) {
+    if (error instanceof AgentRuntimeProfileError) throw error
+    throw profileError(sandbox, "gateway-connectivity")
+  }
+}
+
+function profileError(sandbox: Sandbox, check: AgentRuntimeProfileCheck): AgentRuntimeProfileError {
+  return new AgentRuntimeProfileError(sandbox.provider, check)
+}
+
+const LOCAL_BEHAVIOR_PROBE = `set -u
+[ "\${SIXB_BASH_ENV_READY:-}" = "1" ] || exit 20
+[ "\${SIXB_AGENT_RUNTIME_PROFILE:-}" = "${AGENT_RUNTIME_PROFILE}" ] || exit 21
+[ "$(command -v sixb)" = "$SIXB_BIN_DIR/sixb" ] || exit 22
+[ -x "$SIXB_BIN_DIR/sixb" ] || exit 23
+[ -r "$SIXB_CONTEXT_DIR/lib/sixb.mjs" ] || exit 24
+realpath_bin="$(command -v realpath)" || exit 25
+tail_bin="$(command -v tail)" || exit 26
+head_bin="$(command -v head)" || exit 27
+base64_bin="$(command -v base64)" || exit 28
+resolved_probe="$("$realpath_bin" "$SIXB_RUNTIME_PROBE_FILE")" || exit 30
+[ -f "$resolved_probe" ] || exit 30
+"$tail_bin" -n "+2" -- "$resolved_probe" | "$head_bin" -n 1 | "$head_bin" -c 19 | "$base64_bin" > "$SIXB_CONTEXT_DIR/runtime/read-probe.out"
+for status in "\${PIPESTATUS[@]}"; do
+  case "$status" in 0|141) ;; *) exit 30 ;; esac
+done
+IFS= read -r read_probe < "$SIXB_CONTEXT_DIR/runtime/read-probe.out"
+[ "$read_probe" = "c2l4Yi1ydW50aW1lLXByb2JlCg==" ] || exit 30
+runtime_path="$(command -v bun || true)"
+if [ -n "$runtime_path" ]; then
+  runtime_name="bun"
+  runtime_version="$("$runtime_path" --version)" || exit 29
+else
+  runtime_path="$(command -v node || true)"
+fi
+if [ -z "\${runtime_name:-}" ] && [ -n "$runtime_path" ]; then
+  runtime_name="node"
+  runtime_version="$("$runtime_path" --version)" || exit 29
+fi
+if [ -z "\${runtime_name:-}" ]; then
+  exit 29
+fi
+cli_version="$(sixb --version)" || exit 31
+printf '%s\t%s\t%s\n' "$runtime_name" "$runtime_version" "$cli_version"`

--- a/packages/agent-worker/src/agent-runtime/preflight.ts
+++ b/packages/agent-worker/src/agent-runtime/preflight.ts
@@ -4,8 +4,9 @@ import { AgentRuntimeProfileError } from "./errors"
 import {
   AGENT_RUNTIME_MINIMUM_VERSIONS,
   AGENT_RUNTIME_PROFILE,
+  type AgentDoctorReport,
   type AgentJavascriptRuntime,
-  type AgentRuntimeInfo,
+  type AgentRuntimeFailureReason,
   type AgentRuntimeProfileCheck,
 } from "./profile"
 
@@ -13,17 +14,11 @@ const PREFLIGHT_TIMEOUT_MS = 15_000
 
 const CHECK_BY_EXIT_CODE: Readonly<Record<number, AgentRuntimeProfileCheck>> = {
   20: "environment-bootstrap",
-  21: "environment-bootstrap",
-  22: "path-bootstrap",
-  23: "cli-installation",
-  24: "cli-installation",
-  25: "read-tool",
-  26: "read-tool",
-  27: "read-tool",
-  28: "read-tool",
-  29: "javascript-runtime",
-  30: "read-tool",
-  31: "cli-execution",
+  21: "path-bootstrap",
+  22: "cli-installation",
+  23: "file-tools",
+  24: "javascript-runtime",
+  25: "cli-execution",
 }
 
 export interface AssertAgentRuntimeProfileInput {
@@ -41,35 +36,28 @@ export interface AssertAgentRuntimeProfileInput {
  */
 export async function assertAgentRuntimeProfile(
   input: AssertAgentRuntimeProfileInput
-): Promise<AgentRuntimeInfo> {
+): Promise<void> {
   const local = await runProbe(input.sandbox, LOCAL_BEHAVIOR_PROBE, input.env, "bash")
   if (local.exitCode !== 0) {
-    throw profileError(input.sandbox, CHECK_BY_EXIT_CODE[local.exitCode] ?? "bash")
+    throw profileError(
+      input.sandbox,
+      CHECK_BY_EXIT_CODE[local.exitCode] ?? "bash",
+      "nonzero-exit",
+      local.exitCode
+    )
   }
 
   const runtime = parseLocalProbe(input.sandbox, local.stdout)
   assertSupportedRuntime(input.sandbox, runtime.name, runtime.version)
   if (runtime.cliVersion !== AGENT_CLI_VERSION) {
-    throw profileError(input.sandbox, "cli-execution")
+    throw profileError(input.sandbox, "cli-execution", "invalid-output")
   }
 
-  const gateway = await runProbe(
-    input.sandbox,
-    "sixb project show",
-    input.env,
-    "gateway-connectivity"
-  )
+  const gateway = await runProbe(input.sandbox, "sixb doctor", input.env, "gateway-connectivity")
   if (gateway.exitCode !== 0) {
-    throw profileError(input.sandbox, "gateway-connectivity")
+    throw profileError(input.sandbox, "gateway-connectivity", "nonzero-exit", gateway.exitCode)
   }
-  assertGatewayProject(input.sandbox, gateway.stdout, input.projectId)
-
-  return {
-    profile: AGENT_RUNTIME_PROFILE,
-    provider: input.sandbox.provider,
-    javascript: { name: runtime.name, version: runtime.version },
-    cliVersion: runtime.cliVersion,
-  }
+  assertDoctorReport(input.sandbox, gateway.stdout, input.projectId, runtime)
 }
 
 async function runProbe(
@@ -83,11 +71,11 @@ async function runProbe(
       env,
       timeout: PREFLIGHT_TIMEOUT_MS,
     })
-    if (result.timedOut) throw profileError(sandbox, failureCheck)
+    if (result.timedOut) throw profileError(sandbox, failureCheck, "timed-out")
     return result
   } catch (error) {
     if (error instanceof AgentRuntimeProfileError) throw error
-    throw profileError(sandbox, failureCheck)
+    throw profileError(sandbox, failureCheck, "command-error")
   }
 }
 
@@ -100,13 +88,15 @@ function parseLocalProbe(
   readonly cliVersion: string
 } {
   const fields = stdout.trim().split("\t")
-  if (fields.length !== 3) throw profileError(sandbox, "cli-execution")
+  if (fields.length !== 3) throw profileError(sandbox, "cli-execution", "invalid-output")
   const [name, version, cliOutput] = fields
   if ((name !== "bun" && name !== "node") || !version || !cliOutput) {
-    throw profileError(sandbox, "cli-execution")
+    throw profileError(sandbox, "cli-execution", "invalid-output")
   }
   const prefix = "sixb agent CLI "
-  if (!cliOutput.startsWith(prefix)) throw profileError(sandbox, "cli-execution")
+  if (!cliOutput.startsWith(prefix)) {
+    throw profileError(sandbox, "cli-execution", "invalid-output")
+  }
   return { name, version, cliVersion: cliOutput.slice(prefix.length) }
 }
 
@@ -122,7 +112,7 @@ function assertSupportedRuntime(
     parsed.major < minimum.major ||
     (parsed.major === minimum.major && parsed.minor < minimum.minor)
   ) {
-    throw profileError(sandbox, "javascript-runtime")
+    throw profileError(sandbox, "javascript-runtime", "unsupported-version")
   }
 }
 
@@ -132,59 +122,125 @@ function parseVersion(version: string): { readonly major: number; readonly minor
   return { major: Number(match[1]), minor: Number(match[2]) }
 }
 
-function assertGatewayProject(sandbox: Sandbox, stdout: string, projectId: string): void {
+function assertDoctorReport(
+  sandbox: Sandbox,
+  stdout: string,
+  projectId: string,
+  localRuntime: { readonly name: AgentJavascriptRuntime; readonly version: string }
+): void {
+  let report: AgentDoctorReport
   try {
     const value: unknown = JSON.parse(stdout)
-    if (
-      typeof value !== "object" ||
-      value === null ||
-      Array.isArray(value) ||
-      !("id" in value) ||
-      value.id !== projectId
-    ) {
-      throw profileError(sandbox, "gateway-connectivity")
-    }
-  } catch (error) {
-    if (error instanceof AgentRuntimeProfileError) throw error
-    throw profileError(sandbox, "gateway-connectivity")
+    report = parseDoctorReport(value)
+  } catch {
+    throw profileError(sandbox, "cli-execution", "invalid-output")
+  }
+  if (
+    report.cli.version !== AGENT_CLI_VERSION ||
+    report.javascript.name !== localRuntime.name ||
+    normalizeVersion(report.javascript.version) !== normalizeVersion(localRuntime.version)
+  ) {
+    throw profileError(sandbox, "cli-execution", "invalid-output")
+  }
+  if (report.project.id !== projectId) {
+    throw profileError(sandbox, "gateway-connectivity", "invalid-output")
   }
 }
 
-function profileError(sandbox: Sandbox, check: AgentRuntimeProfileCheck): AgentRuntimeProfileError {
-  return new AgentRuntimeProfileError(sandbox.provider, check)
+function parseDoctorReport(value: unknown): AgentDoctorReport {
+  const report = record(value)
+  const cli = record(report.cli)
+  const javascript = record(report.javascript)
+  const project = record(report.project)
+  if (
+    report.ok !== true ||
+    report.profile !== AGENT_RUNTIME_PROFILE ||
+    typeof cli.version !== "string" ||
+    cli.version.length === 0 ||
+    (javascript.name !== "bun" && javascript.name !== "node") ||
+    typeof javascript.version !== "string" ||
+    javascript.version.length === 0 ||
+    typeof project.id !== "string" ||
+    project.id.length === 0
+  ) {
+    throw new Error("invalid doctor report")
+  }
+  return {
+    ok: true,
+    profile: report.profile,
+    cli: { version: cli.version },
+    javascript: { name: javascript.name, version: javascript.version },
+    project: { id: project.id },
+  }
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("expected object")
+  }
+  return value as Record<string, unknown>
+}
+
+function normalizeVersion(value: string): string {
+  return value.trim().replace(/^v/, "")
+}
+
+function profileError(
+  sandbox: Sandbox,
+  check: AgentRuntimeProfileCheck,
+  reason: AgentRuntimeFailureReason,
+  exitCode?: number
+): AgentRuntimeProfileError {
+  return new AgentRuntimeProfileError(sandbox.provider, check, reason, exitCode)
 }
 
 const LOCAL_BEHAVIOR_PROBE = `set -u
 [ "\${SIXB_BASH_ENV_READY:-}" = "1" ] || exit 20
-[ "\${SIXB_AGENT_RUNTIME_PROFILE:-}" = "${AGENT_RUNTIME_PROFILE}" ] || exit 21
-[ "$(command -v sixb)" = "$SIXB_BIN_DIR/sixb" ] || exit 22
-[ -x "$SIXB_BIN_DIR/sixb" ] || exit 23
-[ -r "$SIXB_CONTEXT_DIR/lib/sixb.mjs" ] || exit 24
-realpath_bin="$(command -v realpath)" || exit 25
-tail_bin="$(command -v tail)" || exit 26
-head_bin="$(command -v head)" || exit 27
-base64_bin="$(command -v base64)" || exit 28
-resolved_probe="$("$realpath_bin" "$SIXB_RUNTIME_PROBE_FILE")" || exit 30
-[ -f "$resolved_probe" ] || exit 30
+[ "\${SIXB_AGENT_RUNTIME_PROFILE:-}" = "${AGENT_RUNTIME_PROFILE}" ] || exit 20
+[ "$(command -v sixb)" = "$SIXB_BIN_DIR/sixb" ] || exit 21
+[ -x "$SIXB_BIN_DIR/sixb" ] || exit 22
+[ -r "$SIXB_CONTEXT_DIR/lib/sixb.mjs" ] || exit 22
+realpath_bin="$(command -v realpath)" || exit 23
+tail_bin="$(command -v tail)" || exit 23
+head_bin="$(command -v head)" || exit 23
+base64_bin="$(command -v base64)" || exit 23
+resolved_probe="$("$realpath_bin" "$SIXB_RUNTIME_PROBE_FILE")" || exit 23
+[ -f "$resolved_probe" ] || exit 23
 "$tail_bin" -n "+2" -- "$resolved_probe" | "$head_bin" -n 1 | "$head_bin" -c 19 | "$base64_bin" > "$SIXB_CONTEXT_DIR/runtime/read-probe.out"
 for status in "\${PIPESTATUS[@]}"; do
-  case "$status" in 0|141) ;; *) exit 30 ;; esac
+  case "$status" in 0|141) ;; *) exit 23 ;; esac
 done
 IFS= read -r read_probe < "$SIXB_CONTEXT_DIR/runtime/read-probe.out"
-[ "$read_probe" = "c2l4Yi1ydW50aW1lLXByb2JlCg==" ] || exit 30
+[ "$read_probe" = "c2l4Yi1ydW50aW1lLXByb2JlCg==" ] || exit 23
+find_bin="$(command -v find)" || exit 23
+wc_bin="$(command -v wc)" || exit 23
+tr_bin="$(command -v tr)" || exit 23
+probe_dir="\${resolved_probe%/*}"
+"$find_bin" "$probe_dir" -type f -name "read-probe.txt" -print0 | while IFS= read -r -d '' path; do
+  size="$("$wc_bin" -c < "$path" | "$tr_bin" -d ' ')" || exit 1
+  encoded="$(printf '%s' "$path" | "$base64_bin" | "$tr_bin" -d '\n')" || exit 1
+  printf '%s\t%s\n' "$size" "$encoded"
+done > "$SIXB_CONTEXT_DIR/runtime/file-tools-probe.out"
+for status in "\${PIPESTATUS[@]}"; do
+  [ "$status" = "0" ] || exit 23
+done
+IFS=$'\t' read -r file_size encoded_path < "$SIXB_CONTEXT_DIR/runtime/file-tools-probe.out"
+[ "$file_size" = "31" ] || exit 23
+decoded_path="$(printf '%s' "$encoded_path" | "$base64_bin" -d)" || exit 23
+[ "$decoded_path" = "$resolved_probe" ] || exit 23
 runtime_path="$(command -v bun || true)"
 if [ -n "$runtime_path" ]; then
   runtime_name="bun"
-  runtime_version="$("$runtime_path" --version)" || exit 29
+  runtime_version="$("$runtime_path" --version)" || exit 24
 else
   runtime_path="$(command -v node || true)"
 fi
 if [ -z "\${runtime_name:-}" ] && [ -n "$runtime_path" ]; then
   runtime_name="node"
-  runtime_version="$("$runtime_path" --version)" || exit 29
+  runtime_version="$("$runtime_path" --version)" || exit 24
 fi
 if [ -z "\${runtime_name:-}" ]; then
-  exit 29
+  exit 24
 fi
-cli_version="$(sixb --version)" || exit 31
+cli_version="$(sixb --version)" || exit 25
 printf '%s\t%s\t%s\n' "$runtime_name" "$runtime_version" "$cli_version"`

--- a/packages/agent-worker/src/agent-runtime/profile.ts
+++ b/packages/agent-worker/src/agent-runtime/profile.ts
@@ -12,17 +12,26 @@ export type AgentRuntimeProfileCheck =
   | "environment-bootstrap"
   | "path-bootstrap"
   | "cli-installation"
-  | "read-tool"
+  | "file-tools"
   | "javascript-runtime"
   | "cli-execution"
   | "gateway-connectivity"
 
-export interface AgentRuntimeInfo {
+export type AgentRuntimeFailureReason =
+  | "command-error"
+  | "timed-out"
+  | "nonzero-exit"
+  | "invalid-output"
+  | "unsupported-version"
+
+/** Stable JSON emitted by `sixb doctor` and consumed by worker preflight. */
+export interface AgentDoctorReport {
+  readonly ok: true
   readonly profile: typeof AGENT_RUNTIME_PROFILE
-  readonly provider: string
+  readonly cli: { readonly version: string }
   readonly javascript: {
     readonly name: AgentJavascriptRuntime
     readonly version: string
   }
-  readonly cliVersion: string
+  readonly project: { readonly id: string }
 }

--- a/packages/agent-worker/src/agent-runtime/profile.ts
+++ b/packages/agent-worker/src/agent-runtime/profile.ts
@@ -1,0 +1,28 @@
+export const AGENT_RUNTIME_PROFILE = "sixb-agent-runtime/v1" as const
+
+export const AGENT_RUNTIME_MINIMUM_VERSIONS = {
+  bun: { major: 1, minor: 3 },
+  node: { major: 22, minor: 0 },
+} as const
+
+export type AgentJavascriptRuntime = keyof typeof AGENT_RUNTIME_MINIMUM_VERSIONS
+
+export type AgentRuntimeProfileCheck =
+  | "bash"
+  | "environment-bootstrap"
+  | "path-bootstrap"
+  | "cli-installation"
+  | "read-tool"
+  | "javascript-runtime"
+  | "cli-execution"
+  | "gateway-connectivity"
+
+export interface AgentRuntimeInfo {
+  readonly profile: typeof AGENT_RUNTIME_PROFILE
+  readonly provider: string
+  readonly javascript: {
+    readonly name: AgentJavascriptRuntime
+    readonly version: string
+  }
+  readonly cliVersion: string
+}

--- a/packages/agent-worker/src/failure.ts
+++ b/packages/agent-worker/src/failure.ts
@@ -46,6 +46,8 @@ function translateAgentExecutionError(
         provider: error.provider,
         runtimeProfile: error.profile,
         runtimeCheck: error.check,
+        runtimeFailure: error.reason,
+        ...(error.exitCode === undefined ? {} : { runtimeExitCode: String(error.exitCode) }),
         remediation: error.remediation,
       },
     })

--- a/packages/agent-worker/src/failure.ts
+++ b/packages/agent-worker/src/failure.ts
@@ -6,6 +6,7 @@ import {
   summarizeErrorMessage,
 } from "@sixb/core/internal/errors"
 import { AGENT_RUN_FAILURE_CODES, type AgentRunFailureCode } from "@sixb/core/storage"
+import { AgentRuntimeProfileError } from "./agent-runtime/errors"
 
 export type AgentRunFailure = SixbFailure<AgentRunFailureCode>
 
@@ -37,6 +38,19 @@ function translateAgentExecutionError(
   error: unknown,
   details: Readonly<Record<string, string>>
 ): unknown {
+  if (error instanceof AgentRuntimeProfileError) {
+    return createSixbError("agent.execution_failed", error.message, {
+      cause: error,
+      details: {
+        ...details,
+        provider: error.provider,
+        runtimeProfile: error.profile,
+        runtimeCheck: error.check,
+        remediation: error.remediation,
+      },
+    })
+  }
+
   if (
     isSixbError(error) &&
     (error.code === "internal.unexpected" || error.code === "agent.execution_failed")

--- a/packages/agent-worker/src/run-agent-turn.ts
+++ b/packages/agent-worker/src/run-agent-turn.ts
@@ -23,6 +23,7 @@ import { appendMessageAndFinishRunOrThrow, finishRunOrThrow } from "./finalize"
 import { AiModelCallRecorder } from "./model-call-recorder"
 import { collectAgentOutputAttachments } from "./output-attachments"
 import { runAgentLoop } from "./run-agent-loop"
+import { monitorSandboxReadiness } from "./sandbox-readiness"
 import { loadAgentThreadModelContext } from "./thread-context"
 import type { AgentTurnContext } from "./types"
 
@@ -130,14 +131,9 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
   // turn ends now. We do NOT await provisioning before finalizing: a turn that out-runs a slow boot
   // keeps the latency win, so a boot that fails only after the turn has drained still finalizes
   // (best-effort strict).
-  const provisionAbort = new AbortController()
-  let provisionError: unknown
-  context.sandboxReady?.catch((error) => {
-    provisionError = error
-    provisionAbort.abort()
-  })
+  const sandboxReadiness = monitorSandboxReadiness(context.sandboxReady)
 
-  const abortSignal = AbortSignal.any([signal, timeoutAbort.signal, provisionAbort.signal])
+  const abortSignal = AbortSignal.any([signal, timeoutAbort.signal, sandboxReadiness.signal])
 
   const result = runAgentLoop({
     agent,
@@ -199,9 +195,7 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
     // interpreting the stream as a success or cancellation.
     usageRecorder.assertHealthy()
     // A sandbox failure and a timeout take precedence over the abort-shaped error they cause.
-    if (provisionError !== undefined) {
-      throw provisionError
-    }
+    sandboxReadiness.throwIfFailed()
     if (timedOut) {
       const completedAt = new Date()
       return finalizeInterruptedTurn({

--- a/packages/agent-worker/src/run-environment.ts
+++ b/packages/agent-worker/src/run-environment.ts
@@ -2,6 +2,7 @@ import type { AgentDefinition, Sandbox } from "@sixb/core"
 import { resolveLoggingService } from "@sixb/core/internal/logging"
 import type { WorkflowIOSnapshot } from "@sixb/core/internal/workflows"
 import type { AgentRunRecord, WorkflowAgentNodeRunRecord } from "@sixb/core/storage"
+import { assertAgentRuntimeProfile } from "./agent-runtime/preflight"
 import { type AgentExecutionMode, renderAgentSkillCatalog } from "./agent-skills"
 import { aiSdkToolsFromAgentDefinitions } from "./ai-sdk-adapters"
 import { createAgentApiGatewayBaseUrl } from "./api-url"
@@ -272,6 +273,11 @@ async function provisionSandbox(input: ProvisionSandboxInput): Promise<BashSandb
       runId: run.id,
       attachments: input.attachmentContext,
       skills,
+    })
+    await assertAgentRuntimeProfile({
+      sandbox,
+      env: apiContext.env,
+      projectId: context.id,
     })
     return { sandbox, env: apiContext.env }
   } catch (error) {

--- a/packages/agent-worker/src/run-workflow-agent-node.ts
+++ b/packages/agent-worker/src/run-workflow-agent-node.ts
@@ -16,6 +16,7 @@ import { generateText, jsonSchema, type ModelMessage, NoObjectGeneratedError, Ou
 import { type AiSdkTraceStep, agentTraceFromAiSdkSteps } from "./ai-sdk-adapters"
 import type { AiModelCallRecorder } from "./model-call-recorder"
 import { runAgentLoop } from "./run-agent-loop"
+import { monitorSandboxReadiness } from "./sandbox-readiness"
 import type { AgentTurnContext } from "./types"
 
 const WORKFLOW_OUTPUT_FINALIZATION_ATTEMPTS = 2
@@ -94,7 +95,8 @@ export async function runWorkflowAgentNode(
 
   const timeout = new AbortController()
   const timer = setTimeout(() => timeout.abort(), input.context.turnTimeoutMs)
-  const abortSignal = AbortSignal.any([input.signal, timeout.signal])
+  const sandboxReadiness = monitorSandboxReadiness(input.context.sandboxReady)
+  const abortSignal = AbortSignal.any([input.signal, timeout.signal, sandboxReadiness.signal])
   const completedSteps: AiSdkTraceStep[] = []
   const traceDetails = {
     agentId: input.agent.id,
@@ -133,6 +135,7 @@ export async function runWorkflowAgentNode(
       },
     })
     input.usageRecorder.assertHealthy()
+    sandboxReadiness.throwIfFailed()
     if (researchError !== undefined) throw researchError
 
     const researchText = await research.text
@@ -211,6 +214,7 @@ export async function runWorkflowAgentNode(
       )
     }
 
+    sandboxReadiness.throwIfFailed()
     const output = snapshotWorkflowAgentStepOutput({
       workflowId: input.workflowId,
       agentStep: input.agentStep,
@@ -224,6 +228,8 @@ export async function runWorkflowAgentNode(
       trace: agentTraceFromAiSdkSteps(completedSteps, traceDetails),
     }
   } catch (cause) {
+    // Prefer the concrete provisioning failure over the abort it causes in either model phase.
+    sandboxReadiness.throwIfFailed()
     throw new WorkflowAgentNodeExecutionError({
       phase,
       finishReason,

--- a/packages/agent-worker/src/sandbox-api-context.ts
+++ b/packages/agent-worker/src/sandbox-api-context.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path"
 import type { Sandbox } from "@sixb/core"
 import { loadAgentCliAssets } from "./agent-cli-assets"
+import { AGENT_RUNTIME_PROFILE } from "./agent-runtime/profile"
 import { type AgentSkill, buildAgentSkillFiles } from "./agent-skills"
 import type { PreparedAgentAttachmentContext } from "./attachments"
 
@@ -28,6 +29,7 @@ export async function prepareAgentSandboxApiContext(
   const libDir = join(contextDir, "lib")
   const runContextPath = join(contextDir, "context", "run.json")
   const bashEnvPath = join(contextDir, "context", "bash-env")
+  const runtimeProbePath = join(contextDir, "runtime", "read-probe.txt")
   const attachmentsManifestPath = join(contextDir, "context", "attachments.json")
   const attachmentsDir = join(contextDir, "attachments")
   const outputRoot = join(contextDir, "outputs")
@@ -43,6 +45,7 @@ export async function prepareAgentSandboxApiContext(
       agentId: input.agentId,
       ...(input.threadId ? { threadId: input.threadId } : {}),
       runId: input.runId,
+      runtimeProfile: AGENT_RUNTIME_PROFILE,
       apiBaseUrl: input.apiBaseUrl,
       attachmentsManifestPath,
       attachmentsDir,
@@ -53,7 +56,7 @@ export async function prepareAgentSandboxApiContext(
     2
   )
 
-  // Materialize skills, CLI, and run context through the sandbox capability rather than the host
+  // Materialize skills + run context through the sandbox capability rather than the host
   // filesystem, so any provider (including non-host-path ones like smolvm) places the bytes in the
   // guest. Awaited before sandbox tools run, so the agent never sees an un-provisioned sandbox.
   await input.sandbox.writeFiles([
@@ -61,6 +64,7 @@ export async function prepareAgentSandboxApiContext(
     { path: join(binDir, "sixb"), contents: cli.launcher, mode: 0o755 },
     { path: join(libDir, "sixb.mjs"), contents: cli.artifact, mode: 0o644 },
     { path: runContextPath, contents: runContext },
+    { path: runtimeProbePath, contents: "first\nsixb-runtime-probe\nthird\n", mode: 0o644 },
     {
       path: bashEnvPath,
       contents: [
@@ -68,6 +72,7 @@ export async function prepareAgentSandboxApiContext(
         `if [ -n "\${SIXB_BIN_DIR:-}" ]; then`,
         '  export PATH="$SIXB_BIN_DIR:$PATH"',
         "fi",
+        "export SIXB_BASH_ENV_READY=1",
         "",
       ].join("\n"),
     },
@@ -89,6 +94,8 @@ export async function prepareAgentSandboxApiContext(
       SIXB_CONTEXT_DIR: contextDir,
       SIXB_SKILLS_DIR: skillsDir,
       SIXB_BIN_DIR: binDir,
+      SIXB_AGENT_RUNTIME_PROFILE: AGENT_RUNTIME_PROFILE,
+      SIXB_RUNTIME_PROBE_FILE: runtimeProbePath,
       BASH_ENV: bashEnvPath,
       SIXB_RUN_CONTEXT: runContextPath,
       SIXB_ATTACHMENTS: attachmentsManifestPath,

--- a/packages/agent-worker/src/sandbox-readiness.ts
+++ b/packages/agent-worker/src/sandbox-readiness.ts
@@ -1,0 +1,22 @@
+interface SandboxReadinessGuard {
+  readonly signal: AbortSignal
+  throwIfFailed(): void
+}
+
+/** Observe concurrent sandbox provisioning without putting healthy boot on the model's critical path. */
+export function monitorSandboxReadiness(
+  ready: Promise<unknown> | undefined
+): SandboxReadinessGuard {
+  const abort = new AbortController()
+  let failure: { readonly error: unknown } | undefined
+  ready?.catch((error) => {
+    failure = { error }
+    abort.abort()
+  })
+  return {
+    signal: abort.signal,
+    throwIfFailed() {
+      if (failure) throw failure.error
+    },
+  }
+}

--- a/packages/agent-worker/tests/agent-cli-contract.ts
+++ b/packages/agent-worker/tests/agent-cli-contract.ts
@@ -7,6 +7,7 @@ export interface AgentCliContractImplementation {
   readonly name: string
   readonly command: readonly string[]
   readonly version: string
+  readonly runtime: "bun" | "node"
 }
 
 interface CliResult {
@@ -191,6 +192,30 @@ export function runAgentCliContractSuite(implementation: AgentCliContractImpleme
 
       const version = await runCli(implementation, ["--version"])
       expect(version).toEqual({ exitCode: 0, stdout: `${implementation.version}\n`, stderr: "" })
+    })
+
+    test("reports one compact, stable doctor contract", async () => {
+      const api = startGraphApi()
+      try {
+        const result = await runCli(implementation, ["doctor"], apiEnv(api))
+        expect(result.exitCode).toBe(0)
+        expect(result.stderr).toBe("")
+        const report = JSON.parse(result.stdout)
+        expect(report).toEqual({
+          ok: true,
+          profile: "sixb-agent-runtime/v1",
+          cli: { version: implementation.version.split(" ").at(-1) },
+          javascript: {
+            name: implementation.runtime,
+            version: expect.stringMatching(/^\d+\.\d+(?:\.\d+)?/),
+          },
+          project: { id: "contract-project" },
+        })
+        expect(report.project.name).toBeUndefined()
+        expect(api.requests.map((request) => request.url.pathname)).toEqual(["/api/project"])
+      } finally {
+        api.close()
+      }
     })
 
     test("uses stable JSON errors and exit codes for local and API failures", async () => {

--- a/packages/agent-worker/tests/agent-cli.test.ts
+++ b/packages/agent-worker/tests/agent-cli.test.ts
@@ -13,12 +13,14 @@ runAgentCliContractSuite({
   name: "generated artifact on Bun",
   command: [process.execPath, artifactPath],
   version: "sixb agent CLI 1",
+  runtime: "bun",
 })
 
 runAgentCliContractSuite({
   name: "generated artifact on Node",
   command: ["node", artifactPath],
   version: "sixb agent CLI 1",
+  runtime: "node",
 })
 
 const CLI_API_ROUTES = [

--- a/packages/agent-worker/tests/agent-runtime-profile.test.ts
+++ b/packages/agent-worker/tests/agent-runtime-profile.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, relative, resolve } from "node:path"
+import type { CommandResult, RunCommandOptions, Sandbox, SandboxFileRecord } from "@sixb/core"
+import { AgentRuntimeProfileError } from "../src/agent-runtime/errors"
+import { assertAgentRuntimeProfile } from "../src/agent-runtime/preflight"
+import { AGENT_RUNTIME_PROFILE } from "../src/agent-runtime/profile"
+import { prepareAgentSandboxApiContext } from "../src/sandbox-api-context"
+
+const PROJECT_ID = "runtime-test"
+const ENV = {
+  SIXB_API_BASE_URL: "https://capability.invalid/run-secret/",
+  SIXB_PROJECT_ID: PROJECT_ID,
+}
+
+const SUCCESSFUL_LOCAL_PROBE: CommandResult = {
+  exitCode: 0,
+  stdout: "node\t22.1.0\tsixb agent CLI 1\n",
+  stderr: "",
+  durationMs: 1,
+}
+
+const SUCCESSFUL_GATEWAY_PROBE: CommandResult = {
+  exitCode: 0,
+  stdout: JSON.stringify({ id: PROJECT_ID }),
+  stderr: "",
+  durationMs: 1,
+}
+
+interface RecordedCommand {
+  readonly command: string
+  readonly args: readonly string[]
+  readonly options: RunCommandOptions
+}
+
+class StubSandbox implements Sandbox {
+  readonly id = "stub"
+  readonly provider: string
+  readonly workingDirectory = "/workspace"
+  readonly status = "running" as const
+  readonly commands: RecordedCommand[] = []
+
+  constructor(
+    private readonly responses: CommandResult[],
+    provider = "test-provider"
+  ) {
+    this.provider = provider
+  }
+
+  async runCommand(
+    command: string,
+    args: readonly string[] = [],
+    options: RunCommandOptions = {}
+  ): Promise<CommandResult> {
+    this.commands.push({ command, args, options })
+    const response = this.responses.shift()
+    if (!response) throw new Error("https://capability.invalid/run-secret/ was unavailable")
+    return response
+  }
+
+  async writeFiles(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async destroy(): Promise<void> {}
+}
+
+describe("sixb-agent-runtime/v1 preflight", () => {
+  test("checks local behavior once, then reaches the gateway through the installed CLI", async () => {
+    const sandbox = new StubSandbox([SUCCESSFUL_LOCAL_PROBE, SUCCESSFUL_GATEWAY_PROBE])
+
+    await expect(
+      assertAgentRuntimeProfile({ sandbox, env: ENV, projectId: PROJECT_ID })
+    ).resolves.toEqual({
+      profile: AGENT_RUNTIME_PROFILE,
+      provider: "test-provider",
+      javascript: { name: "node", version: "22.1.0" },
+      cliVersion: "1",
+    })
+
+    expect(sandbox.commands).toHaveLength(2)
+    expect(sandbox.commands[0]).toMatchObject({ command: "bash", options: { timeout: 15_000 } })
+    expect(sandbox.commands[0]?.args[0]).toBe("-lc")
+    expect(sandbox.commands[0]?.args[1]).toContain("SIXB_BASH_ENV_READY")
+    expect(sandbox.commands[0]?.args[1]).toContain("PIPESTATUS")
+    expect(sandbox.commands[0]?.args[1]).toContain("command -v bun")
+    expect(sandbox.commands[0]?.args[1]).not.toContain(ENV.SIXB_API_BASE_URL)
+    expect(sandbox.commands[1]).toMatchObject({
+      command: "bash",
+      args: ["-lc", "sixb project show"],
+      options: { env: ENV, timeout: 15_000 },
+    })
+  })
+
+  test("maps behavioral probe exits to stable failed checks", async () => {
+    const cases = [
+      [20, "environment-bootstrap"],
+      [22, "path-bootstrap"],
+      [23, "cli-installation"],
+      [25, "read-tool"],
+      [29, "javascript-runtime"],
+      [31, "cli-execution"],
+      [127, "bash"],
+    ] as const
+
+    for (const [exitCode, check] of cases) {
+      const sandbox = new StubSandbox([
+        { exitCode, stdout: "", stderr: "untrusted provider output", durationMs: 1 },
+      ])
+      try {
+        await assertAgentRuntimeProfile({ sandbox, env: ENV, projectId: PROJECT_ID })
+        throw new Error(`Expected exit ${exitCode} to fail.`)
+      } catch (error) {
+        expect(error).toBeInstanceOf(AgentRuntimeProfileError)
+        expect((error as AgentRuntimeProfileError).check).toBe(check)
+      }
+    }
+  })
+
+  test("rejects runtimes below the supported floor even when the CLI starts", async () => {
+    for (const stdout of ["bun\t1.2.9\tsixb agent CLI 1\n", "node\tv21.9.0\tsixb agent CLI 1\n"]) {
+      const sandbox = new StubSandbox([{ ...SUCCESSFUL_LOCAL_PROBE, stdout }])
+      await expect(
+        assertAgentRuntimeProfile({ sandbox, env: ENV, projectId: PROJECT_ID })
+      ).rejects.toMatchObject({ check: "javascript-runtime" })
+    }
+  })
+
+  test("rejects a stale CLI artifact before performing a gateway request", async () => {
+    const sandbox = new StubSandbox([
+      { ...SUCCESSFUL_LOCAL_PROBE, stdout: "node\t22.1.0\tsixb agent CLI stale\n" },
+    ])
+
+    await expect(
+      assertAgentRuntimeProfile({ sandbox, env: ENV, projectId: PROJECT_ID })
+    ).rejects.toMatchObject({ check: "cli-execution" })
+    expect(sandbox.commands).toHaveLength(1)
+  })
+
+  test("requires the gateway response to identify the current project", async () => {
+    for (const stdout of ["not-json", JSON.stringify({ id: "another-project" })]) {
+      const sandbox = new StubSandbox([
+        SUCCESSFUL_LOCAL_PROBE,
+        { ...SUCCESSFUL_GATEWAY_PROBE, stdout },
+      ])
+      await expect(
+        assertAgentRuntimeProfile({ sandbox, env: ENV, projectId: PROJECT_ID })
+      ).rejects.toMatchObject({ check: "gateway-connectivity" })
+    }
+  })
+
+  test("never exposes the gateway capability URL or raw command diagnostics", async () => {
+    const sandbox = new StubSandbox([
+      SUCCESSFUL_LOCAL_PROBE,
+      {
+        exitCode: 3,
+        stdout: "",
+        stderr: `failed to fetch ${ENV.SIXB_API_BASE_URL}`,
+        durationMs: 1,
+      },
+    ])
+
+    try {
+      await assertAgentRuntimeProfile({ sandbox, env: ENV, projectId: PROJECT_ID })
+      throw new Error("Expected gateway preflight failure.")
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentRuntimeProfileError)
+      expect(String(error)).not.toContain(ENV.SIXB_API_BASE_URL)
+      expect(String(error)).not.toContain("failed to fetch")
+      expect(error).toMatchObject({
+        provider: "test-provider",
+        profile: AGENT_RUNTIME_PROFILE,
+        check: "gateway-connectivity",
+      })
+    }
+  })
+})
+
+describe("agent runtime conformance", () => {
+  let sandbox: HostSandbox | undefined
+
+  afterEach(async () => {
+    await sandbox?.destroy()
+    sandbox = undefined
+  })
+
+  test("the local worker environment satisfies the provisioned behavioral profile", async () => {
+    sandbox = await HostSandbox.create()
+    const context = await prepareAgentSandboxApiContext({
+      sandbox,
+      apiBaseUrl: "http://gateway.invalid",
+      projectId: PROJECT_ID,
+      agentId: "assistant",
+      runId: "run-1",
+      skills: [],
+    })
+
+    const runtime = await assertAgentRuntimeProfile({
+      sandbox,
+      env: context.env,
+      projectId: PROJECT_ID,
+    })
+
+    expect(runtime.profile).toBe(AGENT_RUNTIME_PROFILE)
+    expect(runtime.provider).toBe("local")
+    expect(["bun", "node"]).toContain(runtime.javascript.name)
+  })
+})
+
+class HostSandbox implements Sandbox {
+  readonly id = "host-runtime-conformance"
+  readonly provider = "local"
+  status: "running" | "stopped" | "failed" = "running"
+
+  private constructor(readonly workingDirectory: string) {}
+
+  static async create(): Promise<HostSandbox> {
+    return new HostSandbox(await mkdtemp(join(tmpdir(), "sixb-agent-runtime-")))
+  }
+
+  async runCommand(
+    command: string,
+    args: readonly string[] = [],
+    options: RunCommandOptions = {}
+  ): Promise<CommandResult> {
+    if (command === "bash" && args.at(-1) === "sixb project show") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({ id: PROJECT_ID }),
+        stderr: "",
+        durationMs: 1,
+      }
+    }
+    const startedAt = performance.now()
+    const process = Bun.spawn([command, ...args], {
+      cwd: options.cwd ?? this.workingDirectory,
+      env: { ...globalThis.process.env, ...(options.env ?? {}) },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    let timedOut = false
+    const timer = setTimeout(() => {
+      timedOut = true
+      process.kill()
+    }, options.timeout ?? 30_000)
+    try {
+      const [exitCode, stdout, stderr] = await Promise.all([
+        process.exited,
+        new Response(process.stdout).text(),
+        new Response(process.stderr).text(),
+      ])
+      return {
+        exitCode,
+        stdout,
+        stderr,
+        durationMs: performance.now() - startedAt,
+        ...(timedOut ? { timedOut: true } : {}),
+      }
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  async writeFiles(files: readonly SandboxFileRecord[]): Promise<void> {
+    for (const file of files) {
+      const path = resolve(this.workingDirectory, file.path)
+      const escaped = relative(this.workingDirectory, path)
+      if (escaped === ".." || escaped.startsWith("../")) {
+        throw new Error("Test sandbox write escaped its root.")
+      }
+      await mkdir(dirname(path), { recursive: true })
+      await writeFile(path, file.contents)
+      if (file.mode !== undefined) await chmod(path, file.mode)
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.status = "stopped"
+  }
+
+  async destroy(): Promise<void> {
+    await rm(this.workingDirectory, { recursive: true, force: true })
+  }
+}

--- a/packages/agent-worker/tests/agent-runtime-profile.test.ts
+++ b/packages/agent-worker/tests/agent-runtime-profile.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { dirname, join, relative, resolve } from "node:path"
-import type { CommandResult, RunCommandOptions, Sandbox, SandboxFileRecord } from "@sixb/core"
+import { chmod, mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import type { CommandResult, RunCommandOptions, Sandbox } from "@sixb/core"
+import { LocalSandboxFactory } from "@sixb/sandboxes-local"
 import { AgentRuntimeProfileError } from "../src/agent-runtime/errors"
 import { assertAgentRuntimeProfile } from "../src/agent-runtime/preflight"
 import { AGENT_RUNTIME_PROFILE } from "../src/agent-runtime/profile"
@@ -23,7 +23,13 @@ const SUCCESSFUL_LOCAL_PROBE: CommandResult = {
 
 const SUCCESSFUL_GATEWAY_PROBE: CommandResult = {
   exitCode: 0,
-  stdout: JSON.stringify({ id: PROJECT_ID }),
+  stdout: JSON.stringify({
+    ok: true,
+    profile: AGENT_RUNTIME_PROFILE,
+    cli: { version: "1" },
+    javascript: { name: "node", version: "22.1.0" },
+    project: { id: PROJECT_ID },
+  }),
   stderr: "",
   durationMs: 1,
 }
@@ -70,12 +76,7 @@ describe("sixb-agent-runtime/v1 preflight", () => {
 
     await expect(
       assertAgentRuntimeProfile({ sandbox, env: ENV, projectId: PROJECT_ID })
-    ).resolves.toEqual({
-      profile: AGENT_RUNTIME_PROFILE,
-      provider: "test-provider",
-      javascript: { name: "node", version: "22.1.0" },
-      cliVersion: "1",
-    })
+    ).resolves.toBeUndefined()
 
     expect(sandbox.commands).toHaveLength(2)
     expect(sandbox.commands[0]).toMatchObject({ command: "bash", options: { timeout: 15_000 } })
@@ -86,7 +87,7 @@ describe("sixb-agent-runtime/v1 preflight", () => {
     expect(sandbox.commands[0]?.args[1]).not.toContain(ENV.SIXB_API_BASE_URL)
     expect(sandbox.commands[1]).toMatchObject({
       command: "bash",
-      args: ["-lc", "sixb project show"],
+      args: ["-lc", "sixb doctor"],
       options: { env: ENV, timeout: 15_000 },
     })
   })
@@ -94,11 +95,11 @@ describe("sixb-agent-runtime/v1 preflight", () => {
   test("maps behavioral probe exits to stable failed checks", async () => {
     const cases = [
       [20, "environment-bootstrap"],
-      [22, "path-bootstrap"],
-      [23, "cli-installation"],
-      [25, "read-tool"],
-      [29, "javascript-runtime"],
-      [31, "cli-execution"],
+      [21, "path-bootstrap"],
+      [22, "cli-installation"],
+      [23, "file-tools"],
+      [24, "javascript-runtime"],
+      [25, "cli-execution"],
       [127, "bash"],
     ] as const
 
@@ -112,6 +113,46 @@ describe("sixb-agent-runtime/v1 preflight", () => {
       } catch (error) {
         expect(error).toBeInstanceOf(AgentRuntimeProfileError)
         expect((error as AgentRuntimeProfileError).check).toBe(check)
+        expect((error as AgentRuntimeProfileError).reason).toBe("nonzero-exit")
+        expect((error as AgentRuntimeProfileError).exitCode).toBe(exitCode)
+      }
+    }
+  })
+
+  test("classifies probe timeouts and command failures without retaining diagnostics", async () => {
+    const cases = [
+      {
+        sandbox: new StubSandbox([
+          {
+            exitCode: 137,
+            stdout: "",
+            stderr: `timed out while using ${ENV.SIXB_API_BASE_URL}`,
+            durationMs: 15_000,
+            timedOut: true,
+          },
+        ]),
+        check: "bash",
+        reason: "timed-out",
+      },
+      {
+        sandbox: new StubSandbox([]),
+        check: "bash",
+        reason: "command-error",
+      },
+      {
+        sandbox: new StubSandbox([SUCCESSFUL_LOCAL_PROBE]),
+        check: "gateway-connectivity",
+        reason: "command-error",
+      },
+    ] as const
+
+    for (const { sandbox, check, reason } of cases) {
+      try {
+        await assertAgentRuntimeProfile({ sandbox, env: ENV, projectId: PROJECT_ID })
+        throw new Error(`Expected ${reason} to fail.`)
+      } catch (error) {
+        expect(error).toMatchObject({ check, reason, exitCode: undefined })
+        expect(String(error)).not.toContain(ENV.SIXB_API_BASE_URL)
       }
     }
   })
@@ -137,14 +178,24 @@ describe("sixb-agent-runtime/v1 preflight", () => {
   })
 
   test("requires the gateway response to identify the current project", async () => {
-    for (const stdout of ["not-json", JSON.stringify({ id: "another-project" })]) {
+    const wrongProject = JSON.stringify({
+      ...JSON.parse(SUCCESSFUL_GATEWAY_PROBE.stdout),
+      project: { id: "another-project" },
+    })
+    for (const stdout of ["not-json", wrongProject]) {
       const sandbox = new StubSandbox([
         SUCCESSFUL_LOCAL_PROBE,
         { ...SUCCESSFUL_GATEWAY_PROBE, stdout },
       ])
-      await expect(
-        assertAgentRuntimeProfile({ sandbox, env: ENV, projectId: PROJECT_ID })
-      ).rejects.toMatchObject({ check: "gateway-connectivity" })
+      try {
+        await assertAgentRuntimeProfile({ sandbox, env: ENV, projectId: PROJECT_ID })
+        throw new Error("Expected doctor validation to fail.")
+      } catch (error) {
+        expect(error).toMatchObject({
+          check: stdout === "not-json" ? "cli-execution" : "gateway-connectivity",
+          reason: "invalid-output",
+        })
+      }
     }
   })
 
@@ -176,7 +227,7 @@ describe("sixb-agent-runtime/v1 preflight", () => {
 })
 
 describe("agent runtime conformance", () => {
-  let sandbox: HostSandbox | undefined
+  let sandbox: Sandbox | undefined
 
   afterEach(async () => {
     await sandbox?.destroy()
@@ -184,7 +235,41 @@ describe("agent runtime conformance", () => {
   })
 
   test("the local worker environment satisfies the provisioned behavioral profile", async () => {
-    sandbox = await HostSandbox.create()
+    sandbox = await createLocalSandbox()
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        if (new URL(request.url).pathname === "/api/project") {
+          return Response.json({ id: PROJECT_ID, name: "Runtime test" })
+        }
+        return new Response("Not found", { status: 404 })
+      },
+    })
+    const context = await prepareAgentSandboxApiContext({
+      sandbox,
+      apiBaseUrl: `http://127.0.0.1:${server.port}`,
+      projectId: PROJECT_ID,
+      agentId: "assistant",
+      runId: "run-1",
+      skills: [],
+    })
+
+    try {
+      await expect(
+        assertAgentRuntimeProfile({
+          sandbox,
+          env: context.env,
+          projectId: PROJECT_ID,
+        })
+      ).resolves.toBeUndefined()
+    } finally {
+      await server.stop(true)
+    }
+  })
+
+  test("rejects an environment whose output-collection utilities do not behave correctly", async () => {
+    sandbox = await createLocalSandbox()
     const context = await prepareAgentSandboxApiContext({
       sandbox,
       apiBaseUrl: "http://gateway.invalid",
@@ -193,91 +278,37 @@ describe("agent runtime conformance", () => {
       runId: "run-1",
       skills: [],
     })
+    const shimDir = join(sandbox.workingDirectory, "broken-tools")
+    await mkdir(shimDir, { recursive: true })
+    await writeFile(join(shimDir, "find"), "#!/bin/sh\nexit 1\n")
+    await chmod(join(shimDir, "find"), 0o755)
+    const bashEnvPath = context.env.BASH_ENV
+    if (!bashEnvPath) throw new Error("Expected the worker to materialize BASH_ENV.")
+    await sandbox.writeFiles([
+      {
+        path: bashEnvPath,
+        contents: [
+          "# Test a behaviorally incompatible file utility.",
+          `export PATH="$SIXB_BIN_DIR:${shimDir}:$PATH"`,
+          "export SIXB_BASH_ENV_READY=1",
+          "",
+        ].join("\n"),
+      },
+    ])
 
-    const runtime = await assertAgentRuntimeProfile({
-      sandbox,
-      env: context.env,
-      projectId: PROJECT_ID,
-    })
-
-    expect(runtime.profile).toBe(AGENT_RUNTIME_PROFILE)
-    expect(runtime.provider).toBe("local")
-    expect(["bun", "node"]).toContain(runtime.javascript.name)
+    await expect(
+      assertAgentRuntimeProfile({
+        sandbox,
+        env: context.env,
+        projectId: PROJECT_ID,
+      })
+    ).rejects.toMatchObject({ check: "file-tools", reason: "nonzero-exit", exitCode: 23 })
   })
 })
 
-class HostSandbox implements Sandbox {
-  readonly id = "host-runtime-conformance"
-  readonly provider = "local"
-  status: "running" | "stopped" | "failed" = "running"
-
-  private constructor(readonly workingDirectory: string) {}
-
-  static async create(): Promise<HostSandbox> {
-    return new HostSandbox(await mkdtemp(join(tmpdir(), "sixb-agent-runtime-")))
-  }
-
-  async runCommand(
-    command: string,
-    args: readonly string[] = [],
-    options: RunCommandOptions = {}
-  ): Promise<CommandResult> {
-    if (command === "bash" && args.at(-1) === "sixb project show") {
-      return {
-        exitCode: 0,
-        stdout: JSON.stringify({ id: PROJECT_ID }),
-        stderr: "",
-        durationMs: 1,
-      }
-    }
-    const startedAt = performance.now()
-    const process = Bun.spawn([command, ...args], {
-      cwd: options.cwd ?? this.workingDirectory,
-      env: { ...globalThis.process.env, ...(options.env ?? {}) },
-      stdout: "pipe",
-      stderr: "pipe",
-    })
-    let timedOut = false
-    const timer = setTimeout(() => {
-      timedOut = true
-      process.kill()
-    }, options.timeout ?? 30_000)
-    try {
-      const [exitCode, stdout, stderr] = await Promise.all([
-        process.exited,
-        new Response(process.stdout).text(),
-        new Response(process.stderr).text(),
-      ])
-      return {
-        exitCode,
-        stdout,
-        stderr,
-        durationMs: performance.now() - startedAt,
-        ...(timedOut ? { timedOut: true } : {}),
-      }
-    } finally {
-      clearTimeout(timer)
-    }
-  }
-
-  async writeFiles(files: readonly SandboxFileRecord[]): Promise<void> {
-    for (const file of files) {
-      const path = resolve(this.workingDirectory, file.path)
-      const escaped = relative(this.workingDirectory, path)
-      if (escaped === ".." || escaped.startsWith("../")) {
-        throw new Error("Test sandbox write escaped its root.")
-      }
-      await mkdir(dirname(path), { recursive: true })
-      await writeFile(path, file.contents)
-      if (file.mode !== undefined) await chmod(path, file.mode)
-    }
-  }
-
-  async stop(): Promise<void> {
-    this.status = "stopped"
-  }
-
-  async destroy(): Promise<void> {
-    await rm(this.workingDirectory, { recursive: true, force: true })
-  }
+async function createLocalSandbox(): Promise<Sandbox> {
+  return await new LocalSandboxFactory({
+    isolation: "none",
+    network: { mode: "all" },
+  }).create()
 }

--- a/packages/agent-worker/tests/failure.test.ts
+++ b/packages/agent-worker/tests/failure.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { createSixbError } from "@sixb/core/internal/errors"
+import { AgentRuntimeProfileError } from "../src/agent-runtime/errors"
+import { AGENT_RUNTIME_PROFILE } from "../src/agent-runtime/profile"
 import { toAgentExecutionFailure } from "../src/failure"
 
 const at = new Date("2026-08-14T12:00:00.000Z")
@@ -50,5 +52,26 @@ describe("Agent execution failure", () => {
       at: at.toISOString(),
       details,
     })
+  })
+
+  test("records actionable runtime-profile context without exposing a gateway URL", () => {
+    const error = new AgentRuntimeProfileError("smolvm", "javascript-runtime")
+    const failure = toAgentExecutionFailure(error, { status: "failed", at, details })
+
+    expect(failure).toEqual({
+      code: "agent.execution_failed",
+      message: "Agent execution failed.",
+      retryable: false,
+      at: at.toISOString(),
+      details: {
+        ...details,
+        provider: "smolvm",
+        runtimeProfile: AGENT_RUNTIME_PROFILE,
+        runtimeCheck: "javascript-runtime",
+        remediation:
+          "Rebuild the managed smolvm agent image with 'bun run agent:image', or configure a compatible runtime-v1 image.",
+      },
+    })
+    expect(JSON.stringify(failure)).not.toContain("http")
   })
 })

--- a/packages/agent-worker/tests/failure.test.ts
+++ b/packages/agent-worker/tests/failure.test.ts
@@ -55,7 +55,11 @@ describe("Agent execution failure", () => {
   })
 
   test("records actionable runtime-profile context without exposing a gateway URL", () => {
-    const error = new AgentRuntimeProfileError("smolvm", "javascript-runtime")
+    const error = new AgentRuntimeProfileError(
+      "smolvm",
+      "javascript-runtime",
+      "unsupported-version"
+    )
     const failure = toAgentExecutionFailure(error, { status: "failed", at, details })
 
     expect(failure).toEqual({
@@ -68,8 +72,8 @@ describe("Agent execution failure", () => {
         provider: "smolvm",
         runtimeProfile: AGENT_RUNTIME_PROFILE,
         runtimeCheck: "javascript-runtime",
-        remediation:
-          "Rebuild the managed smolvm agent image with 'bun run agent:image', or configure a compatible runtime-v1 image.",
+        runtimeFailure: "unsupported-version",
+        remediation: "Provide Bun 1.3+ or Node 22+ in the configured sandbox host or image.",
       },
     })
     expect(JSON.stringify(failure)).not.toContain("http")

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -71,6 +71,7 @@ import {
 import { jsonSchema, type ToolSet, tool } from "ai"
 import { convertArrayToReadableStream, MockLanguageModelV4 } from "ai/test"
 import { AgentWorker, type AgentWorkerOptions } from "../src"
+import { AGENT_RUNTIME_PROFILE } from "../src/agent-runtime/profile"
 import { loadAgentSkills } from "../src/agent-skills"
 import { normalizeApiBaseUrl } from "../src/api-url"
 import { prepareAgentAttachments, toolResultAttachmentKey } from "../src/attachments"
@@ -852,7 +853,7 @@ interface RecordedCommand {
 
 class RecordingSandbox implements Sandbox {
   readonly id: string
-  readonly provider = "recording"
+  readonly provider: string
   readonly workingDirectory: string
   status: "running" | "stopped" | "failed" = "running"
   readonly commands: RecordedCommand[] = []
@@ -862,8 +863,9 @@ class RecordingSandbox implements Sandbox {
   readonly outputListedSizeOverrides = new Map<string, number>()
   destroyed = false
 
-  constructor(id: string) {
+  constructor(id: string, provider = "recording") {
     this.id = id
+    this.provider = provider
     this.workingDirectory = `/tmp/sixb-recording-sandbox/${id}`
   }
 
@@ -901,6 +903,26 @@ class RecordingSandbox implements Sandbox {
   async runCommand(command: string, args: readonly string[] = [], options: RunCommandOptions = {}) {
     this.commands.push({ command, args, options })
     const script = args.at(-1)
+    if (
+      command === "bash" &&
+      typeof script === "string" &&
+      script.includes("SIXB_BASH_ENV_READY")
+    ) {
+      return {
+        exitCode: 0,
+        stdout: "node\t22.0.0\tsixb agent CLI 1\n",
+        stderr: "",
+        durationMs: 1,
+      }
+    }
+    if (command === "bash" && script === "sixb project show") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({ id: PROJECT_ID }),
+        stderr: "",
+        durationMs: 1,
+      }
+    }
     if (command === "bash" && script === "create-agent-output") {
       this.writeOutputFile("report.txt", "generated report")
       return {
@@ -1095,6 +1117,37 @@ class OversizedOutputSandboxFactory extends RecordingSandboxFactory {
 class FailingSandboxFactory implements SandboxFactory {
   async create(): Promise<Sandbox> {
     throw new Error("sandbox provisioning unavailable")
+  }
+}
+
+class IncompatibleRuntimeSandbox extends RecordingSandbox {
+  constructor() {
+    super("incompatible-runtime", "smolvm")
+  }
+
+  override async runCommand(
+    command: string,
+    args: readonly string[] = [],
+    options: RunCommandOptions = {}
+  ): Promise<CommandResult> {
+    const script = args.at(-1)
+    if (
+      command === "bash" &&
+      typeof script === "string" &&
+      script.includes("SIXB_BASH_ENV_READY")
+    ) {
+      this.commands.push({ command, args, options })
+      return { exitCode: 29, stdout: "", stderr: "node: not found", durationMs: 1 }
+    }
+    return super.runCommand(command, args, options)
+  }
+}
+
+class IncompatibleRuntimeSandboxFactory implements SandboxFactory {
+  readonly sandbox = new IncompatibleRuntimeSandbox()
+
+  async create(): Promise<Sandbox> {
+    return this.sandbox
   }
 }
 
@@ -4994,7 +5047,9 @@ describe("AgentWorker", () => {
       }
       expect(createOptions.network.allow[0]?.origin).toBe("http://localhost:3002")
 
-      const command = sandboxes.sandboxes[0]?.commands[0]
+      const command = sandboxes.sandboxes[0]?.commands.find(
+        (candidate) => candidate.args.at(-1) === "print-sixb-env"
+      )
       expect(command?.command).toBe("bash")
       expect(command?.args).toEqual(["-lc", "print-sixb-env"])
       const env = command?.options.env
@@ -5007,15 +5062,20 @@ describe("AgentWorker", () => {
       expect(env?.SIXB_RUN_ID).toBe(runId)
       expect(env?.SIXB_CONTEXT_DIR).toContain("/.sixb/agent")
       expect(env?.SIXB_SKILLS_DIR).toContain("/.sixb/agent/skills")
+      expect(env?.SIXB_BIN_DIR).toContain("/.sixb/agent/bin")
+      expect(env?.SIXB_AGENT_RUNTIME_PROFILE).toBe(AGENT_RUNTIME_PROFILE)
+      expect(env?.SIXB_RUNTIME_PROBE_FILE).toContain("/.sixb/agent/runtime/read-probe.txt")
+      expect(env?.BASH_ENV).toContain("/.sixb/agent/context/bash-env")
       expect(env?.SIXB_RUN_CONTEXT).toContain("/.sixb/agent/context/run.json")
       expect(env?.SIXB_ATTACHMENTS).toContain("/.sixb/agent/context/attachments.json")
       expect(env?.SIXB_ATTACHMENT_DIR).toContain("/.sixb/agent/attachments")
       expect(env?.SIXB_OUTPUT_STAGING_DIR).toContain("/.sixb/agent/outputs/staging")
       expect(env?.SIXB_OUTPUT_DIR).toContain("/.sixb/agent/outputs/published")
       expect(env?.SIXB_API_GUIDE).toBeUndefined()
+      expect(env?.SIXB_CLI).toBeUndefined()
       expect(env?.SIXB_ACCESS_TOKEN).toBeUndefined()
 
-      if (!env?.SIXB_SKILLS_DIR || !env.SIXB_RUN_CONTEXT) {
+      if (!env?.SIXB_SKILLS_DIR || !env.SIXB_BIN_DIR || !env.BASH_ENV || !env.SIXB_RUN_CONTEXT) {
         throw new Error("Expected sandbox API env.")
       }
 
@@ -5025,6 +5085,16 @@ describe("AgentWorker", () => {
       if (!sandbox) {
         throw new Error("Expected a provisioned sandbox.")
       }
+
+      const bashEnv = sandbox.readFileContents(env.BASH_ENV)
+      expect(bashEnv).toContain('export PATH="$SIXB_BIN_DIR:$PATH"')
+      expect(bashEnv).toContain("export SIXB_BASH_ENV_READY=1")
+      if (!env.SIXB_RUNTIME_PROBE_FILE) {
+        throw new Error("Expected sandbox runtime probe path.")
+      }
+      expect(sandbox.readFileContents(env.SIXB_RUNTIME_PROBE_FILE)).toBe(
+        "first\nsixb-runtime-probe\nthird\n"
+      )
 
       const querySkill = sandbox.readFileContents(
         join(env.SIXB_SKILLS_DIR, "sixb-query", "SKILL.md")
@@ -5110,6 +5180,7 @@ describe("AgentWorker", () => {
         agentId: "assistant",
         threadId,
         runId,
+        runtimeProfile: AGENT_RUNTIME_PROFILE,
         apiBaseUrl: env.SIXB_API_BASE_URL,
         outputDir: env.SIXB_OUTPUT_DIR,
         outputStagingDir: env.SIXB_OUTPUT_STAGING_DIR,
@@ -5934,6 +6005,49 @@ describe("AgentWorker", () => {
       // Thread released so a later message can run.
       const thread = await storage.threads.getById({ projectId: PROJECT_ID, id: threadId })
       expect(thread?.activeRunId).toBeNull()
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("blocks sandbox tool use with actionable runtime-profile details", async () => {
+    const sandboxes = new IncompatibleRuntimeSandboxFactory()
+    const sixb = buildSixb(apiBashThenAnswerModel(), new InMemoryBroker(), sandboxes)
+    const storage = agentStorageOf(sixb)
+
+    const worker = new AgentWorker(sixb, workerOptions())
+    await worker.start()
+    try {
+      const {
+        run: { threadId },
+      } = await requestAgent(sixb, { agentId: "assistant", text: "hi" })
+      const run = await waitFor(
+        async () => {
+          const list = await storage.runs.list({ projectId: PROJECT_ID, threadId })
+          const found = list.runs[0]
+          return found && found.status !== "queued" && found.status !== "running" ? found : null
+        },
+        { label: "runtime profile run failed" }
+      )
+
+      expect(run.status).toBe("failed")
+      expect(run.error).toMatchObject({
+        code: "agent.execution_failed",
+        details: {
+          agentId: "assistant",
+          runId: run.id,
+          threadId,
+          provider: "smolvm",
+          runtimeProfile: AGENT_RUNTIME_PROFILE,
+          runtimeCheck: "javascript-runtime",
+          remediation: expect.stringContaining("bun run agent:image"),
+        },
+      })
+      expect(JSON.stringify(run.error)).not.toContain("node: not found")
+      expect(sandboxes.sandbox.destroyed).toBe(true)
+      expect(
+        (await listMessages(storage, threadId)).every((message) => message.role !== "assistant")
+      ).toBe(true)
     } finally {
       await worker.stop()
     }

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -457,6 +457,20 @@ function structuredAnswerModel(): MockLanguageModelV4 {
   })
 }
 
+function structuredAnswerUntilAbortedModel(): MockLanguageModelV4 {
+  return new MockLanguageModelV4({
+    modelId: "mock-model",
+    doGenerate: async (options) => {
+      await new Promise<void>((_resolve, reject) => {
+        const abort = () => reject(new DOMException("Aborted", "AbortError"))
+        if (options.abortSignal?.aborted) abort()
+        else options.abortSignal?.addEventListener("abort", abort, { once: true })
+      })
+      throw new Error("unreachable")
+    },
+  })
+}
+
 function invalidStructuredAnswerModel(): MockLanguageModelV4 {
   return new MockLanguageModelV4({
     modelId: "mock-model",
@@ -915,10 +929,16 @@ class RecordingSandbox implements Sandbox {
         durationMs: 1,
       }
     }
-    if (command === "bash" && script === "sixb project show") {
+    if (command === "bash" && script === "sixb doctor") {
       return {
         exitCode: 0,
-        stdout: JSON.stringify({ id: PROJECT_ID }),
+        stdout: JSON.stringify({
+          ok: true,
+          profile: AGENT_RUNTIME_PROFILE,
+          cli: { version: "1" },
+          javascript: { name: "node", version: "22.0.0" },
+          project: { id: PROJECT_ID },
+        }),
         stderr: "",
         durationMs: 1,
       }
@@ -1137,7 +1157,7 @@ class IncompatibleRuntimeSandbox extends RecordingSandbox {
       script.includes("SIXB_BASH_ENV_READY")
     ) {
       this.commands.push({ command, args, options })
-      return { exitCode: 29, stdout: "", stderr: "node: not found", durationMs: 1 }
+      return { exitCode: 24, stdout: "", stderr: "node: not found", durationMs: 1 }
     }
     return super.runCommand(command, args, options)
   }
@@ -1257,6 +1277,7 @@ async function queueWorkflowAgentNode(input: {
   readonly model: LanguageModelV4
   readonly tools?: readonly AgentToolDefinition[]
   readonly storage?: Storage
+  readonly sandboxes?: SandboxFactory
   readonly runId: string
   readonly requestedByPrincipal?: typeof REQUESTER
   readonly requesterGroupIds?: readonly string[]
@@ -1284,7 +1305,7 @@ async function queueWorkflowAgentNode(input: {
     lakeStorage: new InMemoryLakeStorage(),
     blobStorage: new InMemoryBlobStorage(),
     queues: new InMemoryQueues(),
-    sandboxes: new RecordingSandboxFactory(),
+    sandboxes: input.sandboxes ?? new RecordingSandboxFactory(),
   })
   const runs = sixb.storage.workflowRuns
   if (!runs) throw new Error("expected workflow run storage")
@@ -2065,6 +2086,57 @@ describe("AgentWorker", () => {
           nodeRunId,
         },
       })
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("fails a workflow agent node when concurrent sandbox preflight fails", async () => {
+    const sandboxes = new IncompatibleRuntimeSandboxFactory()
+    const { sixb, runs, nodeRunId } = await queueWorkflowAgentNode({
+      model: structuredAnswerUntilAbortedModel(),
+      sandboxes,
+      runId: "workflow-runtime-profile-failure",
+    })
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+
+    await worker.start()
+    try {
+      const execution = await waitFor(
+        async () => {
+          const record = await runs.agentNodes.getByNodeRunId({
+            projectId: PROJECT_ID,
+            nodeRunId,
+          })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "workflow runtime profile failure" }
+      )
+
+      expect(execution).toMatchObject({
+        status: "failed",
+        error: {
+          code: "agent.execution_failed",
+          details: {
+            agentId: "workflow-usage-agent",
+            workflowId: "workflow-usage-test",
+            workflowRunId: "workflow-runtime-profile-failure",
+            nodeId: "workflow-usage-step",
+            nodeRunId,
+            provider: "smolvm",
+            runtimeProfile: AGENT_RUNTIME_PROFILE,
+            runtimeCheck: "javascript-runtime",
+            runtimeFailure: "nonzero-exit",
+            runtimeExitCode: "24",
+            remediation: "Provide Bun 1.3+ or Node 22+ in the configured sandbox host or image.",
+          },
+        },
+      })
+      await expect(
+        runs.getById({ projectId: PROJECT_ID, id: "workflow-runtime-profile-failure" })
+      ).resolves.toMatchObject({ status: "failed" })
+      expect(sandboxes.sandbox.destroyed).toBe(true)
+      expect(JSON.stringify(execution.error)).not.toContain("node: not found")
     } finally {
       await worker.stop()
     }
@@ -6040,7 +6112,9 @@ describe("AgentWorker", () => {
           provider: "smolvm",
           runtimeProfile: AGENT_RUNTIME_PROFILE,
           runtimeCheck: "javascript-runtime",
-          remediation: expect.stringContaining("bun run agent:image"),
+          runtimeFailure: "nonzero-exit",
+          runtimeExitCode: "24",
+          remediation: "Provide Bun 1.3+ or Node 22+ in the configured sandbox host or image.",
         },
       })
       expect(JSON.stringify(run.error)).not.toContain("node: not found")


### PR DESCRIPTION
## Why

Provider defaults are not enough: users can configure custom images, snapshots, hosts, and
third-party providers. If one is incompatible, the run should fail before the model spends tokens
discovering missing commands or narrating sandbox errors to the user.

## What changes

- Add a worker-owned `sixb-agent-runtime/v1` preflight immediately after sandbox provisioning.
- Run one deterministic, network-free behavioral probe that verifies:
  - Bash and `BASH_ENV`
  - the installed CLI path and file modes
  - bounded-read utilities
  - Bun/Node presence and minimum version
  - CLI execution
- Run `sixb project show` through the scoped gateway to prove fetch, connectivity, TLS/CA behavior,
  capability routing, and project identity together.
- Block all model-issued sandbox commands until both checks pass.
- Destroy partially provisioned sandboxes on failure.
- Record a stable failed check and provider-specific remediation without persisting raw stderr or
  the gateway capability URL.
- Expose the runtime profile in the run context and `sixb doctor`.

## Why behavioral preflight

Provider names and image labels do not prove the concrete environment. Testing the same command
paths the worker will actually use catches custom-image drift, bad file modes, missing PATH
bootstrap, unsupported runtimes, and unreachable gateways without expanding the generic
`Sandbox` interface.

The preflight is deliberately two commands: one local probe and one end-to-end gateway probe. That
keeps startup cost bounded while producing much clearer failures than waiting for an agent command.

## Verification

- Runtime-profile unit and local conformance tests
- Stable error/redaction coverage
- Worker integration coverage for successful provisioning, command ordering, cleanup, and
  incompatible-runtime failure
- 79 targeted worker/preflight tests
- Agent worker typecheck and generated CLI freshness
- Biome on all touched code, tests, and docs

## Stack

**5 of 7.** Depends on the provider runtime foundations in PR 4.

### Full stack

1. [#465 — objects: add exact-reference query sources](https://github.com/sixb-ai/sixb/pull/465)
2. [#466 — objects: query links for object sets](https://github.com/sixb-ai/sixb/pull/466)
3. [#467 — agents: ship a self-documenting sandbox CLI](https://github.com/sixb-ai/sixb/pull/467)
4. [#468 — sandboxes: standardize the agent runtime](https://github.com/sixb-ai/sixb/pull/468)
5. [#469 — agents: validate sandbox readiness before execution](https://github.com/sixb-ai/sixb/pull/469)
6. [#470 — agents: replace built-in API skills with CLI guidance](https://github.com/sixb-ai/sixb/pull/470)
7. [#471 — agent-ui: present agent activity in product language](https://github.com/sixb-ai/sixb/pull/471)
