### PR TITLE
linkedin: fix analytics payload compatibility

### DIFF
--- a/connectors/linkedin/README.md
+++ b/connectors/linkedin/README.md
@@ -109,6 +109,11 @@ token lifetime, which the current core credential contract cannot store. When th
 the provider's definitive `invalid_grant` response moves the connection to the same reauthorization
 state.
 
+LinkedIn does not document a programmatic revocation endpoint for this flow. Sixb's revoke
+operation therefore deletes its stored credentials and disconnects the local connections, but the
+member must also remove the application from LinkedIn to revoke the upstream grant. Applications
+can link to the exported `LINKEDIN_PERMITTED_SERVICES_URL` constant for that manual step.
+
 ### LinkedIn PKCE compatibility
 
 Sixb currently requires every managed OAuth adapter to preserve its `state`, `code_challenge`, and
@@ -328,6 +333,7 @@ the served region.
 - [Marketing API versioning](https://learn.microsoft.com/en-us/linkedin/marketing/versioning?view=li-lms-2026-08)
 - [Rest.li query tunneling](https://learn.microsoft.com/en-us/linkedin/shared/api-guide/concepts/query-tunneling)
 - [LinkedIn authorization code flow](https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow)
+- [LinkedIn third-party application removal](https://www.linkedin.com/help/linkedin/answer/a519947/third-party-applications-data-use)
 - [LinkedIn programmatic refresh tokens](https://learn.microsoft.com/en-us/linkedin/shared/authentication/programmatic-refresh-tokens)
 - [LinkedIn native PKCE flow](https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow-native)
 - [Sixb connectors](https://docs.sixb.ai/data/connectors)

--- a/connectors/linkedin/src/index.ts
+++ b/connectors/linkedin/src/index.ts
@@ -6,7 +6,11 @@ export {
   LINKEDIN_RESTLI_PROTOCOL_VERSION,
   linkedin,
 } from "./linkedin"
-export { LINKEDIN_ACCESS_TOKEN_URL, LINKEDIN_AUTHORIZATION_URL } from "./oauth"
+export {
+  LINKEDIN_ACCESS_TOKEN_URL,
+  LINKEDIN_AUTHORIZATION_URL,
+  LINKEDIN_PERMITTED_SERVICES_URL,
+} from "./oauth"
 export type { AdAccountUsersResource } from "./resources/ad-account-users"
 export type { AdAccountsResource } from "./resources/ad-accounts"
 export type { AdAnalyticsResource } from "./resources/ad-analytics"

--- a/connectors/linkedin/src/oauth.ts
+++ b/connectors/linkedin/src/oauth.ts
@@ -11,6 +11,8 @@ import type { LinkedinOAuthScope } from "./types/options"
 
 export const LINKEDIN_AUTHORIZATION_URL = "https://www.linkedin.com/oauth/v2/authorization"
 export const LINKEDIN_ACCESS_TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
+export const LINKEDIN_PERMITTED_SERVICES_URL =
+  "https://www.linkedin.com/psettings/permitted-services"
 
 export interface LinkedinOAuthOptions {
   readonly clientId: string

--- a/connectors/linkedin/src/resources/ad-analytics.ts
+++ b/connectors/linkedin/src/resources/ad-analytics.ts
@@ -1,5 +1,5 @@
 import type { LinkedinHttp } from "../http"
-import { restliDateRange, restliList, withQuery } from "../restli"
+import { restliDateRange, restliList, restliProjection, withQuery } from "../restli"
 import type {
   LinkedinAdAnalyticsQuery,
   LinkedinAdAnalyticsRow,
@@ -37,7 +37,7 @@ export function createAdAnalyticsResource(http: LinkedinHttp): AdAnalyticsResour
           pivot: query.pivot,
           dateRange: restliDateRange(query.dateRange),
           timeGranularity: query.timeGranularity,
-          fields: query.fields.join(","),
+          fields: restliProjection(query.fields),
           campaignType: query.campaignType,
           shares: list(query.shares),
           campaigns: list(query.campaigns),
@@ -61,7 +61,7 @@ export function createAdAnalyticsResource(http: LinkedinHttp): AdAnalyticsResour
           pivots: restliList(query.pivots),
           dateRange: restliDateRange(query.dateRange),
           timeGranularity: query.timeGranularity,
-          fields: query.fields.join(","),
+          fields: restliProjection(query.fields),
           objectiveType: query.objectiveType,
           campaignType: query.campaignType,
           shares: list(query.shares),
@@ -89,7 +89,7 @@ export function createAdAnalyticsResource(http: LinkedinHttp): AdAnalyticsResour
           pivots: restliList(query.pivots),
           account: restliList([query.account]),
           dateRange: restliDateRange(query.dateRange),
-          fields: query.fields.join(","),
+          fields: restliProjection(query.fields),
           campaigns: list(query.campaigns),
           campaignGroups: list(query.campaignGroups),
         })

--- a/connectors/linkedin/src/restli.ts
+++ b/connectors/linkedin/src/restli.ts
@@ -37,6 +37,11 @@ export function restliList(values: readonly QueryScalar[]): RestliQueryValue {
   return restli(`List(${values.map((value) => encodeURIComponent(String(value))).join(",")})`)
 }
 
+/** Comma-delimited field projection with encoded values and preserved separators. */
+export function restliProjection(fields: readonly string[]): RestliQueryValue {
+  return restli(fields.map((field) => encodeURIComponent(field)).join(","))
+}
+
 /** Search document used by ad account, campaign group, and campaign finders. */
 export function restliSearch(
   fields: Readonly<Record<string, readonly QueryScalar[] | boolean | undefined>>

--- a/connectors/linkedin/src/types/community-analytics.ts
+++ b/connectors/linkedin/src/types/community-analytics.ts
@@ -16,6 +16,11 @@ export interface LinkedinFollowerCounts {
   readonly paidFollowerCount: number
 }
 
+export interface LinkedinFollowerGains {
+  readonly organicFollowerGain: number
+  readonly paidFollowerGain: number
+}
+
 export interface LinkedinFollowerFacetCount {
   readonly followerCounts: LinkedinFollowerCounts
   readonly associationType?: string
@@ -36,29 +41,37 @@ export interface LinkedinOrganizationFollowerStatistic {
   readonly followerCountsByIndustry?: readonly LinkedinFollowerFacetCount[]
   readonly followerCountsBySeniority?: readonly LinkedinFollowerFacetCount[]
   readonly followerCountsByStaffCountRange?: readonly LinkedinFollowerFacetCount[]
-  readonly followerGains?: LinkedinFollowerCounts
+  readonly followerGains?: LinkedinFollowerGains
   readonly timeRange?: LinkedinTimeRange
   [field: string]: unknown
 }
 
-export interface LinkedinPageViews {
-  readonly allPageViews?: number
-  readonly overviewPageViews?: number
-  readonly careersPageViews?: number
-  readonly jobsPageViews?: number
-  readonly peoplePageViews?: number
-  readonly productsPageViews?: number
+export interface LinkedinPageViewMetric {
+  readonly pageViews: number
+  /** Returned for time-bound metrics when LinkedIn can provide a deduplicated count. */
   readonly uniquePageViews?: number
-  [metric: string]: number | undefined
+}
+
+export interface LinkedinPageViews {
+  readonly allPageViews?: LinkedinPageViewMetric
+  readonly overviewPageViews?: LinkedinPageViewMetric
+  readonly careersPageViews?: LinkedinPageViewMetric
+  readonly jobsPageViews?: LinkedinPageViewMetric
+  readonly peoplePageViews?: LinkedinPageViewMetric
+  readonly productsPageViews?: LinkedinPageViewMetric
+  [metric: string]: LinkedinPageViewMetric | undefined
+}
+
+export interface LinkedinCustomButtonClickCount {
+  readonly clicks: number
+  readonly customButtonType?: string
+  [field: string]: unknown
 }
 
 export interface LinkedinPageClicks {
-  readonly careersPageClicks?: number
-  readonly careersPagePromoLinksClicks?: number
-  readonly customButtonClicks?: number
-  readonly desktopCustomButtonClicks?: number
-  readonly mobileCustomButtonClicks?: number
-  [metric: string]: number | undefined
+  readonly desktopCustomButtonClickCounts?: readonly LinkedinCustomButtonClickCount[]
+  readonly mobileCustomButtonClickCounts?: readonly LinkedinCustomButtonClickCount[]
+  [metric: string]: readonly LinkedinCustomButtonClickCount[] | undefined
 }
 
 export interface LinkedinPageStatistics {
@@ -67,15 +80,27 @@ export interface LinkedinPageStatistics {
   [group: string]: unknown
 }
 
+export interface LinkedinPageStatisticFacet {
+  readonly pageStatistics: LinkedinPageStatistics
+  readonly function?: LinkedinUrn
+  readonly geo?: LinkedinUrn
+  readonly industry?: LinkedinUrn
+  readonly industryV2?: LinkedinUrn
+  readonly seniority?: LinkedinUrn
+  readonly staffCountRange?: string
+  [field: string]: unknown
+}
+
 export interface LinkedinOrganizationPageStatistic {
   readonly organization: LinkedinOrganizationUrn
   readonly totalPageStatistics?: LinkedinPageStatistics
-  readonly pageStatisticsBySeniority?: readonly Readonly<Record<string, unknown>>[]
-  readonly pageStatisticsByIndustry?: readonly Readonly<Record<string, unknown>>[]
-  readonly pageStatisticsByStaffCountRange?: readonly Readonly<Record<string, unknown>>[]
-  readonly pageStatisticsByFunction?: readonly Readonly<Record<string, unknown>>[]
-  readonly pageStatisticsByGeoCountry?: readonly Readonly<Record<string, unknown>>[]
-  readonly pageStatisticsByGeo?: readonly Readonly<Record<string, unknown>>[]
+  readonly pageStatisticsBySeniority?: readonly LinkedinPageStatisticFacet[]
+  readonly pageStatisticsByIndustry?: readonly LinkedinPageStatisticFacet[]
+  readonly pageStatisticsByIndustryV2?: readonly LinkedinPageStatisticFacet[]
+  readonly pageStatisticsByStaffCountRange?: readonly LinkedinPageStatisticFacet[]
+  readonly pageStatisticsByFunction?: readonly LinkedinPageStatisticFacet[]
+  readonly pageStatisticsByGeoCountry?: readonly LinkedinPageStatisticFacet[]
+  readonly pageStatisticsByGeo?: readonly LinkedinPageStatisticFacet[]
   readonly timeRange?: LinkedinTimeRange
   [field: string]: unknown
 }

--- a/connectors/linkedin/tests/analytics.test.ts
+++ b/connectors/linkedin/tests/analytics.test.ts
@@ -41,6 +41,9 @@ describe("linkedin ad analytics", () => {
     )
     expect(params.get("accounts")).toBe("List(urn:li:sponsoredAccount:123)")
     expect(params.get("fields")).toBe("impressions,costInLocalCurrency,pivotValues")
+    // Regression guard: join(",") percent-encodes separators and fails this raw URL assertion.
+    expect(calls[0]?.url).toContain("fields=impressions,costInLocalCurrency,pivotValues")
+    expect(calls[0]?.url).not.toContain("fields=impressions%2CcostInLocalCurrency")
     expect(params.get("sortBy.field")).toBe("IMPRESSIONS")
     expect(rows[0]?.costInLocalCurrency).toBe("12.50")
   })
@@ -58,6 +61,7 @@ describe("linkedin ad analytics", () => {
     })
 
     expect(new URL(calls[0]?.url ?? "").searchParams.get("pivots")).toBe("List(CAMPAIGN,CREATIVE)")
+    expect(calls[0]?.url).toContain("fields=impressions,pivotValues")
   })
 
   test("serializes the attributed-revenue account as a Rest.li list", async () => {
@@ -74,6 +78,7 @@ describe("linkedin ad analytics", () => {
     const params = new URL(calls[0]?.url ?? "").searchParams
     expect(params.get("q")).toBe("attributedRevenueMetrics")
     expect(params.get("account")).toBe("List(urn:li:sponsoredAccount:123)")
+    expect(calls[0]?.url).toContain("fields=revenueAttributionMetrics,dateRange,pivotValues")
   })
 
   test("tunnels long GET queries through a form-encoded POST", async () => {
@@ -94,6 +99,8 @@ describe("linkedin ad analytics", () => {
     expect(calls[0]?.headers.get("content-type")).toBe("application/x-www-form-urlencoded")
     expect(calls[0]?.body).toContain("q=analytics")
     expect(calls[0]?.body).toContain("accounts=List(urn%3Ali%3AsponsoredAccount%3A123)")
+    expect(calls[0]?.body).toContain("fields=impressions,clicks")
+    expect(calls[0]?.body).not.toContain("fields=impressions%2Cclicks")
   })
 
   test("rejects invalid report shapes before making a request", async () => {

--- a/connectors/linkedin/tests/community-analytics.test.ts
+++ b/connectors/linkedin/tests/community-analytics.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { organizationUrn, shareUrn, ugcPostUrn } from "../src"
+import {
+  type LinkedinOrganizationFollowerStatistic,
+  type LinkedinOrganizationPageStatistic,
+  organizationUrn,
+  shareUrn,
+  ugcPostUrn,
+} from "../src"
 import { createTestClient, json, recorder } from "./helpers"
 
 const originalFetch = globalThis.fetch
@@ -8,23 +14,49 @@ afterEach(() => {
 })
 
 describe("linkedin community analytics", () => {
-  test("serializes organization follower, Page, share, and video analytics", async () => {
+  test("serializes organization follower, page, share, and video analytics", async () => {
     const organization = organizationUrn(123)
     const share = shareUrn(456)
     const ugcPost = ugcPostUrn(789)
+    // Regression guard: these 202608-shaped fixtures must satisfy the public wire types.
+    const followerStatistic = {
+      organizationalEntity: organization,
+      followerGains: { organicFollowerGain: 223, paidFollowerGain: 12 },
+      timeRange: { start: 1_700_000_000_000, end: 1_700_086_400_000 },
+    } as const satisfies LinkedinOrganizationFollowerStatistic
+    const pageStatistic = {
+      organization,
+      totalPageStatistics: {
+        clicks: {
+          desktopCustomButtonClickCounts: [{ clicks: 4, customButtonType: "VISIT_WEBSITE" }],
+          mobileCustomButtonClickCounts: [{ clicks: 2, customButtonType: "VISIT_WEBSITE" }],
+        },
+        views: {
+          allPageViews: { pageViews: 42, uniquePageViews: 31 },
+          overviewPageViews: { pageViews: 40, uniquePageViews: 30 },
+        },
+      },
+      pageStatisticsByIndustryV2: [
+        {
+          industryV2: "urn:li:industry:4",
+          pageStatistics: { views: { allPageViews: { pageViews: 6 } } },
+        },
+      ],
+      timeRange: { start: 1_700_000_000_000, end: 1_700_086_400_000 },
+    } as const satisfies LinkedinOrganizationPageStatistic
     const calls = recorder([
-      json({ elements: [{ organizationalEntity: organization, followerGains: {} }] }),
-      json({ elements: [{ organization, totalPageStatistics: {} }] }),
+      json({ elements: [followerStatistic] }),
+      json({ elements: [pageStatistic] }),
       json({ elements: [{ organizationalEntity: organization, totalShareStatistics: {} }] }),
       json({ elements: [{ entity: ugcPost, value: 100 }] }),
     ])
     const client = await createTestClient()
 
-    await client.organizationAnalytics.followers(organization, {
+    const followers = await client.organizationAnalytics.followers(organization, {
       timeRange: { start: 1_700_000_000_000, end: 1_700_086_400_000 },
       timeGranularityType: "DAY",
     })
-    await client.organizationAnalytics.pages(organization)
+    const pages = await client.organizationAnalytics.pages(organization)
     await client.organizationAnalytics.shares(organization, { posts: [share, ugcPost] })
     await client.organizationAnalytics.video({
       entity: ugcPost,
@@ -45,6 +77,14 @@ describe("linkedin community analytics", () => {
     expect(new URL(calls[3]?.url ?? "").searchParams.get("timeRange")).toBe(
       "(start:1700000000000,end:1700086400000)"
     )
+    expect(followers[0]?.followerGains?.organicFollowerGain).toBe(223)
+    expect(pages[0]?.totalPageStatistics?.views?.allPageViews?.uniquePageViews).toBe(31)
+    expect(pages[0]?.totalPageStatistics?.clicks?.desktopCustomButtonClickCounts?.[0]?.clicks).toBe(
+      4
+    )
+    expect(pages[0]?.pageStatisticsByIndustryV2?.[0]?.pageStatistics.views?.allPageViews).toEqual({
+      pageViews: 6,
+    })
   })
 
   test("serializes authenticated-member follower, post, and video analytics", async () => {

--- a/connectors/linkedin/tests/oauth.test.ts
+++ b/connectors/linkedin/tests/oauth.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { ConnectorOAuthError } from "@sixb/core"
-import { LINKEDIN_ACCESS_TOKEN_URL, LINKEDIN_AUTHORIZATION_URL, linkedin } from "../src"
+import {
+  LINKEDIN_ACCESS_TOKEN_URL,
+  LINKEDIN_AUTHORIZATION_URL,
+  LINKEDIN_PERMITTED_SERVICES_URL,
+  linkedin,
+} from "../src"
 import { CONTEXT, DEFAULT_OPTIONS, json, mockFetch, type RecordedCall } from "./helpers"
 
 const originalFetch = globalThis.fetch
@@ -114,5 +119,15 @@ describe("linkedin managed OAuth", () => {
     ).rejects.toMatchObject({
       kind: "terminal",
     })
+  })
+
+  test("exposes manual grant removal without claiming provider revocation support", () => {
+    const authentication = linkedin(DEFAULT_OPTIONS).authentication
+
+    // LinkedIn documents manual removal but no OAuth revocation endpoint for this flow.
+    expect(authentication.revoke).toBeUndefined()
+    expect(LINKEDIN_PERMITTED_SERVICES_URL).toBe(
+      "https://www.linkedin.com/psettings/permitted-services"
+    )
   })
 })


### PR DESCRIPTION
## What changed

| Area | Change |
| --- | --- |
| Ads Analytics | Preserve raw commas in multi-field projections for regular and query-tunneled requests. |
| Follower statistics | Model `organicFollowerGain` and `paidFollowerGain` from LinkedIn 202608 payloads. |
| Page statistics | Type nested view metrics, custom-button click lists, and demographic facets including `pageStatisticsByIndustryV2`. |
| Revocation | Export the official Permitted Services URL and document the required manual upstream removal. |

## Why

- Percent-encoded projection separators make LinkedIn treat several metrics as one invalid field.
- Accurate wire types remove downstream casts and compatibility parsers.
- LinkedIn does not document a programmatic revocation endpoint, so the connector avoids an unsupported API call while keeping Sixb credential deletion explicit.

## Validation

- `bun test connectors/linkedin/tests` — 51 passed
- LinkedIn connector build and typecheck
- Test-suite typecheck after `build:types`
- Biome and `git diff --check`