### PR TITLE
data: support empty snapshots and BIGINT sums

### DIFF
--- a/docs/data/syncs.md
+++ b/docs/data/syncs.md
@@ -233,9 +233,12 @@ never received a row, that run does not create a dataset version, so dataset-upd
 not fire. This lets incremental readers advance an initial cursor without inventing placeholder
 rows.
 
-A first snapshot that returns no rows behaves the same way: it succeeds without creating a dataset
-version. Once a previous version exists, an empty snapshot still commits a new empty version so
-projections can withdraw source-owned objects that disappeared upstream.
+A snapshot is the complete source state, including when that state is empty. A first snapshot that
+returns no rows therefore commits an addressable empty dataset version. Pipelines and projections
+can consume that version normally, and later empty snapshots reuse it until the visible contents
+change. The initial version emits the normal dataset-version event, so dataset-updated schedules can
+run against the known-empty state. An empty snapshot after a non-empty version still commits a new
+empty version so projections can withdraw source-owned objects that disappeared upstream.
 
 A merge run may also succeed and advance its checkpoint without creating a version. This happens
 when an initial run only deletes absent keys, or when every staged change leaves the current rows

--- a/packages/core/src/lake-storage/types.ts
+++ b/packages/core/src/lake-storage/types.ts
@@ -84,7 +84,8 @@ export interface DatasetWriteCommitResult extends DatasetVersion {
    * report `unchanged` and reuse it for commits that cannot change visible
    * dataset content: a snapshot whose rows equal the latest visible rows
    * (order-insensitive, with equal duplicate counts), or an append of zero
-   * rows.
+   * rows. Without a latest version, an empty snapshot or append still creates
+   * the first addressable dataset version.
    */
   readonly outcome: "created" | "unchanged"
 }

--- a/packages/core/src/testing/lake-storage-contract.ts
+++ b/packages/core/src/testing/lake-storage-contract.ts
@@ -438,6 +438,62 @@ export function runLakeStorageContractSuite<TStorage extends LakeStorage>(
         })
       })
 
