### PR TITLE
projections: support grouped telemetry properties

### DIFF
--- a/docs/data/projections.md
+++ b/docs/data/projections.md
@@ -10,7 +10,8 @@ links on top of them. `defineProjection` selects the right builder from its onto
 
 | Target | Produces | One row becomes |
 | --- | --- | --- |
-| `ObjectType` | Objects (and FK links) | One complete object root |
+| `ObjectType` + `.properties(...)` | Objects (and FK links) | One complete object root |
+| `ObjectType` + `.points(...)` | Grouped telemetry points | Zero to N readings sharing one object and instant |
 | `ObjectType.l.<linkId>` | Many-to-many links | One complete link root |
 | `ObjectType.p.<telemetryId>` | Telemetry points | One reading on a series |
 
@@ -159,8 +160,8 @@ Source and target fields must be string columns.
 
 ## Telemetry projection
 
-A telemetry projection records timestamped readings onto a telemetry-mode property. Use it when a
-dataset has one row per measurement: a value, the object it belongs to, and when it was recorded.
+A telemetry projection records timestamped readings onto telemetry-mode properties. When one row
+contains several readings for the same object and instant, map them together from the object type:
 
 First mark the property as telemetry in the ontology (see
 [Properties](../ontology/properties.md)):
@@ -169,7 +170,50 @@ First mark the property as telemetry in the ontology (see
 prop("progress", "integer", { mode: "telemetry" })
 ```
 
-Then map a dataset of readings onto it with `.points(...)`:
+Then map the dataset with `.points(...)`:
+
+```ts
+import { defineProjection } from "@sixb/core"
+import { googleAnalyticsActivity } from "../datasets/google-analytics"
+import { GoogleAnalyticsProperty } from "../ontology/google-analytics-property"
+
+export const activityProjection = defineProjection("ga-activity", GoogleAnalyticsProperty)
+  .fromDataset(googleAnalyticsActivity)
+  .points({
+    objectId: "account_id",
+    at: "day",
+    properties: {
+      activeUsers: "active_users",
+      newUsers: "new_users",
+      engagementDuration: "engagement_duration",
+      temperature: {
+        value: "temperature",
+        unit: "temperature_unit",
+      },
+    },
+  })
+```
+
+| Mapping key | Meaning |
+| --- | --- |
+| `objectId` | Dataset column holding the target object's primary id |
+| `at` | Timestamp column for the reading |
+| `properties.<id>` | Shorthand value column for a unitless telemetry property |
+| `properties.<id>.value` | Value column when the property also needs a unit |
+| `properties.<id>.unit` | Unit column; required for semantic types with units and forbidden otherwise |
+
+The shared `objectId` and `at` are parsed once. A blank value omits only that property's point; the
+row is counted as skipped only when it emits no points. A nonblank invalid value or unit rejects the
+whole physical batch atomically, so a row cannot be partially committed. The `at` column must be a
+string, date, or timestamp; values without a time zone (no trailing `Z` or numeric offset) are read
+as UTC.
+
+Group properties only when they share the same dataset, object id, timestamp, and projection
+lifecycle. The grouped projection owns every mapped `ObjectType + telemetry property` scope and
+processes the source rows once. Storage still keeps each telemetry series independent.
+
+For a dataset with one telemetry value per row, the property-token form remains concise sugar for a
+one-property `properties` mapping:
 
 ```ts
 import { defineProjection } from "@sixb/core"
@@ -187,17 +231,6 @@ export const projectProgressProjection = defineProjection(
     value: "progress_pct",
   })
 ```
-
-| Mapping key | Meaning |
-| --- | --- |
-| `objectId` | Dataset column holding the target object's primary id |
-| `at` | Timestamp column for the reading |
-| `value` | Column holding the reading |
-| `unit` | Optional column holding the reading's unit (required only for properties that carry a unit) |
-
-Each row appends one point to the `progress` series of the `Project` named by `project_id`. The `at`
-column must be a string, date, or timestamp; values without a time zone (no trailing `Z` or numeric
-offset) are read as UTC.
 
 How point identity works — and what re-projecting the same instant does — is covered in
 [Telemetry](../objects/telemetry.md).

--- a/examples/panasonic-ac/projections/devices.ts
+++ b/examples/panasonic-ac/projections/devices.ts
@@ -10,98 +10,23 @@ export const panasonicDevicesProjection: ObjectProjectionDefinition = defineProj
   .fromDataset(panasonicDeviceSnapshots)
   .properties({ id: "id", guid: "guid", deviceName: "deviceName" })
 
-export const panasonicPowerProjection = defineProjection("panasonic-power", PanasonicAcUnit.p.power)
-  .fromDataset(panasonicDeviceSnapshots)
-  .points({ objectId: "id", at: "observedAt", value: "power" })
-
-export const panasonicOperatingModeProjection = defineProjection(
-  "panasonic-operating-mode",
-  PanasonicAcUnit.p.operatingMode
-)
-  .fromDataset(panasonicDeviceSnapshots)
-  .points({ objectId: "id", at: "observedAt", value: "operatingMode" })
-
-export const panasonicIndoorTemperatureProjection = defineProjection(
-  "panasonic-indoor-temperature",
-  PanasonicAcUnit.p.indoorTemperature
-)
+export const panasonicTelemetryProjection = defineProjection("panasonic-telemetry", PanasonicAcUnit)
   .fromDataset(panasonicDeviceSnapshots)
   .points({
     objectId: "id",
     at: "observedAt",
-    value: "indoorTemperature",
-    unit: "temperatureUnit",
+    properties: {
+      power: "power",
+      operatingMode: "operatingMode",
+      indoorTemperature: { value: "indoorTemperature", unit: "temperatureUnit" },
+      outdoorTemperature: { value: "outdoorTemperature", unit: "temperatureUnit" },
+      targetTemperature: { value: "targetTemperature", unit: "temperatureUnit" },
+      fanSpeed: "fanSpeed",
+      swingHorizontal: "swingHorizontal",
+      swingVertical: "swingVertical",
+      ecoMode: "ecoMode",
+      nanoeMode: "nanoeMode",
+      ecoNaviMode: "ecoNaviMode",
+      iAutoMode: "iAutoMode",
+    },
   })
-
-export const panasonicOutdoorTemperatureProjection = defineProjection(
-  "panasonic-outdoor-temperature",
-  PanasonicAcUnit.p.outdoorTemperature
-)
-  .fromDataset(panasonicDeviceSnapshots)
-  .points({
-    objectId: "id",
-    at: "observedAt",
-    value: "outdoorTemperature",
-    unit: "temperatureUnit",
-  })
-
-export const panasonicTargetTemperatureProjection = defineProjection(
-  "panasonic-target-temperature",
-  PanasonicAcUnit.p.targetTemperature
-)
-  .fromDataset(panasonicDeviceSnapshots)
-  .points({
-    objectId: "id",
-    at: "observedAt",
-    value: "targetTemperature",
-    unit: "temperatureUnit",
-  })
-
-export const panasonicFanSpeedProjection = defineProjection(
-  "panasonic-fan-speed",
-  PanasonicAcUnit.p.fanSpeed
-)
-  .fromDataset(panasonicDeviceSnapshots)
-  .points({ objectId: "id", at: "observedAt", value: "fanSpeed" })
-
-export const panasonicSwingHorizontalProjection = defineProjection(
-  "panasonic-swing-horizontal",
-  PanasonicAcUnit.p.swingHorizontal
-)
-  .fromDataset(panasonicDeviceSnapshots)
-  .points({ objectId: "id", at: "observedAt", value: "swingHorizontal" })
-
-export const panasonicSwingVerticalProjection = defineProjection(
-  "panasonic-swing-vertical",
-  PanasonicAcUnit.p.swingVertical
-)
-  .fromDataset(panasonicDeviceSnapshots)
-  .points({ objectId: "id", at: "observedAt", value: "swingVertical" })
-
-export const panasonicEcoModeProjection = defineProjection(
-  "panasonic-eco-mode",
-  PanasonicAcUnit.p.ecoMode
-)
-  .fromDataset(panasonicDeviceSnapshots)
-  .points({ objectId: "id", at: "observedAt", value: "ecoMode" })
-
-export const panasonicNanoeModeProjection = defineProjection(
-  "panasonic-nanoe-mode",
-  PanasonicAcUnit.p.nanoeMode
-)
-  .fromDataset(panasonicDeviceSnapshots)
-  .points({ objectId: "id", at: "observedAt", value: "nanoeMode" })
-
-export const panasonicEcoNaviModeProjection = defineProjection(
-  "panasonic-eco-navi-mode",
-  PanasonicAcUnit.p.ecoNaviMode
-)
-  .fromDataset(panasonicDeviceSnapshots)
-  .points({ objectId: "id", at: "observedAt", value: "ecoNaviMode" })
-
-export const panasonicIAutoModeProjection = defineProjection(
-  "panasonic-i-auto-mode",
-  PanasonicAcUnit.p.iAutoMode
-)
-  .fromDataset(panasonicDeviceSnapshots)
-  .points({ objectId: "id", at: "observedAt", value: "iAutoMode" })

--- a/packages/atlas/src/pages/ObjectTypeDetail.tsx
+++ b/packages/atlas/src/pages/ObjectTypeDetail.tsx
@@ -446,12 +446,19 @@ export function ObjectTypeDetail({
                       <div className="space-y-1.5">
                         <SectionLabel>Point mapping</SectionLabel>
                         <dl className="grid grid-cols-[max-content_max-content_minmax(0,1fr)] items-baseline gap-x-3 gap-y-1 font-mono text-xs">
-                          <TelemetryMappingRow label={proj.propertyId} column={proj.valueField} />
-                          <TelemetryMappingRow label="at" column={proj.atField} />
                           <TelemetryMappingRow label="object" column={proj.objectIdField} />
-                          {proj.unitField ? (
-                            <TelemetryMappingRow label="unit" column={proj.unitField} />
-                          ) : null}
+                          <TelemetryMappingRow label="at" column={proj.atField} />
+                          {Object.entries(proj.properties).map(([propertyId, mapping]) => (
+                            <Fragment key={propertyId}>
+                              <TelemetryMappingRow label={propertyId} column={mapping.valueField} />
+                              {mapping.unitField ? (
+                                <TelemetryMappingRow
+                                  label={`${propertyId} unit`}
+                                  column={mapping.unitField}
+                                />
+                              ) : null}
+                            </Fragment>
+                          ))}
                         </dl>
                       </div>
                     </Card>

--- a/packages/atlas/src/pages/ProjectionsPage.tsx
+++ b/packages/atlas/src/pages/ProjectionsPage.tsx
@@ -632,6 +632,10 @@ function ProjectionFlow({ projection }: { projection: GetProjectionResponse }) {
       onClick={() => navigate(`/datasets/${encodeURIComponent(projection.datasetId)}`)}
     />
   )
+  const telemetryPropertyCount =
+    projection._tag === "TelemetryProjectionDefinition"
+      ? Object.keys(projection.properties).length
+      : 0
 
   if (projection._tag === "LinkProjectionDefinition") {
     return (
@@ -664,7 +668,10 @@ function ProjectionFlow({ projection }: { projection: GetProjectionResponse }) {
         onClick={() => toType(projection.objectTypeId)}
       />
       {projection._tag === "TelemetryProjectionDefinition" && (
-        <Mono value={`· ${projection.propertyId}`} muted />
+        <Mono
+          value={`· ${telemetryPropertyCount} telemetry ${telemetryPropertyCount === 1 ? "property" : "properties"}`}
+          muted
+        />
       )}
     </div>
   )
@@ -745,8 +752,9 @@ function ProjectionMapping({ projection }: { projection: GetProjectionResponse }
     )
   }
 
+  const properties = Object.entries(projection.properties)
   return (
-    <div className="max-w-md">
+    <div className="grid gap-6 lg:grid-cols-2">
       <MappingTable
         columns={["Point field", "Dataset column"]}
         rows={[
@@ -755,21 +763,24 @@ function ProjectionMapping({ projection }: { projection: GetProjectionResponse }
             cells: ["Object id", <Mono key="c" value={projection.objectIdField} muted />],
           },
           { key: "at", cells: ["Timestamp", <Mono key="c" value={projection.atField} muted />] },
-          { key: "value", cells: ["Value", <Mono key="c" value={projection.valueField} muted />] },
-          {
-            key: "unit",
-            cells: [
-              "Unit",
-              projection.unitField ? (
-                <Mono key="c" value={projection.unitField} muted />
-              ) : (
-                <span key="c" className="text-muted-foreground">
-                  —
-                </span>
-              ),
-            ],
-          },
         ]}
+      />
+      <MappingTable
+        columns={["Telemetry property", "Value column", "Unit column"]}
+        rows={properties.map(([propertyId, mapping]) => ({
+          key: propertyId,
+          cells: [
+            <Mono key="p" value={propertyId} />,
+            <Mono key="v" value={mapping.valueField} muted />,
+            mapping.unitField ? (
+              <Mono key="u" value={mapping.unitField} muted />
+            ) : (
+              <span key="u" className="text-muted-foreground">
+                —
+              </span>
+            ),
+          ],
+        }))}
       />
     </div>
   )

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -31995,9 +31995,6 @@
                           "objectTypeId": {
                             "type": "string"
                           },
-                          "propertyId": {
-                            "type": "string"
-                          },
                           "datasetId": {
                             "type": "string"
                           },
@@ -32007,11 +32004,21 @@
                           "atField": {
                             "type": "string"
                           },
-                          "valueField": {
-                            "type": "string"
-                          },
-                          "unitField": {
-                            "type": "string"
+                          "properties": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "object",
+                              "properties": {
+                                "valueField": {
+                                  "type": "string"
+                                },
+                                "unitField": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["valueField"],
+                              "additionalProperties": false
+                            }
                           },
                           "latestRun": {
                             "anyOf": [
@@ -32554,11 +32561,10 @@
                           "_tag",
                           "id",
                           "objectTypeId",
-                          "propertyId",
                           "datasetId",
                           "objectIdField",
                           "atField",
-                          "valueField",
+                          "properties",
                           "latestRun"
                         ],
                         "additionalProperties": false
@@ -33774,9 +33780,6 @@
                         "objectTypeId": {
                           "type": "string"
                         },
-                        "propertyId": {
-                          "type": "string"
-                        },
                         "datasetId": {
                           "type": "string"
                         },
@@ -33786,11 +33789,21 @@
                         "atField": {
                           "type": "string"
                         },
-                        "valueField": {
-                          "type": "string"
-                        },
-                        "unitField": {
-                          "type": "string"
+                        "properties": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                              "valueField": {
+                                "type": "string"
+                              },
+                              "unitField": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["valueField"],
+                            "additionalProperties": false
+                          }
                         },
                         "latestRun": {
                           "anyOf": [
@@ -34315,11 +34328,10 @@
                         "_tag",
                         "id",
                         "objectTypeId",
-                        "propertyId",
                         "datasetId",
                         "objectIdField",
                         "atField",
-                        "valueField",
+                        "properties",
                         "latestRun"
                       ],
                       "additionalProperties": false

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -10925,12 +10925,15 @@ export type ListProjectionsResponses = {
       _tag: "TelemetryProjectionDefinition"
       id: string
       objectTypeId: string
-      propertyId: string
       datasetId: string
       objectIdField: string
       atField: string
-      valueField: string
-      unitField?: string
+      properties: {
+        [key: string]: {
+          valueField: string
+          unitField?: string
+        }
+      }
       latestRun:
         | {
             id: string
@@ -11487,12 +11490,15 @@ export type GetProjectionResponses = {
         _tag: "TelemetryProjectionDefinition"
         id: string
         objectTypeId: string
-        propertyId: string
         datasetId: string
         objectIdField: string
         atField: string
-        valueField: string
-        unitField?: string
+        properties: {
+          [key: string]: {
+            valueField: string
+            unitField?: string
+          }
+        }
         latestRun:
           | {
               id: string

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1034,6 +1034,7 @@ export type {
   ProjectionTargetByKind,
   SourceEditConflictResolution,
   TelemetryProjectionDefinition,
+  TelemetryProjectionPropertyMapping,
 } from "./projections"
 
 export {

--- a/packages/core/src/materializer/telemetry/append.ts
+++ b/packages/core/src/materializer/telemetry/append.ts
@@ -90,7 +90,6 @@ function prepareTelemetryAppend(
     points: raw.input.points.map((point) => validateTelemetryPoint(context.ontology, point)),
   })
   const inputPointCount = telemetryInputPointCount(input, rawInputPointCount)
-  validateTelemetryBatch(input, inputPointCount)
 
   const ontologyRevision = context.projectionRegistry.ontologyRevision
   const execution = prepareMaterializerExecution(context.projectId, raw.scope)
@@ -112,21 +111,6 @@ function telemetryInputPointCount(
 ): number {
   if (input.source.kind === "projection") return rawInputPointCount
   return input.points.length
-}
-
-function validateTelemetryBatch(input: NormalizedTelemetryAppend, inputPointCount: number): void {
-  if (input.source.kind === "projection") {
-    if (input.source.sourceRowCount === 0) {
-      throw new MaterializationValidationError(
-        "Projection telemetry batches must consume at least one source row; an empty dataset produces no batch commit."
-      )
-    }
-    if (input.source.sourceRowCount !== inputPointCount + input.source.sourceRowsSkipped) {
-      throw new MaterializationValidationError(
-        "Projection telemetry sourceRowCount must equal input points plus skipped rows."
-      )
-    }
-  }
 }
 
 function prepareRuntimeTelemetry(
@@ -157,6 +141,7 @@ function prepareProjectionTelemetry(
   )
   validateTelemetryProjectionDataset(resolvedProjection, source)
   validateTelemetryOwnership(resolvedProjection, input)
+  validateTelemetryBatchCardinality(resolvedProjection, source, inputPointCount)
 
   const runIdentity = createProjectionRunMaterializationIdentity({
     resolved: resolvedProjection,
@@ -179,6 +164,38 @@ function prepareProjectionTelemetry(
     identity,
     resolvedProjection,
     runIdentity,
+  }
+}
+
+function validateTelemetryBatchCardinality(
+  resolved: ResolvedTelemetryProjection,
+  source: ProjectionTelemetrySource,
+  inputPointCount: number
+): void {
+  if (source.sourceRowCount === 0) {
+    throw new MaterializationValidationError(
+      "Projection telemetry batches must consume at least one source row; an empty dataset produces no batch commit."
+    )
+  }
+
+  const mappedPropertyCount = resolved.ownership.telemetry.length
+  if (mappedPropertyCount === 0) {
+    throw new MaterializationValidationError(
+      `Telemetry projection '${resolved.projectionId}' must own at least one telemetry property.`
+    )
+  }
+
+  const sourceRowsEmitted = source.sourceRowCount - source.sourceRowsSkipped
+  const maximumPointCount = sourceRowsEmitted * mappedPropertyCount
+  if (!Number.isSafeInteger(maximumPointCount)) {
+    throw new MaterializationValidationError(
+      `Telemetry projection '${resolved.projectionId}' batch point capacity exceeds the safe integer range.`
+    )
+  }
+  if (inputPointCount < sourceRowsEmitted || inputPointCount > maximumPointCount) {
+    throw new MaterializationValidationError(
+      `Telemetry projection '${resolved.projectionId}' must emit between ${sourceRowsEmitted} and ${maximumPointCount} points for ${source.sourceRowCount} source rows with ${source.sourceRowsSkipped} skipped.`
+    )
   }
 }
 

--- a/packages/core/src/projections/builders.ts
+++ b/packages/core/src/projections/builders.ts
@@ -24,6 +24,7 @@ import type {
   ProjectionTarget,
   SourceEditConflictResolution,
   TelemetryProjectionDefinition,
+  TelemetryProjectionPropertyMapping,
 } from "./types"
 import {
   validateAndLowerLinkMapping,
@@ -186,6 +187,18 @@ type TelemetryPropertyToken<TObjectTypeId extends string = string> = PropertyTok
   Property & { readonly mode: "telemetry" }
 >
 
+type TelemetryPropertyOf<TObjectType extends ObjectType> = Extract<
+  TObjectType["properties"][number],
+  { readonly mode: "telemetry" }
+>
+
+type TelemetryPropertyIdOf<TObjectType extends ObjectType> = TelemetryPropertyOf<TObjectType>["id"]
+
+type TelemetryPropertyById<
+  TObjectType extends ObjectType,
+  TPropertyId extends TelemetryPropertyIdOf<TObjectType>,
+> = Extract<TelemetryPropertyOf<TObjectType>, { readonly id: TPropertyId }>
+
 type TelemetryProjectionPointMapping<
   TPropertyToken extends TelemetryPropertyToken,
   TDataset extends DatasetDefinition,
@@ -201,6 +214,58 @@ type TelemetryProjectionPointMapping<
 
 type ExactTelemetryProjectionPointMapping<TMapping> = TMapping & {
   readonly [TKey in Exclude<keyof TMapping, "objectId" | "at" | "value" | "unit">]: never
+}
+
+type TelemetryProjectionPropertyInput<
+  TProperty extends Property,
+  TDataset extends DatasetDefinition,
+> =
+  | DatasetColumnNameCompatibleWithSchema<TDataset, TProperty["schema"]>
+  | {
+      readonly value: DatasetColumnNameCompatibleWithSchema<TDataset, TProperty["schema"]>
+      readonly unit: StringDatasetColumnNameOf<TDataset>
+    }
+
+type TelemetryProjectionPropertiesMapping<
+  TObjectType extends ObjectType,
+  TDataset extends DatasetDefinition,
+> = {
+  readonly [TPropertyId in TelemetryPropertyIdOf<TObjectType>]?: TelemetryProjectionPropertyInput<
+    TelemetryPropertyById<TObjectType, TPropertyId>,
+    TDataset
+  >
+}
+
+type ExactTelemetryProjectionPropertiesMapping<
+  TObjectType extends ObjectType,
+  TMapping,
+> = TMapping & {
+  readonly [TKey in Exclude<keyof TMapping, TelemetryPropertyIdOf<TObjectType>>]: never
+}
+
+type ExactTelemetryProjectionPropertyInputs<TMapping> = {
+  readonly [TPropertyId in keyof TMapping]: TMapping[TPropertyId] extends object
+    ? TMapping[TPropertyId] & {
+        readonly [TKey in Exclude<keyof TMapping[TPropertyId], "value" | "unit">]: never
+      }
+    : TMapping[TPropertyId]
+}
+
+type NonEmptyTelemetryProjectionProperties<TMapping> = keyof TMapping extends never
+  ? never
+  : TMapping
+
+type TelemetryProjectionPropertiesPointMapping<
+  TObjectType extends ObjectType,
+  TDataset extends DatasetDefinition,
+  TProperties,
+> = {
+  readonly objectId: StringDatasetColumnNameOf<TDataset>
+  readonly at: DateLikeDatasetColumnNameOf<TDataset>
+  readonly properties: NonEmptyTelemetryProjectionProperties<
+    ExactTelemetryProjectionPropertiesMapping<TObjectType, TProperties> &
+      ExactTelemetryProjectionPropertyInputs<TProperties>
+  >
 }
 
 type ForeignKeyFromSourceProperty = Omit<
@@ -284,19 +349,22 @@ function isForeignKeyDescriptor(value: unknown): value is ForeignKeyDescriptor {
 
 // ── defineProjection ─────────────────────────────────────────
 
-interface ObjectProjectionSourceBuilder<TObjectType extends ObjectType> {
+interface ObjectTypeProjectionSourceBuilder<TObjectType extends ObjectType> {
   fromDataset<const TDataset extends DatasetDefinition>(
     dataset: TDataset
-  ): ObjectProjectionMappingBuilder<TObjectType, TDataset>
+  ): ObjectTypeProjectionDatasetBuilder<TObjectType, TDataset>
 }
 
-interface ObjectProjectionMappingBuilder<
+interface ObjectTypeProjectionDatasetBuilder<
   TObjectType extends ObjectType,
   TDataset extends DatasetDefinition,
 > {
   properties<const TMapping extends ProjectionMappingFor<TObjectType, TDataset>>(
     mapping: ExactProjectionMapping<TObjectType, TMapping>
   ): ObjectProjectionBuilder<TObjectType, TDataset>
+  points<const TProperties extends TelemetryProjectionPropertiesMapping<TObjectType, TDataset>>(
+    mapping: TelemetryProjectionPropertiesPointMapping<TObjectType, TDataset, TProperties>
+  ): TelemetryProjectionDefinition
 }
 
 export type ObjectProjectionConflictResolution<TDataset extends DatasetDefinition> =
@@ -338,7 +406,7 @@ export interface ObjectProjectionBuilder<
 export function defineProjection<const TObjectType extends ObjectType>(
   id: string,
   objectType: TObjectType
-): ObjectProjectionSourceBuilder<TObjectType>
+): ObjectTypeProjectionSourceBuilder<TObjectType>
 export function defineProjection<
   TObjectTypeId extends string,
   TLinkId extends string,
@@ -355,24 +423,24 @@ export function defineProjection(
   id: string,
   target: ObjectType | LinkToken<string, string, string> | TelemetryPropertyToken
 ):
-  | ObjectProjectionSourceBuilder<ObjectType>
+  | ObjectTypeProjectionSourceBuilder<ObjectType>
   | LinkProjectionSourceBuilder
   | TelemetryProjectionSourceBuilder<TelemetryPropertyToken> {
   if ("link" in target) return buildLinkProjection(id, target)
   if ("property" in target) return buildTelemetryProjection(id, target)
-  return buildObjectProjection(id, target)
+  return buildObjectTypeProjection(id, target)
 }
 
-function buildObjectProjection<const TObjectType extends ObjectType>(
+function buildObjectTypeProjection<const TObjectType extends ObjectType>(
   id: string,
   objectType: TObjectType
-): ObjectProjectionSourceBuilder<TObjectType> {
+): ObjectTypeProjectionSourceBuilder<TObjectType> {
   assertNonEmpty(id, "id")
 
   return {
     fromDataset<const TDataset extends DatasetDefinition>(
       dataset: TDataset
-    ): ObjectProjectionMappingBuilder<TObjectType, TDataset> {
+    ): ObjectTypeProjectionDatasetBuilder<TObjectType, TDataset> {
       assertProjectionDataset(dataset)
       const datasetId = dataset.id
 
@@ -391,6 +459,29 @@ function buildObjectProjection<const TObjectType extends ObjectType>(
             links: {},
             conflictResolution: { strategy: "editsWin" },
           })
+        },
+        points<
+          const TProperties extends TelemetryProjectionPropertiesMapping<TObjectType, TDataset>,
+        >(
+          mapping: TelemetryProjectionPropertiesPointMapping<TObjectType, TDataset, TProperties>
+        ): TelemetryProjectionDefinition {
+          const pointMapping = lowerTelemetryPropertiesPointMapping(
+            objectType,
+            mapping as {
+              readonly objectId?: string
+              readonly at?: string
+              readonly properties?: Readonly<Record<string, unknown>>
+            }
+          )
+          return {
+            _tag: "TelemetryProjectionDefinition",
+            id,
+            objectTypeId: objectType.id,
+            datasetId,
+            objectIdField: pointMapping.objectId,
+            atField: pointMapping.at,
+            properties: pointMapping.properties,
+          }
         },
       }
     },
@@ -505,12 +596,15 @@ function buildTelemetryProjection<const TPropertyToken extends TelemetryProperty
             _tag: "TelemetryProjectionDefinition",
             id,
             objectTypeId: propertyToken.objectTypeId,
-            propertyId: propertyToken.id,
             datasetId,
             objectIdField: pointMapping.objectId,
             atField: pointMapping.at,
-            valueField: pointMapping.value,
-            ...(pointMapping.unit !== undefined ? { unitField: pointMapping.unit } : {}),
+            properties: {
+              [propertyToken.id]: {
+                valueField: pointMapping.value,
+                ...(pointMapping.unit !== undefined ? { unitField: pointMapping.unit } : {}),
+              },
+            },
           }
         },
       }
@@ -569,6 +663,109 @@ function lowerTelemetryPointMapping(mapping: {
     value: mapping.value,
     ...(mapping.unit !== undefined ? { unit: mapping.unit } : {}),
   }
+}
+
+function lowerTelemetryPropertiesPointMapping(
+  objectType: ObjectType,
+  mapping: {
+    readonly objectId?: string
+    readonly at?: string
+    readonly properties?: Readonly<Record<string, unknown>>
+  }
+): {
+  readonly objectId: string
+  readonly at: string
+  readonly properties: Readonly<Record<string, TelemetryProjectionPropertyMapping>>
+} {
+  const allowedKeys = new Set(["objectId", "at", "properties"])
+  for (const key of Object.keys(mapping)) {
+    if (!allowedKeys.has(key)) {
+      throw new ProjectionValidationError(
+        `Telemetry projection point mapping contains unknown key '${key}'.`
+      )
+    }
+  }
+
+  if (mapping.objectId === undefined) {
+    throw new ProjectionValidationError("Telemetry projection point mapping requires objectId.")
+  }
+  if (mapping.at === undefined) {
+    throw new ProjectionValidationError("Telemetry projection point mapping requires at.")
+  }
+  if (mapping.properties === undefined) {
+    throw new ProjectionValidationError("Telemetry projection point mapping requires properties.")
+  }
+  if (!isRecord(mapping.properties)) {
+    throw new ProjectionValidationError(
+      "Telemetry projection point mapping properties must be an object."
+    )
+  }
+
+  assertNonEmpty(mapping.objectId, "objectId field")
+  assertNonEmpty(mapping.at, "at field")
+
+  const propertyEntries = Object.entries(mapping.properties)
+  if (propertyEntries.length === 0) {
+    throw new ProjectionValidationError(
+      "Telemetry projection point mapping requires at least one property."
+    )
+  }
+
+  const propertiesById = new Map(objectType.properties.map((property) => [property.id, property]))
+  const properties: Record<string, TelemetryProjectionPropertyMapping> = {}
+  for (const [propertyId, input] of propertyEntries) {
+    const property = propertiesById.get(propertyId)
+    if (!property) {
+      throw new ProjectionValidationError(
+        `Property '${propertyId}' does not exist on object type '${objectType.id}'.`
+      )
+    }
+    if (property.mode !== "telemetry") {
+      throw new ProjectionValidationError(
+        `Projection property '${objectType.id}.${propertyId}' must be telemetry-enabled.`
+      )
+    }
+    properties[propertyId] = lowerTelemetryPropertyMapping(propertyId, input)
+  }
+
+  return { objectId: mapping.objectId, at: mapping.at, properties }
+}
+
+function lowerTelemetryPropertyMapping(
+  propertyId: string,
+  input: unknown
+): TelemetryProjectionPropertyMapping {
+  if (typeof input === "string") {
+    assertNonEmpty(input, `property '${propertyId}' value field`)
+    return { valueField: input }
+  }
+  if (!isRecord(input)) {
+    throw new ProjectionValidationError(
+      `Telemetry projection property '${propertyId}' must map a value column or value/unit columns.`
+    )
+  }
+
+  const allowedKeys = new Set(["value", "unit"])
+  for (const key of Object.keys(input)) {
+    if (!allowedKeys.has(key)) {
+      throw new ProjectionValidationError(
+        `Telemetry projection property '${propertyId}' contains unknown key '${key}'.`
+      )
+    }
+  }
+  if (typeof input.value !== "string") {
+    throw new ProjectionValidationError(
+      `Telemetry projection property '${propertyId}' requires a value field.`
+    )
+  }
+  if (typeof input.unit !== "string") {
+    throw new ProjectionValidationError(
+      `Telemetry projection property '${propertyId}' requires a unit field.`
+    )
+  }
+  assertNonEmpty(input.value, `property '${propertyId}' value field`)
+  assertNonEmpty(input.unit, `property '${propertyId}' unit field`)
+  return { valueField: input.value, unitField: input.unit }
 }
 
 // ── fromForeignKey ───────────────────────────────────────────
@@ -765,12 +962,20 @@ export function isTelemetryProjectionDefinition(
     value._tag === "TelemetryProjectionDefinition" &&
     typeof value.id === "string" &&
     typeof value.objectTypeId === "string" &&
-    typeof value.propertyId === "string" &&
     typeof value.datasetId === "string" &&
     typeof value.objectIdField === "string" &&
     typeof value.atField === "string" &&
-    typeof value.valueField === "string" &&
-    (value.unitField === undefined || typeof value.unitField === "string")
+    isTelemetryProjectionProperties(value.properties)
+  )
+}
+
+function isTelemetryProjectionProperties(value: unknown): boolean {
+  if (!isRecord(value) || Object.keys(value).length === 0) return false
+  return Object.values(value).every(
+    (mapping) =>
+      isRecord(mapping) &&
+      typeof mapping.valueField === "string" &&
+      (mapping.unitField === undefined || typeof mapping.unitField === "string")
   )
 }
 

--- a/packages/core/src/projections/index.ts
+++ b/packages/core/src/projections/index.ts
@@ -31,6 +31,7 @@ export type {
   ProjectionTargetByKind,
   SourceEditConflictResolution,
   TelemetryProjectionDefinition,
+  TelemetryProjectionPropertyMapping,
 } from "./types"
 // ── Validation ───────────────────────────────────────────────
 export {

--- a/packages/core/src/projections/ownership.ts
+++ b/packages/core/src/projections/ownership.ts
@@ -42,12 +42,12 @@ export function computeProjectionOwnership(
   return freezeOwnership({
     objects: [],
     links: [],
-    telemetry: [
-      {
+    telemetry: Object.keys(projection.properties)
+      .sort(compareStrings)
+      .map((propertyId) => ({
         objectTypeId: projection.objectTypeId,
-        propertyId: projection.propertyId,
-      },
-    ],
+        propertyId,
+      })),
   })
 }
 

--- a/packages/core/src/projections/registry.ts
+++ b/packages/core/src/projections/registry.ts
@@ -273,12 +273,18 @@ function cloneTelemetryProjectionDefinition(
     _tag: "TelemetryProjectionDefinition",
     id: projection.id,
     objectTypeId: projection.objectTypeId,
-    propertyId: projection.propertyId,
     datasetId: projection.datasetId,
     objectIdField: projection.objectIdField,
     atField: projection.atField,
-    valueField: projection.valueField,
-    ...(projection.unitField !== undefined ? { unitField: projection.unitField } : {}),
+    properties: Object.fromEntries(
+      Object.entries(projection.properties).map(([propertyId, mapping]) => [
+        propertyId,
+        {
+          valueField: mapping.valueField,
+          ...(mapping.unitField !== undefined ? { unitField: mapping.unitField } : {}),
+        },
+      ])
+    ),
   }
 }
 

--- a/packages/core/src/projections/revision.ts
+++ b/packages/core/src/projections/revision.ts
@@ -160,14 +160,38 @@ function normalizeProjectionDefinition(projection: ProjectionDefinition): JsonVa
       targetField: projection.targetField,
     }
   }
+  const properties = Object.entries(projection.properties).sort(([left], [right]) =>
+    compareStrings(left, right)
+  )
+  if (properties.length === 1) {
+    const [propertyId, mapping] = properties[0]
+    // Preserve the pre-grouping semantic hash for one-property projections. The authoring form and
+    // lowered shape changed, but the source semantics did not; keeping the hash stable prevents a
+    // deployment from invalidating queued jobs or replaying completed dataset versions.
+    return {
+      kind: "telemetry",
+      objectTypeId: projection.objectTypeId,
+      propertyId,
+      objectIdField: projection.objectIdField,
+      atField: projection.atField,
+      valueField: mapping.valueField,
+      unitField: mapping.unitField ?? null,
+    }
+  }
   return {
     kind: "telemetry",
     objectTypeId: projection.objectTypeId,
-    propertyId: projection.propertyId,
     objectIdField: projection.objectIdField,
     atField: projection.atField,
-    valueField: projection.valueField,
-    unitField: projection.unitField ?? null,
+    properties: Object.fromEntries(
+      properties.map(([propertyId, mapping]) => [
+        propertyId,
+        {
+          valueField: mapping.valueField,
+          unitField: mapping.unitField ?? null,
+        },
+      ])
+    ),
   }
 }
 
@@ -189,8 +213,10 @@ function projectionColumns(projection: ProjectionDefinition): Set<string> {
   return new Set([
     projection.objectIdField,
     projection.atField,
-    projection.valueField,
-    ...(projection.unitField === undefined ? [] : [projection.unitField]),
+    ...Object.values(projection.properties).flatMap((mapping) => [
+      mapping.valueField,
+      ...(mapping.unitField === undefined ? [] : [mapping.unitField]),
+    ]),
   ])
 }
 

--- a/packages/core/src/projections/run-dispatch.ts
+++ b/packages/core/src/projections/run-dispatch.ts
@@ -23,6 +23,7 @@ import {
   type ProjectionRunFailureCode,
 } from "./types"
 
+/** Target maximum mapped points per telemetry commit; a single-property projection reads 500 rows. */
 export const PROJECTION_TELEMETRY_BATCH_SIZE = 500
 
 export interface ProjectionRunDispatchInput {
@@ -403,9 +404,17 @@ function queueProjectionRun(
         ...common,
         identity: input.identity,
         target: { objectTypeId: input.projection.objectTypeId },
-        fixedBatchSize: PROJECTION_TELEMETRY_BATCH_SIZE,
+        fixedBatchSize: telemetryProjectionBatchRowCount(input.projection),
       })
   }
+}
+
+function telemetryProjectionBatchRowCount(
+  projection: Extract<ProjectionDefinition, { readonly _tag: "TelemetryProjectionDefinition" }>
+): number {
+  const mappedPropertyCount = Object.keys(projection.properties).length
+  if (mappedPropertyCount === 0) throw invalidProjectionDefinition(projection.id)
+  return Math.max(1, Math.floor(PROJECTION_TELEMETRY_BATCH_SIZE / mappedPropertyCount))
 }
 
 function requeueProjectionRun(

--- a/packages/core/src/projections/types.ts
+++ b/packages/core/src/projections/types.ts
@@ -84,28 +84,32 @@ export interface LinkProjectionDefinition {
   readonly targetField: string
 }
 
+/** Dataset columns that produce one telemetry property value. */
+export interface TelemetryProjectionPropertyMapping {
+  /** Dataset column holding the telemetry value. */
+  readonly valueField: string
+  /** Dataset column holding the telemetry unit, when the property requires one. */
+  readonly unitField?: string
+}
+
 /**
  * Lowered, serializable definition for projecting dataset rows into telemetry history.
  *
- * Each row in the dataset becomes one telemetry point for a single object type property.
- * The target object type and property are fixed by the telemetry property token used by
- * the builder; the point mapping selects the dataset columns for object id, timestamp,
- * value, and optional unit.
+ * Each row shares one target object id and observation timestamp, then contributes up to one
+ * telemetry point for every mapped property. A property-token projection is lowered to the same
+ * shape with one entry, so execution and ownership have one canonical contract.
  */
 export interface TelemetryProjectionDefinition {
   readonly _tag: "TelemetryProjectionDefinition"
   readonly id: string
   readonly objectTypeId: string
-  readonly propertyId: string
   readonly datasetId: string
   /** Dataset column holding the target object's primary id. */
   readonly objectIdField: string
   /** Dataset column holding the telemetry observation timestamp. */
   readonly atField: string
-  /** Dataset column holding the telemetry value. */
-  readonly valueField: string
-  /** Dataset column holding the telemetry unit, when the property requires one. */
-  readonly unitField?: string
+  /** Maps telemetry property id -> value and optional unit dataset columns. */
+  readonly properties: Readonly<Record<string, TelemetryProjectionPropertyMapping>>
 }
 
 /** Union of all projection definition types. */

--- a/packages/core/src/projections/validation.ts
+++ b/packages/core/src/projections/validation.ts
@@ -7,7 +7,8 @@
 
 import type { DatasetDefinition } from "../datasets"
 import type { OntologyDefinitionCatalog } from "../ontology"
-import type { ObjectType, Property } from "../ontology/types"
+import type { ObjectType, Property, ValueType } from "../ontology/types"
+import { resolveSemanticType } from "../ontology/validation"
 import { ProjectionValidationError } from "./errors"
 import {
   computeProjectionOwnership,
@@ -196,37 +197,29 @@ export function validateLinkProjectionTarget(linkToken: {
 
 /**
  * Validates a telemetry projection's field mapping against its dataset columns
- * and object type: the telemetry property exists and is telemetry-enabled, and
+ * and object type: every mapped property exists and is telemetry-enabled, and
  * every mapped field (objectId/at/value/unit) resolves to a real dataset column.
  *
  * Owned here so startup validation and the projection worker's pre-execution
  * check share one implementation and cannot drift; the worker layers
  * dataset-version column type compatibility on top of these rules. Returns the
- * resolved telemetry property for callers that need its schema.
+ * resolved telemetry properties for callers that need their schemas.
  */
 export function validateTelemetryProjectionFieldMapping(
   projection: TelemetryProjectionDefinition,
   objectType: { readonly id: string; readonly properties: readonly Property[] },
   datasetColumnNames: ReadonlySet<string>,
+  valueTypesById: ReadonlyMap<string, ValueType>,
   prefix: string
-): Property {
-  const property = objectType.properties.find((candidate) => candidate.id === projection.propertyId)
-  if (!property) {
-    throw new ProjectionValidationError(
-      `${prefix}: unknown property "${projection.propertyId}" on type "${projection.objectTypeId}"`
-    )
-  }
-  if (property.mode !== "telemetry") {
-    throw new ProjectionValidationError(
-      `${prefix}: property "${projection.propertyId}" on type "${projection.objectTypeId}" must be telemetry-enabled`
-    )
+): ReadonlyMap<string, Property> {
+  const mappedProperties = Object.entries(projection.properties)
+  if (mappedProperties.length === 0) {
+    throw new ProjectionValidationError(`${prefix}: must map at least one telemetry property`)
   }
 
   const mappedFields = [
     ["objectId", projection.objectIdField],
     ["at", projection.atField],
-    ["value", projection.valueField],
-    ...(projection.unitField !== undefined ? ([["unit", projection.unitField]] as const) : []),
   ] as const
   for (const [fieldRole, columnName] of mappedFields) {
     if (!datasetColumnNames.has(columnName)) {
@@ -237,7 +230,49 @@ export function validateTelemetryProjectionFieldMapping(
     }
   }
 
-  return property
+  const propertiesById = new Map(objectType.properties.map((property) => [property.id, property]))
+  const resolvedProperties = new Map<string, Property>()
+  for (const [propertyId, mapping] of mappedProperties) {
+    const property = propertiesById.get(propertyId)
+    if (!property) {
+      throw new ProjectionValidationError(
+        `${prefix}: unknown property "${propertyId}" on type "${projection.objectTypeId}"`
+      )
+    }
+    if (property.mode !== "telemetry") {
+      throw new ProjectionValidationError(
+        `${prefix}: property "${propertyId}" on type "${projection.objectTypeId}" must be telemetry-enabled`
+      )
+    }
+
+    for (const [fieldRole, columnName] of [
+      ["value", mapping.valueField],
+      ...(mapping.unitField !== undefined ? ([["unit", mapping.unitField]] as const) : []),
+    ] as const) {
+      if (!datasetColumnNames.has(columnName)) {
+        throw new ProjectionValidationError(
+          `${prefix}: property "${propertyId}" ${fieldRole} field "${columnName}" references ` +
+            `unknown dataset column on dataset "${projection.datasetId}"`
+        )
+      }
+    }
+
+    const semanticType = resolveSemanticType(property, valueTypesById)
+    if (semanticType !== undefined && mapping.unitField === undefined) {
+      throw new ProjectionValidationError(
+        `${prefix}: property "${propertyId}" requires a unit field because it uses semantic type "${semanticType}"`
+      )
+    }
+    if (semanticType === undefined && mapping.unitField !== undefined) {
+      throw new ProjectionValidationError(
+        `${prefix}: property "${propertyId}" cannot map a unit field because it has no semantic type`
+      )
+    }
+
+    resolvedProperties.set(propertyId, property)
+  }
+
+  return resolvedProperties
 }
 
 /**
@@ -262,8 +297,9 @@ export function validateTelemetryProjectionFieldMapping(
  * For telemetry projections:
  * 1. `datasetId` exists in the dataset registry.
  * 2. `objectTypeId` exists in the type registry.
- * 3. `propertyId` exists on the object type and is telemetry-enabled.
+ * 3. Every mapped property exists on the object type and is telemetry-enabled.
  * 4. Point mapping fields exist in the referenced dataset.
+ * 5. Unit mappings match each property's semantic type requirements.
  */
 export interface ValidatedProjectionRecord<TDefinition extends ProjectionDefinition>
   extends ProjectionOwnershipRecord<TDefinition> {
@@ -512,7 +548,13 @@ export function validateProjectionsAtStartup(
     }
 
     const datasetColumnNames = new Set(dataset.schema.columns.map((column) => column.name))
-    validateTelemetryProjectionFieldMapping(projection, objectType, datasetColumnNames, prefix)
+    validateTelemetryProjectionFieldMapping(
+      projection,
+      objectType,
+      datasetColumnNames,
+      ontology.getValueTypesById(),
+      prefix
+    )
     validatedTelemetryProjections.push({
       definition: projection,
       dataset,

--- a/packages/core/src/storage/ontology/provider-header-validation.ts
+++ b/packages/core/src/storage/ontology/provider-header-validation.ts
@@ -155,9 +155,9 @@ function assertProjectionTelemetryBatch(
   if (source.sourceRowsSkipped > source.sourceRowCount) {
     invalidCorrelation("Projection telemetry skipped rows exceed its source row count.")
   }
-  if (source.sourceRowCount !== inputPointCount + source.sourceRowsSkipped) {
+  if (inputPointCount < source.sourceRowCount - source.sourceRowsSkipped) {
     invalidCorrelation(
-      "Projection telemetry source row count does not match input points plus skipped rows."
+      "Projection telemetry input points do not account for every non-skipped source row."
     )
   }
   if (typeof source.inputExhausted !== "boolean") {

--- a/packages/core/tests/create-sixb.test.ts
+++ b/packages/core/tests/create-sixb.test.ts
@@ -1158,7 +1158,9 @@ export const roomTemperatureProjection = defineProjection(
     expect(sixb.definitions.projections.listTelemetry()).toHaveLength(1)
     expect(sixb.definitions.projections.listTelemetry()[0].id).toBe("room-temperatures")
     expect(sixb.definitions.projections.listTelemetry()[0].objectTypeId).toBe("Room")
-    expect(sixb.definitions.projections.listTelemetry()[0].propertyId).toBe("temperature")
+    expect(sixb.definitions.projections.listTelemetry()[0].properties).toEqual({
+      temperature: { valueField: "temperature" },
+    })
     expect(sixb.definitions.projections.listTelemetry()[0].datasetId).toBe(
       "canonical.room-readings"
     )
@@ -1555,11 +1557,10 @@ export const setTemperature = defineAction("setTemperature")
       _tag: "TelemetryProjectionDefinition" as const,
       id: "room-temperatures",
       objectTypeId: "Room",
-      propertyId: "temperature",
       datasetId: "canonical.room-readings",
       objectIdField: "room_id",
       atField: "missing_observed_at",
-      valueField: "temperature",
+      properties: { temperature: { valueField: "temperature" } },
     }
 
     await expect(
@@ -1604,11 +1605,10 @@ export const setTemperature = defineAction("setTemperature")
       _tag: "TelemetryProjectionDefinition" as const,
       id: "room-temperatures",
       objectTypeId: "Room",
-      propertyId: "temperature",
       datasetId: "canonical.room-readings",
       objectIdField: "room_id",
       atField: "observed_at",
-      valueField: "temperature",
+      properties: { temperature: { valueField: "temperature" } },
     }
 
     await expect(
@@ -1629,6 +1629,85 @@ export const setTemperature = defineAction("setTemperature")
         ...createTestRuntimeDeps(),
       })
     ).rejects.toThrow('property "temperature" on type "Room" must be telemetry-enabled')
+  })
+
+  test("validates grouped telemetry units from each property's semantic type", async () => {
+    const projectRoot = await createTempProjectRoot()
+    const Room = defineObjectType({
+      id: "Room",
+      name: "Room",
+      properties: [
+        prop("id", "string", { required: true, primary: true }),
+        prop("temperature", "double", { mode: "telemetry", semanticType: "Temperature" }),
+        prop("humidity", "double", { mode: "telemetry" }),
+      ],
+    })
+    const readings = defineDataset("room-readings", {
+      schema: [
+        col("room_id", "string"),
+        col("observed_at", "timestamp"),
+        col("temperature", "float64"),
+        col("temperature_unit", "string"),
+        col("humidity", "float64"),
+        col("humidity_unit", "string"),
+      ],
+    })
+
+    const missingUnit = defineProjection("missing-unit", Room)
+      .fromDataset(readings)
+      .points({
+        objectId: "room_id",
+        at: "observed_at",
+        properties: { temperature: "temperature" },
+      })
+    await expect(
+      createSixb({
+        projectRoot,
+        ontologies: [Room],
+        datasets: [readings],
+        projections: [missingUnit],
+        ...createTestRuntimeDeps(),
+      })
+    ).rejects.toThrow(
+      'property "temperature" requires a unit field because it uses semantic type "Temperature"'
+    )
+
+    const unexpectedUnit = defineProjection("unexpected-unit", Room)
+      .fromDataset(readings)
+      .points({
+        objectId: "room_id",
+        at: "observed_at",
+        properties: { humidity: { value: "humidity", unit: "humidity_unit" } },
+      })
+    await expect(
+      createSixb({
+        projectRoot,
+        ontologies: [Room],
+        datasets: [readings],
+        projections: [unexpectedUnit],
+        ...createTestRuntimeDeps(),
+      })
+    ).rejects.toThrow('property "humidity" cannot map a unit field because it has no semantic type')
+
+    const valid = defineProjection("room-activity", Room)
+      .fromDataset(readings)
+      .points({
+        objectId: "room_id",
+        at: "observed_at",
+        properties: {
+          temperature: { value: "temperature", unit: "temperature_unit" },
+          humidity: "humidity",
+        },
+      })
+    await expect(
+      createSixb({
+        projectRoot,
+        ontologies: [Room],
+        datasets: [readings],
+        projections: [valid],
+        ...createTestRuntimeDeps(),
+      })
+    ).resolves.toBeDefined()
   })
 
   test("treats missing projections folder as empty", async () => {

--- a/packages/core/tests/materializer-fixture.ts
+++ b/packages/core/tests/materializer-fixture.ts
@@ -32,6 +32,7 @@ export const Device = defineObjectType({
     prop("name", "string", { required: true }),
     prop("note", "string", { nullable: true }),
     prop("temperature", "double", { mode: "telemetry" }),
+    prop("humidity", "double", { mode: "telemetry" }),
   ],
   links: [link.self("parent", { cardinality: "one" }), link.self("peers", { cardinality: "many" })],
 })
@@ -46,7 +47,12 @@ const devices = defineDataset("devices", {
   ],
 })
 const readings = defineDataset("readings", {
-  schema: [col("device_id", "string"), col("at", "timestamp"), col("value", "float64")],
+  schema: [
+    col("device_id", "string"),
+    col("at", "timestamp"),
+    col("value", "float64"),
+    col("humidity", "float64"),
+  ],
 })
 const deviceProjection = defineProjection("devices", Device)
   .fromDataset(devices)
@@ -69,9 +75,13 @@ const mostRecentDeviceProjection = defineProjection("devices", Device)
     },
   })
   .resolveConflicts({ strategy: "mostRecent", sourceTimestamp: "updated_at" })
-const temperatureProjection = defineProjection("temperatures", Device.p.temperature)
+const temperatureProjection = defineProjection("temperatures", Device)
   .fromDataset(readings)
-  .points({ objectId: "device_id", at: "at", value: "value" })
+  .points({
+    objectId: "device_id",
+    at: "at",
+    properties: { temperature: "value", humidity: "humidity" },
+  })
 
 export function createMaterializerFixture(
   input: {

--- a/packages/core/tests/materializer-telemetry.test.ts
+++ b/packages/core/tests/materializer-telemetry.test.ts
@@ -16,8 +16,95 @@ const series = {
   object: { objectTypeId: "Device", primaryId: "one" },
   propertyId: "temperature",
 }
+const humiditySeries = { ...series, propertyId: "humidity" }
 
 describe("ontology materializer telemetry", () => {
+  test("accepts partial and complete rows from a grouped telemetry projection", async () => {
+    const { materializer, storage } = createMaterializerFixture()
+    await materializer.projections.replace(
+      replacement("grouped-telemetry", "2026-01-01T00:00:00Z", [sourceEntry("one", "one")])
+    )
+
+    await expect(
+      materializer.telemetry.append({
+        source: {
+          kind: "projection",
+          projection: { projectionId: "temperatures" },
+          datasetVersion: {
+            datasetId: "readings",
+            versionId: "grouped-v1",
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+          execution: pendingProjectionExecution("grouped-telemetry-run"),
+          batchOrdinal: 0,
+          sourceRowCount: 2,
+          sourceRowsSkipped: 0,
+          inputExhausted: true,
+        },
+        points: [
+          { series, value: 20, at: "2026-01-01T01:00:00Z" },
+          { series: humiditySeries, value: 45, at: "2026-01-01T01:00:00Z" },
+          { series, value: 21, at: "2026-01-01T02:00:00Z" },
+        ],
+      })
+    ).resolves.toMatchObject({ pointsCreated: 3 })
+
+    expect(
+      await storage.timeseries.getHistory({
+        projectId: "project",
+        objectTypeId: "Device",
+        objectId: "one",
+        propertyId: "temperature",
+      })
+    ).toHaveLength(2)
+    expect(
+      await storage.timeseries.getHistory({
+        projectId: "project",
+        objectTypeId: "Device",
+        objectId: "one",
+        propertyId: "humidity",
+      })
+    ).toHaveLength(1)
+  })
+
+  test("rejects grouped projection batches outside their row/property bounds", async () => {
+    const { materializer } = createMaterializerFixture()
+    await materializer.projections.replace(
+      replacement("grouped-bounds", "2026-01-01T00:00:00Z", [sourceEntry("one", "one")])
+    )
+    const append = (points: Parameters<typeof materializer.telemetry.append>[0]["points"]) =>
+      materializer.telemetry.append({
+        source: {
+          kind: "projection",
+          projection: { projectionId: "temperatures" },
+          datasetVersion: {
+            datasetId: "readings",
+            versionId: "grouped-bounds-v1",
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+          execution: pendingProjectionExecution("grouped-bounds-run"),
+          batchOrdinal: 0,
+          sourceRowCount: 2,
+          sourceRowsSkipped: 0,
+          inputExhausted: true,
+        },
+        points,
+      })
+
+    await expect(append([{ series, value: 20, at: "2026-01-01T01:00:00Z" }])).rejects.toThrow(
+      "must emit between 2 and 4 points"
+    )
+    await expect(
+      append([
+        { series, value: 20, at: "2026-01-01T01:00:00Z" },
+        { series, value: 21, at: "2026-01-01T02:00:00Z" },
+        { series, value: 22, at: "2026-01-01T03:00:00Z" },
+        { series, value: 23, at: "2026-01-01T04:00:00Z" },
+        { series, value: 24, at: "2026-01-01T05:00:00Z" },
+      ])
+    ).rejects.toThrow("must emit between 2 and 4 points")
+  })
+
   test("correlates durable targets for telemetry batches and terminal decisions", async () => {
     const { materializer, storage, projections } = createMaterializerFixture()
     const resolved = projections.resolveTelemetry("temperatures")

--- a/packages/core/tests/projection-registry.test.ts
+++ b/packages/core/tests/projection-registry.test.ts
@@ -13,6 +13,7 @@ import {
   valueTypeRef,
 } from "../src"
 import type { ProjectionMaterializationIdentity } from "../src/materialization"
+import { sha256Canonical } from "../src/materialization/identity"
 import {
   computeOntologyRevision,
   computeProjectionRevision,
@@ -37,6 +38,7 @@ const Room = defineObjectType({
     prop("name", "string"),
     prop("sensorId", "string"),
     prop("temperature", "double", { mode: "telemetry" }),
+    prop("humidity", "double", { mode: "telemetry" }),
   ],
   links: [link("hasSensor", Sensor, { cardinality: "one" })],
 })
@@ -52,7 +54,12 @@ const roomSensors = defineDataset("room-sensors", {
   schema: [col("sensor_id", "string"), col("room_id", "string")],
 })
 const readings = defineDataset("readings", {
-  schema: [col("value", "float64"), col("observed_at", "timestamp"), col("room_id", "string")],
+  schema: [
+    col("value", "float64"),
+    col("humidity", "float64"),
+    col("observed_at", "timestamp"),
+    col("room_id", "string"),
+  ],
 })
 
 function registry(): OntologyRegistry {
@@ -68,9 +75,13 @@ describe("projection registry", () => {
     const roomProjection = defineProjection("rooms", Room)
       .fromDataset(rooms)
       .properties({ id: "room_id", name: "room_name" })
-    const temperatureProjection = defineProjection("temperatures", Room.p.temperature)
+    const temperatureProjection = defineProjection("temperatures", Room)
       .fromDataset(readings)
-      .points({ objectId: "room_id", at: "observed_at", value: "value" })
+      .points({
+        objectId: "room_id",
+        at: "observed_at",
+        properties: { temperature: "value", humidity: "humidity" },
+      })
     const projectionRegistry = new ProjectionRegistry({
       projections: [roomProjection, temperatureProjection],
       ontology: registry(),
@@ -96,9 +107,14 @@ describe("projection registry", () => {
     expect(Object.isFrozen(resolved)).toBe(true)
     expect(Object.isFrozen(resolved.definition)).toBe(true)
     expect(Object.isFrozen(resolved.ownership.objects[0].propertyIds)).toBe(true)
-    expect(projectionRegistry.resolveTelemetry("temperatures").definition.propertyId).toBe(
-      "temperature"
-    )
+    expect(projectionRegistry.resolveTelemetry("temperatures").definition.properties).toEqual({
+      temperature: { valueField: "value" },
+      humidity: { valueField: "humidity" },
+    })
+    expect(projectionRegistry.resolveTelemetry("temperatures").ownership.telemetry).toEqual([
+      { objectTypeId: "Room", propertyId: "humidity" },
+      { objectTypeId: "Room", propertyId: "temperature" },
+    ])
     expect(() => projectionRegistry.resolveSource("temperatures")).toThrow("telemetry-only")
     expect(() => projectionRegistry.resolveTelemetry("rooms")).toThrow(
       "does not own a telemetry source"
@@ -194,6 +210,7 @@ describe("projection registry", () => {
       description: "Display-only description",
       properties: [
         prop("temperature", "double", { mode: "telemetry" }),
+        prop("humidity", "double", { mode: "telemetry" }),
         prop("sensorId", "string"),
         prop("name", "string"),
         prop("id", "string", { primary: true, required: true }),
@@ -259,6 +276,24 @@ describe("projection registry", () => {
         renamedReadings
       )
     )
+    expect(computeProjectionRevision(telemetryProjection, readings)).toBe(
+      sha256Canonical({
+        mapping: {
+          kind: "telemetry",
+          objectTypeId: "Room",
+          propertyId: "temperature",
+          objectIdField: "room_id",
+          atField: "observed_at",
+          valueField: "value",
+          unitField: null,
+        },
+        columns: [
+          { name: "observed_at", type: "timestamp", nullable: false },
+          { name: "room_id", type: "string", nullable: false },
+          { name: "value", type: "float64", nullable: false },
+        ],
+      })
+    )
 
     expect(
       computeProjectionRevision(
@@ -289,6 +324,40 @@ describe("projection registry", () => {
     expect(computeProjectionRevision(objectProjection, nullableRooms)).not.toBe(
       computeProjectionRevision(objectProjection, rooms)
     )
+  })
+
+  test("keeps grouped telemetry revisions order-independent and rejects partial ownership overlap", () => {
+    const first = defineProjection("room-readings", Room)
+      .fromDataset(readings)
+      .points({
+        objectId: "room_id",
+        at: "observed_at",
+        properties: { temperature: "value", humidity: "humidity" },
+      })
+    const reordered = defineProjection("renamed", Room)
+      .fromDataset(readings)
+      .points({
+        objectId: "room_id",
+        at: "observed_at",
+        properties: { humidity: "humidity", temperature: "value" },
+      })
+
+    expect(computeProjectionRevision(first, readings)).toBe(
+      computeProjectionRevision(reordered, readings)
+    )
+    expect(
+      () =>
+        new ProjectionRegistry({
+          projections: [
+            first,
+            defineProjection("humidity-only", Room.p.humidity)
+              .fromDataset(readings)
+              .points({ objectId: "room_id", at: "observed_at", value: "humidity" }),
+          ],
+          ontology: registry(),
+          datasetsById: datasets(readings),
+        })
+    ).toThrow("overlaps telemetry source 'Room.humidity'")
   })
 
   test("clones resolved definitions field by field", () => {

--- a/packages/core/tests/projection-run-dispatch.test.ts
+++ b/packages/core/tests/projection-run-dispatch.test.ts
@@ -9,6 +9,7 @@ import {
   InMemoryLakeStorage,
   InMemoryQueues,
   InMemoryStorage,
+  type ProjectionDefinition,
   prop,
   type SixbErrorContext,
   SixbHost,
@@ -18,19 +19,38 @@ import { ProjectionRunDispatcher } from "../src/projections/run-dispatch"
 const Device = defineObjectType({
   id: "Device",
   name: "Device",
-  properties: [prop("id", "string", { primary: true, required: true }), prop("name", "string")],
+  properties: [
+    prop("id", "string", { primary: true, required: true }),
+    prop("name", "string"),
+    prop("temperature", "double", { mode: "telemetry" }),
+    prop("humidity", "double", { mode: "telemetry" }),
+  ],
 })
 
 const devices = defineDataset("raw.devices", {
-  schema: [col("device_id", "string"), col("device_name", "string")],
+  schema: [
+    col("device_id", "string"),
+    col("device_name", "string"),
+    col("observed_at", "timestamp"),
+    col("temperature", "float64"),
+    col("humidity", "float64"),
+  ],
 })
 
 const deviceProjection = defineProjection("project-devices", Device)
   .fromDataset(devices)
   .properties({ id: "device_id" })
 
+const groupedTelemetryProjection = defineProjection("device-readings", Device)
+  .fromDataset(devices)
+  .points({
+    objectId: "device_id",
+    at: "observed_at",
+    properties: { temperature: "temperature", humidity: "humidity" },
+  })
+
 function createDependencies(
-  projection = deviceProjection,
+  projection: ProjectionDefinition = deviceProjection,
   onError?: (error: Error, context: SixbErrorContext) => void
 ) {
   const storage = new InMemoryStorage()
@@ -61,13 +81,24 @@ async function commitDevicesVersion(
 ) {
   await lakeStorage.createDataset(devices)
   const write = await lakeStorage.beginWrite({ dataset: devices, mode: "snapshot", producer })
-  await write.writeRows([{ device_id: "device-1", device_name: "Kitchen sensor" }])
+  await write.writeRows([
+    {
+      device_id: "device-1",
+      device_name: "Kitchen sensor",
+      observed_at: "2026-01-01T00:00:00.000Z",
+      temperature: 21,
+      humidity: 45,
+    },
+  ])
   return write.commit()
 }
 
-function dispatchInput(version: Awaited<ReturnType<typeof commitDevicesVersion>>) {
+function dispatchInput(
+  version: Awaited<ReturnType<typeof commitDevicesVersion>>,
+  projectionId = deviceProjection.id
+) {
   return {
-    projectionId: deviceProjection.id,
+    projectionId,
     datasetVersion: {
       datasetId: version.datasetId,
       versionId: version.versionId,
@@ -77,6 +108,22 @@ function dispatchInput(version: Awaited<ReturnType<typeof commitDevicesVersion>>
 }
 
 describe("ProjectionRunDispatcher", () => {
+  test("bounds grouped telemetry batches by their maximum mapped point count", async () => {
+    const { host, lakeStorage, storage } = createDependencies(groupedTelemetryProjection)
+    const version = await commitDevicesVersion(lakeStorage)
+
+    const result = await new ProjectionRunDispatcher(host).dispatch(
+      dispatchInput(version, groupedTelemetryProjection.id)
+    )
+
+    expect(
+      await storage.projectionRuns.getById({ projectId: host.id, id: result.runId })
+    ).toMatchObject({
+      identity: { projectionKind: "telemetry", protocol: "telemetry" },
+      telemetryCheckpoint: { fixedBatchSize: 250 },
+    })
+  })
+
   test("persists the execution and queued run before publishing their run identity", async () => {
     const { host, lakeStorage, queues, storage } = createDependencies()
     await storage.auth.users.create({

--- a/packages/core/tests/projection-run-visibility.test.ts
+++ b/packages/core/tests/projection-run-visibility.test.ts
@@ -30,11 +30,10 @@ const telemetryProjection: TelemetryProjectionDefinition = {
   _tag: "TelemetryProjectionDefinition",
   id: "room-temps",
   objectTypeId: "room",
-  propertyId: "temperature",
   datasetId: "ds",
   objectIdField: "room_id",
   atField: "at",
-  valueField: "value",
+  properties: { temperature: { valueField: "value" } },
 }
 
 const linkProjection: LinkProjectionDefinition = {

--- a/packages/core/tests/projection.test.ts
+++ b/packages/core/tests/projection.test.ts
@@ -32,6 +32,7 @@ const Room = defineObjectType({
     prop("buildingRef", "string"),
     prop("sensorRef", "string"),
     prop("temperature", "double", { mode: "telemetry" }),
+    prop("humidity", "double", { mode: "telemetry" }),
   ],
   links: [
     link("inBuilding", Building, { cardinality: "one" }),
@@ -62,6 +63,7 @@ const roomReadingsDataset = defineDataset("canonical.room-readings", {
     col("room_id", "string"),
     col("observed_at", "timestamp"),
     col("temperature", "float64"),
+    col("humidity", "float64"),
     col("unit", "string"),
   ],
 })
@@ -488,12 +490,10 @@ describe("defineProjection — telemetry target", () => {
     expect(result._tag).toBe("TelemetryProjectionDefinition")
     expect(result.id).toBe("room-temperatures")
     expect(result.objectTypeId).toBe("room")
-    expect(result.propertyId).toBe("temperature")
     expect(result.datasetId).toBe("canonical.room-readings")
     expect(result.objectIdField).toBe("room_id")
     expect(result.atField).toBe("observed_at")
-    expect(result.valueField).toBe("temperature")
-    expect(result.unitField).toBeUndefined()
+    expect(result.properties).toEqual({ temperature: { valueField: "temperature" } })
   })
 
   test("builds definition with optional unit field", () => {
@@ -506,7 +506,73 @@ describe("defineProjection — telemetry target", () => {
         unit: "unit",
       })
 
-    expect(result.unitField).toBe("unit")
+    expect(result.properties).toEqual({
+      temperature: { valueField: "temperature", unitField: "unit" },
+    })
+  })
+
+  test("builds one canonical definition for multiple telemetry properties", () => {
+    const result = defineProjection("room-readings", Room)
+      .fromDataset(roomReadingsDataset)
+      .points({
+        objectId: "room_id",
+        at: "observed_at",
+        properties: {
+          temperature: { value: "temperature", unit: "unit" },
+          humidity: "humidity",
+        },
+      })
+
+    expect(result).toEqual({
+      _tag: "TelemetryProjectionDefinition",
+      id: "room-readings",
+      objectTypeId: "room",
+      datasetId: "canonical.room-readings",
+      objectIdField: "room_id",
+      atField: "observed_at",
+      properties: {
+        temperature: { valueField: "temperature", unitField: "unit" },
+        humidity: { valueField: "humidity" },
+      },
+    })
+  })
+
+  test("rejects invalid grouped telemetry mappings", () => {
+    expect(() =>
+      defineProjection("empty", Room)
+        .fromDataset(roomReadingsDataset)
+        .points({ objectId: "room_id", at: "observed_at", properties: {} } as never)
+    ).toThrow("requires at least one property")
+
+    expect(() =>
+      defineProjection("static", Room)
+        .fromDataset(roomReadingsDataset)
+        .points({
+          objectId: "room_id",
+          at: "observed_at",
+          properties: { name: "temperature" },
+        } as never)
+    ).toThrow("must be telemetry-enabled")
+
+    expect(() =>
+      defineProjection("unknown", Room)
+        .fromDataset(roomReadingsDataset)
+        .points({
+          objectId: "room_id",
+          at: "observed_at",
+          properties: { missing: "temperature" },
+        } as never)
+    ).toThrow("does not exist")
+
+    expect(() =>
+      defineProjection("descriptor", Room)
+        .fromDataset(roomReadingsDataset)
+        .points({
+          objectId: "room_id",
+          at: "observed_at",
+          properties: { temperature: { value: "temperature", extra: "unit" } },
+        } as never)
+    ).toThrow("unknown key 'extra'")
   })
 
   test("rejects static property token", () => {

--- a/packages/core/tests/projection.types.ts
+++ b/packages/core/tests/projection.types.ts
@@ -48,6 +48,7 @@ const _Room = defineObjectType({
     prop("openedOn", "date"),
     prop("lastSeenAt", "timestamp"),
     prop("currentTemperature", "double", { mode: "telemetry" }),
+    prop("currentHumidity", "double", { mode: "telemetry" }),
     prop("mode", stringEnum(["occupied", "vacant"])),
     prop("metadata", {
       type: "object",
@@ -73,6 +74,7 @@ const roomDataset = defineDataset("canonical.rooms", {
     col("col_area", "float64"),
     col("col_exact_amount", "decimal"),
     col("col_temperature", "float64"),
+    col("col_humidity", "float64"),
     col("col_opened_on", "date"),
     col("col_last_seen_at", "timestamp"),
     col("col_nullable_updated_at", "timestamp", { nullable: true }),
@@ -304,3 +306,78 @@ defineProjection("test", _Room.p.currentTemperature).fromDataset(roomDataset).po
   // @ts-expect-error — point mappings only accept objectId, at, value, and unit
   extra: "col_id",
 })
+
+// 15. object targets group telemetry properties that share objectId and at
+const groupedTelemetryProjection = defineProjection("grouped", _Room)
+  .fromDataset(roomDataset)
+  .points({
+    objectId: "col_id",
+    at: "col_last_seen_at",
+    properties: {
+      currentTemperature: { value: "col_temperature", unit: "col_unit" },
+      currentHumidity: "col_humidity",
+    },
+  })
+type _groupedTelemetryProjTag = Expect<
+  Equal<typeof groupedTelemetryProjection._tag, "TelemetryProjectionDefinition">
+>
+
+defineProjection("grouped", _Room)
+  .fromDataset(roomDataset)
+  // @ts-expect-error — grouped telemetry projections require at least one property
+  .points({ objectId: "col_id", at: "col_last_seen_at", properties: {} })
+
+defineProjection("grouped", _Room)
+  .fromDataset(roomDataset)
+  // @ts-expect-error — static properties cannot be mapped as telemetry
+  .points({ objectId: "col_id", at: "col_last_seen_at", properties: { name: "col_name" } })
+
+defineProjection("grouped", _Room)
+  .fromDataset(roomDataset)
+  .points({
+    objectId: "col_id",
+    at: "col_last_seen_at",
+    properties: { currentTemperature: "col_temperature" },
+    // @ts-expect-error — grouped point mappings only accept objectId, at, and properties
+    extra: "col_id",
+  })
+
+defineProjection("grouped", _Room)
+  .fromDataset(roomDataset)
+  .points({
+    objectId: "col_id",
+    at: "col_last_seen_at",
+    properties: {
+      // @ts-expect-error — value columns remain schema-compatible per property
+      currentTemperature: "col_name",
+    },
+  })
+
+defineProjection("grouped", _Room)
+  .fromDataset(roomDataset)
+  .points({
+    objectId: "col_id",
+    at: "col_last_seen_at",
+    properties: {
+      currentTemperature: {
+        value: "col_temperature",
+        // @ts-expect-error — unit must be a string dataset column
+        unit: "col_room_number",
+      },
+    },
+  })
+
+defineProjection("grouped", _Room)
+  .fromDataset(roomDataset)
+  .points({
+    objectId: "col_id",
+    at: "col_last_seen_at",
+    properties: {
+      currentTemperature: {
+        value: "col_temperature",
+        unit: "col_unit",
+        // @ts-expect-error — property descriptors only accept value and unit
+        extra: "col_id",
+      },
+    },
+  })

--- a/packages/core/tests/provider-header-validation.test.ts
+++ b/packages/core/tests/provider-header-validation.test.ts
@@ -99,6 +99,11 @@ describe("materialization header validation", () => {
   test("accepts correlated projection and telemetry headers", () => {
     expect(() => assertMaterializationHeader(projectionHeader())).not.toThrow()
     expect(() => assertMaterializationHeader(telemetryHeader())).not.toThrow()
+    expect(() =>
+      assertMaterializationHeader(
+        telemetryHeader({ sourceRowCount: 2, sourceRowsSkipped: 0, inputPointCount: 4 })
+      )
+    ).not.toThrow()
   })
 
   test("reports the exact projection correlation that failed", () => {
@@ -112,8 +117,6 @@ describe("materialization header validation", () => {
       assertMaterializationHeader(
         telemetryHeader({ sourceRowCount: 3, sourceRowsSkipped: 1, inputPointCount: 1 })
       )
-    ).toThrow(
-      "Projection telemetry source row count does not match input points plus skipped rows."
-    )
+    ).toThrow("Projection telemetry input points do not account for every non-skipped source row.")
   })
 })

--- a/packages/projection-worker/src/run-telemetry-projection.ts
+++ b/packages/projection-worker/src/run-telemetry-projection.ts
@@ -6,6 +6,7 @@ import {
   MaterializationValidationError,
   type Schema,
   type TelemetryProjectionDefinition,
+  type TelemetryProjectionPropertyMapping,
 } from "@sixb/core"
 import { createSixbError } from "@sixb/core/internal/errors"
 import type { TelemetryPointWrite } from "@sixb/core/internal/materialization"
@@ -20,13 +21,19 @@ import { isBlank, isPlainObject, throwIfAborted } from "./utils"
 interface TelemetryProjectionPlan {
   readonly projection: TelemetryProjectionDefinition
   readonly dataset: DatasetDefinition
-  readonly valueColumnType: DatasetColumnDefinition["type"]
-  readonly valueSchema: Schema
+  readonly properties: readonly TelemetryProjectionPropertyPlan[]
   readonly readColumns: readonly string[]
 }
 
+interface TelemetryProjectionPropertyPlan {
+  readonly propertyId: string
+  readonly mapping: TelemetryProjectionPropertyMapping
+  readonly valueColumnType: DatasetColumnDefinition["type"]
+  readonly valueSchema: Schema
+}
+
 type ProjectTelemetryRowResult =
-  | { readonly kind: "point"; readonly point: TelemetryPointWrite }
+  | { readonly kind: "points"; readonly points: readonly TelemetryPointWrite[] }
   | { readonly kind: "skip" }
   | { readonly kind: "invalid"; readonly message: string }
 
@@ -191,7 +198,7 @@ async function appendPhysicalBatch(input: {
       sourceRowsSkipped += 1
       continue
     }
-    points.push(projected.point)
+    points.push(...projected.points)
   }
 
   throwIfAborted(signal)
@@ -222,11 +229,7 @@ function buildTelemetryProjectionPlan(input: {
 }): TelemetryProjectionPlan {
   const { runtime, projection, dataset, errorDetails } = input
   const objectType = runtime.ontology.getObjectTypeById(projection.objectTypeId)
-  const property = objectType?.properties.find(
-    (candidate) => candidate.id === projection.propertyId
-  )
-  const valueColumn = dataset.schema.columns.find((column) => column.name === projection.valueField)
-  if (!objectType || !property || !valueColumn) {
+  if (!objectType) {
     throw createSixbError(
       "internal.unexpected",
       `[SixbProjectionWorker] Telemetry projection '${projection.id}' was not validated before execution.`,
@@ -234,25 +237,56 @@ function buildTelemetryProjectionPlan(input: {
         details: {
           ...errorDetails,
           objectTypeId: projection.objectTypeId,
-          propertyId: projection.propertyId,
-          columnName: projection.valueField,
         },
       }
     )
   }
 
+  const propertiesById = new Map(objectType.properties.map((property) => [property.id, property]))
+  const columnsByName = new Map(dataset.schema.columns.map((column) => [column.name, column]))
+  const properties = Object.entries(projection.properties)
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([propertyId, mapping]): TelemetryProjectionPropertyPlan => {
+      const property = propertiesById.get(propertyId)
+      const valueColumn = columnsByName.get(mapping.valueField)
+      if (!property || !valueColumn) {
+        throw createSixbError(
+          "internal.unexpected",
+          `[SixbProjectionWorker] Telemetry projection '${projection.id}' was not validated before execution.`,
+          {
+            details: {
+              ...errorDetails,
+              objectTypeId: projection.objectTypeId,
+              propertyId,
+              columnName: mapping.valueField,
+            },
+          }
+        )
+      }
+
+      return {
+        propertyId,
+        mapping,
+        valueColumnType: valueColumn.type,
+        valueSchema: resolveProjectionSchema(
+          property.schema,
+          runtime.ontology.getValueTypesById(),
+          {
+            details: {
+              ...errorDetails,
+              objectTypeId: objectType.id,
+              propertyId,
+              columnName: valueColumn.name,
+            },
+          }
+        ),
+      }
+    })
+
   return {
     projection,
     dataset,
-    valueColumnType: valueColumn.type,
-    valueSchema: resolveProjectionSchema(property.schema, runtime.ontology.getValueTypesById(), {
-      details: {
-        ...errorDetails,
-        objectTypeId: objectType.id,
-        propertyId: property.id,
-        columnName: valueColumn.name,
-      },
-    }),
+    properties,
     readColumns: telemetryProjectionReadColumns(projection),
   }
 }
@@ -264,8 +298,10 @@ function telemetryProjectionReadColumns(
     ...new Set([
       projection.objectIdField,
       projection.atField,
-      projection.valueField,
-      ...(projection.unitField !== undefined ? [projection.unitField] : []),
+      ...Object.values(projection.properties).flatMap((mapping) => [
+        mapping.valueField,
+        ...(mapping.unitField !== undefined ? [mapping.unitField] : []),
+      ]),
     ]),
   ]
 }
@@ -285,8 +321,10 @@ function projectTelemetryRow(
 
   const objectId = row[projection.objectIdField]
   const at = row[projection.atField]
-  const value = row[projection.valueField]
-  if (isBlank(objectId) || isBlank(at) || isBlank(value)) return { kind: "skip" }
+  if (isBlank(objectId) || isBlank(at)) return { kind: "skip" }
+  if (plan.properties.every((property) => isBlank(row[property.mapping.valueField]))) {
+    return { kind: "skip" }
+  }
   if (typeof objectId !== "string") {
     return invalidIdentity(projection, projection.objectIdField)
   }
@@ -299,38 +337,44 @@ function projectTelemetryRow(
     }
   }
 
-  const normalized = normalizeProjectedValue({
-    columnType: plan.valueColumnType,
-    schema: plan.valueSchema,
-    value,
-  })
-  if (!normalized.ok || !isJsonValue(normalized.value)) {
-    return {
-      kind: "invalid",
-      message: `Telemetry projection '${projection.id}' value field '${projection.valueField}' is invalid${normalized.ok ? "" : `: ${normalized.errorMessage}`}.`,
-    }
-  }
+  const points: TelemetryPointWrite[] = []
+  for (const property of plan.properties) {
+    const value = row[property.mapping.valueField]
+    if (isBlank(value)) continue
 
-  const rawUnit = projection.unitField === undefined ? undefined : row[projection.unitField]
-  if (!isBlank(rawUnit) && typeof rawUnit !== "string") {
-    return {
-      kind: "invalid",
-      message: `Telemetry projection '${projection.id}' unit field '${projection.unitField}' must be a string.`,
+    const normalized = normalizeProjectedValue({
+      columnType: property.valueColumnType,
+      schema: property.valueSchema,
+      value,
+    })
+    if (!normalized.ok || !isJsonValue(normalized.value)) {
+      return {
+        kind: "invalid",
+        message: `Telemetry projection '${projection.id}' property '${property.propertyId}' value field '${property.mapping.valueField}' is invalid${normalized.ok ? "" : `: ${normalized.errorMessage}`}.`,
+      }
     }
-  }
 
-  return {
-    kind: "point",
-    point: {
+    const rawUnit =
+      property.mapping.unitField === undefined ? undefined : row[property.mapping.unitField]
+    if (!isBlank(rawUnit) && typeof rawUnit !== "string") {
+      return {
+        kind: "invalid",
+        message: `Telemetry projection '${projection.id}' property '${property.propertyId}' unit field '${property.mapping.unitField}' must be a string.`,
+      }
+    }
+
+    points.push({
       series: {
         object: { objectTypeId: projection.objectTypeId, primaryId: objectId },
-        propertyId: projection.propertyId,
+        propertyId: property.propertyId,
       },
       value: normalized.value,
       at: parsedAt.toISOString(),
       ...(typeof rawUnit === "string" && rawUnit.trim().length > 0 ? { unit: rawUnit } : {}),
-    },
+    })
   }
+
+  return points.length === 0 ? { kind: "skip" } : { kind: "points", points }
 }
 
 function invalidIdentity(

--- a/packages/projection-worker/src/schema-validation.ts
+++ b/packages/projection-worker/src/schema-validation.ts
@@ -47,8 +47,10 @@ function projectionDatasetColumns(projection: ProjectionDefinition): ReadonlySet
   return new Set([
     projection.objectIdField,
     projection.atField,
-    projection.valueField,
-    ...(projection.unitField === undefined ? [] : [projection.unitField]),
+    ...Object.values(projection.properties).flatMap((mapping) => [
+      mapping.valueField,
+      ...(mapping.unitField === undefined ? [] : [mapping.unitField]),
+    ]),
   ])
 }
 
@@ -250,10 +252,11 @@ export function assertProjectionCompatibleWithDataset(input: {
     // startup and worker checks share one implementation and cannot drift. The
     // worker then layers dataset-version column type compatibility on top.
     const datasetColumnNames = new Set(dataset.schema.columns.map((column) => column.name))
-    const property = validateTelemetryProjectionFieldMapping(
+    const properties = validateTelemetryProjectionFieldMapping(
       projection,
       objectType,
       datasetColumnNames,
+      ontology.getValueTypesById(),
       `[SixbProjectionWorker] Projection "${projection.id}"`
     )
 
@@ -283,44 +286,55 @@ export function assertProjectionCompatibleWithDataset(input: {
       )
     }
 
-    const valueColumn = requireColumn(columnsByName, projection.valueField, context)
-    if (
-      !isDatasetColumnCompatibleWithSchema(
-        valueColumn.type,
-        property.schema,
-        ontology.getValueTypesById(),
-        {
-          ...context,
-          objectTypeId: objectType.id,
-          propertyId: property.id,
-          columnName: valueColumn.name,
-        }
-      )
-    ) {
-      throw invalidProjectionDefinition(
-        `[SixbProjectionWorker] Telemetry projection '${projection.id}' maps dataset column '${valueColumn.name}' (${valueColumn.type}) to incompatible property '${projection.propertyId}'.`,
-        {
-          ...context,
-          objectTypeId: objectType.id,
-          propertyId: projection.propertyId,
-          columnName: valueColumn.name,
-          columnType: valueColumn.type,
-        }
-      )
-    }
-
-    if (projection.unitField !== undefined) {
-      const unitColumn = requireColumn(columnsByName, projection.unitField, context)
-      if (unitColumn.type !== "string") {
+    for (const [propertyId, mapping] of Object.entries(projection.properties)) {
+      const property = properties.get(propertyId)
+      if (!property) {
         throw invalidProjectionDefinition(
-          `[SixbProjectionWorker] Telemetry projection '${projection.id}' unit field '${projection.unitField}' must be a string dataset column.`,
+          `[SixbProjectionWorker] Telemetry projection '${projection.id}' property '${propertyId}' was not validated before execution.`,
+          { ...context, objectTypeId: objectType.id, propertyId }
+        )
+      }
+
+      const valueColumn = requireColumn(columnsByName, mapping.valueField, context)
+      if (
+        !isDatasetColumnCompatibleWithSchema(
+          valueColumn.type,
+          property.schema,
+          ontology.getValueTypesById(),
           {
             ...context,
             objectTypeId: objectType.id,
-            columnName: projection.unitField,
-            columnType: unitColumn.type,
+            propertyId,
+            columnName: valueColumn.name,
           }
         )
+      ) {
+        throw invalidProjectionDefinition(
+          `[SixbProjectionWorker] Telemetry projection '${projection.id}' maps dataset column '${valueColumn.name}' (${valueColumn.type}) to incompatible property '${propertyId}'.`,
+          {
+            ...context,
+            objectTypeId: objectType.id,
+            propertyId,
+            columnName: valueColumn.name,
+            columnType: valueColumn.type,
+          }
+        )
+      }
+
+      if (mapping.unitField !== undefined) {
+        const unitColumn = requireColumn(columnsByName, mapping.unitField, context)
+        if (unitColumn.type !== "string") {
+          throw invalidProjectionDefinition(
+            `[SixbProjectionWorker] Telemetry projection '${projection.id}' property '${propertyId}' unit field '${mapping.unitField}' must be a string dataset column.`,
+            {
+              ...context,
+              objectTypeId: objectType.id,
+              propertyId,
+              columnName: mapping.unitField,
+              columnType: unitColumn.type,
+            }
+          )
+        }
       }
     }
 

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -86,6 +86,7 @@ const Room = defineObjectType({
     prop("name", "string"),
     prop("buildingRef", "string"),
     prop("temperature", "double", { mode: "telemetry" }),
+    prop("humidity", "double", { mode: "telemetry" }),
     prop("targetTemperature", "double", { mode: "telemetry", semanticType: "Temperature" }),
   ],
   links: [
@@ -169,6 +170,29 @@ const roomSensorProjection = defineProjection("room-sensor-proj", Room.l.hasSens
 const roomTemperatureProjection = defineProjection("room-temperature-proj", Room.p.temperature)
   .fromDataset(roomReadingsDataset)
   .points({ objectId: "room_id", at: "observed_at", value: "temperature" })
+
+const groupedRoomReadingsDataset = defineDataset("canonical.grouped-room-readings", {
+  schema: [
+    col("room_id", "string"),
+    col("observed_at", "timestamp"),
+    col("temperature", "float64", { nullable: true }),
+    col("humidity", "float64", { nullable: true }),
+    col("target", "float64", { nullable: true }),
+    col("target_unit", "string", { nullable: true }),
+  ],
+})
+
+const groupedRoomReadingsProjection = defineProjection("grouped-room-readings-proj", Room)
+  .fromDataset(groupedRoomReadingsDataset)
+  .points({
+    objectId: "room_id",
+    at: "observed_at",
+    properties: {
+      temperature: "temperature",
+      humidity: "humidity",
+      targetTemperature: { value: "target", unit: "target_unit" },
+    },
+  })
 
 const roomTargetsDataset = defineDataset("canonical.room-targets", {
   schema: [
@@ -801,6 +825,130 @@ describe("runProjectionJob", () => {
 
     expect(lakeStorage.readInputs).toHaveLength(1)
     expect(lakeStorage.readInputs[0]?.columns).toEqual(["room_id", "observed_at", "temperature"])
+  })
+
+  test("materializes grouped telemetry in one read while omitting only blank properties", async () => {
+    const deps = createDeps()
+    const lakeStorage = new RecordingLakeStorage(deps.lakeStorage)
+    const sixb = createSixb(
+      {
+        datasets: [groupedRoomReadingsDataset],
+        projections: [groupedRoomReadingsProjection],
+      },
+      { ...deps, lakeStorage }
+    )
+    await createTestSixb(sixb)
+      .objects(Room)
+      .upsert({ properties: { id: "r1", name: "Kitchen" } })
+    const version = await commitDatasetVersion(lakeStorage, groupedRoomReadingsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01T12:00:00.000Z",
+        temperature: 20,
+        humidity: 40,
+        target: 21,
+        target_unit: "degreeCelsius",
+      },
+      {
+        room_id: "r1",
+        observed_at: "2026-06-02T12:00:00.000Z",
+        temperature: 22,
+        humidity: null,
+        target: null,
+        target_unit: null,
+      },
+      {
+        room_id: "r1",
+        observed_at: "2026-06-03T12:00:00.000Z",
+        temperature: null,
+        humidity: null,
+        target: null,
+        target_unit: "ignored-without-a-value",
+      },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-grouped-telemetry",
+        projectionId: groupedRoomReadingsProjection.id,
+        projectionKind: "telemetry",
+        datasetId: groupedRoomReadingsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    expect(result.run).toMatchObject({
+      status: "succeeded",
+      progress: { sourceRowsRead: 3, sourceRowsSkipped: 1 },
+    })
+    expect(lakeStorage.readInputs).toHaveLength(1)
+    expect(lakeStorage.readInputs[0]?.columns).toEqual([
+      "room_id",
+      "observed_at",
+      "temperature",
+      "humidity",
+      "target",
+      "target_unit",
+    ])
+    const history = (propertyId: string) =>
+      deps.storage.timeseries.getHistory({
+        projectId: sixb.id,
+        objectTypeId: "Room",
+        objectId: "r1",
+        propertyId,
+      })
+    expect((await history("temperature")).map((point) => point.value)).toEqual([20, 22])
+    expect((await history("humidity")).map((point) => point.value)).toEqual([40])
+    expect(await history("targetTemperature")).toMatchObject([{ value: 21, unit: "degreeCelsius" }])
+  })
+
+  test("rolls back every property when one grouped telemetry value is invalid", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [groupedRoomReadingsDataset],
+        projections: [groupedRoomReadingsProjection],
+      },
+      deps
+    )
+    await createTestSixb(sixb)
+      .objects(Room)
+      .upsert({ properties: { id: "r1", name: "Kitchen" } })
+    const version = await commitDatasetVersion(deps.lakeStorage, groupedRoomReadingsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01T12:00:00.000Z",
+        temperature: 20,
+        humidity: 40,
+        target: 21,
+        target_unit: "bananas",
+      },
+    ])
+
+    await expect(
+      runProjectionJob({
+        runtime: createRuntime(sixb),
+        job: {
+          id: "projrun-invalid-grouped-telemetry",
+          projectionId: groupedRoomReadingsProjection.id,
+          projectionKind: "telemetry",
+          datasetId: groupedRoomReadingsDataset.id,
+          versionId: version.versionId,
+        },
+      })
+    ).rejects.toBeInstanceOf(MaterializationValidationError)
+
+    for (const propertyId of ["temperature", "humidity", "targetTemperature"]) {
+      expect(
+        await deps.storage.timeseries.getHistory({
+          projectId: sixb.id,
+          objectTypeId: "Room",
+          objectId: "r1",
+          propertyId,
+        })
+      ).toEqual([])
+    }
   })
 
   test("telemetry projections materialize object latest by telemetry timestamp", async () => {
@@ -3371,11 +3519,10 @@ describe("runProjectionJob", () => {
       _tag: "TelemetryProjectionDefinition",
       id: "room-invalid-at-proj",
       objectTypeId: "Room",
-      propertyId: "temperature",
       datasetId: roomReadingsDataset.id,
       objectIdField: "room_id",
       atField: "temperature", // float64 column, not date-like
-      valueField: "temperature",
+      properties: { temperature: { valueField: "temperature" } },
     } satisfies ProjectionDefinition
     const sixb = createSixb(
       {

--- a/packages/server/src/schemas/projections.ts
+++ b/packages/server/src/schemas/projections.ts
@@ -115,12 +115,15 @@ export const TelemetryProjectionSchema = z.object({
   _tag: z.literal("TelemetryProjectionDefinition"),
   id: z.string(),
   objectTypeId: z.string(),
-  propertyId: z.string(),
   datasetId: z.string(),
   objectIdField: z.string(),
   atField: z.string(),
-  valueField: z.string(),
-  unitField: z.string().optional(),
+  properties: z.record(
+    z.object({
+      valueField: z.string(),
+      unitField: z.string().optional(),
+    })
+  ),
   latestRun: ProjectionRunSchema.nullable(),
 })
 

--- a/packages/server/tests/projections-routes.test.ts
+++ b/packages/server/tests/projections-routes.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import type { AuthorizationContext, ObjectProjectionDefinition, OntologySource } from "@sixb/core"
+import type {
+  AuthorizationContext,
+  ObjectProjectionDefinition,
+  OntologySource,
+  ProjectionDefinition,
+  TelemetryProjectionDefinition,
+} from "@sixb/core"
 import {
   emptyGrantIndex,
   InMemoryBlobStorage,
@@ -36,6 +42,19 @@ const sensorsProjection: ObjectProjectionDefinition = {
   datasetId: "ds.sensors",
   properties: { id: "sensor_id" },
   links: {},
+}
+
+const roomActivityProjection: TelemetryProjectionDefinition = {
+  _tag: "TelemetryProjectionDefinition",
+  id: "room-activity",
+  objectTypeId: "room",
+  datasetId: "ds.room-activity",
+  objectIdField: "room_id",
+  atField: "observed_at",
+  properties: {
+    temperature: { valueField: "temperature", unitField: "temperature_unit" },
+    humidity: { valueField: "humidity" },
+  },
 }
 
 const projectionFailure = {
@@ -105,15 +124,16 @@ function createSixbStub(
     blobStorage: new InMemoryBlobStorage(),
     queues: new InMemoryQueues(),
   })
-  const definitions = [roomsProjection, sensorsProjection]
+  const objectProjections = [roomsProjection, sensorsProjection]
+  const definitions: ProjectionDefinition[] = [...objectProjections, roomActivityProjection]
   Object.defineProperty(sixb, "definitions", {
     value: {
       ...sixb.definitions,
       projections: {
         list: () => definitions,
-        listObjects: () => definitions,
+        listObjects: () => objectProjections,
         listLinks: () => [],
-        listTelemetry: () => [],
+        listTelemetry: () => [roomActivityProjection],
         getById: (id: string) => definitions.find((projection) => projection.id === id) ?? null,
       },
     },
@@ -153,13 +173,17 @@ describe("projection routes", () => {
 
     const body = (await response.json()) as {
       objectProjections: { id: string; latestRun: { id: string } | null }[]
+      telemetryProjections: Array<
+        TelemetryProjectionDefinition & { latestRun: { id: string } | null }
+      >
     }
 
     // Only the room projection is visible; the latest-run lookup is scoped to it.
-    expect(requested).toEqual([["rooms"]])
+    expect(requested).toEqual([["rooms", "room-activity"]])
     expect(body.objectProjections.map((p) => [p.id, p.latestRun?.id ?? null])).toEqual([
       ["rooms", "run-rooms"],
     ])
+    expect(body.telemetryProjections).toEqual([{ ...roomActivityProjection, latestRun: null }])
   })
 
   test("run list passes the viewable object type set to storage", async () => {


### PR DESCRIPTION
## What

- Adds grouped telemetry projections for properties sharing one dataset, object id and timestamp.
- Keeps the property-token form as concise single-property sugar.
- Carries the grouped contract through validation, ownership, revisions, execution, materialization, OpenAPI/client types and Atlas.
- Updates the Panasonic example, documentation and regression coverage.

## DX

```ts
defineProjection("ga-activity", GoogleAnalyticsProperty)
  .fromDataset(dataset)
  .points({
    objectId: "account_id",
    at: "day",
    properties: {
      activeUsers: "active_users",
      newUsers: "new_users",
      temperature: { value: "temperature", unit: "temperature_unit" },
    },
  })
```

## Why

- One source row can now emit zero to N telemetry points without duplicating projection declarations.
- Dataset rows are scanned once while storage and ownership remain independent per `ObjectType + property` scope.

## Design choices

| Choice | Reason |
| --- | --- |
| Canonical internal `properties` map | Keeps one validation and execution path for both DSL forms |
| Ownership per telemetry property | Preserves independent series lifecycle and conflict semantics |
| Adaptive source batch size | Keeps emitted mutations within the materializer batch limit |
| Stable legacy revision hash | Avoids rematerializing unchanged single-property projections |
| Atomic physical batches | Prevents partial commits when a nonblank value or unit is invalid |

## Validation

- `bun run generate:client`
- `bun run build`
- `bun run typecheck`
- `bun run check`
- `bun run test:ci` — 4,437 passed; 7 external integrations skipped