### PR TITLE
agent-ui: present agent activity in product language

### DIFF
--- a/packages/agent-ui/src/activity-label.ts
+++ b/packages/agent-ui/src/activity-label.ts
@@ -1,0 +1,38 @@
+import {
+  classifyCommand,
+  coerceBashInput,
+  coerceBashOutput,
+  describeBash,
+  humanize,
+} from "./bash/interpret"
+import type { NormalizedPart, NormalizedTool } from "./parts"
+import { coerceReadInput, coerceReadOutput, describeRead } from "./read/interpret"
+
+/** A short, present-tense label for the newest visible step in a live work group. */
+export function latestWorkLabel(parts: readonly NormalizedPart[]): string {
+  for (let index = parts.length - 1; index >= 0; index -= 1) {
+    const part = parts[index]
+    if (part?.kind === "tool") return toolProgressLabel(part.tool)
+    if (part?.kind === "reasoning" && part.text.trim()) return "Thinking"
+  }
+  return "Working"
+}
+
+function toolProgressLabel(tool: NormalizedTool): string {
+  if (tool.toolName === "bash") {
+    if (tool.state === "input-streaming") return "Preparing a command"
+    const input = coerceBashInput(tool.input)
+    const command = input?.command ?? tool.inputText ?? ""
+    const intent = classifyCommand(command)
+    const description = describeBash(intent, coerceBashOutput(tool.output))
+    return description.runningTitle
+  }
+
+  if (tool.toolName === "read") {
+    const description = describeRead(coerceReadInput(tool.input), coerceReadOutput(tool.output))
+    return `Reading ${description.target}`
+  }
+
+  const name = humanize(tool.toolName)
+  return name ? `Using ${name}` : "Working"
+}

--- a/packages/agent-ui/src/activity-label.ts
+++ b/packages/agent-ui/src/activity-label.ts
@@ -13,7 +13,9 @@ export function latestWorkLabel(parts: readonly NormalizedPart[]): string {
   for (let index = parts.length - 1; index >= 0; index -= 1) {
     const part = parts[index]
     if (part?.kind === "tool") return toolProgressLabel(part.tool)
-    if (part?.kind === "reasoning" && part.text.trim()) return "Thinking"
+    // `reasoning-start` has no text. Keep the pre-token "Thinking" label through that lifecycle
+    // chunk so the first reasoning delta does not look like a new row mounting.
+    if (part?.kind === "reasoning") return "Thinking"
   }
   return "Working"
 }

--- a/packages/agent-ui/src/bash/BashToolView.tsx
+++ b/packages/agent-ui/src/bash/BashToolView.tsx
@@ -196,7 +196,7 @@ function BashResult({
     ) : null
   }
 