+      test("creates an initial empty snapshot version", async () => {
+        await withStorage(async (storage) => {
+          await storage.createDataset(writeDataset)
+
+          const write = await storage.beginWrite({ dataset: writeDataset, mode: "snapshot" })
+          const version = await write.commit()
+
+          expect(version).toMatchObject({
+            datasetId: writeDataset.id,
+            mode: "snapshot",
+            outcome: "created",
+            rowCount: 0,
+          })
+          expect(await storage.getLatestVersion(writeDataset.id)).toMatchObject({
+            versionId: version.versionId,
+          })
+          expect(await storage.listVersions(writeDataset.id)).toHaveLength(1)
+
+          const repeatedWrite = await storage.beginWrite({
+            dataset: writeDataset,
+            mode: "snapshot",
+          })
+          const repeatedVersion = await repeatedWrite.commit()
+          expect(repeatedVersion.outcome).toBe("unchanged")
+          expect(repeatedVersion.versionId).toBe(version.versionId)
+          expect(await storage.listVersions(writeDataset.id)).toHaveLength(1)
+
+          await expect(
+            collectRows(storage.readRows({ datasetId: writeDataset.id }))
+          ).resolves.toEqual([])
+        })
+      })
+
+      test("creates an initial empty append version", async () => {
+        await withStorage(async (storage) => {
+          await storage.createDataset(writeDataset)
+
+          const write = await storage.beginWrite({ dataset: writeDataset, mode: "append" })
+          const version = await write.commit()
+
+          expect(version).toMatchObject({
+            datasetId: writeDataset.id,
+            mode: "append",
+            outcome: "created",
+          })
+          expect(version.parentVersionId).toBeUndefined()
+          expect(await storage.getLatestVersion(writeDataset.id)).toMatchObject({
+            versionId: version.versionId,
+          })
+          expect(await storage.listVersions(writeDataset.id)).toHaveLength(1)
+          await expect(
+            collectRows(storage.readRows({ datasetId: writeDataset.id }))
+          ).resolves.toEqual([])
+        })
+      })
+
       test("snapshot writes replace the visible latest rows", async () => {
         await withStorage(async (storage) => {
           await storage.createDataset(writeDataset)

--- a/packages/sync-worker/src/run-sync-job.ts
+++ b/packages/sync-worker/src/run-sync-job.ts
@@ -430,39 +430,37 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
       )
       throwIfAborted(signal)
 
-      if (rowsRead === 0) {
+      if (rowsRead === 0 && sync.config.mode === "append") {
         const version = await lakeStorage.getLatestVersion(dataset.id)
-        if (sync.config.mode === "append" || !version) {
-          await rowWrite.abort()
-          abortWrite = undefined
-          const finishedRun = await syncRunsStorage.finish({
-            projectId: runtime.id,
-            id: job.id,
-            status: "succeeded",
-            rowsRead,
-            ...(version
-              ? { output: { datasetId: version.datasetId, versionId: version.versionId } }
-              : {}),
-            checkpoint: nextCheckpoint,
-          })
-          const finishedAt = requireFinishedAt({
-            syncId: sync.id,
-            runId: job.id,
-            finishedAt: finishedRun.finishedAt,
-          })
-          await notifyRunFinished(input.onRunFinished, finishedRun)
+        await rowWrite.abort()
+        abortWrite = undefined
+        const finishedRun = await syncRunsStorage.finish({
+          projectId: runtime.id,
+          id: job.id,
+          status: "succeeded",
+          rowsRead,
+          ...(version
+            ? { output: { datasetId: version.datasetId, versionId: version.versionId } }
+            : {}),
+          checkpoint: nextCheckpoint,
+        })
+        const finishedAt = requireFinishedAt({
+          syncId: sync.id,
+          runId: job.id,
+          finishedAt: finishedRun.finishedAt,
+        })
+        await notifyRunFinished(input.onRunFinished, finishedRun)
 
-          return {
-            id: job.id,
-            syncId: sync.id,
-            datasetId: dataset.id,
-            mode: sync.config.mode,
-            startedAt: requireStartedAt(job.id, startedRun.startedAt),
-            finishedAt,
-            rowsRead,
-            ...(version ? { version } : {}),
-            versionCreated: false,
-          }
+        return {
+          id: job.id,
+          syncId: sync.id,
+          datasetId: dataset.id,
+          mode: sync.config.mode,
+          startedAt: requireStartedAt(job.id, startedRun.startedAt),
+          finishedAt,
+          rowsRead,
+          ...(version ? { version } : {}),
+          versionCreated: false,
         }
       }
 

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -22,7 +22,7 @@ import {
   InMemoryStorage,
 } from "@sixb/core"
 import type { SyncConnectorSourceResolver } from "@sixb/core/internal/syncs"
-import type { BeginDatasetWriteInput, LakeWriteSession } from "@sixb/core/lake-storage"
+import type { LakeWriteSession } from "@sixb/core/lake-storage"
 import type { ExecutionStorage, SyncRunRecord, SyncRunStorage } from "@sixb/core/storage"
 import { LocalLakeStorage } from "@sixb/lake-local"
 import { runSyncJob as runSyncJobWithDurableRun } from "../src/run-sync-job"
@@ -243,33 +243,6 @@ async function collectRows(rows: AsyncIterable<DatasetRow>): Promise<DatasetRow[
     result.push(row)
   }
   return result
-}
-
-class RejectingFirstEmptyCommitLakeStorage extends InMemoryLakeStorage {
-  override async beginWrite(input: BeginDatasetWriteInput): Promise<LakeWriteSession> {
-    const write = await super.beginWrite(input)
-    let rowsWritten = 0
-
-    return {
-      async writeRows(rows) {
-        await write.writeRows(
-          (async function* () {
-            for await (const row of rows) {
-              rowsWritten += 1
-              yield row
-            }
-          })()
-        )
-      },
-      commit: async (commitInput) => {
-        if (rowsWritten === 0 && !(await this.getLatestVersion(input.dataset.id))) {
-          throw new Error("A first empty commit cannot create a dataset version.")
-        }
-        return write.commit(commitInput)
-      },
-      abort: () => write.abort(),
-    }
-  }
 }
 
 describe("runSyncJob", () => {
@@ -785,9 +758,9 @@ describe("runSyncJob", () => {
     })
   })
 
-  test("succeeds without committing a first empty snapshot", async () => {
+  test("commits a first empty snapshot as an addressable dataset version", async () => {
     const syncRunsStorage = createSyncRunStorage()
-    const lakeStorage = new RejectingFirstEmptyCommitLakeStorage()
+    const lakeStorage = new InMemoryLakeStorage()
     const sync = defineSync("sync-empty-orders")
       .from(erpDb)
       .read(() => [])
@@ -802,21 +775,30 @@ describe("runSyncJob", () => {
     expect(result).toMatchObject({
       mode: "snapshot",
       rowsRead: 0,
-      versionCreated: false,
+      versionCreated: true,
+      version: {
+        datasetId: rawOrdersDataset.id,
+        mode: "snapshot",
+        rowCount: 0,
+      },
     })
-    expect(result.version).toBeUndefined()
-    expect(await lakeStorage.getLatestVersion(rawOrdersDataset.id)).toBeNull()
+    expect(await lakeStorage.getLatestVersion(rawOrdersDataset.id)).toMatchObject({
+      versionId: result.version?.versionId,
+    })
     expect(
       await syncRunsStorage.getById({ projectId: "project-1", id: "run_empty_snapshot" })
     ).toMatchObject({
       status: "succeeded",
       rowsRead: 0,
-      output: undefined,
+      output: {
+        datasetId: rawOrdersDataset.id,
+        versionId: result.version?.versionId,
+      },
     })
   })
 
   test("commits an empty snapshot when it must clear a previous version", async () => {
-    const lakeStorage = new RejectingFirstEmptyCommitLakeStorage()
+    const lakeStorage = new InMemoryLakeStorage()
     await lakeStorage.createDataset(rawOrdersDataset)
     const seed = await lakeStorage.beginWrite({ dataset: rawOrdersDataset, mode: "snapshot" })
     await seed.writeRows([{ orderId: "ord_1" }])

--- a/packages/sync-worker/tests/worker.test.ts
+++ b/packages/sync-worker/tests/worker.test.ts
@@ -616,7 +616,7 @@ describe("SyncWorker", () => {
     })
   })
 
-  test("finishes a first empty snapshot without emitting a dataset version", async () => {
+  test("commits and emits a dataset version for a first empty snapshot", async () => {
     const dataset = defineDataset("raw.erp.empty-orders", {
       schema: [col("orderId", "string")],
     })
@@ -641,16 +641,30 @@ describe("SyncWorker", () => {
     await Bun.sleep(50)
     await worker.stop()
 
-    expect(run?.output).toBeUndefined()
+    expect(run?.output).toMatchObject({ datasetId: dataset.id })
     const events = await sixb.events.read({
       types: ["sync.run.started", "dataset.version.committed", "sync.run.finished"],
     })
-    expect(events.map((event) => event.type)).toEqual(["sync.run.started", "sync.run.finished"])
-    expect(events[1]?.payload).toEqual({
+    expect(events.map((event) => event.type)).toEqual([
+      "sync.run.started",
+      "dataset.version.committed",
+      "sync.run.finished",
+    ])
+    expect(events[1]?.payload).toMatchObject({
+      datasetId: dataset.id,
+      versionId: run?.output?.versionId,
+      producer: {
+        kind: "sync",
+        id: sync.id,
+        runId: "run-first-empty-snapshot",
+      },
+    })
+    expect(events[2]?.payload).toEqual({
       syncId: sync.id,
       runId: "run-first-empty-snapshot",
       status: "succeeded",
       datasetId: dataset.id,
+      versionId: run?.output?.versionId,
     })
   })
 

--- a/storage/ducklake/README.md
+++ b/storage/ducklake/README.md
@@ -270,6 +270,10 @@ new rows to the existing target. Omitting a source `versionId` resolves the late
 committed version at execution time; providing a `versionId` pins that source for
 repeatable transforms.
 
+DuckDB promotes `sum(BIGINT)` results to `HUGEINT`. When the matching target column is a Sixb
+`int64`, the executor applies a checked conversion back to `BIGINT` before comparing or writing
+rows. Values outside the signed 64-bit range fail the transform instead of being truncated.
+
 ## Definition Updates
 
 DuckLake supports schema evolution, and this provider exposes a small safe

--- a/storage/ducklake/src/internal/ducklake-sql-executor.ts
+++ b/storage/ducklake/src/internal/ducklake-sql-executor.ts
@@ -15,13 +15,14 @@ import {
   applyDatasetRowsFromRelation,
   assertDatasetWriteMode,
 } from "./dataset-row-commit"
+import { findDatasetColumnTypeForDuckDbSql } from "./duckdb-column-types"
 import { getString } from "./duckdb-row"
 import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
 import type { DuckLakeDatasetCatalog } from "./ducklake-dataset-catalog"
 import type { DuckLakeSnapshotReader } from "./ducklake-snapshot-reader"
 import type { DuckLakeWriteCoordinator } from "./ducklake-write-coordinator"
-import { duckDbTypeToDatasetColumnType } from "./schema"
+import { datasetColumnTypeToDuckDbSql } from "./schema"
 import { quoteIdentifier } from "./sql"
 import {
   type DuckLakeSqlTransformSourceRelation,
@@ -42,7 +43,18 @@ interface ApplySqlTransformInput {
   readonly target: DatasetDefinition
   readonly mode: DatasetWriteMode
   readonly sql: string
+  readonly checkedCasts: readonly SqlTransformCheckedCast[]
   readonly previousRowCount?: number
+}
+
+interface SqlTransformResultColumn {
+  readonly name: string
+  readonly typeSql: string
+}
+
+interface SqlTransformCheckedCast {
+  readonly columnName: string
+  readonly targetTypeSql: string
 }
 
 /**
@@ -95,7 +107,7 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
         sql: input.sql,
       })
 
-      await this.assertResultSchemaMatchesTarget(runtime, target, sql)
+      const checkedCasts = await this.assertResultSchemaMatchesTarget(runtime, target, sql)
 
       return this.writes.commitDatasetVersionOnExclusiveRuntime(runtime, {
         dataset: target,
@@ -110,6 +122,7 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
             target,
             mode: input.mode,
             sql,
+            checkedCasts,
             previousRowCount: context.previousRowCount,
           }),
       })
@@ -199,12 +212,13 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
     runtime: DuckDbQueryRuntime,
     target: DatasetDefinition,
     sql: string
-  ): Promise<void> {
+  ): Promise<readonly SqlTransformCheckedCast[]> {
     const rows = await runtime.query(
       `DESCRIBE SELECT * FROM (${sql}) AS sixb_sql_transform_result_schema`
     )
     const actualColumns = rows.map((row) => resultColumnFromDescribeRow(row))
     const expectedColumns = target.schema.columns
+    const checkedCasts: SqlTransformCheckedCast[] = []
 
     if (actualColumns.length !== expectedColumns.length) {
       throwResultSchemaMismatch(
@@ -224,13 +238,26 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
         )
       }
 
-      if (actual.type !== expected.type) {
-        throwResultSchemaMismatch(
-          target.id,
-          `column '${expected.name}' should have type '${expected.type}', got '${actual.type}'`
-        )
+      const actualDatasetType = findDatasetColumnTypeForDuckDbSql(actual.typeSql)
+      if (actualDatasetType === expected.type) {
+        continue
       }
+
+      if (isCheckedInt64Cast(actual.typeSql, expected.type)) {
+        checkedCasts.push({
+          columnName: expected.name,
+          targetTypeSql: datasetColumnTypeToDuckDbSql(expected.type),
+        })
+        continue
+      }
+
+      throwResultSchemaMismatch(
+        target.id,
+        `column '${expected.name}' should have type '${expected.type}', got '${actualDatasetType ?? actual.typeSql}'`
+      )
     }
+
+    return checkedCasts
   }
 
   private async applySqlTransform(input: ApplySqlTransformInput): Promise<ApplyDatasetRowsResult> {
@@ -243,6 +270,14 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
 
     let result: ApplyDatasetRowsResult
     try {
+      for (const checkedCast of input.checkedCasts) {
+        await input.runtime.run(
+          `ALTER TABLE ${tempTable} ALTER COLUMN ${quoteIdentifier(
+            checkedCast.columnName
+          )} SET DATA TYPE ${checkedCast.targetTypeSql}`
+        )
+      }
+
       result = await applyDatasetRowsFromRelation({
         options: this.options,
         runtime: input.runtime,
@@ -280,11 +315,19 @@ function buildPreviewSql(sql: string, limit: number): string {
 
 function resultColumnFromDescribeRow(
   row: Readonly<Record<string, unknown>>
-): DatasetColumnDefinition {
+): SqlTransformResultColumn {
   const name = getString(row, "column_name")
-  const type = duckDbTypeToDatasetColumnType(getString(row, "column_type"))
+  const typeSql = getString(row, "column_type")
 
-  return { name, type }
+  return { name, typeSql }
+}
+
+function isCheckedInt64Cast(
+  actualTypeSql: string,
+  expectedType: DatasetColumnDefinition["type"]
+): boolean {
+  const normalizedType = actualTypeSql.trim().toUpperCase()
+  return expectedType === "int64" && (normalizedType === "HUGEINT" || normalizedType === "INT128")
 }
 
 function normalizePreviewRow(row: Readonly<Record<string, unknown>>): DatasetRow {

--- a/storage/ducklake/src/internal/ducklake-write-coordinator.ts
+++ b/storage/ducklake/src/internal/ducklake-write-coordinator.ts
@@ -27,7 +27,14 @@ import type { DuckLakeDatasetCatalog } from "./ducklake-dataset-catalog"
 import { createDuckLakeMergeSession, type DuckLakeCommitMergeInput } from "./ducklake-merge-session"
 import type { DuckLakeSnapshotReader, DuckLakeVersionSummary } from "./ducklake-snapshot-reader"
 import { createDuckLakeWriteSession, type DuckLakeCommitWriteInput } from "./ducklake-write-session"
-import { duckLakeAlias, duckLakeMetadataTableName, quoteIdentifier, quoteSqlString } from "./sql"
+import { encodeDatasetTableName } from "./names"
+import {
+  duckLakeAlias,
+  duckLakeMetadataTableName,
+  qualifiedTableName,
+  quoteIdentifier,
+  quoteSqlString,
+} from "./sql"
 import { parseCommitMetadata, type SixbCommitMetadata } from "./versions"
 
 export interface DuckLakeCommitDatasetVersionInput {
@@ -325,6 +332,7 @@ export class DuckLakeWriteCoordinator {
         previousRowCount: latestVersion?.rowCount,
         validatedPrimaryKeyColumns: latestVersion?.validatedPrimaryKeyColumns,
       })
+      await this.ensureInitialNoOpHasSnapshot(input, changeResult, latestVersion)
       const commitId = randomUUID()
       await this.setCommitMetadata(
         input,
@@ -477,6 +485,32 @@ export class DuckLakeWriteCoordinator {
         JSON.stringify({ sixb: metadata })
       )})`
     )
+  }
+
+  private async ensureInitialNoOpHasSnapshot(
+    input: DuckLakeCommitVersionOutcomeRuntimeInput,
+    changeResult: ApplyDatasetRowsResult,
+    knownLatestVersion: DuckLakeVersionSummary | null
+  ): Promise<void> {
+    if (changeResult.dataChangeExpected || input.allowInitialNoOp) {
+      return
+    }
+
+    const latestVersion =
+      knownLatestVersion ??
+      (await this.snapshots.getLatestVersionSummaryForDefinition(input.runtime, input.dataset))
+    if (latestVersion) {
+      return
+    }
+
+    // DuckLake 1.5.2 does not create a snapshot for a transaction whose data and metadata are
+    // unchanged, and set_commit_message alone cannot force one. Reapplying the current table
+    // comment is an idempotent metadata write: it leaves the visible DatasetDefinition unchanged
+    // while giving the first empty write a real DuckLake snapshot for time travel and lineage.
+    const table = qualifiedTableName(this.options, encodeDatasetTableName(input.dataset.id))
+    const descriptionSql =
+      input.dataset.description === undefined ? "NULL" : quoteSqlString(input.dataset.description)
+    await input.runtime.run(`COMMENT ON TABLE ${table} IS ${descriptionSql}`)
   }
 
   private async versionForNoOpCommit(

--- a/storage/ducklake/tests/ducklake-sql-transforms.e2e.ts
+++ b/storage/ducklake/tests/ducklake-sql-transforms.e2e.ts
@@ -267,6 +267,73 @@ describe("DuckLake SQL transforms", () => {
     ])
   })
 
+  test("normalizes promoted BIGINT sums to the target int64 type", async () => {
+    const totalsDataset = defineDataset("analytics.order_totals", {
+      schema: [col("customerId", "string"), col("total", "int64")],
+    })
+    await storage.createDataset(totalsDataset)
+    await commitRows(storage, ordersDataset, [
+      { orderId: "ord_1", customerId: "cust_1", amount: 10 },
+      { orderId: "ord_2", customerId: "cust_2", amount: 20 },
+    ])
+
+    const first = await storage.sql.execute({
+      sources: { orders: { dataset: ordersDataset } },
+      target: totalsDataset,
+      mode: "snapshot",
+      sql: ({ orders }) => `
+        SELECT customerId, sum(amount) AS total
+        FROM ${orders}
+        GROUP BY customerId
+        ORDER BY customerId DESC
+      `,
+    })
+
+    expect(first.outcome).toBe("created")
+    expect(first.rowCount).toBe(2)
+    await expect(collectRows(storage.readRows({ datasetId: totalsDataset.id }))).resolves.toEqual([
+      { customerId: "cust_2", total: "20" },
+      { customerId: "cust_1", total: "10" },
+    ])
+
+    const repeated = await storage.sql.execute({
+      sources: { orders: { dataset: ordersDataset } },
+      target: totalsDataset,
+      mode: "snapshot",
+      sql: ({ orders }) => `
+        SELECT customerId, sum(amount) AS total
+        FROM ${orders}
+        GROUP BY customerId
+        ORDER BY customerId DESC
+      `,
+    })
+
+    expect(repeated.outcome).toBe("unchanged")
+    expect(repeated.versionId).toBe(first.versionId)
+
+    await commitRows(storage, ordersDataset, [
+      { orderId: "ord_max_1", customerId: "cust_1", amount: "9223372036854775807" },
+      { orderId: "ord_max_2", customerId: "cust_1", amount: "9223372036854775807" },
+    ])
+
+    await expect(
+      storage.sql.execute({
+        sources: { orders: { dataset: ordersDataset } },
+        target: totalsDataset,
+        mode: "snapshot",
+        sql: ({ orders }) => `
+          SELECT customerId, sum(amount) AS total
+          FROM ${orders}
+          GROUP BY customerId
+        `,
+      })
+    ).rejects.toThrow("out of range")
+    expect(await storage.getLatestVersion(totalsDataset.id)).toMatchObject({
+      versionId: first.versionId,
+    })
+    expect(await storage.listVersions(totalsDataset.id)).toHaveLength(1)
+  })
+
   test("pins SQL execute sources before committing the target snapshot", async () => {
     const ordersVersion = await commitRows(storage, ordersDataset, [
       { orderId: "ord_1", customerId: "cust_1", amount: 10 },
@@ -549,20 +616,24 @@ describe("DuckLake SQL transforms", () => {
   })
 
   test("keeps explicit empty-result commit semantics for SQL execute", async () => {
+    const initialEmptyVersion = await storage.sql.execute({
+      sources: {},
+      target: customerInsightsDataset,
+      mode: "snapshot",
+      sql: () => `
+        SELECT
+          'cust_none' AS customerId,
+          0::BIGINT AS orders,
+          0::BIGINT AS revenue
+        WHERE false
+      `,
+    })
+
+    expect(initialEmptyVersion.outcome).toBe("created")
+    expect(initialEmptyVersion.rowCount).toBe(0)
     await expect(
-      storage.sql.execute({
-        sources: {},
-        target: customerInsightsDataset,
-        mode: "snapshot",
-        sql: () => `
-          SELECT
-            'cust_none' AS customerId,
-            0::BIGINT AS orders,
-            0::BIGINT AS revenue
-          WHERE false
-        `,
-      })
-    ).rejects.toThrow("No DuckLake changes were committed")
+      collectRows(storage.readRows({ datasetId: customerInsightsDataset.id }))
+    ).resolves.toEqual([])
 
     const seedVersion = await storage.sql.execute({
       sources: {},
@@ -611,21 +682,53 @@ describe("DuckLake SQL transforms", () => {
     ).resolves.toEqual([])
   })
 
-  test("throws a clear no-op error for empty first SQL append", async () => {
+  test("consumes an initial empty source version and commits an empty target version", async () => {
+    const sourceWrite = await storage.beginWrite({ dataset: ordersDataset, mode: "snapshot" })
+    const sourceVersion = await sourceWrite.commit()
+
+    const targetVersion = await storage.sql.execute({
+      sources: { orders: { dataset: ordersDataset, versionId: sourceVersion.versionId } },
+      target: customerInsightsDataset,
+      mode: "snapshot",
+      sql: ({ orders }) => `
+        SELECT
+          customerId,
+          0::BIGINT AS orders,
+          amount AS revenue
+        FROM ${orders}
+      `,
+    })
+
+    expect(targetVersion).toMatchObject({
+      outcome: "created",
+      mode: "snapshot",
+      rowCount: 0,
+      inputs: [{ datasetId: ordersDataset.id, versionId: sourceVersion.versionId }],
+    })
     await expect(
-      storage.sql.execute({
-        sources: {},
-        target: customerInsightsDataset,
-        mode: "append",
-        sql: () => `
-          SELECT
-            'cust_none' AS customerId,
-            0::BIGINT AS orders,
-            0::BIGINT AS revenue
-          WHERE false
-        `,
-      })
-    ).rejects.toThrow("No DuckLake changes were committed")
+      collectRows(storage.readRows({ datasetId: customerInsightsDataset.id }))
+    ).resolves.toEqual([])
+  })
+
+  test("creates a first version for an empty SQL append", async () => {
+    const version = await storage.sql.execute({
+      sources: {},
+      target: customerInsightsDataset,
+      mode: "append",
+      sql: () => `
+        SELECT
+          'cust_none' AS customerId,
+          0::BIGINT AS orders,
+          0::BIGINT AS revenue
+        WHERE false
+      `,
+    })
+
+    expect(version.outcome).toBe("created")
+    expect(version.mode).toBe("append")
+    await expect(
+      collectRows(storage.readRows({ datasetId: customerInsightsDataset.id }))
+    ).resolves.toEqual([])
   })
 })
 

--- a/storage/ducklake/tests/ducklake-writes.e2e.ts
+++ b/storage/ducklake/tests/ducklake-writes.e2e.ts
@@ -755,30 +755,36 @@ describe("DuckLakeStorage writes and latest reads", () => {
     ])
   })
 
-  test("throws a clear no-op error when an empty first snapshot changes nothing", async () => {
+  test("creates a metadata-backed version for an empty first snapshot", async () => {
     const write = await storage.beginWrite({
       dataset: ordersDataset,
       mode: "snapshot",
     })
 
-    await expect(write.commit()).rejects.toThrow(
-      `No DuckLake changes were committed for dataset '${ordersDataset.id}', and no previous version exists.`
-    )
-    expect(await storage.getLatestVersion(ordersDataset.id)).toBeNull()
-    expect(await storage.listVersions(ordersDataset.id)).toEqual([])
+    const version = await write.commit()
+
+    expect(version).toMatchObject({ outcome: "created", mode: "snapshot", rowCount: 0 })
+    expect(await storage.getLatestVersion(ordersDataset.id)).toMatchObject({
+      versionId: version.versionId,
+    })
+    expect(await storage.listVersions(ordersDataset.id)).toHaveLength(1)
+    expect(await storage.getDataset(ordersDataset.id)).toEqual(ordersDataset)
   })
 
-  test("throws a clear no-op error when an empty first append changes nothing", async () => {
+  test("creates a metadata-backed version for an empty first append", async () => {
     const write = await storage.beginWrite({
       dataset: ordersDataset,
       mode: "append",
     })
 
-    await expect(write.commit()).rejects.toThrow(
-      `No DuckLake changes were committed for dataset '${ordersDataset.id}', and no previous version exists.`
-    )
-    expect(await storage.getLatestVersion(ordersDataset.id)).toBeNull()
-    expect(await storage.listVersions(ordersDataset.id)).toEqual([])
+    const version = await write.commit()
+
+    expect(version).toMatchObject({ outcome: "created", mode: "append" })
+    expect(await storage.getLatestVersion(ordersDataset.id)).toMatchObject({
+      versionId: version.versionId,
+    })
+    expect(await storage.listVersions(ordersDataset.id)).toHaveLength(1)
+    expect(await storage.getDataset(ordersDataset.id)).toEqual(ordersDataset)
   })
 })
 


### PR DESCRIPTION
## Summary

- Create an addressable first version for empty snapshot syncs and SQL transforms.
- Accept DuckDB `sum(BIGINT)` results for Sixb `int64` targets through a checked conversion.
- Align the initial empty-write contract across InMemory, Local, and DuckLake storage.

`empty snapshot` → `version(rowCount: 0)` → `pipeline / projection can consume it`

## Why

- Accounts without campaigns or creatives no longer leave canonical datasets unversioned.
- Consumers can distinguish a known-empty dataset from one that was never materialized.
- Aggregate pipelines no longer need manual casts, while overflow remains a hard failure.

## Behavior

| Operation | Result |
| --- | --- |
| First empty snapshot | Creates an empty version and emits the normal version event |
| Repeated identical empty snapshot | Reuses the current version |
| Empty sync append | Advances the checkpoint without creating a version |
| Initial no-op merge | Remains versionless |
| `HUGEINT` result targeting `int64` | Checked conversion; out-of-range values fail atomically |

## Design choices

- `HUGEINT` is not added to the public dataset type system; only the safe aggregate promotion to an `int64` target is handled.
- DuckLake 1.5.2 cannot explicitly force a no-op snapshot. The provider creates a metadata-only snapshot by idempotently reapplying the current table comment, preserving the dataset definition, time travel, and lineage.

## Linked issue

No linked issue; this addresses framework feedback.

## Validation

- `bun run test:ci` — 4,432 passed, 7 skipped
- `bun --filter @sixb/ducklake test:e2e:local` — 132 passed
- `bun run typecheck`
- `bun run build`
- `bun run check`
- `bun run test:publish` — 52 packages verified