-  if (intent.kind === "generic") {
+  if (intent.kind === "generic" || intent.kind === "compound") {
     return <GenericCommandView parsed={parsed} command={command} />
   }
   if (intent.kind === "read-skill") return <StructuredDataView parsed={parsed} />

--- a/packages/agent-ui/src/bash/BashToolView.tsx
+++ b/packages/agent-ui/src/bash/BashToolView.tsx
@@ -21,19 +21,20 @@ import {
   classifyCommand,
   coerceBashInput,
   coerceBashOutput,
+  commandPreview,
   describeBash,
   type ParsedBashOutput,
 } from "./interpret"
 import {
   ActionResultView,
   ActionRunView,
-  ApiDataView,
   FacetsView,
   GenericCommandView,
   ObjectDetailView,
   ObjectListView,
   ObjectTypeSchemaView,
   ObjectTypesView,
+  StructuredDataView,
   TelemetryBulkView,
   TelemetryHistoryView,
 } from "./renderers"
@@ -67,12 +68,16 @@ const ICONS: Record<BashIcon, LucideIcon> = {
  * A "View raw" toggle keeps the underlying payload one click away for developers.
  */
 export function BashToolView({ tool }: { tool: BashTool }) {
+  if (tool.state === "input-streaming") {
+    return <ToolLine icon={Terminal} label="Preparing a command" running />
+  }
+
   const input = coerceBashInput(tool.input)
   const command = input?.command ?? tool.inputText ?? ""
   const intent = classifyCommand(command)
   const parsed = coerceBashOutput(tool.output)
 
-  const running = tool.state === "input-streaming" || tool.state === "input-available"
+  const running = tool.state === "input-available"
   const isError = tool.state === "output-error" || (parsed !== null && !parsed.ok)
   const description = describeBash(intent, parsed)
   const Icon = ICONS[description.icon]
@@ -88,7 +93,7 @@ export function BashToolView({ tool }: { tool: BashTool }) {
         <CollapsibleTrigger className="group flex w-fit max-w-full items-center gap-1.5 text-[13px] leading-normal text-muted-foreground transition-colors hover:text-foreground">
           <Icon className="size-3.5 shrink-0" />
           <span className="min-w-0 truncate font-medium">{label}</span>
-          <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
+          <ChevronRight className="size-3.5 shrink-0 opacity-0 transition-all group-hover:opacity-100 group-focus-visible:opacity-100 group-data-[state=open]:rotate-90 group-data-[state=open]:opacity-100" />
         </CollapsibleTrigger>
         <CollapsibleContent>
           <div className="mt-3 space-y-2 text-xs">
@@ -123,7 +128,7 @@ export function BashToolView({ tool }: { tool: BashTool }) {
             {description.detail}
           </span>
         ) : null}
-        <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
+        <ChevronRight className="size-3.5 shrink-0 opacity-0 transition-all group-hover:opacity-100 group-focus-visible:opacity-100 group-data-[state=open]:rotate-90 group-data-[state=open]:opacity-100" />
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="mt-3 space-y-3 text-xs">
@@ -160,12 +165,8 @@ function ToolLine({
 
 /** Results whose headline already says everything — no expandable body needed. */
 function isLeafResult(intent: BashIntent, running: boolean): boolean {
-  if (running) return false
-  return (
-    intent.kind === "api-count" ||
-    intent.kind === "api-exists" ||
-    intent.kind === "api-telemetry-latest"
-  )
+  if (running || intent.kind !== "sixb") return false
+  return ["objects.count", "objects.exists", "telemetry.latest"].includes(intent.command)
 }
 
 function BashResult({
@@ -178,41 +179,45 @@ function BashResult({
   command: string
 }) {
   if (parsed === null) {
-    // Still running — show the command being run, nothing else.
+    // Still running — keep multiline payloads folded; the raw disclosure retains the full command.
     return command ? (
-      <pre className="overflow-x-auto rounded bg-muted/50 px-2 py-1.5 font-mono text-[11px] text-muted-foreground">
+      <pre className="overflow-x-auto rounded bg-muted/50 px-2 py-1.5 font-mono text-[11px] whitespace-pre-wrap text-muted-foreground">
         <span className="select-none text-muted-foreground/50">$ </span>
-        {command}
+        {commandPreview(command)}
       </pre>
     ) : null
   }
 
-  switch (intent.kind) {
-    case "api-object-types":
+  if (intent.kind === "generic") {
+    return <GenericCommandView parsed={parsed} command={command} />
+  }
+  if (intent.kind === "read-skill") return <StructuredDataView parsed={parsed} />
+
+  switch (intent.command) {
+    case "ontology.list":
       return <ObjectTypesView parsed={parsed} />
-    case "api-objects-list":
-    case "api-objects-query":
+    case "objects.list":
+    case "objects.get":
+    case "objects.search":
+    case "objects.query":
       return <ObjectListView parsed={parsed} />
-    case "api-object-detail":
+    case "objects.inspect":
       return <ObjectDetailView parsed={parsed} />
-    case "api-object-type-detail":
+    case "ontology.get":
       return <ObjectTypeSchemaView parsed={parsed} />
-    case "api-facets":
+    case "objects.facets":
       return <FacetsView parsed={parsed} />
-    case "api-telemetry-history":
+    case "telemetry.history":
       return <TelemetryHistoryView parsed={parsed} />
-    case "api-telemetry-bulk":
+    case "telemetry.query":
       return <TelemetryBulkView parsed={parsed} />
-    case "api-action-request":
+    case "actions.request":
       return <ActionResultView parsed={parsed} />
-    case "api-action-run":
+    case "action-runs.get":
       return <ActionRunView parsed={parsed} />
-    case "generic":
-      return <GenericCommandView parsed={parsed} command={command} />
-    // Remaining surfaces (actions list, project info) render through the neutral data view —
-    // structured, never raw JSON.
+    // Remaining CLI surfaces render through the neutral data view — structured, never raw JSON.
     default:
-      return <ApiDataView parsed={parsed} />
+      return <StructuredDataView parsed={parsed} />
   }
 }
 

--- a/packages/agent-ui/src/bash/BashToolView.tsx
+++ b/packages/agent-ui/src/bash/BashToolView.tsx
@@ -1,5 +1,4 @@
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@sixb/ui/components"
-import { cn } from "@sixb/ui/lib/utils"
 import {
   Activity,
   BarChart3,
@@ -15,6 +14,7 @@ import {
   Zap,
 } from "lucide-react"
 import { useState } from "react"
+import { ActivityStatusText } from "../components/ActivityStatus"
 import {
   type BashIcon,
   type BashIntent,
@@ -122,7 +122,11 @@ export function BashToolView({ tool }: { tool: BashTool }) {
     <Collapsible>
       <CollapsibleTrigger className="group flex w-fit max-w-full items-center gap-1.5 text-[13px] leading-normal text-muted-foreground transition-colors hover:text-foreground">
         <Icon className="size-3.5 shrink-0" />
-        <span className={cn("min-w-0 truncate font-medium", running && "shimmer")}>{label}</span>
+        {running ? (
+          <ActivityStatusText label={label} className="font-medium shimmer" />
+        ) : (
+          <span className="min-w-0 truncate font-medium">{label}</span>
+        )}
         {!running && description.detail ? (
           <span className="min-w-0 shrink truncate text-muted-foreground/60">
             {description.detail}
@@ -155,7 +159,11 @@ function ToolLine({
   return (
     <div className="flex w-fit max-w-full items-center gap-1.5 text-[13px] leading-normal text-muted-foreground">
       <Icon className="size-3.5 shrink-0" />
-      <span className={cn("min-w-0 truncate font-medium", running && "shimmer")}>{label}</span>
+      {running ? (
+        <ActivityStatusText label={label} className="font-medium shimmer" />
+      ) : (
+        <span className="min-w-0 truncate font-medium">{label}</span>
+      )}
       {detail ? (
         <span className="min-w-0 shrink truncate text-muted-foreground/60">{detail}</span>
       ) : null}

--- a/packages/agent-ui/src/bash/data.ts
+++ b/packages/agent-ui/src/bash/data.ts
@@ -1,5 +1,5 @@
 // Pure data shaping for the bash renderers: pull the rows, columns, series, and labels a native
-// view needs out of a decoded API response. No React here — these are exercised directly by unit
+// view needs out of decoded CLI output. No React here — these are exercised directly by unit
 // tests and re-used by `renderers.tsx`, which owns the JSX.
 
 import { formatRelativeTime } from "../format"
@@ -24,7 +24,7 @@ export interface SeriesPoint {
   readonly timestamp: string
 }
 
-/** Objects across both the list (`[...]`) and query (`{ objects: [...] }`) response envelopes. */
+/** Objects across both the list (`[...]`) and query (`{ objects: [...] }`) CLI output shapes. */
 export function extractObjects(json: unknown): ObjectRecord[] | null {
   if (Array.isArray(json)) return json.filter(isRecord) as ObjectRecord[]
   if (isRecord(json) && Array.isArray(json.objects)) {

--- a/packages/agent-ui/src/bash/interpret.ts
+++ b/packages/agent-ui/src/bash/interpret.ts
@@ -1,8 +1,6 @@
-// Interpret the single `bash` tool into a human-friendly view. The agent only ever does a small,
-// predictable set of things — read a Sixb Agent Skill, curl the per-run Sixb API proxy, or run a
-// plain shell command — because we author the skills and the proxy that shape those commands. This
-// module turns the raw `{ command }` input and `{ exitCode, stdout, ... }` output into a typed
-// intent plus a friendly title, so the UI can render native views instead of escaped JSON.
+// Interpret the single `bash` tool into a human-friendly view. Sixb interactions go through a
+// stable CLI command tree, so the UI only needs to tokenize one command and identify its group and
+// operation. Plain shell commands and the initial skill read keep neutral fallbacks.
 
 /** The bash tool input as authored by the agent. */
 export interface BashInput {
@@ -21,31 +19,41 @@ export interface BashOutput {
   readonly stderrTruncated: boolean
 }
 
+const CLI_COMMANDS = {
+  project: ["show"],
+  ontology: ["list", "get"],
+  objects: ["inspect", "list", "get", "search", "query", "count", "exists", "facets", "links"],
+  telemetry: ["latest", "history", "query"],
+  actions: ["list", "get", "request"],
+  "action-runs": ["list", "get"],
+  files: ["upload", "download"],
+  workflows: ["list", "get", "start"],
+  "workflow-runs": ["list", "get"],
+  api: ["get", "post"],
+} as const
+
+type CliGroup = keyof typeof CLI_COMMANDS
+type CliCommandName = {
+  [Group in CliGroup]: `${Group}.${(typeof CLI_COMMANDS)[Group][number]}`
+}[CliGroup]
+
+export type SixbCommandName =
+  | "help"
+  | "version"
+  | "doctor"
+  | "context"
+  | "objects.query-example"
+  | CliCommandName
+  | "unknown"
+
 /** What the agent was trying to do, derived from the command string. */
 export type BashIntent =
-  | { readonly kind: "api-object-types" }
-  | { readonly kind: "api-object-type-detail"; readonly objectTypeId: string }
-  | { readonly kind: "api-objects-list"; readonly objectTypeId?: string }
-  | { readonly kind: "api-objects-query"; readonly objectTypeId?: string }
-  | { readonly kind: "api-count"; readonly objectTypeId?: string }
-  | { readonly kind: "api-exists"; readonly objectTypeId?: string }
-  | { readonly kind: "api-facets"; readonly objectTypeId?: string }
-  | { readonly kind: "api-object-detail"; readonly objectTypeId: string; readonly objectId: string }
   | {
-      readonly kind: "api-telemetry-latest"
-      readonly objectId: string
-      readonly propertyId: string
+      readonly kind: "sixb"
+      readonly command: SixbCommandName
+      /** Arguments after the recognized command path. Quotes have been removed. */
+      readonly args: readonly string[]
     }
-  | {
-      readonly kind: "api-telemetry-history"
-      readonly objectId: string
-      readonly propertyId: string
-    }
-  | { readonly kind: "api-telemetry-bulk" }
-  | { readonly kind: "api-actions-list" }
-  | { readonly kind: "api-action-request"; readonly actionId: string }
-  | { readonly kind: "api-action-run"; readonly runId: string }
-  | { readonly kind: "api-project" }
   | { readonly kind: "read-skill"; readonly skillName?: string; readonly reference?: string }
   | { readonly kind: "generic"; readonly command: string }
 
@@ -91,118 +99,105 @@ export function coerceBashOutput(output: unknown): ParsedBashOutput | null {
 // --- Command classification ------------------------------------------------
 
 export function classifyCommand(command: string): BashIntent {
-  const api = extractApiRequest(command)
-  if (api) {
-    return classifyApiRequest(api)
-  }
+  const sixb = classifySixbCommand(command)
+  if (sixb) return sixb
   const skill = classifySkillRead(command)
   if (skill) return skill
   return { kind: "generic", command: command.trim() }
 }
 
-interface ApiRequest {
-  readonly method: string
-  readonly segments: readonly string[]
-  readonly query: URLSearchParams
-  readonly body: unknown
+function classifySixbCommand(command: string): Extract<BashIntent, { kind: "sixb" }> | null {
+  const tokens = tokenizeShellCommand(command)
+  if (!tokens || executableName(tokens[0]) !== "sixb") return null
+
+  const cliArgs = tokens.slice(1)
+  const helpIndex = cliArgs.findIndex(
+    (token) => token === "--help" || token === "-h" || token === "help"
+  )
+  if (helpIndex !== -1 || cliArgs.length === 0) {
+    return { kind: "sixb", command: "help", args: cliArgs.filter((_, i) => i !== helpIndex) }
+  }
+  if (cliArgs[0] === "version" || cliArgs[0] === "--version") {
+    return { kind: "sixb", command: "version", args: cliArgs.slice(1) }
+  }
+  if (cliArgs[0] === "doctor" || cliArgs[0] === "context") {
+    return { kind: "sixb", command: cliArgs[0], args: cliArgs.slice(1) }
+  }
+
+  const [group, operation, ...args] = cliArgs
+  if (!group || !operation) {
+    return { kind: "sixb", command: "help", args: group ? [group] : [] }
+  }
+  if (!isCliGroup(group) || !isCliOperation(group, operation)) {
+    return { kind: "sixb", command: "unknown", args: cliArgs }
+  }
+  if (group === "objects" && operation === "query" && optionValue(args, "--example")) {
+    return { kind: "sixb", command: "objects.query-example", args }
+  }
+  return { kind: "sixb", command: `${group}.${operation}` as CliCommandName, args }
 }
 
-/** Pull the `/api/...` request out of a curl command, independent of the base-URL placeholder. */
-function extractApiRequest(command: string): ApiRequest | null {
-  const match = command.match(/\/api\/[^\s"'`]*/)
-  if (!match) return null
-
-  const raw = match[0]
-  const queryIndex = raw.indexOf("?")
-  const path = queryIndex === -1 ? raw : raw.slice(0, queryIndex)
-  const query = new URLSearchParams(queryIndex === -1 ? "" : raw.slice(queryIndex + 1))
-  const segments = path.split("/").filter(Boolean).slice(1) // drop leading "api"
-
-  // Detect the method on the command with quoted spans blanked out, so a `-X`/`-d` token that only
-  // appears inside the URL, a header value, or a JSON body is never mistaken for a real curl flag.
-  const flags = command.replace(/'[^']*'|"[^"]*"/g, " ")
-  const explicitMethod = flags.match(/(?:-X|--request)\s*([A-Za-z]+)/)?.[1]
-  // curl treats a body flag with no explicit method as an implicit POST, so infer it here rather
-  // than mislabelling e.g. `curl .../api/actions/:id -d '{}'` as a GET (an actions list).
-  const method = explicitMethod
-    ? explicitMethod.toUpperCase()
-    : CURL_DATA_FLAG_RE.test(flags)
-      ? "POST"
-      : "GET"
-
-  return { method, segments, query, body: extractCurlBody(command) }
+function isCliGroup(value: string): value is CliGroup {
+  return Object.hasOwn(CLI_COMMANDS, value)
 }
 
-// A curl body flag (`-d`, `--data`, `--data-raw|binary|ascii|urlencode`) as a standalone token,
-// including glued forms (`-d@file`, `--data=…`). Detects presence for method inference only — apply
-// it to the quote-blanked command so payload text can't trigger a false match.
-const CURL_DATA_FLAG_RE = /(?:^|\s)(?:--data(?:-raw|-binary|-ascii|-urlencode)?|-d)(?=[\s=@])/
-
-/** Extract and JSON-parse a curl `--data '...'` / `-d '...'` payload, if present. */
-function extractCurlBody(command: string): unknown {
-  const match = command.match(/(?:--data(?:-raw|-binary|-ascii)?|-d)\s+(['"])([\s\S]*?)\1/)
-  if (!match) return undefined
-  return tryParseJson(match[2])
+function isCliOperation<Group extends CliGroup>(
+  group: Group,
+  value: string
+): value is (typeof CLI_COMMANDS)[Group][number] {
+  return (CLI_COMMANDS[group] as readonly string[]).includes(value)
 }
 
-function classifyApiRequest(api: ApiRequest): BashIntent {
-  const [head, ...rest] = api.segments
+/**
+ * Tokenize the small shell subset needed for a direct CLI invocation. Compound shell expressions
+ * intentionally fall back to the generic command view; guessing which command owns a pipeline or
+ * redirection would make the transcript misleading.
+ */
+function tokenizeShellCommand(command: string): string[] | null {
+  const tokens: string[] = []
+  let token = ""
+  let quote: "'" | '"' | null = null
+  let escaped = false
 
-  if (head === "project") return { kind: "api-project" }
-
-  // Bulk telemetry lives at the top level: POST /api/telemetry/history
-  if (head === "telemetry") return { kind: "api-telemetry-bulk" }
-
-  if (head === "object-types") {
-    return rest.length === 0
-      ? { kind: "api-object-types" }
-      : { kind: "api-object-type-detail", objectTypeId: rest[0] }
+  const push = () => {
+    if (token) tokens.push(token)
+    token = ""
   }
 
-  if (head === "actions") {
-    if (rest.length === 0) return { kind: "api-actions-list" }
-    if (api.method === "POST") return { kind: "api-action-request", actionId: rest[0] }
-    return { kind: "api-actions-list" }
+  for (const character of command.trim()) {
+    if (escaped) {
+      token += character
+      escaped = false
+      continue
+    }
+    if (character === "\\" && quote !== "'") {
+      escaped = true
+      continue
+    }
+    if (quote) {
+      if (character === quote) quote = null
+      else token += character
+      continue
+    }
+    if (character === "'" || character === '"') {
+      quote = character
+      continue
+    }
+    if (/\s/.test(character)) {
+      push()
+      continue
+    }
+    if ("|;&<>()`".includes(character)) return null
+    token += character
   }
 
-  // Action run lifecycle: GET /api/action-runs/:runId
-  if (head === "action-runs" && rest.length >= 1) {
-    return { kind: "api-action-run", runId: rest[0] }
-  }
-
-  if (head === "objects") {
-    return classifyObjectsRequest(api, rest)
-  }
-
-  return { kind: "generic", command: api.segments.join("/") }
+  if (quote || escaped) return null
+  push()
+  return tokens
 }
 
-function classifyObjectsRequest(api: ApiRequest, rest: readonly string[]): BashIntent {
-  if (rest.length === 0) {
-    return { kind: "api-objects-list", objectTypeId: api.query.get("objectTypeId") ?? undefined }
-  }
-
-  if (rest[0] === "query") {
-    const objectTypeId = findObjectTypeId(api.body)
-    if (rest[1] === "count") return { kind: "api-count", objectTypeId }
-    if (rest[1] === "exists") return { kind: "api-exists", objectTypeId }
-    if (rest[1] === "facets") return { kind: "api-facets", objectTypeId }
-    return { kind: "api-objects-query", objectTypeId }
-  }
-
-  // /api/objects/:type/:id/telemetry/:prop/(latest|history)
-  if (rest.length >= 4 && rest[2] === "telemetry" && rest[3]) {
-    const objectId = rest[1]
-    const propertyId = rest[3]
-    return rest[4] === "history"
-      ? { kind: "api-telemetry-history", objectId, propertyId }
-      : { kind: "api-telemetry-latest", objectId, propertyId }
-  }
-  if (rest.length >= 2) {
-    return { kind: "api-object-detail", objectTypeId: rest[0], objectId: rest[1] }
-  }
-
-  return { kind: "api-objects-list", objectTypeId: rest[0] }
+function executableName(value: string | undefined): string | undefined {
+  return value?.split("/").at(-1)
 }
 
 const SKILL_READ_RE = /\b(?:cat|less|bat|head|tail|sed|nl)\b/
@@ -246,8 +241,82 @@ export interface BashDescription {
 }
 
 export function describeBash(intent: BashIntent, parsed: ParsedBashOutput | null): BashDescription {
-  switch (intent.kind) {
-    case "api-object-types": {
+  if (intent.kind === "sixb") return describeSixb(intent, parsed)
+  if (intent.kind === "read-skill") {
+    const label = skillLabel(intent)
+    return icon("skill", `Read the ${label}`, `Reading the ${label}`)
+  }
+  return describeGenericCommand(intent.command)
+}
+
+function describeGenericCommand(command: string): BashDescription {
+  const firstLine = command.trim().split(/\r?\n/, 1)[0]?.trim() ?? ""
+  const fileKind = writtenFileKind(command, firstLine)
+  if (fileKind) {
+    return icon("terminal", `Created ${fileKind}`, `Creating ${fileKind}`)
+  }
+  if (/\bapply_patch\b/.test(firstLine)) {
+    return icon("terminal", "Edited files", "Editing files")
+  }
+  if (/(?:^|[;&|]\s*|\s)(?:rg|grep)(?:\s|$)/.test(firstLine)) {
+    return icon("terminal", "Searched files", "Searching files")
+  }
+  if (/(?:^|[;&|]\s*|\s)bun\s+test(?:\s|$)/.test(firstLine)) {
+    return icon("terminal", "Ran tests", "Running tests")
+  }
+  if (/(?:^|[;&|]\s*|\s)mkdir(?:\s|$)/.test(firstLine)) {
+    return icon("terminal", "Created a folder", "Creating a folder")
+  }
+  if (/(?:^|[;&|]\s*|\s)cp(?:\s|$)/.test(firstLine)) {
+    return icon("terminal", "Copied files", "Copying files")
+  }
+  if (/(?:^|[;&|]\s*|\s)mv(?:\s|$)/.test(firstLine)) {
+    return icon("terminal", "Moved files", "Moving files")
+  }
+  return icon("terminal", "Ran", "Running a command", commandPreview(command, 64))
+}
+
+function writtenFileKind(command: string, firstLine: string): string | null {
+  if (!/(?:^|\s)(?:cat|tee|printf|echo)(?:\s|$)/.test(firstLine)) return null
+  const redirect = firstLine.match(/(?:^|\s)>{1,2}\s*(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))/)
+  if (!redirect) return null
+
+  const target = (redirect[1] ?? redirect[2] ?? redirect[3] ?? "").toLowerCase()
+  if (/<!doctype\s+html|<html(?:\s|>)/i.test(command) || /\.html?$/.test(target)) {
+    return "an HTML file"
+  }
+  if (/\.json$/.test(target)) return "a JSON file"
+  if (/\.(?:md|mdx)$/.test(target)) return "a Markdown file"
+  if (/\.(?:csv|tsv)$/.test(target)) return "a data file"
+  return "a file"
+}
+
+/** A stable one-line command preview. Multiline payloads stay folded behind the raw disclosure. */
+export function commandPreview(command: string, max = 96): string {
+  const lines = command.trim().split(/\r?\n/)
+  const firstLine = truncateEnd(lines[0]?.trim() ?? "", max)
+  if (lines.length <= 1) return firstLine
+  const remaining = lines.length - 1
+  return `${firstLine}\n… ${remaining.toLocaleString()} more ${remaining === 1 ? "line" : "lines"}`
+}
+
+function describeSixb(
+  intent: Extract<BashIntent, { kind: "sixb" }>,
+  parsed: ParsedBashOutput | null
+): BashDescription {
+  const type = commandObjectType(intent, parsed)
+  switch (intent.command) {
+    case "help": {
+      const subject = helpSubject(intent.args)
+      return icon("skill", `Checked ${subject}`, `Checking ${subject}`)
+    }
+    case "version":
+      return icon("terminal", "Checked the Sixb version", "Checking the Sixb version")
+    case "doctor":
+      return icon("terminal", "Checked the agent runtime", "Checking the agent runtime")
+    case "context":
+      return icon("project", "Read the run context", "Reading the run context")
+    case "ontology.list": {
       const n = arrayLength(parsed?.json)
       return icon(
         "ontology",
@@ -256,23 +325,36 @@ export function describeBash(intent: BashIntent, parsed: ParsedBashOutput | null
         count(n, "object type")
       )
     }
-    case "api-object-type-detail":
+    case "ontology.get":
       return icon(
         "ontology",
-        `Inspected the ${humanize(intent.objectTypeId)} type`,
-        `Inspecting the ${humanize(intent.objectTypeId)} type`
+        `Inspected the ${humanize(intent.args[0]) || "object"} type`,
+        `Inspecting the ${humanize(intent.args[0]) || "object"} type`
       )
-    case "api-objects-list":
-    case "api-objects-query": {
+    case "objects.inspect": {
+      const objectId = intent.args[1] ?? "object"
+      return icon(
+        "object",
+        `Inspected ${objectId}`,
+        `Inspecting ${objectId}`,
+        graphDetail(parsed?.json)
+      )
+    }
+    case "objects.list":
+    case "objects.get":
+    case "objects.search":
+    case "objects.query": {
       const n = objectCount(parsed?.json)
-      const label = humanize(intent.objectTypeId) || "object"
+      const label = humanize(type) || "object"
       const title = n === null ? "Queried objects" : `Found ${count(n, label)}`
       return icon("objects", title, `Looking up ${plural(label)}`)
     }
-    case "api-count": {
+    case "objects.query-example":
+      return icon("skill", "Read a query example", "Reading a query example")
+    case "objects.count": {
       const value = numberField(parsed?.json, "count")
       // Singular base — `plural()` adds the suffix, so "objects" here would become "objectses".
-      const label = humanize(intent.objectTypeId) || "object"
+      const label = humanize(type) || "object"
       return icon(
         "count",
         `Counted ${plural(label)}`,
@@ -280,7 +362,7 @@ export function describeBash(intent: BashIntent, parsed: ParsedBashOutput | null
         value === null ? undefined : value.toLocaleString()
       )
     }
-    case "api-exists": {
+    case "objects.exists": {
       const value = boolField(parsed?.json, "exists")
       return icon(
         "count",
@@ -289,27 +371,34 @@ export function describeBash(intent: BashIntent, parsed: ParsedBashOutput | null
         value === null ? undefined : value ? "Yes" : "No"
       )
     }
-    case "api-facets":
+    case "objects.facets":
       return icon("facets", "Broke down the data", "Breaking down the data")
-    case "api-object-detail":
-      return icon("object", `Opened ${intent.objectId}`, `Opening ${intent.objectId}`)
-    case "api-telemetry-latest":
+    case "objects.links": {
+      const n = nestedArrayLength(parsed?.json, "links")
+      return icon(
+        "objects",
+        `Read links for ${intent.args[1] ?? "an object"}`,
+        `Reading links for ${intent.args[1] ?? "an object"}`,
+        count(n, "link")
+      )
+    }
+    case "telemetry.latest":
       return icon(
         "telemetry",
-        `Read latest ${humanize(intent.propertyId)}`,
-        `Reading latest ${humanize(intent.propertyId)}`,
+        `Read latest ${humanize(intent.args[2]) || "telemetry"}`,
+        `Reading latest ${humanize(intent.args[2]) || "telemetry"}`,
         latestReading(parsed?.json)
       )
-    case "api-telemetry-history": {
+    case "telemetry.history": {
       const n = arrayLength(parsed?.json)
       return icon(
         "telemetry",
-        `Read ${humanize(intent.propertyId)} history`,
-        `Reading ${humanize(intent.propertyId)} history`,
+        `Read ${humanize(intent.args[2]) || "telemetry"} history`,
+        `Reading ${humanize(intent.args[2]) || "telemetry"} history`,
         count(n, "point")
       )
     }
-    case "api-telemetry-bulk": {
+    case "telemetry.query": {
       const n = seriesCount(parsed?.json)
       return icon(
         "telemetry",
@@ -318,32 +407,102 @@ export function describeBash(intent: BashIntent, parsed: ParsedBashOutput | null
         n === null ? undefined : `${n} series`
       )
     }
-    case "api-action-run": {
+    case "actions.list": {
+      const n = arrayLength(parsed?.json)
+      return icon(
+        "actions",
+        "Listed available actions",
+        "Listing available actions",
+        count(n, "action")
+      )
+    }
+    case "actions.get":
+      return icon(
+        "actions",
+        `Inspected the ${humanize(intent.args[0]) || "action"} action`,
+        `Inspecting the ${humanize(intent.args[0]) || "action"} action`
+      )
+    case "actions.request":
+      return icon(
+        "actions",
+        `Ran the ${humanize(intent.args[0]) || "requested"} action`,
+        `Running the ${humanize(intent.args[0]) || "requested"} action`,
+        actionOutcome(parsed?.json)
+      )
+    case "action-runs.get": {
       const run = actionRunInfo(parsed?.json)
       return icon("actions", actionRunTitle(run), "Checking the action run", run.subjectLabel)
     }
-    case "api-actions-list":
-      return icon("actions", "Listed available actions", "Listing available actions")
-    case "api-action-request":
+    case "action-runs.list": {
+      const n = arrayLength(parsed?.json)
+      return icon("actions", "Listed action runs", "Listing action runs", count(n, "run"))
+    }
+    case "workflows.list": {
+      const n = arrayLength(parsed?.json)
+      return icon("actions", "Listed workflows", "Listing workflows", count(n, "workflow"))
+    }
+    case "workflows.get":
       return icon(
         "actions",
-        `Ran the ${humanize(intent.actionId)} action`,
-        `Running the ${humanize(intent.actionId)} action`,
-        actionOutcome(parsed?.json)
+        `Inspected the ${humanize(intent.args[0]) || "workflow"} workflow`,
+        `Inspecting the ${humanize(intent.args[0]) || "workflow"} workflow`
       )
-    case "api-project":
-      return icon("project", "Read project info", "Reading project info")
-    case "read-skill": {
-      const label = skillLabel(intent)
-      return icon("skill", `Read the ${label}`, `Reading the ${label}`)
+    case "workflows.start":
+      return icon(
+        "actions",
+        `Started the ${humanize(intent.args[0]) || "requested"} workflow`,
+        `Starting the ${humanize(intent.args[0]) || "requested"} workflow`,
+        runOutcome(parsed?.json)
+      )
+    case "workflow-runs.list": {
+      const n = arrayLength(parsed?.json)
+      return icon("actions", "Listed workflow runs", "Listing workflow runs", count(n, "run"))
     }
+    case "workflow-runs.get":
+      return icon(
+        "actions",
+        "Checked a workflow run",
+        "Checking a workflow run",
+        runStatus(parsed?.json)
+      )
+    case "files.upload":
+      return icon("object", "Uploaded a file", "Uploading a file", filePath(parsed?.json))
+    case "files.download":
+      return icon("object", "Downloaded a file", "Downloading a file", filePath(parsed?.json))
+    case "project.show":
+      return icon("project", "Read project info", "Reading project info")
+    case "api.get":
+    case "api.post":
+      return icon("terminal", "Called the Sixb API", "Calling the Sixb API", intent.args[0])
     default:
       return icon(
         "terminal",
-        "Ran a command",
-        "Running a command",
-        truncateMiddle(intent.command, 64)
+        "Ran a Sixb command",
+        "Running a Sixb command",
+        truncateMiddle(intent.args.join(" "), 64)
       )
+  }
+}
+
+function helpSubject(args: readonly string[]): string {
+  const group = args.find((value) => !value.startsWith("-"))
+  switch (group) {
+    case "objects":
+      return "how to work with project data"
+    case "ontology":
+      return "the project data model"
+    case "telemetry":
+      return "how to work with telemetry"
+    case "actions":
+      return "available actions"
+    case "workflows":
+      return "available workflows"
+    case "files":
+      return "how to work with files"
+    case "project":
+      return "project information"
+    default:
+      return "available project operations"
   }
 }
 
@@ -394,6 +553,34 @@ function arrayLength(value: unknown): number | null {
   return Array.isArray(value) ? value.length : null
 }
 
+function nestedArrayLength(value: unknown, field: string): number | null {
+  return isRecord(value) && Array.isArray(value[field]) ? value[field].length : null
+}
+
+function commandObjectType(
+  intent: Extract<BashIntent, { kind: "sixb" }>,
+  parsed: ParsedBashOutput | null
+): string | undefined {
+  if (intent.command === "objects.list") return optionValue(intent.args, "--type")
+  if (intent.command === "objects.get" || intent.command === "objects.inspect") {
+    return intent.args[0]
+  }
+  return findObjectTypeId(parsed?.json)
+}
+
+function optionValue(args: readonly string[], option: string): string | undefined {
+  const index = args.indexOf(option)
+  return index === -1 ? undefined : args[index + 1]
+}
+
+function graphDetail(value: unknown): string | undefined {
+  if (!isRecord(value) || !isRecord(value.graph)) return undefined
+  const objectCount = numberField(value.graph, "objectCount")
+  const linkCount = numberField(value.graph, "linkCount")
+  const parts = [count(objectCount, "object"), count(linkCount, "link")].filter(Boolean)
+  return parts.join(" · ") || undefined
+}
+
 /** A single latest telemetry point's value, e.g. "1,240 rpm". */
 function latestReading(value: unknown): string | undefined {
   if (!isRecord(value)) return undefined
@@ -416,6 +603,24 @@ function seriesCount(value: unknown): number | null {
 function actionOutcome(value: unknown): string | undefined {
   if (!isRecord(value)) return undefined
   if (typeof value.runId === "string") return value.created === false ? "already queued" : "queued"
+  return undefined
+}
+
+function runOutcome(value: unknown): string | undefined {
+  if (!isRecord(value)) return undefined
+  if (typeof value.runId === "string" || typeof value.id === "string") return "queued"
+  return runStatus(value)
+}
+
+function runStatus(value: unknown): string | undefined {
+  return isRecord(value) && typeof value.status === "string" ? humanize(value.status) : undefined
+}
+
+function filePath(value: unknown): string | undefined {
+  if (!isRecord(value)) return undefined
+  for (const field of ["output", "logicalPath", "path"]) {
+    if (typeof value[field] === "string") return value[field]
+  }
   return undefined
 }
 
@@ -524,6 +729,11 @@ function truncateMiddle(text: string, max: number): string {
   const head = Math.ceil((max - 1) / 2)
   const tail = Math.floor((max - 1) / 2)
   return `${text.slice(0, head)}…${text.slice(text.length - tail)}`
+}
+
+function truncateEnd(text: string, max: number): string {
+  if (text.length <= max) return text
+  return `${text.slice(0, Math.max(0, max - 1)).trimEnd()}…`
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/agent-ui/src/bash/interpret.ts
+++ b/packages/agent-ui/src/bash/interpret.ts
@@ -2,21 +2,13 @@
 // stable CLI command tree, so the UI only needs to tokenize one command and identify its group and
 // operation. Plain shell commands and the initial skill read keep neutral fallbacks.
 
+import { commandInvocation, executableName, lexShellCommand, type ShellSegment } from "./shell"
+
 /** The bash tool input as authored by the agent. */
 export interface BashInput {
   readonly command: string
   readonly cwd?: string
   readonly timeoutMs?: number
-}
-
-/** The bash tool output envelope returned by the sandbox (see agent-worker `BashToolOutput`). */
-export interface BashOutput {
-  readonly exitCode: number
-  readonly stdout: string
-  readonly stderr: string
-  readonly durationMs: number
-  readonly stdoutTruncated: boolean
-  readonly stderrTruncated: boolean
 }
 
 const CLI_COMMANDS = {
@@ -37,7 +29,7 @@ type CliCommandName = {
   [Group in CliGroup]: `${Group}.${(typeof CLI_COMMANDS)[Group][number]}`
 }[CliGroup]
 
-export type SixbCommandName =
+type SixbCommandName =
   | "help"
   | "version"
   | "doctor"
@@ -46,8 +38,7 @@ export type SixbCommandName =
   | CliCommandName
   | "unknown"
 
-/** What the agent was trying to do, derived from the command string. */
-export type BashIntent =
+type AtomicBashIntent =
   | {
       readonly kind: "sixb"
       readonly command: SixbCommandName
@@ -56,6 +47,16 @@ export type BashIntent =
     }
   | { readonly kind: "read-skill"; readonly skillName?: string; readonly reference?: string }
   | { readonly kind: "generic"; readonly command: string }
+
+/** What the agent was trying to do, derived from the command string. */
+export type BashIntent =
+  | AtomicBashIntent
+  | {
+      readonly kind: "compound"
+      /** The most meaningful segment, used only to present this work in product language. */
+      readonly primary: AtomicBashIntent
+      readonly stepCount: number
+    }
 
 /** Parsed bash output, with stdout JSON-decoded when it looks like JSON. */
 export interface ParsedBashOutput {
@@ -99,23 +100,82 @@ export function coerceBashOutput(output: unknown): ParsedBashOutput | null {
 // --- Command classification ------------------------------------------------
 
 export function classifyCommand(command: string): BashIntent {
-  const sixb = classifySixbCommand(command)
-  if (sixb) return sixb
-  const skill = classifySkillRead(command)
-  if (skill) return skill
-  return { kind: "generic", command: command.trim() }
+  const segments = lexShellCommand(command)
+  if (!segments) return { kind: "generic", command: command.trim() }
+  if (segments.length > 1) {
+    return {
+      kind: "compound",
+      primary: selectCompoundPrimary(segments),
+      stepCount: segments.length,
+    }
+  }
+  return classifyAtomicCommand(segments[0])
 }
 
-function classifySixbCommand(command: string): Extract<BashIntent, { kind: "sixb" }> | null {
-  const tokens = tokenizeShellCommand(command)
-  if (!tokens || executableName(tokens[0]) !== "sixb") return null
+function classifyAtomicCommand(segment: ShellSegment | undefined): AtomicBashIntent {
+  if (!segment) return { kind: "generic", command: "" }
+  const invocation = commandInvocation(segment.tokens)
+  const sixb = classifySixbCommand(invocation)
+  if (sixb) return sixb
+  const skill = classifySkillRead(segment, invocation)
+  if (skill) return skill
+  return { kind: "generic", command: segment.command }
+}
+
+function selectCompoundPrimary(segments: readonly ShellSegment[]): AtomicBashIntent {
+  const fallbackIndex = segments.findIndex((segment) => segment.operatorBefore === "||")
+  const primaryBranch = fallbackIndex === -1 ? segments : segments.slice(0, fallbackIndex)
+  const intents = primaryBranch.map((segment) => classifyAtomicCommand(segment))
+  let selected = intents[0] ?? classifyAtomicCommand(segments[0])
+  let selectedPriority = compoundIntentPriority(selected)
+
+  for (const intent of intents.slice(1)) {
+    const priority = compoundIntentPriority(intent)
+    // Prefer the final operation when two segments are equally meaningful.
+    if (priority >= selectedPriority) {
+      selected = intent
+      selectedPriority = priority
+    }
+  }
+  return selected
+}
+
+function compoundIntentPriority(intent: AtomicBashIntent): number {
+  if (intent.kind === "sixb" || intent.kind === "read-skill") return 3
+  const category = genericCommandCategory(intent.command)
+  if (category.kind === "unknown") return isShellPlumbing(intent.command) ? -1 : 0
+  if (
+    category.kind === "inspect-files" ||
+    category.kind === "workspace-location" ||
+    category.kind === "read-file"
+  ) {
+    return 1
+  }
+  return 2
+}
+
+function isShellPlumbing(command: string): boolean {
+  const executable = directCommandExecutable(command)
+  return Boolean(
+    executable &&
+      ["cd", "export", "set", "unset", "source", ".", "env", "jq", "true", "false"].includes(
+        executable
+      )
+  )
+}
+
+function classifySixbCommand(
+  tokens: readonly string[]
+): Extract<BashIntent, { kind: "sixb" }> | null {
+  if (executableName(tokens[0]) !== "sixb") return null
 
   const cliArgs = tokens.slice(1)
-  const helpIndex = cliArgs.findIndex(
-    (token) => token === "--help" || token === "-h" || token === "help"
-  )
-  if (helpIndex !== -1 || cliArgs.length === 0) {
-    return { kind: "sixb", command: "help", args: cliArgs.filter((_, i) => i !== helpIndex) }
+  if (cliArgs.length === 0 || isHelpToken(cliArgs[0])) {
+    return { kind: "sixb", command: "help", args: [] }
+  }
+  if (isHelpToken(cliArgs[1])) return { kind: "sixb", command: "help", args: [cliArgs[0]] }
+  if (isHelpToken(cliArgs[2])) {
+    return { kind: "sixb", command: "help", args: cliArgs.slice(0, 2) }
   }
   if (cliArgs[0] === "version" || cliArgs[0] === "--version") {
     return { kind: "sixb", command: "version", args: cliArgs.slice(1) }
@@ -137,6 +197,10 @@ function classifySixbCommand(command: string): Extract<BashIntent, { kind: "sixb
   return { kind: "sixb", command: `${group}.${operation}` as CliCommandName, args }
 }
 
+function isHelpToken(value: string | undefined): boolean {
+  return value === "--help" || value === "-h" || value === "help"
+}
+
 function isCliGroup(value: string): value is CliGroup {
   return Object.hasOwn(CLI_COMMANDS, value)
 }
@@ -148,62 +212,14 @@ function isCliOperation<Group extends CliGroup>(
   return (CLI_COMMANDS[group] as readonly string[]).includes(value)
 }
 
-/**
- * Tokenize the small shell subset needed for a direct CLI invocation. Compound shell expressions
- * intentionally fall back to the generic command view; guessing which command owns a pipeline or
- * redirection would make the transcript misleading.
- */
-function tokenizeShellCommand(command: string): string[] | null {
-  const tokens: string[] = []
-  let token = ""
-  let quote: "'" | '"' | null = null
-  let escaped = false
+const SKILL_READ_COMMANDS = new Set(["cat", "less", "bat", "head", "tail", "sed", "nl"])
 
-  const push = () => {
-    if (token) tokens.push(token)
-    token = ""
-  }
-
-  for (const character of command.trim()) {
-    if (escaped) {
-      token += character
-      escaped = false
-      continue
-    }
-    if (character === "\\" && quote !== "'") {
-      escaped = true
-      continue
-    }
-    if (quote) {
-      if (character === quote) quote = null
-      else token += character
-      continue
-    }
-    if (character === "'" || character === '"') {
-      quote = character
-      continue
-    }
-    if (/\s/.test(character)) {
-      push()
-      continue
-    }
-    if ("|;&<>()`".includes(character)) return null
-    token += character
-  }
-
-  if (quote || escaped) return null
-  push()
-  return tokens
-}
-
-function executableName(value: string | undefined): string | undefined {
-  return value?.split("/").at(-1)
-}
-
-const SKILL_READ_RE = /\b(?:cat|less|bat|head|tail|sed|nl)\b/
-
-function classifySkillRead(command: string): BashIntent | null {
-  const looksLikeRead = SKILL_READ_RE.test(command)
+function classifySkillRead(
+  segment: ShellSegment,
+  invocation: readonly string[]
+): Extract<AtomicBashIntent, { kind: "read-skill" }> | null {
+  const looksLikeRead = SKILL_READ_COMMANDS.has(executableName(invocation[0]) ?? "")
+  const command = segment.command
   const touchesSkill =
     command.includes("SKILL.md") ||
     command.includes("/skills/") ||
@@ -230,7 +246,7 @@ export type BashIcon =
   | "skill"
   | "terminal"
 
-export interface BashDescription {
+interface BashDescription {
   readonly icon: BashIcon
   /** Past-tense headline once the command has run, e.g. "Explored the ontology". */
   readonly title: string
@@ -241,6 +257,12 @@ export interface BashDescription {
 }
 
 export function describeBash(intent: BashIntent, parsed: ParsedBashOutput | null): BashDescription {
+  if (intent.kind === "compound") {
+    const primary = describeBash(intent.primary, parsed)
+    if (primary.runningTitle !== "Running a command") return primary
+    const steps = `${intent.stepCount.toLocaleString()} steps`
+    return icon("terminal", `Ran ${steps}`, `Running ${steps}`)
+  }
   if (intent.kind === "sixb") return describeSixb(intent, parsed)
   if (intent.kind === "read-skill") {
     const label = skillLabel(intent)
@@ -249,39 +271,109 @@ export function describeBash(intent: BashIntent, parsed: ParsedBashOutput | null
   return describeGenericCommand(intent.command)
 }
 
+type GenericCommandCategory =
+  | { readonly kind: "write-file"; readonly fileKind: string }
+  | {
+      readonly kind:
+        | "edit-files"
+        | "search-files"
+        | "run-tests"
+        | "create-folder"
+        | "copy-files"
+        | "move-files"
+        | "inspect-files"
+        | "workspace-location"
+        | "read-file"
+        | "unknown"
+    }
+
 function describeGenericCommand(command: string): BashDescription {
-  const firstLine = command.trim().split(/\r?\n/, 1)[0]?.trim() ?? ""
-  const fileKind = writtenFileKind(command, firstLine)
-  if (fileKind) {
-    return icon("terminal", `Created ${fileKind}`, `Creating ${fileKind}`)
+  const category = genericCommandCategory(command)
+  switch (category.kind) {
+    case "write-file":
+      return icon("terminal", `Created ${category.fileKind}`, `Creating ${category.fileKind}`)
+    case "edit-files":
+      return icon("terminal", "Edited files", "Editing files")
+    case "search-files":
+      return icon("terminal", "Searched files", "Searching files")
+    case "run-tests":
+      return icon("terminal", "Ran tests", "Running tests")
+    case "create-folder":
+      return icon("terminal", "Created a folder", "Creating a folder")
+    case "copy-files":
+      return icon("terminal", "Copied files", "Copying files")
+    case "move-files":
+      return icon("terminal", "Moved files", "Moving files")
+    case "inspect-files":
+      return icon("terminal", "Inspected files", "Inspecting files")
+    case "workspace-location":
+      return icon("terminal", "Checked the workspace location", "Checking the workspace location")
+    case "read-file":
+      return icon("terminal", "Read a file", "Reading a file")
+    default:
+      return icon("terminal", "Ran a command", "Running a command")
   }
-  if (/\bapply_patch\b/.test(firstLine)) {
-    return icon("terminal", "Edited files", "Editing files")
-  }
-  if (/(?:^|[;&|]\s*|\s)(?:rg|grep)(?:\s|$)/.test(firstLine)) {
-    return icon("terminal", "Searched files", "Searching files")
-  }
-  if (/(?:^|[;&|]\s*|\s)bun\s+test(?:\s|$)/.test(firstLine)) {
-    return icon("terminal", "Ran tests", "Running tests")
-  }
-  if (/(?:^|[;&|]\s*|\s)mkdir(?:\s|$)/.test(firstLine)) {
-    return icon("terminal", "Created a folder", "Creating a folder")
-  }
-  if (/(?:^|[;&|]\s*|\s)cp(?:\s|$)/.test(firstLine)) {
-    return icon("terminal", "Copied files", "Copying files")
-  }
-  if (/(?:^|[;&|]\s*|\s)mv(?:\s|$)/.test(firstLine)) {
-    return icon("terminal", "Moved files", "Moving files")
-  }
-  return icon("terminal", "Ran", "Running a command", commandPreview(command, 64))
 }
 
-function writtenFileKind(command: string, firstLine: string): string | null {
-  if (!/(?:^|\s)(?:cat|tee|printf|echo)(?:\s|$)/.test(firstLine)) return null
-  const redirect = firstLine.match(/(?:^|\s)>{1,2}\s*(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))/)
-  if (!redirect) return null
+function genericCommandCategory(command: string): GenericCommandCategory {
+  const firstLine = command.trim().split(/\r?\n/, 1)[0]?.trim() ?? ""
+  const segment = directCommandSegment(command)
+  const invocation = commandInvocation(segment?.tokens ?? [])
+  const fileKind = writtenFileKind(command, firstLine, segment, invocation)
+  if (fileKind) return { kind: "write-file", fileKind }
+  const executable = executableName(invocation[0]) ?? leadingExecutable(firstLine)
+  if (executable === "apply_patch") return { kind: "edit-files" }
+  if (executable === "rg" || executable === "grep") return { kind: "search-files" }
+  if (executable === "bun" && invocation[1] === "test") return { kind: "run-tests" }
+  if (executable === "mkdir") return { kind: "create-folder" }
+  if (executable === "cp") return { kind: "copy-files" }
+  if (executable === "mv") return { kind: "move-files" }
+  if (executable === "ls" || executable === "find") return { kind: "inspect-files" }
+  if (executable === "pwd") return { kind: "workspace-location" }
+  if (executable === "head" && headReadsFile(invocation)) return { kind: "read-file" }
+  return { kind: "unknown" }
+}
 
-  const target = (redirect[1] ?? redirect[2] ?? redirect[3] ?? "").toLowerCase()
+function headReadsFile(tokens: readonly string[]): boolean {
+  return tokens.slice(1).some((token) => !token.startsWith("-") && !/^\d+$/.test(token))
+}
+
+function directCommandSegment(command: string): ShellSegment | undefined {
+  const segments = lexShellCommand(command)
+  return segments?.length === 1 ? segments[0] : undefined
+}
+
+function directCommandExecutable(command: string): string | undefined {
+  const invocation = commandInvocation(directCommandSegment(command)?.tokens ?? [])
+  return executableName(invocation[0])
+}
+
+function leadingExecutable(firstLine: string): string | undefined {
+  const match = firstLine.match(/^\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*=[^\s]+)\s+)*([^\s;&|<>]+)/)
+  return executableName(match?.[1])
+}
+
+function writtenFileKind(
+  command: string,
+  firstLine: string,
+  segment: ShellSegment | undefined,
+  invocation: readonly string[]
+): string | null {
+  const executable = executableName(invocation[0]) ?? leadingExecutable(firstLine)
+  if (!executable || !["cat", "tee", "printf", "echo"].includes(executable)) return null
+
+  const directTarget = segment?.outputRedirects?.at(-1)
+  const heredocTarget = command.includes("<<")
+    ? firstLine.match(/(?:^|\s)>{1,2}\s*(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))/)
+    : null
+  const target = (
+    directTarget ??
+    heredocTarget?.[1] ??
+    heredocTarget?.[2] ??
+    heredocTarget?.[3] ??
+    ""
+  ).toLowerCase()
+  if (!target) return null
   if (/<!doctype\s+html|<html(?:\s|>)/i.test(command) || /\.html?$/.test(target)) {
     return "an HTML file"
   }
@@ -624,7 +716,7 @@ function filePath(value: unknown): string | undefined {
   return undefined
 }
 
-export type ActionRunStatus = "queued" | "running" | "succeeded" | "failed" | "cancelled"
+type ActionRunStatus = "queued" | "running" | "succeeded" | "failed" | "cancelled"
 
 interface ActionRunInfo {
   readonly actionId?: string

--- a/packages/agent-ui/src/bash/renderers.tsx
+++ b/packages/agent-ui/src/bash/renderers.tsx
@@ -17,7 +17,14 @@ import {
   stringField,
   toSeriesData,
 } from "./data"
-import { capitalize, humanize, isRecord, type ParsedBashOutput, subjectLabel } from "./interpret"
+import {
+  capitalize,
+  commandPreview,
+  humanize,
+  isRecord,
+  type ParsedBashOutput,
+  subjectLabel,
+} from "./interpret"
 
 // Each renderer takes the already-parsed bash output and renders the decoded `json` natively, with
 // the lightest possible chrome — no nested boxes, no badge pills. Anything a renderer doesn't
@@ -26,14 +33,14 @@ import { capitalize, humanize, isRecord, type ParsedBashOutput, subjectLabel } f
 
 const MAX_ROWS = 50
 
-interface ApiViewProps {
+interface CommandViewProps {
   readonly parsed: ParsedBashOutput
 }
 
-/** `GET /api/object-types` — a calm two-column list of the live ontology. */
-export function ObjectTypesView({ parsed }: ApiViewProps) {
+/** `sixb ontology list` — a calm two-column list of the live ontology. */
+export function ObjectTypesView({ parsed }: CommandViewProps) {
   const types = Array.isArray(parsed.json) ? parsed.json.filter(isRecord) : null
-  if (!types) return <ApiDataView parsed={parsed} />
+  if (!types) return <StructuredDataView parsed={parsed} />
 
   return (
     <div className="grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2">
@@ -58,10 +65,10 @@ export function ObjectTypesView({ parsed }: ApiViewProps) {
   )
 }
 
-/** `GET /api/objects` and `POST /api/objects/query` — a clean, separator-only table. */
-export function ObjectListView({ parsed }: ApiViewProps) {
+/** Sixb object list, lookup, search, and query results — a clean, separator-only table. */
+export function ObjectListView({ parsed }: CommandViewProps) {
   const objects = extractObjects(parsed.json)
-  if (!objects) return <ApiDataView parsed={parsed} />
+  if (!objects) return <StructuredDataView parsed={parsed} />
   if (objects.length === 0) return <Empty message="No matching objects." />
 
   const columns = pickColumns(objects)
@@ -108,10 +115,10 @@ export function ObjectListView({ parsed }: ApiViewProps) {
   )
 }
 
-/** `GET /api/objects/:type/:id` — a property sheet for one object. */
-export function ObjectDetailView({ parsed }: ApiViewProps) {
+/** `sixb objects inspect` — a property sheet for the root object. */
+export function ObjectDetailView({ parsed }: CommandViewProps) {
   const object = singleObject(parsed.json)
-  if (!object) return <ApiDataView parsed={parsed} />
+  if (!object) return <StructuredDataView parsed={parsed} />
 
   const properties = isRecord(object.properties) ? object.properties : object
   const entries = Object.entries(properties).filter(([key]) => key !== "properties")
@@ -124,11 +131,11 @@ export function ObjectDetailView({ parsed }: ApiViewProps) {
   )
 }
 
-/** `POST /api/objects/query/facets` — a compact proportional breakdown. */
-export function FacetsView({ parsed }: ApiViewProps) {
+/** `sixb objects facets` — a compact proportional breakdown. */
+export function FacetsView({ parsed }: CommandViewProps) {
   const facets =
     isRecord(parsed.json) && Array.isArray(parsed.json.facets) ? parsed.json.facets : null
-  if (!facets) return <ApiDataView parsed={parsed} />
+  if (!facets) return <StructuredDataView parsed={parsed} />
 
   const populated = facets.filter(
     (facet): facet is Record<string, unknown> =>
@@ -174,15 +181,15 @@ export function FacetsView({ parsed }: ApiViewProps) {
   )
 }
 
-/** `GET …/telemetry/:prop/history` — latest value plus a clean sparkline. */
-export function TelemetryHistoryView({ parsed }: ApiViewProps) {
+/** `sixb telemetry history` — latest value plus a clean sparkline. */
+export function TelemetryHistoryView({ parsed }: CommandViewProps) {
   const data = toSeriesData(parsed.json)
   if (data.length === 0) return <Empty message="No readings." />
   return <SeriesChart data={data} unit={seriesUnit(parsed.json)} />
 }
 
-/** `POST /api/telemetry/history` — one labeled sparkline per series. */
-export function TelemetryBulkView({ parsed }: ApiViewProps) {
+/** `sixb telemetry query` — one labeled sparkline per series. */
+export function TelemetryBulkView({ parsed }: CommandViewProps) {
   const series =
     isRecord(parsed.json) && Array.isArray(parsed.json.series)
       ? parsed.json.series.filter(isRecord)
@@ -213,10 +220,10 @@ export function TelemetryBulkView({ parsed }: ApiViewProps) {
   )
 }
 
-/** `GET /api/object-types/:id` — a single type's schema, in plain labeled sections. */
-export function ObjectTypeSchemaView({ parsed }: ApiViewProps) {
+/** `sixb ontology get` — a single type's schema, in plain labeled sections. */
+export function ObjectTypeSchemaView({ parsed }: CommandViewProps) {
   const type = isRecord(parsed.json) ? parsed.json : null
-  if (!type) return <ApiDataView parsed={parsed} />
+  if (!type) return <StructuredDataView parsed={parsed} />
 
   return (
     <div className="space-y-3">
@@ -230,11 +237,11 @@ export function ObjectTypeSchemaView({ parsed }: ApiViewProps) {
   )
 }
 
-/** `POST /api/actions/:id` — a calm confirmation that a run was requested. */
-export function ActionResultView({ parsed }: ApiViewProps) {
+/** `sixb actions request` — a calm confirmation that a run was requested. */
+export function ActionResultView({ parsed }: CommandViewProps) {
   const result = isRecord(parsed.json) ? parsed.json : null
   const runId = result && typeof result.runId === "string" ? result.runId : null
-  if (!runId) return <ApiDataView parsed={parsed} />
+  if (!runId) return <StructuredDataView parsed={parsed} />
 
   const created = result?.created !== false
   const queuedAt = typeof result?.queuedAt === "string" ? result.queuedAt : undefined
@@ -260,10 +267,10 @@ const STATUS_DOT: Record<string, string> = {
   cancelled: "bg-muted-foreground/40",
 }
 
-/** `GET /api/action-runs/:runId` — the run's status, timing, and any error. */
-export function ActionRunView({ parsed }: ApiViewProps) {
+/** `sixb action-runs get` — the run's status, timing, and any error. */
+export function ActionRunView({ parsed }: CommandViewProps) {
   const run = isRecord(parsed.json) ? parsed.json : null
-  if (!run) return <ApiDataView parsed={parsed} />
+  if (!run) return <StructuredDataView parsed={parsed} />
 
   const status = stringField(run, "status") ?? "queued"
   const subject = subjectLabel(run.subject)
@@ -303,13 +310,13 @@ export function ActionRunView({ parsed }: ApiViewProps) {
 export function GenericCommandView({
   parsed,
   command,
-}: ApiViewProps & { readonly command?: string }) {
+}: CommandViewProps & { readonly command?: string }) {
   return (
     <div className="space-y-2">
       {command ? (
-        <pre className="overflow-x-auto rounded bg-muted/50 px-2 py-1.5 font-mono text-[11px] text-muted-foreground">
+        <pre className="overflow-x-auto rounded bg-muted/50 px-2 py-1.5 font-mono text-[11px] whitespace-pre-wrap text-muted-foreground">
           <span className="select-none text-muted-foreground/50">$ </span>
-          {command}
+          {commandPreview(command)}
         </pre>
       ) : null}
       {parsed.stdout.trim() ? (
@@ -332,11 +339,10 @@ export function GenericCommandView({
 }
 
 /**
- * Neutral fallback for parsed API responses without a dedicated renderer (project, actions,
- * telemetry) or shapes a renderer didn't recognize. Arrays become a simple list, objects a
- * property sheet of their scalar fields. Never prints raw JSON in the reading path.
+ * Neutral fallback for parsed CLI results without a dedicated renderer. Arrays become a simple
+ * list, objects a property sheet of their scalar fields. Never prints raw JSON in the reading path.
  */
-export function ApiDataView({ parsed }: ApiViewProps) {
+export function StructuredDataView({ parsed }: CommandViewProps) {
   const json = parsed.json
 
   if (Array.isArray(json)) {

--- a/packages/agent-ui/src/bash/shell.ts
+++ b/packages/agent-ui/src/bash/shell.ts
@@ -1,0 +1,195 @@
+export type ShellOperator = "&&" | "||" | "|" | ";" | "newline"
+
+export interface ShellSegment {
+  readonly command: string
+  readonly tokens: readonly string[]
+  readonly outputRedirects?: readonly string[]
+  readonly operatorBefore?: ShellOperator
+}
+
+/**
+ * Lex the conservative shell subset needed for activity presentation. It understands top-level
+ * sequencing and quoting, but leaves control flow and heredocs opaque instead of guessing.
+ */
+export function lexShellCommand(command: string): readonly ShellSegment[] | null {
+  if (
+    /(?:^|\s)<<-?\s*/.test(command) ||
+    /(?:^|[;\n]\s*)(?:if|for|while|until|case|select|function)\b/.test(command) ||
+    command.includes("[[")
+  ) {
+    return null
+  }
+
+  const segments: ShellSegment[] = []
+  let commandText = ""
+  let word = ""
+  let wordStarted = false
+  let tokens: string[] = []
+  let outputRedirects: string[] = []
+  let pendingRedirect: "input" | "output" | null = null
+  let operatorBefore: ShellOperator | undefined
+  let quote: "'" | '"' | null = null
+  let escaped = false
+
+  const pushWord = () => {
+    if (wordStarted) {
+      if (pendingRedirect === "output") outputRedirects.push(word)
+      else if (pendingRedirect === null) tokens.push(word)
+      pendingRedirect = null
+    }
+    word = ""
+    wordStarted = false
+  }
+
+  const pushSegment = (operator?: ShellOperator): boolean => {
+    pushWord()
+    const value = commandText.trim()
+    if (!value) return false
+    segments.push({
+      command: value,
+      tokens,
+      ...(outputRedirects.length > 0 ? { outputRedirects } : {}),
+      operatorBefore,
+    })
+    commandText = ""
+    tokens = []
+    outputRedirects = []
+    pendingRedirect = null
+    operatorBefore = operator
+    return true
+  }
+
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index]
+    const next = command[index + 1]
+
+    if (escaped) {
+      commandText += character
+      word += character
+      wordStarted = true
+      escaped = false
+      continue
+    }
+    if (character === "\\" && quote !== "'") {
+      commandText += character
+      escaped = true
+      continue
+    }
+    if (quote) {
+      if (quote === '"' && character === "`") return null
+      commandText += character
+      if (character === quote) quote = null
+      else {
+        word += character
+        wordStarted = true
+      }
+      continue
+    }
+    if (character === "'" || character === '"') {
+      commandText += character
+      quote = character
+      wordStarted = true
+      continue
+    }
+    if (character === "`" || "(){}".includes(character)) return null
+    if (/\s/.test(character) && character !== "\n") {
+      commandText += character
+      pushWord()
+      continue
+    }
+    if (character === ">" || character === "<") {
+      // A numeric word touching the redirect is a file descriptor (`2>errors.log`), not an arg.
+      if (wordStarted && /^\d+$/.test(word)) {
+        word = ""
+        wordStarted = false
+      } else {
+        pushWord()
+      }
+      const isDouble = next === character
+      commandText += isDouble ? `${character}${next}` : character
+      pendingRedirect = character === ">" ? "output" : "input"
+      if (isDouble) index += 1
+      continue
+    }
+
+    let operator: ShellOperator | undefined
+    let width = 1
+    if (character === "&" && next === "&") {
+      operator = "&&"
+      width = 2
+    } else if (character === "|" && next === "|") {
+      operator = "||"
+      width = 2
+    } else if (character === "|") {
+      operator = "|"
+    } else if (character === ";") {
+      operator = ";"
+    } else if (character === "\n") {
+      operator = "newline"
+    } else if (character === "&") {
+      // Background jobs and unquoted URL query strings need a complete shell parser.
+      return null
+    }
+
+    if (operator) {
+      if (pendingRedirect && !wordStarted) return null
+      if (!commandText.trim()) {
+        // Allow formatting newlines after another operator (`foo &&\nbar`).
+        if (operator === "newline" && segments.length > 0) continue
+        return null
+      }
+      pushSegment(operator)
+      index += width - 1
+      continue
+    }
+
+    commandText += character
+    word += character
+    wordStarted = true
+  }
+
+  if (quote || escaped || (pendingRedirect && !wordStarted)) {
+    return null
+  }
+  const pushedFinalSegment = pushSegment()
+  if (
+    !pushedFinalSegment &&
+    operatorBefore !== undefined &&
+    operatorBefore !== ";" &&
+    operatorBefore !== "newline"
+  ) {
+    return null
+  }
+  return segments.length > 0 ? segments : null
+}
+
+export function executableName(value: string | undefined): string | undefined {
+  return value?.split("/").at(-1)
+}
+
+/** Resolve the actual invocation after ordinary leading assignments and `env` configuration. */
+export function commandInvocation(tokens: readonly string[]): readonly string[] {
+  let index = skipAssignments(tokens, 0)
+  if (executableName(tokens[index]) !== "env") return tokens.slice(index)
+
+  index += 1
+  while (index < tokens.length) {
+    const token = tokens[index]
+    if (token === "-u" || token === "--unset") {
+      index += 2
+      continue
+    }
+    if (token?.startsWith("-")) {
+      index += 1
+      continue
+    }
+    break
+  }
+  return tokens.slice(skipAssignments(tokens, index))
+}
+
+function skipAssignments(tokens: readonly string[], start: number): number {
+  let index = start
+  while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[index] ?? "")) index += 1
+  return index
+}

--- a/packages/agent-ui/src/components/ActivityStatus.tsx
+++ b/packages/agent-ui/src/components/ActivityStatus.tsx
@@ -17,14 +17,6 @@ const THINKING_STATUS_STEPS: readonly ActivityStatusStep[] = [
   { afterMs: 55_000, label: "Still working" },
 ]
 
-const WORKING_STATUS_STEPS: readonly ActivityStatusStep[] = [
-  { afterMs: 0, label: "Working" },
-  { afterMs: 8_000, label: "Working through it" },
-  { afterMs: 20_000, label: "Taking a closer look" },
-  { afterMs: 35_000, label: "Checking the details" },
-  { afterMs: 55_000, label: "Still working" },
-]
-
 const CONTINUING_STATUS_DELAY_MS = 12_000
 
 /**
@@ -40,59 +32,41 @@ export function activityStatusAt(label: string, elapsedMs: number): string {
   return label
 }
 
-/** Animated status text whose widest phrase reserves the row width, so copy changes never jump. */
+/** Render the current status as one visible phrase so adjacent controls stay attached to it. */
 export function ActivityStatusText({
   label,
-  active = true,
   className,
 }: {
   readonly label: string
-  readonly active?: boolean
   readonly className?: string
 }) {
   const steps = useMemo(() => activityStatusSteps(label), [label])
-  const [phase, setPhase] = useState({ label, index: 0 })
-  // A real activity change can shorten the timeline. Select its first phrase during render rather
-  // than waiting for the effect, otherwise the old index can produce one blank or stale frame.
-  const activeIndex = active && phase.label === label ? phase.index : 0
+  const [elapsed, setElapsed] = useState({ label, elapsedMs: 0 })
+  // A real activity change resets immediately during render, before the effect replaces timers.
+  const elapsedMs = elapsed.label === label ? elapsed.elapsedMs : 0
+  const currentLabel = activityStatusAt(label, elapsedMs)
 
   useEffect(() => {
-    setPhase((current) =>
-      current.label === label && current.index === 0 ? current : { label, index: 0 }
+    setElapsed((current) =>
+      current.label === label && current.elapsedMs === 0 ? current : { label, elapsedMs: 0 }
     )
-    if (!active || steps.length < 2) return
+    if (steps.length < 2) return
 
     const timers = steps
       .slice(1)
-      .map((step, index) =>
-        window.setTimeout(() => setPhase({ label, index: index + 1 }), step.afterMs)
+      .map((step) =>
+        window.setTimeout(() => setElapsed({ label, elapsedMs: step.afterMs }), step.afterMs)
       )
     return () => {
       for (const timer of timers) window.clearTimeout(timer)
     }
-  }, [active, steps, label])
+  }, [steps, label])
 
-  return (
-    <span className={cn("inline-grid min-w-0 max-w-full", className)}>
-      {steps.map((step, index) => (
-        <span
-          key={`${step.afterMs}:${step.label}`}
-          aria-hidden={index !== activeIndex}
-          className={cn(
-            "col-start-1 row-start-1 min-w-0 truncate transition-opacity duration-300 motion-reduce:transition-none",
-            index === activeIndex ? "opacity-100" : "pointer-events-none opacity-0"
-          )}
-        >
-          {step.label}…
-        </span>
-      ))}
-    </span>
-  )
+  return <span className={cn("min-w-0 truncate text-left", className)}>{currentLabel}…</span>
 }
 
 function activityStatusSteps(label: string): readonly ActivityStatusStep[] {
   if (label === "Thinking") return THINKING_STATUS_STEPS
-  if (label === "Working") return WORKING_STATUS_STEPS
   return [
     { afterMs: 0, label },
     { afterMs: CONTINUING_STATUS_DELAY_MS, label: `Still ${lowercaseFirst(label)}` },

--- a/packages/agent-ui/src/components/ActivityStatus.tsx
+++ b/packages/agent-ui/src/components/ActivityStatus.tsx
@@ -1,0 +1,104 @@
+import { cn } from "@sixb/ui/lib/utils"
+import { useEffect, useMemo, useState } from "react"
+
+export const ACTIVITY_STATUS_ROW_CLASS_NAME =
+  "group flex w-fit max-w-full items-center gap-1.5 rounded-md px-1 py-0.5 text-[13px] leading-normal text-muted-foreground"
+
+interface ActivityStatusStep {
+  readonly afterMs: number
+  readonly label: string
+}
+
+const THINKING_STATUS_STEPS: readonly ActivityStatusStep[] = [
+  { afterMs: 0, label: "Thinking" },
+  { afterMs: 8_000, label: "Working through it" },
+  { afterMs: 20_000, label: "Taking a closer look" },
+  { afterMs: 35_000, label: "Checking the details" },
+  { afterMs: 55_000, label: "Still working" },
+]
+
+const WORKING_STATUS_STEPS: readonly ActivityStatusStep[] = [
+  { afterMs: 0, label: "Working" },
+  { afterMs: 8_000, label: "Working through it" },
+  { afterMs: 20_000, label: "Taking a closer look" },
+  { afterMs: 35_000, label: "Checking the details" },
+  { afterMs: 55_000, label: "Still working" },
+]
+
+const CONTINUING_STATUS_DELAY_MS = 12_000
+
+/**
+ * Return honest activity copy for an indeterminate wait. Thinking gets a few calm, neutral updates;
+ * a known operation keeps its real current-step label and only adds "Still" after a long wait.
+ */
+export function activityStatusAt(label: string, elapsedMs: number): string {
+  const steps = activityStatusSteps(label)
+  for (let index = steps.length - 1; index >= 0; index -= 1) {
+    const step = steps[index]
+    if (step && elapsedMs >= step.afterMs) return step.label
+  }
+  return label
+}
+
+/** Animated status text whose widest phrase reserves the row width, so copy changes never jump. */
+export function ActivityStatusText({
+  label,
+  active = true,
+  className,
+}: {
+  readonly label: string
+  readonly active?: boolean
+  readonly className?: string
+}) {
+  const steps = useMemo(() => activityStatusSteps(label), [label])
+  const [phase, setPhase] = useState({ label, index: 0 })
+  // A real activity change can shorten the timeline. Select its first phrase during render rather
+  // than waiting for the effect, otherwise the old index can produce one blank or stale frame.
+  const activeIndex = active && phase.label === label ? phase.index : 0
+
+  useEffect(() => {
+    setPhase((current) =>
+      current.label === label && current.index === 0 ? current : { label, index: 0 }
+    )
+    if (!active || steps.length < 2) return
+
+    const timers = steps
+      .slice(1)
+      .map((step, index) =>
+        window.setTimeout(() => setPhase({ label, index: index + 1 }), step.afterMs)
+      )
+    return () => {
+      for (const timer of timers) window.clearTimeout(timer)
+    }
+  }, [active, steps, label])
+
+  return (
+    <span className={cn("inline-grid min-w-0 max-w-full", className)}>
+      {steps.map((step, index) => (
+        <span
+          key={`${step.afterMs}:${step.label}`}
+          aria-hidden={index !== activeIndex}
+          className={cn(
+            "col-start-1 row-start-1 min-w-0 truncate transition-opacity duration-300 motion-reduce:transition-none",
+            index === activeIndex ? "opacity-100" : "pointer-events-none opacity-0"
+          )}
+        >
+          {step.label}…
+        </span>
+      ))}
+    </span>
+  )
+}
+
+function activityStatusSteps(label: string): readonly ActivityStatusStep[] {
+  if (label === "Thinking") return THINKING_STATUS_STEPS
+  if (label === "Working") return WORKING_STATUS_STEPS
+  return [
+    { afterMs: 0, label },
+    { afterMs: CONTINUING_STATUS_DELAY_MS, label: `Still ${lowercaseFirst(label)}` },
+  ]
+}
+
+function lowercaseFirst(value: string): string {
+  return value ? `${value[0]?.toLowerCase()}${value.slice(1)}` : value
+}

--- a/packages/agent-ui/src/components/Composer.tsx
+++ b/packages/agent-ui/src/components/Composer.tsx
@@ -97,6 +97,14 @@ type ComposerAttachment =
 
 const MAX_HEIGHT_PX = 200
 
+export function composerCanFocus({
+  disabled,
+  pending,
+  running,
+}: Pick<ComposerProps, "disabled" | "pending" | "running">): boolean {
+  return !disabled && !pending && !running
+}
+
 export function Composer({
   onSend,
   disabled,
@@ -223,15 +231,15 @@ export function Composer({
   useEffect(() => {
     const wasRunning = wasRunningRef.current
     wasRunningRef.current = Boolean(running)
-    if (!wasRunning || running || disabled) return
+    if (!wasRunning || !composerCanFocus({ disabled, pending, running })) return
 
     const frame = requestAnimationFrame(() => textareaRef.current?.focus())
     return () => cancelAnimationFrame(frame)
-  }, [disabled, running])
+  }, [disabled, pending, running])
 
   useEffect(() => {
     const focusWhenAvailable = () => {
-      if (disabled || pending || running) return
+      if (!composerCanFocus({ disabled, pending, running })) return
       textareaRef.current?.focus()
     }
     const handleVisibilityChange = () => {
@@ -580,7 +588,7 @@ export function Composer({
             </button>
             <Textarea
               ref={textareaRef}
-              autoFocus={!disabled && !pending && !running}
+              autoFocus={composerCanFocus({ disabled, pending, running })}
               value={value}
               onChange={(event) => {
                 setValue(event.target.value)

--- a/packages/agent-ui/src/components/Composer.tsx
+++ b/packages/agent-ui/src/components/Composer.tsx
@@ -229,6 +229,23 @@ export function Composer({
     return () => cancelAnimationFrame(frame)
   }, [disabled, running])
 
+  useEffect(() => {
+    const focusWhenAvailable = () => {
+      if (disabled || pending || running) return
+      textareaRef.current?.focus()
+    }
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") focusWhenAvailable()
+    }
+
+    window.addEventListener("focus", focusWhenAvailable)
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+    return () => {
+      window.removeEventListener("focus", focusWhenAvailable)
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+    }
+  }, [disabled, pending, running])
+
   // Grow the textarea to fit its content, up to a max height where it starts scrolling.
   // Keep overflow hidden until the content actually exceeds the cap so an empty input does not
   // render a scrollbar in browsers configured to always show scroll bars.
@@ -563,6 +580,7 @@ export function Composer({
             </button>
             <Textarea
               ref={textareaRef}
+              autoFocus={!disabled && !pending && !running}
               value={value}
               onChange={(event) => {
                 setValue(event.target.value)

--- a/packages/agent-ui/src/components/MessageParts.tsx
+++ b/packages/agent-ui/src/components/MessageParts.tsx
@@ -6,6 +6,7 @@ import { latestWorkLabel } from "../activity-label"
 import { BashToolView } from "../bash/BashToolView"
 import type { NormalizedPart, NormalizedTool } from "../parts"
 import { ReadToolView } from "../read/ReadToolView"
+import { ACTIVITY_STATUS_ROW_CLASS_NAME, ActivityStatusText } from "./ActivityStatus"
 import { FileAttachmentCard } from "./FileAttachmentCard"
 
 /**
@@ -99,14 +100,24 @@ function WorkGroup({
 
   const toolCount = parts.reduce((count, part) => count + (part.kind === "tool" ? 1 : 0), 0)
   const hasTools = toolCount > 0
-  const label = inProgress ? `${latestWorkLabel(parts)}…` : hasTools ? "Worked" : "Reasoning"
+  const liveLabel = latestWorkLabel(parts)
+  const label = hasTools ? "Worked" : "Reasoning"
   const detail =
     !inProgress && hasTools ? `${toolCount} ${toolCount === 1 ? "step" : "steps"}` : undefined
 
   return (
     <Collapsible open={open} onOpenChange={setOpen} className="max-w-full">
-      <CollapsibleTrigger className="group flex w-fit max-w-full items-center gap-1.5 rounded-md px-1 py-0.5 text-[13px] leading-normal text-muted-foreground outline-none transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring">
-        <span className={cn(inProgress && "shimmer")}>{label}</span>
+      <CollapsibleTrigger
+        className={cn(
+          ACTIVITY_STATUS_ROW_CLASS_NAME,
+          "outline-none transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+        )}
+      >
+        {inProgress ? (
+          <ActivityStatusText label={liveLabel} className="shimmer" />
+        ) : (
+          <span>{label}</span>
+        )}
         {detail ? <span className="text-muted-foreground/60">· {detail}</span> : null}
         <ChevronRight className="size-4 shrink-0 opacity-0 transition-all group-hover:opacity-100 group-focus-visible:opacity-100 group-data-[state=open]:rotate-90 group-data-[state=open]:opacity-100" />
       </CollapsibleTrigger>

--- a/packages/agent-ui/src/components/MessageParts.tsx
+++ b/packages/agent-ui/src/components/MessageParts.tsx
@@ -1,7 +1,8 @@
 import { Collapsible, CollapsibleContent, CollapsibleTrigger, Markdown } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
 import { ChevronRight, Wrench } from "lucide-react"
-import { memo, useEffect, useRef, useState } from "react"
+import { memo, useState } from "react"
+import { latestWorkLabel } from "../activity-label"
 import { BashToolView } from "../bash/BashToolView"
 import type { NormalizedPart, NormalizedTool } from "../parts"
 import { ReadToolView } from "../read/ReadToolView"
@@ -18,7 +19,7 @@ export function AssistantBody({
   live = false,
 }: {
   parts: readonly NormalizedPart[]
-  /** True while this body is driven by an in-flight run, so the trailing work group stays open. */
+  /** True while this body is driven by an in-flight run, so its headline shows live progress. */
   live?: boolean
 }) {
   const blocks: React.ReactNode[] = []
@@ -63,7 +64,7 @@ export function AssistantBody({
     workBuffer.push(part)
   })
   flushText()
-  // The final work run is the only one that can still be receiving steps: keep it open while live.
+  // The final work run is the only one that can still be receiving steps.
   flushWork(live)
 
   return <div className="flex flex-col gap-3">{blocks}</div>
@@ -82,12 +83,10 @@ const FileBlock = memo(function FileBlock({
 })
 
 /**
- * A consecutive run of reasoning + tool parts, folded into a single disclosure. It stays open while
- * `inProgress` — i.e. this is the trailing run of a live turn still receiving steps — and collapses
- * once it settles (the run finishes, or narration text moves past it). Open/close is keyed off that
- * single signal, never per-part streaming, so it doesn't flicker as each step settles before the
- * next begins. Inside, items flow in a single indented column — reasoning as plain text, tools as
- * their own quiet markers that expand inline — never as dropdowns stacked inside this dropdown.
+ * A consecutive run of reasoning + tool parts, folded into a single disclosure. It stays closed
+ * unless the user explicitly opens it, including while work is live. The collapsed shimmer follows
+ * the newest step, keeping the main transcript informative without exposing debug detail. Inside,
+ * items flow in one indented column and can expand inline when deeper inspection is useful.
  */
 function WorkGroup({
   parts,
@@ -96,27 +95,11 @@ function WorkGroup({
   parts: readonly NormalizedPart[]
   inProgress: boolean
 }) {
-  const [open, setOpen] = useState(inProgress)
-  const wasInProgressRef = useRef(inProgress)
-
-  useEffect(() => {
-    if (inProgress && !wasInProgressRef.current) {
-      setOpen(true)
-    } else if (!inProgress && wasInProgressRef.current) {
-      setOpen(false)
-    }
-    wasInProgressRef.current = inProgress
-  }, [inProgress])
+  const [open, setOpen] = useState(false)
 
   const toolCount = parts.reduce((count, part) => count + (part.kind === "tool" ? 1 : 0), 0)
   const hasTools = toolCount > 0
-  const label = inProgress
-    ? hasTools
-      ? "Working…"
-      : "Reasoning…"
-    : hasTools
-      ? "Worked"
-      : "Reasoning"
+  const label = inProgress ? `${latestWorkLabel(parts)}…` : hasTools ? "Worked" : "Reasoning"
   const detail =
     !inProgress && hasTools ? `${toolCount} ${toolCount === 1 ? "step" : "steps"}` : undefined
 
@@ -125,7 +108,7 @@ function WorkGroup({
       <CollapsibleTrigger className="group flex w-fit max-w-full items-center gap-1.5 rounded-md px-1 py-0.5 text-[13px] leading-normal text-muted-foreground outline-none transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring">
         <span className={cn(inProgress && "shimmer")}>{label}</span>
         {detail ? <span className="text-muted-foreground/60">· {detail}</span> : null}
-        <ChevronRight className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
+        <ChevronRight className="size-4 shrink-0 opacity-0 transition-all group-hover:opacity-100 group-focus-visible:opacity-100 group-data-[state=open]:rotate-90 group-data-[state=open]:opacity-100" />
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="scrollbar-thin mt-2 ml-1.5 flex max-h-[min(24rem,50vh)] flex-col gap-3 overflow-y-auto overscroll-contain border-l-2 border-border py-0.5 pr-2 pl-3">
@@ -196,7 +179,7 @@ function ToolCallRow({ tool }: { tool: NormalizedTool }) {
           <span className="min-w-0 truncate font-medium">{tool.toolName}</span>
           <ToolStatus state={tool.state} />
           {expandable ? (
-            <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
+            <ChevronRight className="size-3.5 shrink-0 opacity-0 transition-all group-hover:opacity-100 group-focus-visible:opacity-100 group-data-[state=open]:rotate-90 group-data-[state=open]:opacity-100" />
           ) : null}
         </CollapsibleTrigger>
         <CollapsibleContent className="mt-2 space-y-2">

--- a/packages/agent-ui/src/components/MessageView.tsx
+++ b/packages/agent-ui/src/components/MessageView.tsx
@@ -163,15 +163,11 @@ export function LiveAssistant({
 
 export function ThinkingMarker({ takingLonger = false }: { takingLonger?: boolean }) {
   return (
-    <div className="flex flex-col gap-1">
-      <div className={ACTIVITY_STATUS_ROW_CLASS_NAME} role="status" aria-label="Agent is working">
-        <ActivityStatusText label="Thinking" className="shimmer" />
-      </div>
-      {takingLonger ? (
-        <p className="px-1 text-xs text-muted-foreground" role="status">
-          Taking a little longer than usual…
-        </p>
-      ) : null}
+    <div className={ACTIVITY_STATUS_ROW_CLASS_NAME} role="status" aria-label="Agent is working">
+      <ActivityStatusText
+        label={takingLonger ? "Taking a little longer" : "Thinking"}
+        className="shimmer"
+      />
     </div>
   )
 }

--- a/packages/agent-ui/src/components/MessageView.tsx
+++ b/packages/agent-ui/src/components/MessageView.tsx
@@ -18,6 +18,7 @@ import type {
   AgentFileRef,
   AgentMessage,
 } from "../types"
+import { ACTIVITY_STATUS_ROW_CLASS_NAME, ActivityStatusText } from "./ActivityStatus"
 import { ContextChips } from "./ContextChips"
 import { FileAttachmentCard } from "./FileAttachmentCard"
 import { AssistantBody } from "./MessageParts"
@@ -163,11 +164,11 @@ export function LiveAssistant({
 export function ThinkingMarker({ takingLonger = false }: { takingLonger?: boolean }) {
   return (
     <div className="flex flex-col gap-1">
-      <Marker role="status" aria-label="Agent is thinking">
-        <MarkerContent className="shimmer">Thinking…</MarkerContent>
-      </Marker>
+      <div className={ACTIVITY_STATUS_ROW_CLASS_NAME} role="status" aria-label="Agent is working">
+        <ActivityStatusText label="Thinking" className="shimmer" />
+      </div>
       {takingLonger ? (
-        <p className="pl-6 text-xs text-muted-foreground" role="status">
+        <p className="px-1 text-xs text-muted-foreground" role="status">
           Taking a little longer than usual…
         </p>
       ) : null}

--- a/packages/agent-ui/src/hooks/useAgentConversation.ts
+++ b/packages/agent-ui/src/hooks/useAgentConversation.ts
@@ -17,11 +17,11 @@ import {
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useEffect, useMemo, useState } from "react"
 import {
-  DELAYED_WAITING_COPY_MS,
+  EXTENDED_WAITING_STATUS_MS,
   isActiveAgentRunStatus,
   presentActiveTurn,
   selectActiveRunId,
-  shouldShowDelayedWaitingCopy,
+  shouldShowExtendedWaitingStatus,
 } from "../runPresentation"
 import { THREAD_PAGE_SIZE } from "../threadNavigation"
 import type { AgentContextEntryInput, AgentFileRef, AgentRun } from "../types"
@@ -206,7 +206,7 @@ export function useAgentConversation({
     messagesLoading: messagesQuery.isFetching,
   })
   const isRunning = presentation.kind === "responding"
-  const waitingLonger = useDelayedWaitingCopy(
+  const waitingLonger = useExtendedWaitingStatus(
     presentation.kind === "responding" ? presentation.queuedRun : null
   )
 
@@ -395,15 +395,15 @@ function deriveTitle(text: string): string {
   return firstLine.length <= 60 ? firstLine : `${firstLine.slice(0, 57)}...`
 }
 
-function useDelayedWaitingCopy(run: Pick<AgentRun, "status" | "createdAt"> | null): boolean {
-  const [visible, setVisible] = useState(() => shouldShowDelayedWaitingCopy(run))
+function useExtendedWaitingStatus(run: Pick<AgentRun, "status" | "createdAt"> | null): boolean {
+  const [visible, setVisible] = useState(() => shouldShowExtendedWaitingStatus(run))
 
   useEffect(() => {
     if (!run || run.status !== "queued") {
       setVisible(false)
       return
     }
-    const remaining = DELAYED_WAITING_COPY_MS - (Date.now() - Date.parse(run.createdAt))
+    const remaining = EXTENDED_WAITING_STATUS_MS - (Date.now() - Date.parse(run.createdAt))
     if (remaining <= 0) {
       setVisible(true)
       return

--- a/packages/agent-ui/src/read/ReadToolView.tsx
+++ b/packages/agent-ui/src/read/ReadToolView.tsx
@@ -1,6 +1,6 @@
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@sixb/ui/components"
-import { cn } from "@sixb/ui/lib/utils"
 import { BookOpen, ChevronRight, FileText, type LucideIcon } from "lucide-react"
+import { ActivityStatusText } from "../components/ActivityStatus"
 import type { NormalizedTool } from "../parts"
 import { coerceReadInput, coerceReadOutput, describeRead } from "./interpret"
 
@@ -67,7 +67,11 @@ function ReadLine({
   return (
     <div className="flex w-fit max-w-full items-center gap-1.5 text-[13px] leading-normal text-muted-foreground">
       <Icon className="size-3.5 shrink-0" />
-      <span className={cn("min-w-0 truncate font-medium", running && "shimmer")}>{label}</span>
+      {running ? (
+        <ActivityStatusText label={label} className="font-medium shimmer" />
+      ) : (
+        <span className="min-w-0 truncate font-medium">{label}</span>
+      )}
       {detail ? (
         <span className="min-w-0 shrink truncate text-muted-foreground/60">{detail}</span>
       ) : null}

--- a/packages/agent-ui/src/read/ReadToolView.tsx
+++ b/packages/agent-ui/src/read/ReadToolView.tsx
@@ -29,7 +29,7 @@ export function ReadToolView({ tool }: { tool: NormalizedTool }) {
             {description.detail}
           </span>
         ) : null}
-        <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
+        <ChevronRight className="size-3.5 shrink-0 opacity-0 transition-all group-hover:opacity-100 group-focus-visible:opacity-100 group-data-[state=open]:rotate-90 group-data-[state=open]:opacity-100" />
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="mt-3 min-w-0 space-y-2 text-xs">

--- a/packages/agent-ui/src/runPresentation.ts
+++ b/packages/agent-ui/src/runPresentation.ts
@@ -2,18 +2,18 @@ import type { LiveRunState } from "./liveRun"
 import type { NormalizedPart } from "./parts"
 import type { AgentMessage, AgentRun, AgentRunStatus } from "./types"
 
-export const DELAYED_WAITING_COPY_MS = 20_000
+export const EXTENDED_WAITING_STATUS_MS = 20_000
 
 export function isActiveAgentRunStatus(status: AgentRunStatus): boolean {
   return status === "queued" || status === "running"
 }
 
-/** The delayed copy belongs only to queue startup; running-before-content keeps the plain shimmer. */
-export function shouldShowDelayedWaitingCopy(
+/** The extended status belongs only to queue startup; running-before-content keeps plain thinking. */
+export function shouldShowExtendedWaitingStatus(
   run: Pick<AgentRun, "status" | "createdAt"> | null,
   now = Date.now()
 ): boolean {
-  return run?.status === "queued" && now - Date.parse(run.createdAt) >= DELAYED_WAITING_COPY_MS
+  return run?.status === "queued" && now - Date.parse(run.createdAt) >= EXTENDED_WAITING_STATUS_MS
 }
 
 /**
@@ -65,7 +65,7 @@ export interface ActiveTurnSources {
 
 export type ActiveTurnPresentation =
   /** Waiting or streaming. `queuedRun` is set only while the wait is queue-side, before the run
-   * announces itself on the stream — it feeds the delayed waiting copy. */
+   * announces itself on the stream — it controls the extended waiting status. */
   | { readonly kind: "responding"; readonly queuedRun: AgentRun | null }
   /** The newest run failed before any durable assistant message; `run` feeds the retry endpoint. */
   | { readonly kind: "failed"; readonly run: AgentRun }

--- a/packages/agent-ui/tests/activity.test.ts
+++ b/packages/agent-ui/tests/activity.test.ts
@@ -3,7 +3,9 @@ import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { AgentExecutionTrace } from "../src/AgentExecutionTrace"
 import { BashToolView } from "../src/bash/BashToolView"
+import { ACTIVITY_STATUS_ROW_CLASS_NAME, activityStatusAt } from "../src/components/ActivityStatus"
 import { AssistantBody } from "../src/components/MessageParts"
+import { ThinkingMarker } from "../src/components/MessageView"
 import { type NormalizedPart, normalizeDurableParts } from "../src/parts"
 import type { AgentMessagePart } from "../src/types"
 
@@ -111,6 +113,26 @@ describe("assistant work dropdowns", () => {
     expect(html).toContain("group-focus-visible:opacity-100")
     expect(html).toContain("group-data-[state=open]:opacity-100")
     expect(html).not.toContain("Checking the available records.")
+  })
+
+  test("keeps the pre-token and reasoning activity rows on one layout contract", () => {
+    const waiting = renderToStaticMarkup(createElement(ThinkingMarker))
+    const reasoningStarted = renderAssistant([reasoning("")], true)
+
+    expect(waiting).toContain(ACTIVITY_STATUS_ROW_CLASS_NAME)
+    expect(reasoningStarted).toContain(ACTIVITY_STATUS_ROW_CLASS_NAME)
+    expect(reasoningStarted).toContain("Thinking…")
+    expect(reasoningStarted).not.toContain(">Working…<")
+  })
+
+  test("updates long indeterminate waits without inventing completion progress", () => {
+    expect(activityStatusAt("Thinking", 0)).toBe("Thinking")
+    expect(activityStatusAt("Thinking", 7_999)).toBe("Thinking")
+    expect(activityStatusAt("Thinking", 8_000)).toBe("Working through it")
+    expect(activityStatusAt("Thinking", 20_000)).toBe("Taking a closer look")
+    expect(activityStatusAt("Thinking", 55_000)).toBe("Still working")
+    expect(activityStatusAt("Preparing a command", 11_999)).toBe("Preparing a command")
+    expect(activityStatusAt("Preparing a command", 12_000)).toBe("Still preparing a command")
   })
 
   test("describes Sixb help as project work instead of CLI output", () => {

--- a/packages/agent-ui/tests/activity.test.ts
+++ b/packages/agent-ui/tests/activity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { AgentExecutionTrace } from "../src/AgentExecutionTrace"
+import { BashToolView } from "../src/bash/BashToolView"
 import { AssistantBody } from "../src/components/MessageParts"
 import { type NormalizedPart, normalizeDurableParts } from "../src/parts"
 import type { AgentMessagePart } from "../src/types"
@@ -97,16 +98,46 @@ describe("assistant work dropdowns", () => {
     expect(html).toContain("Dispatch within 90 minutes.")
   })
 
-  test("caps an expanded work group and scrolls its details independently", () => {
+  test("keeps live work closed and summarizes the latest step", () => {
     const html = renderAssistant(
       [reasoning("Checking the available records."), tool("search", "input-available")],
       true
     )
 
-    expect(html).toContain("Working…")
-    expect(html).toContain("max-h-[min(24rem,50vh)]")
-    expect(html).toContain("overflow-y-auto")
-    expect(html).toContain("overscroll-contain")
+    expect(html).toContain("Using search…")
+    expect(html).toContain("shimmer")
+    expect(html).toContain('data-state="closed"')
+    expect(html).toContain("group-hover:opacity-100")
+    expect(html).toContain("group-focus-visible:opacity-100")
+    expect(html).toContain("group-data-[state=open]:opacity-100")
+    expect(html).not.toContain("Checking the available records.")
+  })
+
+  test("describes Sixb help as project work instead of CLI output", () => {
+    const html = renderAssistant([bashTool("sixb objects query --help")], true)
+
+    expect(html).toContain("Checking how to work with project data…")
+    expect(html).not.toContain("CLI")
+  })
+
+  test("never exposes partially streamed Bash argument JSON", () => {
+    const html = renderAssistant(
+      [
+        {
+          kind: "tool",
+          tool: {
+            toolName: "bash",
+            state: "input-streaming",
+            inputText: `{"command":"cat > \\"$SIXB_OUTPUT_PATH\\" <<'HTML'\\n<style>body { color: red; }`,
+          },
+        },
+      ],
+      true
+    )
+
+    expect(html).toContain("Preparing a command…")
+    expect(html).not.toContain("SIXB_OUTPUT_PATH")
+    expect(html).not.toContain("color: red")
   })
 
   test("uses a content-width trigger instead of highlighting the full row", () => {
@@ -150,6 +181,30 @@ describe("assistant work dropdowns", () => {
     expect(html).not.toContain("Reasoning…")
     expect(html).toContain("Direct answer.")
   })
+
+  test("reveals item disclosure arrows only on hover, focus, or open", () => {
+    const html = renderToStaticMarkup(
+      createElement(BashToolView, {
+        tool: {
+          state: "output-available",
+          input: { command: "sixb ontology list" },
+          output: {
+            exitCode: 0,
+            stdout: "[]",
+            stderr: "",
+            durationMs: 10,
+            stdoutTruncated: false,
+            stderrTruncated: false,
+          },
+        },
+      })
+    )
+
+    expect(html).toContain("opacity-0")
+    expect(html).toContain("group-hover:opacity-100")
+    expect(html).toContain("group-focus-visible:opacity-100")
+    expect(html).toContain("group-data-[state=open]:opacity-100")
+  })
 })
 
 function renderAssistant(parts: readonly NormalizedPart[], live = false): string {
@@ -171,6 +226,17 @@ function tool(
       state,
       input: { query: "example" },
       ...(state === "output-available" ? { output: { ok: true } } : {}),
+    },
+  }
+}
+
+function bashTool(command: string): Extract<NormalizedPart, { kind: "tool" }> {
+  return {
+    kind: "tool",
+    tool: {
+      toolName: "bash",
+      state: "input-available",
+      input: { command },
     },
   }
 }

--- a/packages/agent-ui/tests/activity.test.ts
+++ b/packages/agent-ui/tests/activity.test.ts
@@ -3,7 +3,11 @@ import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { AgentExecutionTrace } from "../src/AgentExecutionTrace"
 import { BashToolView } from "../src/bash/BashToolView"
-import { ACTIVITY_STATUS_ROW_CLASS_NAME, activityStatusAt } from "../src/components/ActivityStatus"
+import {
+  ACTIVITY_STATUS_ROW_CLASS_NAME,
+  ActivityStatusText,
+  activityStatusAt,
+} from "../src/components/ActivityStatus"
 import { AssistantBody } from "../src/components/MessageParts"
 import { ThinkingMarker } from "../src/components/MessageView"
 import { type NormalizedPart, normalizeDurableParts } from "../src/parts"
@@ -125,6 +129,15 @@ describe("assistant work dropdowns", () => {
     expect(reasoningStarted).not.toContain(">Working…<")
   })
 
+  test("keeps a long pre-token wait in the same single status row", () => {
+    const html = renderToStaticMarkup(createElement(ThinkingMarker, { takingLonger: true }))
+
+    expect(html).toContain(ACTIVITY_STATUS_ROW_CLASS_NAME)
+    expect(html).toContain("Taking a little longer…")
+    expect(html).not.toContain("Taking a closer look")
+    expect(html.match(/role="status"/g)).toHaveLength(1)
+  })
+
   test("updates long indeterminate waits without inventing completion progress", () => {
     expect(activityStatusAt("Thinking", 0)).toBe("Thinking")
     expect(activityStatusAt("Thinking", 7_999)).toBe("Thinking")
@@ -133,6 +146,21 @@ describe("assistant work dropdowns", () => {
     expect(activityStatusAt("Thinking", 55_000)).toBe("Still working")
     expect(activityStatusAt("Preparing a command", 11_999)).toBe("Preparing a command")
     expect(activityStatusAt("Preparing a command", 12_000)).toBe("Still preparing a command")
+  })
+
+  test("renders only the current activity phrase", () => {
+    const html = renderToStaticMarkup(
+      createElement(ActivityStatusText, { label: "Thinking", className: "shimmer" })
+    )
+
+    expect(html).toContain("Thinking…")
+    expect(html).toContain("text-left")
+    expect(html).not.toContain("Working through it")
+    expect(html).not.toContain("Taking a closer look")
+    expect(html).not.toContain("Checking the details")
+    expect(html).not.toContain("Still working")
+    expect(html).not.toContain("invisible")
+    expect(html).not.toContain("opacity-0")
   })
 
   test("describes Sixb help as project work instead of CLI output", () => {

--- a/packages/agent-ui/tests/bash-interpret.test.ts
+++ b/packages/agent-ui/tests/bash-interpret.test.ts
@@ -80,6 +80,19 @@ describe("classifyCommand", () => {
     })
   })
 
+  test("recognizes CLI commands after ordinary environment setup", () => {
+    expect(classifyCommand("SIXB_DEBUG=1 sixb ontology list")).toEqual({
+      kind: "sixb",
+      command: "ontology.list",
+      args: [],
+    })
+    expect(classifyCommand("env SIXB_DEBUG=1 sixb objects list --type Customer")).toEqual({
+      kind: "sixb",
+      command: "objects.list",
+      args: ["--type", "Customer"],
+    })
+  })
+
   test("separates help and copyable query examples from query execution", () => {
     expect(classifyCommand("sixb objects query --help")).toEqual({
       kind: "sixb",
@@ -90,6 +103,19 @@ describe("classifyCommand", () => {
       kind: "sixb",
       command: "objects.query-example",
       args: ["--example", "incoming"],
+    })
+  })
+
+  test("only treats help tokens in command positions as help", () => {
+    expect(classifyCommand("sixb objects get Customer help")).toEqual({
+      kind: "sixb",
+      command: "objects.get",
+      args: ["Customer", "help"],
+    })
+    expect(classifyCommand("sixb objects query --file help")).toEqual({
+      kind: "sixb",
+      command: "objects.query",
+      args: ["--file", "help"],
     })
   })
 
@@ -114,15 +140,51 @@ describe("classifyCommand", () => {
 
   test("a skill-path read is not mistaken for a Sixb command", () => {
     expect(classifyCommand(`cat skills/sixb/references/query-ir.md`).kind).toBe("read-skill")
+    expect(classifyCommand(`echo cat skills/sixb/references/query-ir.md`).kind).toBe("generic")
   })
 
-  test("falls back to generic for plain, compound, and legacy curl commands", () => {
+  test("falls back to generic for plain and legacy curl commands", () => {
     expect(classifyCommand("ls -la /workspace")).toEqual({
       kind: "generic",
       command: "ls -la /workspace",
     })
-    expect(classifyCommand("sixb ontology list | jq .").kind).toBe("generic")
     expect(classifyCommand(`curl -sS "$SIXB_API_BASE_URL/api/object-types"`).kind).toBe("generic")
+  })
+
+  test("keeps the meaningful intent when commands are combined", () => {
+    expect(classifyCommand("sixb ontology list | jq .")).toEqual({
+      kind: "compound",
+      primary: { kind: "sixb", command: "ontology.list", args: [] },
+      stepCount: 2,
+    })
+
+    const tests = classifyCommand("cd packages/core && bun test tests")
+    expect(tests.kind).toBe("compound")
+    expect(describeBash(tests, null).runningTitle).toBe("Running tests")
+
+    const fallback = classifyCommand("bun test || echo failed")
+    expect(fallback.kind).toBe("compound")
+    expect(describeBash(fallback, null).runningTitle).toBe("Running tests")
+
+    expect(describeBash(classifyCommand("uname -a && date"), null).runningTitle).toBe(
+      "Running 2 steps"
+    )
+    expect(describeBash(classifyCommand("find packages | head -n 20"), null).runningTitle).toBe(
+      "Inspecting files"
+    )
+  })
+
+  test("does not split operators inside quotes or heredocs", () => {
+    expect(classifyCommand(`echo "one && two"`).kind).toBe("generic")
+    expect(
+      describeBash(classifyCommand(`printf '%s' 'one && two' && pwd`), null).runningTitle
+    ).toBe("Checking the workspace location")
+
+    const html = classifyCommand(
+      `cat > output.html <<'HTML'\n<script>ready && render()</script>\nHTML`
+    )
+    expect(html.kind).toBe("generic")
+    expect(describeBash(html, null).runningTitle).toBe("Creating an HTML file")
   })
 })
 
@@ -141,15 +203,12 @@ describe("describeBash", () => {
     expect(`${root.title} ${objects.title}`).not.toContain("CLI")
   })
 
-  test("puts a generic command directly after the activity verb", () => {
-    const description = describeBash(
-      { kind: "generic", command: "ls -la /workspace" },
-      output("files")
-    )
+  test("keeps an unknown generic command out of the collapsed activity line", () => {
+    const description = describeBash({ kind: "generic", command: "uname -a" }, output("files"))
 
-    expect(description.title).toBe("Ran")
+    expect(description.title).toBe("Ran a command")
     expect(description.runningTitle).toBe("Running a command")
-    expect(description.detail).toBe("ls -la /workspace")
+    expect(description.detail).toBeUndefined()
   })
 
   test("describes common generic commands by intent instead of exposing their payload", () => {
@@ -168,6 +227,36 @@ describe("describeBash", () => {
     )
     expect(describeBash(classifyCommand("rg -n Customer packages"), null).runningTitle).toBe(
       "Searching files"
+    )
+  })
+
+  test("describes common file inspection commands", () => {
+    expect(describeBash(classifyCommand("ls -la /workspace"), null).runningTitle).toBe(
+      "Inspecting files"
+    )
+    expect(describeBash(classifyCommand("find packages -name '*.ts'"), null).runningTitle).toBe(
+      "Inspecting files"
+    )
+    expect(describeBash(classifyCommand("pwd"), null).runningTitle).toBe(
+      "Checking the workspace location"
+    )
+    expect(describeBash(classifyCommand("head -n 20 README.md"), null).runningTitle).toBe(
+      "Reading a file"
+    )
+  })
+
+  test("classifies generic commands by executable rather than words in their arguments", () => {
+    for (const command of [
+      "echo bun test",
+      "echo ls packages",
+      "echo head README.md",
+      `echo "cat > report.txt"`,
+      "(bun test || true)",
+    ]) {
+      expect(describeBash(classifyCommand(command), null).runningTitle).toBe("Running a command")
+    }
+    expect(describeBash(classifyCommand("TEST_MODE=1 bun test"), null).runningTitle).toBe(
+      "Running tests"
     )
   })
 

--- a/packages/agent-ui/tests/bash-interpret.test.ts
+++ b/packages/agent-ui/tests/bash-interpret.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import {
   classifyCommand,
   coerceBashOutput,
+  commandPreview,
   describeBash,
   humanize,
   objectCount,
@@ -19,148 +20,160 @@ function output(stdout: string, exitCode = 0) {
 }
 
 describe("classifyCommand", () => {
-  test("classifies the ontology discovery curl", () => {
-    expect(classifyCommand(`curl -sS "$SIXB_API_BASE_URL/api/object-types"`)).toEqual({
-      kind: "api-object-types",
+  test("classifies every supported CLI operation from its fixed command path", () => {
+    const cases = {
+      "sixb doctor": "doctor",
+      "sixb context": "context",
+      "sixb project show": "project.show",
+      "sixb ontology list": "ontology.list",
+      "sixb ontology get Customer": "ontology.get",
+      "sixb objects inspect Customer cust-1": "objects.inspect",
+      "sixb objects list --type Customer": "objects.list",
+      "sixb objects get Customer cust-1": "objects.get",
+      "sixb objects search acme": "objects.search",
+      "sixb objects query --file query.json": "objects.query",
+      "sixb objects count --file query.json": "objects.count",
+      "sixb objects exists --file query.json": "objects.exists",
+      "sixb objects facets --file query.json": "objects.facets",
+      "sixb objects links Customer cust-1": "objects.links",
+      "sixb telemetry latest Device fan-1 rpm": "telemetry.latest",
+      "sixb telemetry history Device fan-1 rpm": "telemetry.history",
+      "sixb telemetry query --file telemetry.json": "telemetry.query",
+      "sixb actions list": "actions.list",
+      "sixb actions get archiveCustomer": "actions.get",
+      "sixb actions request archiveCustomer": "actions.request",
+      "sixb action-runs list": "action-runs.list",
+      "sixb action-runs get run-1": "action-runs.get",
+      "sixb files upload report.pdf": "files.upload",
+      "sixb files download action-run run-1 --path /result --output result.json": "files.download",
+      "sixb workflows list": "workflows.list",
+      "sixb workflows get renewCustomer": "workflows.get",
+      "sixb workflows start renewCustomer": "workflows.start",
+      "sixb workflow-runs list": "workflow-runs.list",
+      "sixb workflow-runs get run-2": "workflow-runs.get",
+      "sixb api get /api/project": "api.get",
+      "sixb api post /api/custom --file body.json": "api.post",
+    } as const
+
+    for (const [command, expected] of Object.entries(cases)) {
+      const intent = classifyCommand(command)
+      expect(intent.kind).toBe("sixb")
+      if (intent.kind === "sixb") expect(intent.command).toBe(expected)
+    }
+  })
+
+  test("tokenizes quoted opaque object ids without interpreting their path characters", () => {
+    expect(
+      classifyCommand(`sixb objects get RepositoryIssue 'github:issue:sixb-ai/sixb#297'`)
+    ).toEqual({
+      kind: "sixb",
+      command: "objects.get",
+      args: ["RepositoryIssue", "github:issue:sixb-ai/sixb#297"],
     })
   })
 
-  test("classifies a single object type detail", () => {
-    expect(classifyCommand(`curl -sS "$SIXB_API_BASE_URL/api/object-types/customer"`)).toEqual({
-      kind: "api-object-type-detail",
-      objectTypeId: "customer",
+  test("recognizes an installed CLI by basename", () => {
+    expect(classifyCommand("/opt/sixb/bin/sixb ontology list")).toEqual({
+      kind: "sixb",
+      command: "ontology.list",
+      args: [],
     })
   })
 
-  test("reads the objectTypeId from a GET objects list query string", () => {
-    expect(
-      classifyCommand(`curl -sS "$SIXB_API_BASE_URL/api/objects?objectTypeId=customer&limit=20"`)
-    ).toEqual({ kind: "api-objects-list", objectTypeId: "customer" })
-  })
-
-  test("reads the objectTypeId from a nested POST query body", () => {
-    const command = `curl -sS -H "Content-Type: application/json" -X POST "$SIXB_API_BASE_URL/api/objects/query" --data '{"query":{"kind":"filter","input":{"kind":"start","objectTypeId":"workOrder"},"predicate":{"kind":"eq","propertyId":"status","value":"open"}}}'`
-    expect(classifyCommand(command)).toEqual({
-      kind: "api-objects-query",
-      objectTypeId: "workOrder",
+  test("separates help and copyable query examples from query execution", () => {
+    expect(classifyCommand("sixb objects query --help")).toEqual({
+      kind: "sixb",
+      command: "help",
+      args: ["objects", "query"],
+    })
+    expect(classifyCommand("sixb objects query --example incoming")).toEqual({
+      kind: "sixb",
+      command: "objects.query-example",
+      args: ["--example", "incoming"],
     })
   })
 
-  test("distinguishes count, exists, and facets", () => {
-    const base = (suffix: string) =>
-      `curl -sS -X POST "$SIXB_API_BASE_URL/api/objects/query/${suffix}" --data '{"query":{"kind":"start","objectTypeId":"customer"}}'`
-    expect(classifyCommand(base("count")).kind).toBe("api-count")
-    expect(classifyCommand(base("exists")).kind).toBe("api-exists")
-    expect(classifyCommand(base("facets")).kind).toBe("api-facets")
-  })
-
-  test("classifies object detail and telemetry reads", () => {
-    expect(classifyCommand(`curl -sS "$SIXB_API_BASE_URL/api/objects/customer/cust-001"`)).toEqual({
-      kind: "api-object-detail",
-      objectTypeId: "customer",
-      objectId: "cust-001",
-    })
-    expect(
-      classifyCommand(`curl -sS "$SIXB_API_BASE_URL/api/objects/device/fan-1/telemetry/rpm/latest"`)
-    ).toEqual({ kind: "api-telemetry-latest", objectId: "fan-1", propertyId: "rpm" })
-    expect(
-      classifyCommand(
-        `curl -sS "$SIXB_API_BASE_URL/api/objects/device/fan-1/telemetry/rpm/history?limit=100"`
-      )
-    ).toEqual({ kind: "api-telemetry-history", objectId: "fan-1", propertyId: "rpm" })
-  })
-
-  test("classifies bulk telemetry at the top-level route", () => {
-    expect(
-      classifyCommand(
-        `curl -sS -X POST "$SIXB_API_BASE_URL/api/telemetry/history" --data '{"series":[]}'`
-      )
-    ).toEqual({ kind: "api-telemetry-bulk" })
-  })
-
-  test("classifies actions list versus action request", () => {
-    expect(classifyCommand(`curl -sS "$SIXB_API_BASE_URL/api/actions"`).kind).toBe(
-      "api-actions-list"
-    )
-    expect(
-      classifyCommand(
-        `curl -sS -X POST "$SIXB_API_BASE_URL/api/actions/archiveCustomer" --data '{}'`
-      )
-    ).toEqual({ kind: "api-action-request", actionId: "archiveCustomer" })
-  })
-
-  test("treats a curl with a body flag but no -X as an implicit POST", () => {
-    // No `-X POST`: curl still POSTs because `-d` is present. Without the inference this would
-    // default to GET and be mislabelled as an actions list rather than an action request.
-    expect(
-      classifyCommand(`curl -sS "$SIXB_API_BASE_URL/api/actions/archiveCustomer" -d '{}'`)
-    ).toEqual({ kind: "api-action-request", actionId: "archiveCustomer" })
-    expect(
-      classifyCommand(
-        `curl -sS "$SIXB_API_BASE_URL/api/actions/archiveCustomer" --data-raw '{"reason":"x"}'`
-      )
-    ).toEqual({ kind: "api-action-request", actionId: "archiveCustomer" })
-    // --data-urlencode is a real curl body flag, so it implies POST too.
-    expect(
-      classifyCommand(
-        `curl -sS "$SIXB_API_BASE_URL/api/actions/archiveCustomer" --data-urlencode 'reason=x'`
-      ).kind
-    ).toBe("api-action-request")
-  })
-
-  test("does not infer POST from a body flag that only appears inside a quoted argument", () => {
-    // The `--data` here is inside a header value, not a real curl flag: method stays GET, so this
-    // is an actions list — not an action request. Guards the quote-blanking in the method detector.
-    expect(
-      classifyCommand(
-        `curl -sS "$SIXB_API_BASE_URL/api/actions/archiveCustomer" -H "X-Note: --data disabled"`
-      ).kind
-    ).toBe("api-actions-list")
-  })
-
-  test("keeps an explicit method even when a body flag is present", () => {
-    // `-X GET` must win over the implicit-POST inference triggered by `-d`.
-    expect(
-      classifyCommand(`curl -sS -X GET "$SIXB_API_BASE_URL/api/actions/archiveCustomer" -d '{}'`)
-        .kind
-    ).toBe("api-actions-list")
-  })
-
-  test("classifies an action run lookup", () => {
-    expect(classifyCommand(`curl -sS "$SIXB_API_BASE_URL/api/action-runs/run-abc123"`)).toEqual({
-      kind: "api-action-run",
-      runId: "run-abc123",
+  test("keeps unknown Sixb operations recognizable without guessing their meaning", () => {
+    expect(classifyCommand("sixb objects future --value x")).toEqual({
+      kind: "sixb",
+      command: "unknown",
+      args: ["objects", "future", "--value", "x"],
     })
   })
 
   test("classifies a skill read with skill name and reference", () => {
-    expect(classifyCommand(`cat "$SIXB_SKILLS_DIR/sixb-query/SKILL.md"`)).toEqual({
+    expect(classifyCommand(`cat "$SIXB_SKILLS_DIR/sixb/SKILL.md"`)).toEqual({
       kind: "read-skill",
-      skillName: "sixb-query",
+      skillName: "sixb",
       reference: undefined,
     })
     expect(
-      classifyCommand(`cat /tmp/sandbox/.sixb/agent/skills/sixb-query/references/query-api.md`)
-    ).toEqual({ kind: "read-skill", skillName: "sixb-query", reference: "query-api.md" })
+      classifyCommand(`cat /tmp/sandbox/.sixb/agent/skills/sixb/references/query-ir.md`)
+    ).toEqual({ kind: "read-skill", skillName: "sixb", reference: "query-ir.md" })
   })
 
-  test("a skill-path read is not mistaken for an API call", () => {
-    // The string contains "query-api" but never "/api/" — must stay a skill read.
-    expect(classifyCommand(`cat skills/sixb-query/references/query-api.md`).kind).toBe("read-skill")
+  test("a skill-path read is not mistaken for a Sixb command", () => {
+    expect(classifyCommand(`cat skills/sixb/references/query-ir.md`).kind).toBe("read-skill")
   })
 
-  test("falls back to generic for plain shell commands", () => {
+  test("falls back to generic for plain, compound, and legacy curl commands", () => {
     expect(classifyCommand("ls -la /workspace")).toEqual({
       kind: "generic",
       command: "ls -la /workspace",
     })
+    expect(classifyCommand("sixb ontology list | jq .").kind).toBe("generic")
+    expect(classifyCommand(`curl -sS "$SIXB_API_BASE_URL/api/object-types"`).kind).toBe("generic")
   })
 })
 
 describe("describeBash", () => {
+  test("describes help as checking project capabilities without CLI terminology", () => {
+    const root = describeBash({ kind: "sixb", command: "help", args: [] }, null)
+    const objects = describeBash(
+      { kind: "sixb", command: "help", args: ["objects", "query"] },
+      null
+    )
+
+    expect(root.title).toBe("Checked available project operations")
+    expect(root.runningTitle).toBe("Checking available project operations")
+    expect(objects.title).toBe("Checked how to work with project data")
+    expect(objects.runningTitle).toBe("Checking how to work with project data")
+    expect(`${root.title} ${objects.title}`).not.toContain("CLI")
+  })
+
+  test("puts a generic command directly after the activity verb", () => {
+    const description = describeBash(
+      { kind: "generic", command: "ls -la /workspace" },
+      output("files")
+    )
+
+    expect(description.title).toBe("Ran")
+    expect(description.runningTitle).toBe("Running a command")
+    expect(description.detail).toBe("ls -la /workspace")
+  })
+
+  test("describes common generic commands by intent instead of exposing their payload", () => {
+    const html = describeBash(
+      classifyCommand(
+        `cat > "$SIXB_OUTPUT_PATH" <<'HTML'\n<!DOCTYPE html>\n<html>\n<body>Hi</body>\n</html>\nHTML`
+      ),
+      null
+    )
+    expect(html.title).toBe("Created an HTML file")
+    expect(html.runningTitle).toBe("Creating an HTML file")
+    expect(html.detail).toBeUndefined()
+
+    expect(describeBash(classifyCommand("bun test packages/core/tests"), null).runningTitle).toBe(
+      "Running tests"
+    )
+    expect(describeBash(classifyCommand("rg -n Customer packages"), null).runningTitle).toBe(
+      "Searching files"
+    )
+  })
+
   test("summarizes the ontology with a count", () => {
     const parsed = output(`[{"id":"Customer"},{"id":"Project"},{"id":"Invoice"}]`)
-    const description = describeBash({ kind: "api-object-types" }, parsed)
+    const description = describeBash({ kind: "sixb", command: "ontology.list", args: [] }, parsed)
     expect(description.title).toBe("Explored the ontology")
     expect(description.detail).toBe("3 object types")
   })
@@ -168,7 +181,7 @@ describe("describeBash", () => {
   test("summarizes a query result count with a humanized type label", () => {
     const parsed = output(`{"objects":[{"primaryId":"a"},{"primaryId":"b"}],"hasMore":false}`)
     const description = describeBash(
-      { kind: "api-objects-query", objectTypeId: "workOrder" },
+      { kind: "sixb", command: "objects.get", args: ["workOrder", "a", "b"] },
       parsed
     )
     expect(description.title).toBe("Found 2 work orders")
@@ -176,10 +189,10 @@ describe("describeBash", () => {
 
   test("summarizes a count response value", () => {
     const description = describeBash(
-      { kind: "api-count", objectTypeId: "customer" },
+      { kind: "sixb", command: "objects.count", args: ["--file", "query.json"] },
       output(`{"count":142}`)
     )
-    expect(description.title).toBe("Counted customers")
+    expect(description.title).toBe("Counted objects")
     expect(description.detail).toBe("142")
   })
 
@@ -189,9 +202,25 @@ describe("describeBash", () => {
       status: "succeeded",
       subject: { kind: "object", objectTypeId: "customer", primaryId: "cust-001" },
     })
-    const description = describeBash({ kind: "api-action-run", runId: "run-1" }, output(json))
+    const description = describeBash(
+      { kind: "sixb", command: "action-runs.get", args: ["run-1"] },
+      output(json)
+    )
     expect(description.title).toBe("Archive customer succeeded")
     expect(description.detail).toBe("customer cust-001")
+  })
+
+  test("summarizes an object inspection graph", () => {
+    const description = describeBash(
+      {
+        kind: "sixb",
+        command: "objects.inspect",
+        args: ["Customer", "github:customer:acme/1#owner"],
+      },
+      output(`{"graph":{"objectCount":4,"linkCount":3}}`)
+    )
+    expect(description.title).toBe("Inspected github:customer:acme/1#owner")
+    expect(description.detail).toBe("4 objects · 3 links")
   })
 })
 
@@ -223,5 +252,13 @@ describe("helpers", () => {
     expect(objectCount([1, 2, 3])).toBe(3)
     expect(objectCount({ objects: [1, 2] })).toBe(2)
     expect(objectCount({ count: 9 })).toBeNull()
+  })
+
+  test("folds multiline command payloads into a stable first-line preview", () => {
+    const preview = commandPreview(
+      "cat > output.html <<'HTML'\n<html>\n<body>large</body>\n</html>"
+    )
+    expect(preview).toBe("cat > output.html <<'HTML'\n… 3 more lines")
+    expect(preview).not.toContain("large")
   })
 })

--- a/packages/agent-ui/tests/bash-shell.test.ts
+++ b/packages/agent-ui/tests/bash-shell.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test"
+import { lexShellCommand } from "../src/bash/shell"
+
+describe("lexShellCommand", () => {
+  test("returns quote-normalized tokens without changing the displayed command", () => {
+    expect(
+      lexShellCommand(`sixb objects get RepositoryIssue 'github:issue:sixb-ai/sixb#297'`)
+    ).toEqual([
+      {
+        command: `sixb objects get RepositoryIssue 'github:issue:sixb-ai/sixb#297'`,
+        tokens: ["sixb", "objects", "get", "RepositoryIssue", "github:issue:sixb-ai/sixb#297"],
+        operatorBefore: undefined,
+      },
+    ])
+  })
+
+  test("splits top-level compound operators and preserves branch relationships", () => {
+    expect(lexShellCommand("cd packages && sixb ontology list | jq .")).toEqual([
+      { command: "cd packages", tokens: ["cd", "packages"], operatorBefore: undefined },
+      {
+        command: "sixb ontology list",
+        tokens: ["sixb", "ontology", "list"],
+        operatorBefore: "&&",
+      },
+      { command: "jq .", tokens: ["jq", "."], operatorBefore: "|" },
+    ])
+  })
+
+  test("does not split quoted operators", () => {
+    expect(lexShellCommand(`printf '%s' 'one && two'`)).toEqual([
+      {
+        command: `printf '%s' 'one && two'`,
+        tokens: ["printf", "%s", "one && two"],
+        operatorBefore: undefined,
+      },
+    ])
+  })
+
+  test("records output redirects without treating their targets as command arguments", () => {
+    expect(lexShellCommand(`echo hello > "report.txt"`)).toEqual([
+      {
+        command: `echo hello > "report.txt"`,
+        tokens: ["echo", "hello"],
+        outputRedirects: ["report.txt"],
+        operatorBefore: undefined,
+      },
+    ])
+  })
+
+  test("leaves shell programs and heredocs opaque", () => {
+    expect(lexShellCommand("if true; then echo yes; fi")).toBeNull()
+    expect(lexShellCommand("cat <<'EOF'\nhello\nEOF")).toBeNull()
+    expect(lexShellCommand("echo one & echo two")).toBeNull()
+    expect(lexShellCommand("(bun test || true)")).toBeNull()
+    expect(lexShellCommand("{ bun test || true; }")).toBeNull()
+  })
+})

--- a/packages/agent-ui/tests/composer.test.ts
+++ b/packages/agent-ui/tests/composer.test.ts
@@ -2,13 +2,20 @@ import { describe, expect, test } from "bun:test"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
-import { Composer, type ComposerProps } from "../src/components/Composer"
+import { Composer, type ComposerProps, composerCanFocus } from "../src/components/Composer"
 
 describe("Composer", () => {
   test("requests initial focus only while the input is available", () => {
     expect(renderComposer()).toContain('autofocus=""')
     expect(renderComposer({ disabled: true, running: true })).not.toContain('autofocus=""')
     expect(renderComposer({ pending: true })).not.toContain('autofocus=""')
+  })
+
+  test("uses one availability policy for initial, return, and completion focus", () => {
+    expect(composerCanFocus({})).toBe(true)
+    expect(composerCanFocus({ disabled: true })).toBe(false)
+    expect(composerCanFocus({ pending: true })).toBe(false)
+    expect(composerCanFocus({ running: true })).toBe(false)
   })
 })
 

--- a/packages/agent-ui/tests/composer.test.ts
+++ b/packages/agent-ui/tests/composer.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { Composer, type ComposerProps } from "../src/components/Composer"
+
+describe("Composer", () => {
+  test("requests initial focus only while the input is available", () => {
+    expect(renderComposer()).toContain('autofocus=""')
+    expect(renderComposer({ disabled: true, running: true })).not.toContain('autofocus=""')
+    expect(renderComposer({ pending: true })).not.toContain('autofocus=""')
+  })
+})
+
+function renderComposer(props: Partial<ComposerProps> = {}): string {
+  const queryClient = new QueryClient()
+  return renderToStaticMarkup(
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(Composer, {
+        onSend: () => undefined,
+        ...props,
+      })
+    )
+  )
+}

--- a/packages/agent-ui/tests/run-presentation.test.ts
+++ b/packages/agent-ui/tests/run-presentation.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from "bun:test"
 import { createLiveRunState, type LiveRunState } from "../src/liveRun"
 import {
   type ActiveTurnSources,
-  DELAYED_WAITING_COPY_MS,
+  EXTENDED_WAITING_STATUS_MS,
   findPreStreamFailedRun,
   presentActiveTurn,
   selectActiveRunId,
-  shouldShowDelayedWaitingCopy,
+  shouldShowExtendedWaitingStatus,
 } from "../src/runPresentation"
 import type { AgentMessage, AgentRun } from "../src/types"
 
@@ -43,18 +43,20 @@ function assistantMessage(runId: string): AgentMessage {
 }
 
 describe("agent run presentation", () => {
-  test("delays extra waiting copy for queued runs only", () => {
+  test("delays the extended waiting status for queued runs only", () => {
     const queued = run({ id: "queued", status: "queued" })
     const createdAt = Date.parse(queued.createdAt)
 
-    expect(shouldShowDelayedWaitingCopy(queued, createdAt + DELAYED_WAITING_COPY_MS - 1)).toBe(
-      false
-    )
-    expect(shouldShowDelayedWaitingCopy(queued, createdAt + DELAYED_WAITING_COPY_MS)).toBe(true)
     expect(
-      shouldShowDelayedWaitingCopy(
+      shouldShowExtendedWaitingStatus(queued, createdAt + EXTENDED_WAITING_STATUS_MS - 1)
+    ).toBe(false)
+    expect(shouldShowExtendedWaitingStatus(queued, createdAt + EXTENDED_WAITING_STATUS_MS)).toBe(
+      true
+    )
+    expect(
+      shouldShowExtendedWaitingStatus(
         run({ id: "running", status: "running" }),
-        createdAt + DELAYED_WAITING_COPY_MS
+        createdAt + EXTENDED_WAITING_STATUS_MS
       )
     ).toBe(false)
   })
@@ -105,7 +107,7 @@ function liveState(overrides: Partial<LiveRunState>): LiveRunState {
 }
 
 describe("presentActiveTurn", () => {
-  test("a queued run responds with the queued run for the delayed copy", () => {
+  test("a queued run responds with the run needed for the extended waiting status", () => {
     const queued = run({ id: "r1", status: "queued" })
     const presentation = presentActiveTurn(
       sources({ activeRunId: "r1", pendingRun: queued, runs: [queued] })


### PR DESCRIPTION
## Why

The new CLI makes agent execution more structured, but the UI was still exposing that structure as
developer noise: raw streamed argument JSON, long shell payloads, automatic expansion, and labels
such as “Ran a command” or “CLI help.”

Regular users need a calm progress signal. Developers should still be able to inspect exact details
on demand.

## What changes

- Recognize the fixed `sixb` command hierarchy and label activity by user intent.
- Describe help as checking project capabilities rather than “showing CLI help.”
- Summarize ontology, object, graph, action, workflow, and file operations from their results.
- Never render partially streamed Bash argument JSON in the collapsed preview.
- Fold large/multiline generic commands into stable, readable previews.
- Keep work groups collapsed while running and show the latest step in the main shimmer.
- Reveal disclosure arrows only on hover, focus, or when open.
- Use the compact `Ran <command>` fallback for unknown commands.
- Keep full commands, stdout, stderr, and structured results available in the expanded developer
  view.
- Autofocus the composer on load, after an agent response finishes, and when the window becomes
  active again—without stealing focus while disabled.

## Why this shape

The collapsed view is product language; the expanded view is diagnostic evidence. Command
classification is deterministic because the agent CLI has a fixed hierarchy, so the UI no longer
needs to infer meaning from arbitrary `curl` URLs and JSON bodies.

This is a presentation change only. It does not hide or discard execution details.

## Verification

- 31 targeted UI tests / 134 expectations
- Coverage for every supported CLI operation, opaque quoted IDs, help, query examples, unknown
  commands, and legacy curl fallback
- Streaming-preview, collapsed-work, hover-disclosure, and composer-focus tests
- Agent UI typecheck
- Biome on the package

## Stack

**7 of 7.** Depends on the standardized CLI and prompt behavior in PRs 3–6.

### Full stack

1. [#465 — objects: add exact-reference query sources](https://github.com/sixb-ai/sixb/pull/465)
2. [#466 — objects: query links for object sets](https://github.com/sixb-ai/sixb/pull/466)
3. [#467 — agents: ship a self-documenting sandbox CLI](https://github.com/sixb-ai/sixb/pull/467)
4. [#468 — sandboxes: standardize the agent runtime](https://github.com/sixb-ai/sixb/pull/468)
5. [#469 — agents: validate sandbox readiness before execution](https://github.com/sixb-ai/sixb/pull/469)
6. [#470 — agents: replace built-in API skills with CLI guidance](https://github.com/sixb-ai/sixb/pull/470)
7. [#471 — agent-ui: present agent activity in product language](https://github.com/sixb-ai/sixb/pull/471)
