### PR TITLE
app: support feature-owned nested layouts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -549,6 +549,7 @@
         "tailwindcss": "^4.1.18",
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.2",
         "@types/bun": "latest",
         "@types/react": "^19.0.0",
         "happy-dom": "^20.11.6",
@@ -1626,7 +1627,7 @@
 
     "@types/react": ["@types/react@19.2.15", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q=="],
 
-    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+    "@types/react-dom": ["@types/react-dom@19.2.5", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg=="],
 
     "@types/ssh2": ["@types/ssh2@1.15.5", "", { "dependencies": { "@types/node": "^18.11.18" } }, "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ=="],
 
@@ -1660,7 +1661,7 @@
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
@@ -2640,7 +2641,17 @@
 
     "@reduxjs/toolkit/immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
 
-    "@sixb/client/@types/react-dom": ["@types/react-dom@19.2.5", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg=="],
+    "@sixb/atlas/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@sixb/docs/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@sixb/example-auth/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@sixb/example-northline/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@sixb/example-panasonic-ac/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@sixb/example-roku-tv/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@sixb/ui/recharts": ["recharts@3.8.0", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ=="],
 
@@ -2686,8 +2697,6 @@
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
-    "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
@@ -2703,6 +2712,8 @@
     "react-devtools-core/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
 
     "sharp/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "vaul/@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.17", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-dismissable-layer": "1.1.13", "@radix-ui/react-focus-guards": "1.1.4", "@radix-ui/react-focus-scope": "1.1.10", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-portal": "1.1.12", "@radix-ui/react-presence": "1.1.6", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-slot": "1.3.0", "@radix-ui/react-use-controllable-state": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.7.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw=="],
 

--- a/docs/apps/overview.md
+++ b/docs/apps/overview.md
@@ -14,12 +14,16 @@ and an app shell, and serves it. There is no separate framework to configure: th
 file tree is the routing table, and sixb wires up everything pages need to talk to
 the API.
 
-| You provide | sixb wires up |
+| You provide | Purpose |
 | --- | --- |
-| `app/**/page.tsx` route components | React Router (file-based routing) |
-| `app/layout.tsx` (optional) | TanStack Query (`QueryClientProvider`) |
-| `app/globals.css` (optional) | Auth session + cookies, CSRF handling |
-| `app/public/` static assets | Same-origin `<a>` click interception (SPA nav) |
+| `app/**/page.tsx` | Route components |
+| `app/layout.tsx` (optional) | Global wrapper and document metadata |
+| `app/**/layout.tsx` (optional) | Persistent layouts for a route subtree |
+| `app/globals.css` (optional) | App-wide styles |
+| `app/public/` | Root-relative static assets |
+
+sixb supplies React Router, TanStack Query, the authenticated client runtime, and conservative
+same-origin SPA navigation around these files.
 
 Pages fetch data with the typed hooks from `@sixb/client/hooks` and the typed
 query builder from `@sixb/client/query`, run action buttons with
@@ -39,7 +43,9 @@ app/
   page.tsx                       -> /
   projects/page.tsx              -> /projects
   invoices/page.tsx              -> /invoices
+  invoices/layout.tsx            -> wraps /invoices/**
   review/[interventionId]/page.tsx -> /review/:interventionId
+  review/[interventionId]/layout.tsx -> wraps /review/:interventionId/**
   layout.tsx                     -> root wrapper and metadata
   globals.css                    -> app styles
   public/logo.svg                -> /logo.svg
@@ -52,10 +58,15 @@ Routing rules:
 | `app/page.tsx` | `/` |
 | `app/invoices/page.tsx` | `/invoices` |
 | `app/review/[interventionId]/page.tsx` | `/review/:interventionId` |
+| `app/invoices/layout.tsx` | Layout for `/invoices` and descendants |
 
 - Only `page.tsx` and `page.ts` create routes.
+- A descendant `layout.tsx` wraps pages in its directory and below; a layout alone does not create
+  a route.
 - A folder named `[param]` becomes a dynamic segment `:param`. Read it with React
   Router's `useParams` inside the `[param]/page.tsx` component.
+- Route groups such as `(admin)` are reserved for future framework support and currently fail with
+  an actionable error.
 - Files or folders starting with `_` are ignored — use the prefix for components,
   helpers, or routes you do not want mounted.
 - The route component is the page module's `default` export.
@@ -124,7 +135,7 @@ its `href` matches a known route, so you get SPA navigation without React Router
 Links to `/api`, `/auth`, `/ws`, `/docs`, cross-origin URLs, `download` links, and
 modified clicks (new tab, etc.) fall through to native navigation.
 
-## Layout and metadata
+## Layouts and metadata
 
 `app/layout.tsx` is optional. Its `default` export wraps every route, and its
 named `metadata` export sets the static document and install identity. sixb loads
@@ -148,6 +159,36 @@ export default function RootLayout({ children }: PropsWithChildren) {
   return <>{children}</>
 }
 ```
+
+Use descendant layouts for feature-owned shells, providers, and persistent state. They receive
+`children` directly — Sixb owns the React Router `Outlet` wiring:
+
+```tsx
+// app/analytics/layout.tsx
+import type { PropsWithChildren } from "react"
+
+export default function AnalyticsLayout({ children }: PropsWithChildren) {
+  return <AnalyticsShell>{children}</AnalyticsShell>
+}
+```
+
+This wraps `/analytics` and every routed descendant. The layout stays mounted when navigating from
+`/analytics/reports/a` to `/analytics/reports/b`, so shell state and subscriptions persist. A
+layout inside a dynamic directory can read that directory's parameter normally:
+
+```tsx
+// app/analytics/reports/[reportId]/layout.tsx
+import type { PropsWithChildren } from "react"
+import { useParams } from "react-router-dom"
+
+export default function ReportLayout({ children }: PropsWithChildren) {
+  const { reportId } = useParams()
+  return <ReportShell reportId={reportId}>{children}</ReportShell>
+}
+```
+
+Only the root `app/layout.tsx` owns `metadata`; metadata exports from descendant layouts are not
+read. Descendant layouts are browser route components.
 
 `AppMetadata` fields are all optional:
 

--- a/examples/northline/app/agents/layout.tsx
+++ b/examples/northline/app/agents/layout.tsx
@@ -1,0 +1,15 @@
+import { AgentWorkspaceProvider } from "@sixb/app/agents"
+import type { PropsWithChildren } from "react"
+import { NorthlineSidebarFooter, NorthlineSidebarHeader } from "../_components/app-shell"
+
+export default function AgentsLayout({ children }: PropsWithChildren) {
+  return (
+    <AgentWorkspaceProvider
+      sidebarHeader={<NorthlineSidebarHeader />}
+      sidebarFooter={<NorthlineSidebarFooter />}
+      sidebarWidth="12.5rem"
+    >
+      {children}
+    </AgentWorkspaceProvider>
+  )
+}

--- a/examples/northline/app/layout.tsx
+++ b/examples/northline/app/layout.tsx
@@ -1,9 +1,8 @@
 import type { AppMetadata } from "@sixb/app"
-import { AgentWorkspaceProvider } from "@sixb/app/agents"
 import { SixbEventsProvider } from "@sixb/client/hooks"
 import { ThemeProvider } from "@sixb/ui/hooks"
 import type { PropsWithChildren } from "react"
-import { AppShell, NorthlineSidebarFooter, NorthlineSidebarHeader } from "./_components/app-shell"
+import { AppShell } from "./_components/app-shell"
 
 export const metadata = {
   title: "Northline Operations",
@@ -17,13 +16,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <ThemeProvider>
       <SixbEventsProvider>
-        <AgentWorkspaceProvider
-          sidebarHeader={<NorthlineSidebarHeader />}
-          sidebarFooter={<NorthlineSidebarFooter />}
-          sidebarWidth="12.5rem"
-        >
-          <AppShell>{children}</AppShell>
-        </AgentWorkspaceProvider>
+        <AppShell>{children}</AppShell>
       </SixbEventsProvider>
     </ThemeProvider>
   )

--- a/examples/northline/scripts/dev.ts
+++ b/examples/northline/scripts/dev.ts
@@ -3,6 +3,13 @@ import { initializeDemoSources } from "../lib/sources/source-state"
 import { apiBaseUrl, apiRequest, isRecord, waitUntil } from "./api"
 import { synchronizeDemo } from "./sync-demo"
 
+const northlineProjectId = "northline"
+
+type NorthlineApiProbe =
+  | { readonly status: "ready" }
+  | { readonly status: "unavailable" }
+  | { readonly status: "wrong-project"; readonly projectId: string }
+
 export function createRuntimeCommand(args: readonly string[]): string[] {
   return [
     process.execPath,
@@ -10,6 +17,27 @@ export function createRuntimeCommand(args: readonly string[]): string[] {
     "dev",
     ...args,
   ]
+}
+
+export async function probeNorthlineApi(
+  baseUrl: string,
+  request: (url: string) => Promise<Response> = fetch
+): Promise<NorthlineApiProbe> {
+  try {
+    const response = await request(`${baseUrl}/project`)
+    if (!response.ok) return { status: "unavailable" }
+
+    const project: unknown = await response.json()
+    if (!isRecord(project) || typeof project.id !== "string") {
+      return { status: "unavailable" }
+    }
+    if (project.id !== northlineProjectId) {
+      return { status: "wrong-project", projectId: project.id }
+    }
+    return { status: "ready" }
+  } catch {
+    return { status: "unavailable" }
+  }
 }
 
 async function main(): Promise<void> {
@@ -28,16 +56,32 @@ async function main(): Promise<void> {
   process.once("SIGINT", stop)
   process.once("SIGTERM", stop)
 
+  let childExitCode: number | undefined
+  void child.exited.then((exitCode) => {
+    childExitCode = exitCode
+  })
+
   try {
+    const baseUrl = apiBaseUrl()
     await waitUntil(
-      "the Sixb API",
+      "the Northline Sixb API",
       async () => {
-        try {
-          const response = await fetch(`${apiBaseUrl()}/syncs`)
-          return response.ok
-        } catch {
-          return false
+        if (childExitCode !== undefined) {
+          throw new Error(
+            `[Northline] Sixb dev exited with code ${childExitCode} before its API became ready. ` +
+              "Review the startup error above; the configured ports may already be in use."
+          )
         }
+
+        const probe = await probeNorthlineApi(baseUrl)
+        if (probe.status === "wrong-project") {
+          throw new Error(
+            `[Northline] Expected project '${northlineProjectId}' at ${baseUrl}, but found ` +
+              `'${probe.projectId}'. Another Sixb dev server is using Northline's API port. ` +
+              "Stop it before starting Northline."
+          )
+        }
+        return probe.status === "ready"
       },
       90_000
     )

--- a/examples/northline/tests/dev-script.test.ts
+++ b/examples/northline/tests/dev-script.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { createRuntimeCommand } from "../scripts/dev"
+import { createRuntimeCommand, probeNorthlineApi } from "../scripts/dev"
 
 describe("Northline development script", () => {
   test("forwards its arguments to the Sixb dev command", () => {
@@ -19,5 +19,36 @@ describe("Northline development script", () => {
       "--host",
       "127.0.0.1",
     ])
+  })
+
+  test("accepts readiness only from the Northline project", async () => {
+    const requests: string[] = []
+    const probe = await probeNorthlineApi("http://localhost:3002/api", async (url) => {
+      requests.push(url)
+      return Response.json({ id: "northline" })
+    })
+
+    expect(requests).toEqual(["http://localhost:3002/api/project"])
+    expect(probe).toEqual({ status: "ready" })
+  })
+
+  test("identifies a different Sixb project on the API port", async () => {
+    const probe = await probeNorthlineApi("http://localhost:3002/api", async () =>
+      Response.json({ id: "apic" })
+    )
+
+    expect(probe).toEqual({ status: "wrong-project", projectId: "apic" })
+  })
+
+  test("keeps waiting for an unavailable or malformed API", async () => {
+    const unavailable = await probeNorthlineApi("http://localhost:3002/api", async () =>
+      Response.json({ error: "starting" }, { status: 503 })
+    )
+    const malformed = await probeNorthlineApi("http://localhost:3002/api", async () =>
+      Response.json({ status: "ok" })
+    )
+
+    expect(unavailable).toEqual({ status: "unavailable" })
+    expect(malformed).toEqual({ status: "unavailable" })
   })
 })

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -14,25 +14,41 @@ The build pipeline has three stages: **scan**, **codegen**, and **build**.
 
 ### 1. Scan
 
-`scanPages(appDir)` recursively walks `app/` looking for `page.tsx` (or `page.ts`) files and converts the file tree into React Router paths. Files and folders prefixed with `_` are ignored.
+The internal scanner recursively walks `app/` for `page.tsx` (or `page.ts`) files and descendant
+`layout.tsx` files. It converts the file tree into nested React Router routes. Files and folders
+prefixed with `_`, plus the static `app/public/` tree, are ignored.
 
 ```
 app/
   page.tsx                -> /
   about/page.tsx          -> /about
+  about/layout.tsx        -> wraps /about and its descendants
   remote/[id]/page.tsx    -> /remote/:id
+  remote/[id]/layout.tsx  -> wraps /remote/:id and its descendants
 ```
 
 ### 2. Codegen
 
 Two functions generate the entry point files into `.sixb/generated/`:
 
-- **`generateRouteManifest(routes, generatedDir)`** -- writes `routes.ts` with a static import for each scanned page. Routes are eager on purpose: project apps bundle small, and a single bundle means no loading gap when navigating between pages.
+- **`generateRouteManifest(routes, generatedDir)`** -- writes `routes.ts` with static page and
+  layout imports plus native nested `RouteObject` entries. Routes are eager on purpose: project
+  apps bundle small, and a single bundle means no loading gap when navigating between pages.
 - **`generateAppEntry(projectRoot, generatedDir, options)`** -- writes `index.html` (HTML shell), `main.tsx` (React entry with BrowserRouter, TanStack Query, and the `@sixb/client` SDK), and `app.webmanifest`.
 
 The generated entry also intercepts plain same-origin `<a href="/...">` clicks and routes them client-side, so internal links work like react-router's `<Link>` without authors having to remember it. The interceptor is conservative — modified clicks, `target`/`download`/`rel="external"` anchors, cross-origin URLs, reserved Sixb paths (`/api`, `/auth`, `/ws`, `/docs`), and destinations that don't match an app route all keep native browser navigation. `<Link>` remains the idiomatic choice in app code.
 
-If `app/layout.tsx` exists, it is used as a root layout wrapper. It can also export a `metadata` object (`title`, `description`, `favicon`, `themeColor`, and `backgroundColor`). Metadata is loaded during generation and written into the static HTML and manifest, so it is available before auth and client startup. The layout module must therefore be import-safe in Bun: do not access `window` or `document` at module scope. An `app/globals.css` file is imported automatically when present.
+If `app/layout.tsx` exists, it is the global wrapper outside the route tree. It can also export a
+`metadata` object (`title`, `description`, `favicon`, `themeColor`, and `backgroundColor`). Metadata
+is loaded during generation and written into the static HTML and manifest, so it is available
+before auth and client startup. The root layout module must therefore be import-safe in Bun: do
+not access `window` or `document` at module scope. An `app/globals.css` file is imported
+automatically when present.
+
+A descendant `app/**/layout.tsx` wraps only pages at its URL prefix. It receives `children`, can use
+React Router hooks such as `useParams`, and stays mounted while navigation remains inside its
+subtree. Descendant layout metadata is not read. A layout with no project or framework page below
+it creates no route and is not bundled.
 
 Add an optional `app/auth.tsx` default export to customize the app audience's magic-link pages. It receives `AuthExperienceProps` from `@sixb/app/auth` with `signIn`, `checkEmail`, `confirm`, `invalidLink`, and `error` states plus framework-owned actions. Sixb builds it separately, includes `app/globals.css`, and serves it from the API's existing `/auth/*` routes. It is not wrapped by `app/layout.tsx`, and it never owns tokens, cookies, callbacks, audience validation, or return redirects. When the file is absent, the generic server login remains the fallback.
 
@@ -50,19 +66,24 @@ These routes are generated only when the project has at least one `app/` page, s
 
 The default agent UI is imported through `@sixb/app/agents`, so app projects do not need to import `@sixb/agent-ui` directly. A framework-owned `agent-ui.css` bundle is generated before the app stylesheet and imports normal `@sixb/ui` styles, which means app-level token overrides in `app/globals.css` still apply in the usual way.
 
-Wrap the app layout with `AgentWorkspaceProvider` to make the built-in agent navigation match the
-custom app shell without replacing any routes:
+Add `app/agents/layout.tsx` with `AgentWorkspaceProvider` to make the built-in agent navigation
+match the custom app shell without making the provider global or replacing any routes:
 
 ```tsx
 import { AgentWorkspaceProvider } from "@sixb/app/agents"
+import type { PropsWithChildren } from "react"
 
-<AgentWorkspaceProvider
-  sidebarHeader={<AppSidebarHeader />}
-  sidebarFooter={<AppSidebarFooter />}
-  sidebarWidth="12.5rem"
->
-  <AppShell>{children}</AppShell>
-</AgentWorkspaceProvider>
+export default function AgentsLayout({ children }: PropsWithChildren) {
+  return (
+    <AgentWorkspaceProvider
+      sidebarHeader={<AppSidebarHeader />}
+      sidebarFooter={<AppSidebarFooter />}
+      sidebarWidth="12.5rem"
+    >
+      {children}
+    </AgentWorkspaceProvider>
+  )
+}
 ```
 
 Explicit props passed to a project-owned `AgentsPage` override provider defaults. The custom width

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -61,6 +61,7 @@
     "react-router-dom": "^7.0.0"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/bun": "latest",
     "@types/react": "^19.0.0",
     "happy-dom": "^20.11.6",

--- a/packages/app/src/agents.ts
+++ b/packages/app/src/agents.ts
@@ -21,7 +21,7 @@ export type AgentWorkspaceProviderProps = PropsWithChildren<AgentWorkspaceChrome
 
 const AgentWorkspaceContext = createContext<AgentWorkspaceChrome>({})
 
-/** Configure the framework-owned Agents routes from a custom app's root layout. */
+/** Configure the framework-owned Agents routes, typically from `app/agents/layout.tsx`. */
 export function AgentWorkspaceProvider({
   sidebarHeader,
   sidebarFooter,

--- a/packages/app/src/codegen.ts
+++ b/packages/app/src/codegen.ts
@@ -4,7 +4,7 @@ import type { AuthSessionAudience } from "@sixb/core"
 import { renderAppManifest } from "./manifest"
 import { resolveAppMetadata } from "./metadata"
 import { renderCustomAppRuntimeScript } from "./runtime"
-import type { PageRoute } from "./scanner"
+import { type AppRouteLayout, type PageRoute, routePatternKey } from "./scanner"
 
 export interface BuiltInRouteManifestEntry {
   readonly path: string
@@ -14,30 +14,35 @@ export interface BuiltInRouteManifestEntry {
 
 export interface GenerateRouteManifestOptions {
   readonly builtInRoutes?: readonly BuiltInRouteManifestEntry[]
+  readonly layouts?: readonly AppRouteLayout[]
 }
 
 export const AUTH_EXPERIENCE_BOOTSTRAP_PLACEHOLDER = "__SIXB_AUTH_BOOTSTRAP__"
 
 /**
- * Generates `.sixb/generated/routes.ts` with static route imports. Pages are
+ * Generates `.sixb/generated/routes.ts` with static page/layout imports. Modules are
  * eager on purpose: project-specific apps bundle small, and a single bundle
  * (one JS file, one render-blocking CSS file) means no Suspense gap or
  * late-arriving styles when navigating — matching how Atlas routes.
  */
 export async function generateRouteManifest(
-  routes: PageRoute[],
+  routes: readonly PageRoute[],
   generatedDir: string,
   options: GenerateRouteManifestOptions = {}
 ): Promise<string> {
   await mkdir(generatedDir, { recursive: true })
 
-  const imports = routes
+  const pages = [...routes].sort(compareRouteModules)
+  const pageImports = pages
     .map((route, index) => {
       const rel = relativeTo(generatedDir, route.filePath)
       return `import Page${index} from ${JSON.stringify(rel)}`
     })
     .join("\n")
-  const builtInRoutes = options.builtInRoutes ?? []
+  const projectRoutePatterns = new Set(pages.map((route) => routePatternKey(route.path)))
+  const builtInRoutes = (options.builtInRoutes ?? []).filter(
+    (route) => !projectRoutePatterns.has(routePatternKey(route.path))
+  )
   const builtInImports = builtInRoutes
     .map((route, index) => {
       if (route.exportName) {
@@ -47,28 +52,224 @@ export async function generateRouteManifest(
       return `import BuiltInPage${index} from ${JSON.stringify(route.moduleSpecifier)}`
     })
     .join("\n")
-
-  const entries = routes
-    .map((route, index) => `  { path: ${JSON.stringify(route.path)}, component: Page${index} },`)
+  const routePatterns = [...pages, ...builtInRoutes].map((route) => routePatternKey(route.path))
+  const layouts = [...(options.layouts ?? [])]
+    .filter((layout) => {
+      const layoutPattern = routePatternKey(layout.path)
+      return routePatterns.some(
+        (routePattern) =>
+          routePattern === layoutPattern || routePattern.startsWith(`${layoutPattern}/`)
+      )
+    })
+    .sort(compareRouteModules)
+  const layoutImports = layouts
+    .map((layout, index) => {
+      const rel = relativeTo(generatedDir, layout.filePath)
+      return `import Layout${index} from ${JSON.stringify(rel)}`
+    })
     .join("\n")
-  const builtInEntries = builtInRoutes
-    .map(
-      (route, index) => `  { path: ${JSON.stringify(route.path)}, component: BuiltInPage${index} },`
+
+  const tree = createRouteTree()
+  for (const [index, layout] of layouts.entries()) {
+    insertRouteLayout(tree, layout, `Layout${index}`)
+  }
+  for (const [index, route] of pages.entries()) {
+    insertRoutePage(tree, route.path, `Page${index}`, route.relativePath)
+  }
+  for (const [index, route] of builtInRoutes.entries()) {
+    insertRoutePage(
+      tree,
+      route.path,
+      `BuiltInPage${index}`,
+      `${route.moduleSpecifier} (${route.path})`
     )
-    .join("\n")
-  const routeEntries = [entries, builtInEntries].filter(Boolean).join("\n")
-  const importEntries = [imports, builtInImports].filter(Boolean).join("\n")
+  }
 
+  const importEntries = [
+    'import { createElement } from "react"',
+    layouts.length > 0
+      ? 'import { Outlet, type RouteObject } from "react-router-dom"'
+      : 'import type { RouteObject } from "react-router-dom"',
+    pageImports,
+    builtInImports,
+    layoutImports,
+  ]
+    .filter(Boolean)
+    .join("\n")
+  const routePaths = [
+    ...pages.map((route) => route.path),
+    ...builtInRoutes.map((route) => route.path),
+  ]
   const content = `${importEntries}
 
+export const routePaths = ${JSON.stringify(routePaths, null, 2)} as const
+
 export const routes = [
-${routeEntries}
-]
+${renderRootRouteObjects(tree)}
+] satisfies RouteObject[]
 `
 
   const outPath = join(generatedDir, "routes.ts")
   await writeFileIfChanged(outPath, content)
   return outPath
+}
+
+interface RouteTreePage {
+  readonly componentName: string
+  readonly source: string
+}
+
+interface RouteTreeLayout {
+  readonly componentName: string
+  readonly source: string
+}
+
+interface RouteTreeNode {
+  readonly segment: string
+  readonly children: Map<string, RouteTreeNode>
+  page?: RouteTreePage
+  layout?: RouteTreeLayout
+}
+
+function createRouteTree(segment = ""): RouteTreeNode {
+  return { segment, children: new Map() }
+}
+
+function insertRouteLayout(
+  root: RouteTreeNode,
+  layout: AppRouteLayout,
+  componentName: string
+): void {
+  if (layout.path === "/") {
+    throw new Error(
+      `[SixbCustomApp] Root layout ${layout.relativePath} must remain the global app wrapper.`
+    )
+  }
+  const node = resolveRouteNode(root, layout.path, layout.relativePath)
+  if (node.layout) {
+    throw new Error(
+      `[SixbCustomApp] Conflicting layouts '${node.layout.source}' and '${layout.relativePath}' own route '${layout.path}'.`
+    )
+  }
+  node.layout = { componentName, source: layout.relativePath }
+}
+
+function insertRoutePage(
+  root: RouteTreeNode,
+  path: string,
+  componentName: string,
+  source: string
+): void {
+  const node = resolveRouteNode(root, path, source)
+  if (node.page) {
+    throw new Error(
+      `[SixbCustomApp] Conflicting pages '${node.page.source}' and '${source}' match route '${path}'.`
+    )
+  }
+  node.page = { componentName, source }
+}
+
+function resolveRouteNode(root: RouteTreeNode, path: string, source: string): RouteTreeNode {
+  let node = root
+  for (const segment of splitRoutePath(path)) {
+    const key = segment.startsWith(":") ? ":" : segment.toLowerCase()
+    const existing = node.children.get(key)
+    if (existing) {
+      if (
+        existing.segment.startsWith(":") &&
+        segment.startsWith(":") &&
+        existing.segment !== segment
+      ) {
+        throw new Error(
+          `[SixbCustomApp] Route '${source}' uses dynamic segment '${segment}', but '${existing.segment}' already owns the same route position. Use one parameter name consistently.`
+        )
+      }
+      node = existing
+      continue
+    }
+
+    const child = createRouteTree(segment)
+    node.children.set(key, child)
+    node = child
+  }
+  return node
+}
+
+function renderRootRouteObjects(root: RouteTreeNode): string {
+  const lines: string[] = []
+  if (root.page) {
+    lines.push(`  { path: "/", element: createElement(${root.page.componentName}) },`)
+  }
+  for (const child of sortedRenderableChildren(root)) {
+    lines.push(...renderRouteNode(child, 1))
+  }
+  return lines.join("\n")
+}
+
+function renderRouteNode(node: RouteTreeNode, depth: number): string[] {
+  const indent = "  ".repeat(depth)
+  const children = sortedRenderableChildren(node)
+  if (!node.layout && node.page && children.length === 0) {
+    return [
+      `${indent}{ path: ${JSON.stringify(node.segment)}, element: createElement(${node.page.componentName}) },`,
+    ]
+  }
+
+  const lines = [`${indent}{`, `${indent}  path: ${JSON.stringify(node.segment)},`]
+  if (node.layout) {
+    lines.push(
+      `${indent}  element: createElement(${node.layout.componentName}, { children: createElement(Outlet) }),`
+    )
+  }
+  lines.push(`${indent}  children: [`)
+  if (node.page) {
+    lines.push(`${indent}    { index: true, element: createElement(${node.page.componentName}) },`)
+  }
+  for (const child of children) {
+    lines.push(...renderRouteNode(child, depth + 2))
+  }
+  lines.push(`${indent}  ],`, `${indent}},`)
+  return lines
+}
+
+function sortedRenderableChildren(node: RouteTreeNode): RouteTreeNode[] {
+  return [...node.children.values()].filter(hasPageDescendant).sort((a, b) => {
+    const aDynamic = a.segment.startsWith(":")
+    const bDynamic = b.segment.startsWith(":")
+    if (aDynamic !== bDynamic) return aDynamic ? 1 : -1
+    return compareText(a.segment, b.segment)
+  })
+}
+
+function hasPageDescendant(node: RouteTreeNode): boolean {
+  if (node.page) return true
+  for (const child of node.children.values()) {
+    if (hasPageDescendant(child)) return true
+  }
+  return false
+}
+
+function splitRoutePath(path: string): string[] {
+  if (path === "/") return []
+  if (!path.startsWith("/")) {
+    throw new Error(`[SixbCustomApp] Route path '${path}' must start with '/'.`)
+  }
+  const segments = path.slice(1).split("/")
+  if (segments.some((segment) => !segment)) {
+    throw new Error(`[SixbCustomApp] Route path '${path}' contains an empty segment.`)
+  }
+  return segments
+}
+
+function compareRouteModules(
+  a: Pick<AppRouteLayout, "path" | "relativePath">,
+  b: Pick<AppRouteLayout, "path" | "relativePath">
+): number {
+  return compareText(a.path, b.path) || compareText(a.relativePath, b.relativePath)
+}
+
+function compareText(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
 }
 
 /** Generates the optional browser entry served by the API for `/auth/*`. */
@@ -273,7 +474,13 @@ export async function generateAppEntry(
   const mainContent = `import React from "react"
 import { createRoot, type Root } from "react-dom/client"
 import { signOut } from "@sixb/client"
-import { BrowserRouter, Routes, Route, matchPath, useNavigate, useLocation } from "react-router-dom"
+import {
+  BrowserRouter,
+  matchPath,
+  useLocation,
+  useNavigate,
+  useRoutes,
+} from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import {
   configureSixbBrowserClient,
@@ -281,7 +488,7 @@ import {
   readSixbBrowserRuntimeConfig,
   requireSixbBrowserAuthSession,
 } from "@sixb/client/browser"
-import { routes } from "./routes"
+import { routePaths, routes } from "./routes"
 ${globalsCssImport}
 ${layoutImport}
 
@@ -381,7 +588,7 @@ function InternalLinkInterceptor() {
       if (isReservedPath(url.pathname)) return
       // Only intercept destinations the app actually routes; anything else may
       // be a real server resource and keeps native navigation.
-      if (!routes.some((route) => matchPath(route.path, url.pathname))) return
+      if (!routePaths.some((path) => matchPath(path, url.pathname))) return
       // Same-document hash links keep native scroll behavior.
       if (
         url.hash &&
@@ -585,6 +792,12 @@ function RoutedErrorBoundary({ children }: { children: React.ReactNode }) {
   )
 }
 
+const appRoutes = [...routes, { path: "*", element: <NotFoundView /> }]
+
+function AppRoutes() {
+  return useRoutes(appRoutes)
+}
+
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -592,12 +805,7 @@ function App() {
         <InternalLinkInterceptor />
         <RoutedErrorBoundary>
           ${layoutWrapperStart}
-            <Routes>
-              {routes.map((route) => (
-                <Route key={route.path} path={route.path} element={<route.component />} />
-              ))}
-              <Route path="*" element={<NotFoundView />} />
-            </Routes>
+            <AppRoutes />
           ${layoutWrapperEnd}
         </RoutedErrorBoundary>
       </BrowserRouter>

--- a/packages/app/src/createCustomApp.ts
+++ b/packages/app/src/createCustomApp.ts
@@ -17,7 +17,7 @@ import {
   generateRouteManifest,
 } from "./codegen"
 import { renderCustomAppRuntimeScript } from "./runtime"
-import { type PageRoute, scanPages } from "./scanner"
+import { type PageRoute, routePatternKey, scanAppRoutes } from "./scanner"
 import { type CustomAppStylesheet, resolveCustomAppStylesheet } from "./styles"
 import { createTailwindCssCompiler, type TailwindCssCompiler } from "./tailwind"
 
@@ -98,11 +98,7 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
   const agentRoutesEnabled = options.agentRoutes ?? true
 
   async function scanRoutes(): Promise<PageRoute[]> {
-    if (!(await pathExists(appDir))) {
-      return []
-    }
-
-    return await scanPages(appDir)
+    return [...(await scanAppRoutes(appDir)).pages]
   }
 
   let tailwindCompiler: TailwindCssCompiler | null = null
@@ -236,14 +232,18 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
     manifestPath: string
     routes: PageRoute[]
   }> {
-    const routes = await scanRoutes()
+    const discovery = await scanAppRoutes(appDir)
+    const routes = [...discovery.pages]
     if (routes.length === 0) {
       throw new Error(`[SixbCustomApp] No app routes found in ${appDir}`)
     }
 
     const builtInRoutes = agentRoutesEnabled ? builtInAgentRoutesFor(routes) : []
     const stylesheets = await prepareStylesheets(builtInRoutes)
-    await generateRouteManifest(routes, generatedDir, { builtInRoutes })
+    await generateRouteManifest(routes, generatedDir, {
+      builtInRoutes,
+      layouts: discovery.layouts,
+    })
     const { htmlPath, mainPath, manifestPath } = await generateAppEntry(rootDir, generatedDir, {
       apiBaseUrl,
       audience,
@@ -530,10 +530,10 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 function builtInAgentRoutesFor(routes: readonly PageRoute[]): BuiltInRouteManifestEntry[] {
-  const projectRoutePaths = new Set(routes.map((route) => route.path))
+  const projectRoutePatterns = new Set(routes.map((route) => routePatternKey(route.path)))
 
   return builtInAgentRoutePaths
-    .filter((path) => !projectRoutePaths.has(path))
+    .filter((path) => !projectRoutePatterns.has(routePatternKey(path)))
     .map((path) => ({
       path,
       moduleSpecifier: builtInAgentRouteModule,

--- a/packages/app/src/scanner.ts
+++ b/packages/app/src/scanner.ts
@@ -1,6 +1,10 @@
 import { readdir } from "node:fs/promises"
 import { join, relative } from "node:path"
 
+const dynamicSegmentPattern = /^\[([\w-]+)\]$/
+const reservedRoutePrefixes = ["/api", "/auth", "/ws", "/docs", "/__sixb"] as const
+const reservedRoutePaths = new Set(["/app.webmanifest"])
+
 export interface PageRoute {
   /** React Router path, e.g. "/" or "/remote/:id" */
   path: string
@@ -10,72 +14,213 @@ export interface PageRoute {
   relativePath: string
 }
 
-/**
- * Recursively scans an `app/` directory for `page.tsx`/`page.ts` files and
- * converts them to React Router route paths.
- *
- * - `app/page.tsx`              -> `/`
- * - `app/about/page.tsx`        -> `/about`
- * - `app/remote/[id]/page.tsx`  -> `/remote/:id`
- * - Files starting with `_` are skipped.
- */
-export async function scanPages(appDir: string): Promise<PageRoute[]> {
-  const routes: PageRoute[] = []
-  await walkDir(appDir, appDir, routes)
-  routes.sort((a, b) => a.path.localeCompare(b.path))
-  return routes
+export interface AppRouteLayout {
+  /** React Router prefix owned by this layout, e.g. "/remote/:id". */
+  path: string
+  /** Absolute file path. */
+  filePath: string
+  /** Relative path from the app directory, e.g. "remote/[id]/layout.tsx". */
+  relativePath: string
 }
 
-async function walkDir(dir: string, appDir: string, routes: PageRoute[]): Promise<void> {
-  let entries: import("node:fs").Dirent[]
-  try {
-    entries = (await readdir(dir, { withFileTypes: true })) as import("node:fs").Dirent[]
-  } catch {
-    return
+export interface AppRouteDiscovery {
+  readonly pages: readonly PageRoute[]
+  /** Descendant layouts only. The root layout remains the global app wrapper. */
+  readonly layouts: readonly AppRouteLayout[]
+}
+
+/**
+ * Recursively scans an `app/` directory for page modules and descendant layouts.
+ *
+ * - `app/page.tsx`                    -> page `/`
+ * - `app/about/page.tsx`              -> page `/about`
+ * - `app/remote/[id]/page.tsx`        -> page `/remote/:id`
+ * - `app/remote/[id]/layout.tsx`      -> layout `/remote/:id/**`
+ * - `app/layout.tsx` remains the global wrapper and is not returned as a route layout.
+ * - Files and folders starting with `_` are skipped.
+ */
+export async function scanAppRoutes(appDir: string): Promise<AppRouteDiscovery> {
+  const pages: PageRoute[] = []
+  const layouts: AppRouteLayout[] = []
+  await walkDir(appDir, appDir, pages, layouts)
+  pages.sort(compareRouteModules)
+  layouts.sort(compareRouteModules)
+  return { pages, layouts }
+}
+
+/** Preserve the existing flat inspection contract while route generation uses the richer scan. */
+export async function scanPages(appDir: string): Promise<PageRoute[]> {
+  return [...(await scanAppRoutes(appDir)).pages]
+}
+
+/** Treat parameter names as labels when comparing route ownership and overrides. */
+export function routePatternKey(path: string): string {
+  if (path === "/") return "/"
+  const segments = routeSegments(path).map((segment) =>
+    segment.startsWith(":") ? ":" : segment.toLowerCase()
+  )
+  return `/${segments.join("/")}`
+}
+
+async function walkDir(
+  dir: string,
+  appDir: string,
+  pages: PageRoute[],
+  layouts: AppRouteLayout[]
+): Promise<void> {
+  const entries = await readDirectory(dir)
+  if (!entries) return
+
+  const visibleEntries = entries
+    .filter((entry) => !String(entry.name).startsWith("_"))
+    .sort((a, b) => compareText(String(a.name), String(b.name)))
+  const relativeDir = normalizeRelativePath(relative(appDir, dir))
+
+  validateChildDirectories(visibleEntries, relativeDir)
+
+  const pageEntries = visibleEntries.filter(
+    (entry) => entry.isFile() && (entry.name === "page.tsx" || entry.name === "page.ts")
+  )
+  if (pageEntries.length > 1) {
+    const modules = pageEntries.map((entry) => displayAppPath(join(relativeDir, entry.name)))
+    throw new Error(
+      `[SixbCustomApp] Conflicting page modules for route '${directoryRoutePath(relativeDir)}': ${modules.join(" and ")}. Keep exactly one of page.tsx or page.ts.`
+    )
   }
+
+  const pageEntry = pageEntries[0]
+  if (pageEntry) {
+    const relativePath = normalizeRelativePath(join(relativeDir, pageEntry.name))
+    const path = directoryRoutePath(relativeDir)
+    assertRouteIsAvailable(path, relativePath)
+    pages.push({ path, filePath: join(dir, pageEntry.name), relativePath })
+  }
+
+  if (relativeDir) {
+    const layoutEntry = visibleEntries.find(
+      (entry) => entry.isFile() && entry.name === "layout.tsx"
+    )
+    if (layoutEntry) {
+      layouts.push({
+        path: directoryRoutePath(relativeDir),
+        filePath: join(dir, layoutEntry.name),
+        relativePath: normalizeRelativePath(join(relativeDir, layoutEntry.name)),
+      })
+    }
+  }
+
+  for (const entry of visibleEntries) {
+    if (!entry.isDirectory()) continue
+    // `app/public/` is the static asset root, never part of the file router.
+    if (!relativeDir && entry.name === "public") continue
+    await walkDir(join(dir, entry.name), appDir, pages, layouts)
+  }
+}
+
+async function readDirectory(dir: string): Promise<import("node:fs").Dirent[] | null> {
+  try {
+    return (await readdir(dir, { withFileTypes: true })) as import("node:fs").Dirent[]
+  } catch (error) {
+    if (isNotFoundError(error)) return null
+    throw error
+  }
+}
+
+function validateChildDirectories(
+  entries: readonly import("node:fs").Dirent[],
+  relativeDir: string
+): void {
+  const claimedSegments = new Map<string, string>()
 
   for (const entry of entries) {
-    const name = String(entry.name)
-    if (name.startsWith("_")) continue
-
-    const fullPath = join(dir, name)
-
-    if (entry.isDirectory()) {
-      await walkDir(fullPath, appDir, routes)
-      continue
+    if (!entry.isDirectory()) continue
+    const segment = routeSegment(entry.name, join(relativeDir, entry.name))
+    const key = segment.startsWith(":") ? ":" : segment.toLowerCase()
+    const existing = claimedSegments.get(key)
+    if (existing && existing !== entry.name) {
+      const parent = relativeDir ? displayAppPath(relativeDir) : "app/"
+      throw new Error(
+        `[SixbCustomApp] Ambiguous route directories '${existing}' and '${entry.name}' under ${parent}. They match the same URL segment.`
+      )
     }
-
-    if (!entry.isFile()) continue
-    const isPageModule = name === "page.tsx" || name === "page.ts"
-    if (!isPageModule) continue
-
-    const relativePath = relative(appDir, fullPath)
-    const routePath = filePathToRoutePath(relativePath)
-
-    routes.push({
-      path: routePath,
-      filePath: fullPath,
-      relativePath,
-    })
+    claimedSegments.set(key, entry.name)
   }
 }
 
-function filePathToRoutePath(filePath: string): string {
-  // Remove extension
-  let route = filePath.replace(/\.(tsx|ts)$/, "")
+function directoryRoutePath(relativeDir: string): string {
+  if (!relativeDir) return "/"
+  return `/${relativeDir
+    .split("/")
+    .map((segment) => routeSegment(segment, relativeDir))
+    .join("/")}`
+}
 
-  // Normalize path separators
-  route = route.split("\\").join("/")
+function routeSegment(segment: string, relativePath: string): string {
+  const dynamic = dynamicSegmentPattern.exec(segment)
+  if (dynamic) return `:${dynamic[1]}`
 
-  // Convert [param] to :param
-  route = route.replace(/\[([^\]]+)\]/g, ":$1")
+  if (segment.includes("[") || segment.includes("]")) {
+    throw new Error(
+      `[SixbCustomApp] Invalid dynamic route directory ${displayAppPath(relativePath)}. Use one name such as '[id]'; catch-all and partial dynamic segments are not supported.`
+    )
+  }
+  if (segment.includes("(") || segment.includes(")")) {
+    throw new Error(
+      `[SixbCustomApp] Invalid route directory ${displayAppPath(relativePath)}. Route groups are not supported yet; use a normal directory name.`
+    )
+  }
+  if (/[:*?]/.test(segment)) {
+    throw new Error(
+      `[SixbCustomApp] Invalid route directory ${displayAppPath(relativePath)}. Use '[name]' for a dynamic segment; ':', '*' and '?' are reserved by React Router.`
+    )
+  }
 
-  // Remove trailing /page
-  if (route === "page") return "/"
-  route = route.replace(/\/page$/, "")
+  return segment
+}
 
-  // Ensure leading slash
-  if (!route.startsWith("/")) route = `/${route}`
+function assertRouteIsAvailable(path: string, relativePath: string): void {
+  const normalizedPath = path.toLowerCase()
+  const reserved =
+    reservedRoutePaths.has(normalizedPath) ||
+    reservedRoutePrefixes.some(
+      (prefix) => normalizedPath === prefix || normalizedPath.startsWith(`${prefix}/`)
+    )
+  if (!reserved) return
 
-  return route
+  throw new Error(
+    `[SixbCustomApp] Page ${displayAppPath(relativePath)} resolves to reserved framework path '${path}'. Choose a route outside /api, /auth, /ws, /docs, /__sixb, and /app.webmanifest.`
+  )
+}
+
+function routeSegments(path: string): string[] {
+  return path === "/" ? [] : path.replace(/^\/+|\/+$/g, "").split("/")
+}
+
+function normalizeRelativePath(path: string): string {
+  return path
+    .split("\\")
+    .join("/")
+    .replace(/^\.\/$/, "")
+}
+
+function displayAppPath(path: string): string {
+  const normalized = normalizeRelativePath(path)
+  return normalized ? `app/${normalized}` : "app/"
+}
+
+function compareRouteModules(
+  a: Pick<PageRoute, "path" | "relativePath">,
+  b: Pick<PageRoute, "path" | "relativePath">
+): number {
+  return compareText(a.path, b.path) || compareText(a.relativePath, b.relativePath)
+}
+
+function compareText(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const code = (error as NodeJS.ErrnoException).code
+  return code === "ENOENT" || code === "ENOTDIR"
 }

--- a/packages/app/tests/createCustomApp.test.ts
+++ b/packages/app/tests/createCustomApp.test.ts
@@ -426,7 +426,8 @@ describe("createCustomApp.dev", () => {
     expect(main).toContain("isSixbApiError(error) && error.status === 404")
     expect(main).toContain("import {\n  configureSixbBrowserClient,\n  isSixbApiError,")
     // Unmatched client routes render the not-found view instead of a blank page.
-    expect(main).toContain('<Route path="*" element={<NotFoundView />} />')
+    expect(main).toContain('{ path: "*", element: <NotFoundView /> }')
+    expect(main).toContain("return useRoutes(appRoutes)")
     expect(main).toContain("function NotFoundView()")
   })
 
@@ -451,12 +452,14 @@ describe("createCustomApp.dev", () => {
 
     expect(manifest).toContain('import Page0 from "../../app/page.tsx"')
     expect(manifest).toContain('import Page1 from "../../app/devices/[id]/page.tsx"')
-    expect(manifest).toContain('{ path: "/", component: Page0 },')
-    expect(manifest).toContain('{ path: "/devices/:id", component: Page1 },')
+    expect(manifest).toContain('export const routePaths = [\n  "/",\n  "/devices/:id"\n]')
+    expect(manifest).toContain('{ path: "/", element: createElement(Page0) },')
+    expect(manifest).toContain('path: "devices"')
+    expect(manifest).toContain('{ path: ":id", element: createElement(Page1) },')
     expect(manifest).not.toContain("lazy(")
   })
 
-  test("route manifest can append framework-owned routes", async () => {
+  test("route manifest nests framework-owned routes under a project layout", async () => {
     const generatedDir = join(tempRoot, ".sixb", "generated")
     const manifestPath = await generateRouteManifest(
       [
@@ -473,6 +476,13 @@ describe("createCustomApp.dev", () => {
           { path: "/agents/new/:agentId", moduleSpecifier: "@sixb/app/agents" },
           { path: "/agents/:threadId", moduleSpecifier: "@sixb/app/agents" },
         ],
+        layouts: [
+          {
+            path: "/agents",
+            filePath: join(tempRoot, "app", "agents", "layout.tsx"),
+            relativePath: "agents/layout.tsx",
+          },
+        ],
       }
     )
     const manifest = await readFile(manifestPath, "utf-8")
@@ -481,10 +491,56 @@ describe("createCustomApp.dev", () => {
     expect(manifest).toContain('import BuiltInPage0 from "@sixb/app/agents"')
     expect(manifest).toContain('import BuiltInPage1 from "@sixb/app/agents"')
     expect(manifest).toContain('import BuiltInPage2 from "@sixb/app/agents"')
-    expect(manifest).toContain('{ path: "/", component: Page0 },')
-    expect(manifest).toContain('{ path: "/agents", component: BuiltInPage0 },')
-    expect(manifest).toContain('{ path: "/agents/new/:agentId", component: BuiltInPage1 },')
-    expect(manifest).toContain('{ path: "/agents/:threadId", component: BuiltInPage2 },')
+    expect(manifest).toContain('import Layout0 from "../../app/agents/layout.tsx"')
+    expect(manifest).toContain(
+      "element: createElement(Layout0, { children: createElement(Outlet) })"
+    )
+    expect(manifest).toContain("{ index: true, element: createElement(BuiltInPage0) },")
+    expect(manifest).toContain('{ path: ":agentId", element: createElement(BuiltInPage1) },')
+    expect(manifest).toContain('{ path: ":threadId", element: createElement(BuiltInPage2) },')
+  })
+
+  test("route manifest composes layouts and ignores layouts without pages", async () => {
+    const generatedDir = join(tempRoot, ".sixb", "generated")
+    const manifestPath = await generateRouteManifest(
+      [
+        {
+          path: "/analytics/reports/:reportId",
+          filePath: join(tempRoot, "app", "analytics", "reports", "[reportId]", "page.tsx"),
+          relativePath: "analytics/reports/[reportId]/page.tsx",
+        },
+      ],
+      generatedDir,
+      {
+        layouts: [
+          {
+            path: "/analytics",
+            filePath: join(tempRoot, "app", "analytics", "layout.tsx"),
+            relativePath: "analytics/layout.tsx",
+          },
+          {
+            path: "/analytics/reports/:reportId",
+            filePath: join(tempRoot, "app", "analytics", "reports", "[reportId]", "layout.tsx"),
+            relativePath: "analytics/reports/[reportId]/layout.tsx",
+          },
+          {
+            path: "/orphan",
+            filePath: join(tempRoot, "app", "orphan", "layout.tsx"),
+            relativePath: "orphan/layout.tsx",
+          },
+        ],
+      }
+    )
+    const manifest = await readFile(manifestPath, "utf-8")
+
+    expect(manifest).toContain('import { Outlet, type RouteObject } from "react-router-dom"')
+    expect(manifest).toContain('import Layout0 from "../../app/analytics/layout.tsx"')
+    expect(manifest).toContain(
+      'import Layout1 from "../../app/analytics/reports/[reportId]/layout.tsx"'
+    )
+    expect(manifest).not.toContain("orphan/layout.tsx")
+    expect(manifest.match(/children: createElement\(Outlet\)/g)).toHaveLength(2)
+    expect(manifest).toContain("{ index: true, element: createElement(Page0) },")
   })
 
   test("generated entry imports framework styles before app styles", async () => {
@@ -546,7 +602,7 @@ describe("createCustomApp.dev", () => {
       'anchor.relList.contains("external")',
       "url.origin !== window.location.origin",
       "isReservedPath(url.pathname)",
-      "matchPath(route.path, url.pathname)",
+      "matchPath(path, url.pathname)",
     ]) {
       expect(main).toContain(guard)
     }
@@ -576,6 +632,11 @@ describe("createCustomApp.dev", () => {
   })
 
   test("custom apps get default agent routes without changing scanRoutes output", async () => {
+    await mkdir(join(tempRoot, "app", "agents"), { recursive: true })
+    await writeFile(
+      join(tempRoot, "app", "agents", "layout.tsx"),
+      "export default function AgentsLayout({ children }) { return children }\n"
+    )
     const port = await getFreePort()
     const app = await createCustomApp({
       rootDir: tempRoot,
@@ -588,10 +649,13 @@ describe("createCustomApp.dev", () => {
       expect((await app.scanRoutes()).map((route) => route.path)).toEqual(["/"])
 
       const manifest = await readFile(join(tempRoot, ".sixb", "generated", "routes.ts"), "utf-8")
-      expect(manifest).toContain('{ path: "/", component: Page0 },')
-      expect(manifest).toContain('{ path: "/agents", component: BuiltInPage0 },')
-      expect(manifest).toContain('{ path: "/agents/new/:agentId", component: BuiltInPage1 },')
-      expect(manifest).toContain('{ path: "/agents/:threadId", component: BuiltInPage2 },')
+      expect(manifest).toContain('import Layout0 from "../../app/agents/layout.tsx"')
+      expect(manifest).toContain(
+        "element: createElement(Layout0, { children: createElement(Outlet) })"
+      )
+      expect(manifest).toContain("{ index: true, element: createElement(BuiltInPage0) },")
+      expect(manifest).toContain('{ path: ":agentId", element: createElement(BuiltInPage1) },')
+      expect(manifest).toContain('{ path: ":threadId", element: createElement(BuiltInPage2) },')
 
       const main = await readFile(join(tempRoot, ".sixb", "generated", "main.tsx"), "utf-8")
       expect(main).toContain('import "./agent-ui.css"')
@@ -601,18 +665,18 @@ describe("createCustomApp.dev", () => {
   }, 30_000)
 
   test("project-owned agent pages override the default agent routes", async () => {
-    await mkdir(join(tempRoot, "app", "agents", "new", "[agentId]"), { recursive: true })
-    await mkdir(join(tempRoot, "app", "agents", "[threadId]"), { recursive: true })
+    await mkdir(join(tempRoot, "app", "agents", "new", "[draft]"), { recursive: true })
+    await mkdir(join(tempRoot, "app", "agents", "[thread]"), { recursive: true })
     await writeFile(
       join(tempRoot, "app", "agents", "page.tsx"),
       "export default function Agents() { return null }\n"
     )
     await writeFile(
-      join(tempRoot, "app", "agents", "new", "[agentId]", "page.tsx"),
+      join(tempRoot, "app", "agents", "new", "[draft]", "page.tsx"),
       "export default function NewAgentChat() { return null }\n"
     )
     await writeFile(
-      join(tempRoot, "app", "agents", "[threadId]", "page.tsx"),
+      join(tempRoot, "app", "agents", "[thread]", "page.tsx"),
       "export default function AgentThread() { return null }\n"
     )
 
@@ -626,9 +690,10 @@ describe("createCustomApp.dev", () => {
 
     try {
       const manifest = await readFile(join(tempRoot, ".sixb", "generated", "routes.ts"), "utf-8")
-      expect(manifest).toContain('{ path: "/agents", component: Page')
-      expect(manifest).toContain('{ path: "/agents/new/:agentId", component: Page')
-      expect(manifest).toContain('{ path: "/agents/:threadId", component: Page')
+      expect(manifest).toContain('"/agents"')
+      expect(manifest).toContain('"/agents/new/:draft"')
+      expect(manifest).toContain('"/agents/:thread"')
+      expect(manifest).toContain("createElement(Page")
       expect(manifest).not.toContain("@sixb/app/agents")
       expect(await Bun.file(join(tempRoot, ".sixb", "generated", "agent-ui.css")).exists()).toBe(
         false

--- a/packages/app/tests/nested-layouts.test.tsx
+++ b/packages/app/tests/nested-layouts.test.tsx
@@ -1,0 +1,198 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react"
+import { Window } from "happy-dom"
+import { MemoryRouter, type RouteObject, useRoutes } from "react-router-dom"
+import { generateRouteManifest } from "../src/codegen"
+import { scanAppRoutes } from "../src/scanner"
+
+const browserWindow = new Window({ url: "https://app.sixb.test/" })
+const installedBrowserGlobals = [
+  "window",
+  "self",
+  "document",
+  "location",
+  "history",
+  "navigator",
+  "Node",
+  "Element",
+  "HTMLElement",
+  "HTMLAnchorElement",
+  "Event",
+  "EventTarget",
+  "MouseEvent",
+  "MutationObserver",
+  "getComputedStyle",
+  "requestAnimationFrame",
+  "cancelAnimationFrame",
+  "IS_REACT_ACT_ENVIRONMENT",
+] as const
+const previousBrowserGlobals = new Map<string, PropertyDescriptor | undefined>()
+
+beforeAll(() => {
+  const values = browserWindow as unknown as Record<string, unknown>
+  for (const key of installedBrowserGlobals) {
+    previousBrowserGlobals.set(key, Object.getOwnPropertyDescriptor(globalThis, key))
+    const value =
+      key === "window" || key === "self"
+        ? browserWindow
+        : key === "IS_REACT_ACT_ENVIRONMENT"
+          ? true
+          : values[key]
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value })
+  }
+})
+
+beforeEach(() => {
+  browserWindow.history.replaceState({}, "", "/")
+  browserWindow.document.body.replaceChildren()
+})
+
+afterEach(async () => {
+  cleanup()
+  await Bun.sleep(0)
+})
+
+afterAll(async () => {
+  await Bun.sleep(0)
+  for (const key of installedBrowserGlobals) {
+    const previous = previousBrowserGlobals.get(key)
+    if (previous) Object.defineProperty(globalThis, key, previous)
+    else Reflect.deleteProperty(globalThis, key)
+  }
+  browserWindow.close()
+})
+
+describe("generated nested layouts", () => {
+  test("preserves layout instances and route params while navigating between children", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "sixb-app-layout-runtime-"))
+    const appDir = join(projectRoot, "app")
+    const reportDir = join(appDir, "analytics", "reports", "[reportId]")
+    const detailsDir = join(reportDir, "details")
+    const generatedDir = join(projectRoot, ".sixb", "generated")
+
+    try {
+      await mkdir(detailsDir, { recursive: true })
+      await Promise.all([
+        writeFile(
+          join(appDir, "analytics", "layout.tsx"),
+          [
+            'import { useState, type PropsWithChildren } from "react"',
+            "let mounts = 0",
+            "export default function AnalyticsLayout({ children }: PropsWithChildren) {",
+            "  const [instance] = useState(() => ++mounts)",
+            '  return <section data-testid="analytics-layout">',
+            '    <span data-testid="analytics-instance">{instance}</span>',
+            "    {children}",
+            "  </section>",
+            "}",
+            "",
+          ].join("\n")
+        ),
+        writeFile(
+          join(reportDir, "layout.tsx"),
+          [
+            'import { useState, type PropsWithChildren } from "react"',
+            'import { Link, useParams } from "react-router-dom"',
+            "let mounts = 0",
+            "export default function ReportLayout({ children }: PropsWithChildren) {",
+            "  const [instance] = useState(() => ++mounts)",
+            "  const { reportId } = useParams()",
+            '  return <section data-testid="report-layout">',
+            '    <span data-testid="report-instance">{instance}</span>',
+            '    <span data-testid="layout-param">{reportId}</span>',
+            '    <Link to={"/analytics/reports/" + reportId + "/details"}>Report details</Link>',
+            '    <Link to="/analytics/reports/second/details">Second report</Link>',
+            "    {children}",
+            "  </section>",
+            "}",
+            "",
+          ].join("\n")
+        ),
+        writeFile(
+          join(reportDir, "page.tsx"),
+          [
+            'import { useParams } from "react-router-dom"',
+            "export default function ReportPage() {",
+            "  const { reportId } = useParams()",
+            '  return <p data-testid="page-param">summary:{reportId}</p>',
+            "}",
+            "",
+          ].join("\n")
+        ),
+        writeFile(
+          join(detailsDir, "page.tsx"),
+          [
+            'import { useParams } from "react-router-dom"',
+            "export default function ReportDetailsPage() {",
+            "  const { reportId } = useParams()",
+            '  return <p data-testid="page-param">details:{reportId}</p>',
+            "}",
+            "",
+          ].join("\n")
+        ),
+      ])
+      await linkDependencies(projectRoot, ["react", "react-dom", "react-router-dom"])
+
+      const discovery = await scanAppRoutes(appDir)
+      const manifestPath = await generateRouteManifest([...discovery.pages], generatedDir, {
+        layouts: discovery.layouts,
+      })
+      const generated = (await import(
+        `${pathToFileURL(manifestPath).href}?runtime-layout-test`
+      )) as {
+        readonly routes: RouteObject[]
+      }
+
+      function TestRoutes() {
+        return useRoutes(generated.routes)
+      }
+
+      const rendered = render(
+        <MemoryRouter initialEntries={["/analytics/reports/first"]}>
+          <TestRoutes />
+        </MemoryRouter>
+      )
+
+      expect(rendered.getByTestId("analytics-instance").textContent).toBe("1")
+      expect(rendered.getByTestId("report-instance").textContent).toBe("1")
+      expect(rendered.getByTestId("layout-param").textContent).toBe("first")
+      expect(rendered.getByTestId("page-param").textContent).toBe("summary:first")
+
+      fireEvent.click(rendered.getByRole("link", { name: "Report details" }))
+
+      await waitFor(() =>
+        expect(rendered.getByTestId("page-param").textContent).toBe("details:first")
+      )
+      expect(rendered.getByTestId("analytics-instance").textContent).toBe("1")
+      expect(rendered.getByTestId("report-instance").textContent).toBe("1")
+
+      fireEvent.click(rendered.getByRole("link", { name: "Second report" }))
+
+      await waitFor(() =>
+        expect(rendered.getByTestId("page-param").textContent).toBe("details:second")
+      )
+      expect(rendered.getByTestId("layout-param").textContent).toBe("second")
+      expect(rendered.getByTestId("analytics-instance").textContent).toBe("1")
+      expect(rendered.getByTestId("report-instance").textContent).toBe("1")
+      // Regression guard: removing the nested layout RouteObjects makes these assertions fail;
+      // the two page routes also prove that shared feature state survives sibling navigation.
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+})
+
+async function linkDependencies(projectRoot: string, packages: readonly string[]): Promise<void> {
+  const atlasRoot = resolve(import.meta.dir, "..", "..", "atlas")
+
+  for (const name of packages) {
+    const packageDir = dirname(Bun.resolveSync(`${name}/package.json`, atlasRoot))
+    const target = join(projectRoot, "node_modules", ...name.split("/"))
+    await mkdir(dirname(target), { recursive: true })
+    await symlink(packageDir, target)
+  }
+}

--- a/packages/app/tests/scanner.test.ts
+++ b/packages/app/tests/scanner.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { routePatternKey, scanAppRoutes, scanPages } from "../src/scanner"
+
+describe("custom app route discovery", () => {
+  let tempRoot = ""
+  let appDir = ""
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), "sixb-app-scanner-"))
+    appDir = join(tempRoot, "app")
+    await mkdir(appDir, { recursive: true })
+  })
+
+  afterEach(async () => {
+    if (tempRoot) await rm(tempRoot, { recursive: true, force: true })
+  })
+
+  test("discovers pages and descendant layouts without treating the root layout as a route", async () => {
+    await mkdir(join(appDir, "analytics", "reports", "[reportId]"), { recursive: true })
+    await mkdir(join(appDir, "_components"), { recursive: true })
+    await mkdir(join(appDir, "public"), { recursive: true })
+    await Promise.all([
+      writeFile(join(appDir, "layout.tsx"), "export default function Layout() { return null }\n"),
+      writeFile(join(appDir, "page.tsx"), "export default function Page() { return null }\n"),
+      writeFile(
+        join(appDir, "analytics", "layout.tsx"),
+        "export default function Layout() { return null }\n"
+      ),
+      writeFile(
+        join(appDir, "analytics", "page.ts"),
+        "export default function Page() { return null }\n"
+      ),
+      writeFile(
+        join(appDir, "analytics", "reports", "[reportId]", "layout.tsx"),
+        "export default function Layout() { return null }\n"
+      ),
+      writeFile(
+        join(appDir, "analytics", "reports", "[reportId]", "page.tsx"),
+        "export default function Page() { return null }\n"
+      ),
+      writeFile(
+        join(appDir, "_components", "page.tsx"),
+        "export default function Ignored() { return null }\n"
+      ),
+      writeFile(
+        join(appDir, "public", "page.tsx"),
+        "export default function Asset() { return null }\n"
+      ),
+    ])
+
+    const discovery = await scanAppRoutes(appDir)
+
+    expect(discovery.pages.map(({ path, relativePath }) => ({ path, relativePath }))).toEqual([
+      { path: "/", relativePath: "page.tsx" },
+      { path: "/analytics", relativePath: "analytics/page.ts" },
+      {
+        path: "/analytics/reports/:reportId",
+        relativePath: "analytics/reports/[reportId]/page.tsx",
+      },
+    ])
+    expect(discovery.layouts.map(({ path, relativePath }) => ({ path, relativePath }))).toEqual([
+      { path: "/analytics", relativePath: "analytics/layout.tsx" },
+      {
+        path: "/analytics/reports/:reportId",
+        relativePath: "analytics/reports/[reportId]/layout.tsx",
+      },
+    ])
+    expect(await scanPages(appDir)).toEqual([...discovery.pages])
+  })
+
+  test("returns an empty discovery for a missing app directory", async () => {
+    await expect(scanAppRoutes(join(tempRoot, "missing"))).resolves.toEqual({
+      pages: [],
+      layouts: [],
+    })
+  })
+
+  test("rejects page.ts and page.tsx at the same route", async () => {
+    await writeFile(join(appDir, "page.ts"), "export default function Page() { return null }\n")
+    await writeFile(join(appDir, "page.tsx"), "export default function Page() { return null }\n")
+
+    await expect(scanAppRoutes(appDir)).rejects.toThrow(
+      "Conflicting page modules for route '/': app/page.ts and app/page.tsx"
+    )
+  })
+
+  test("rejects dynamic siblings that match the same URLs", async () => {
+    await mkdir(join(appDir, "customers", "[id]"), { recursive: true })
+    await mkdir(join(appDir, "customers", "[slug]"), { recursive: true })
+
+    await expect(scanAppRoutes(appDir)).rejects.toThrow(
+      "Ambiguous route directories '[id]' and '[slug]' under app/customers"
+    )
+  })
+
+  test("rejects unsupported dynamic syntax and framework-owned paths", async () => {
+    await mkdir(join(appDir, "reports", "[...slug]"), { recursive: true })
+    await expect(scanAppRoutes(appDir)).rejects.toThrow("catch-all and partial dynamic segments")
+
+    await rm(join(appDir, "reports"), { recursive: true, force: true })
+    await mkdir(join(appDir, "api"), { recursive: true })
+    await writeFile(
+      join(appDir, "api", "page.tsx"),
+      "export default function Page() { return null }\n"
+    )
+    await expect(scanAppRoutes(appDir)).rejects.toThrow(
+      "resolves to reserved framework path '/api'"
+    )
+
+    await rm(join(appDir, "api"), { recursive: true, force: true })
+    await mkdir(join(appDir, "Docs"), { recursive: true })
+    await writeFile(
+      join(appDir, "Docs", "page.tsx"),
+      "export default function Page() { return null }\n"
+    )
+    await expect(scanAppRoutes(appDir)).rejects.toThrow(
+      "resolves to reserved framework path '/Docs'"
+    )
+
+    await rm(join(appDir, "Docs"), { recursive: true, force: true })
+    await mkdir(join(appDir, "(admin)"), { recursive: true })
+    await expect(scanAppRoutes(appDir)).rejects.toThrow("Route groups are not supported yet")
+  })
+
+  test("normalizes case and parameter labels when comparing route ownership", () => {
+    expect(routePatternKey("/Agents/:id")).toBe(routePatternKey("/agents/:threadId"))
+    expect(routePatternKey("/")).toBe("/")
+  })
+})


### PR DESCRIPTION
## What changed

- Discover feature-level `layout.tsx` files alongside custom app pages.
- Generate native nested React Router trees with pathless layout routes and `<Outlet />`.
- Keep `app/layout.tsx` as the single global shell; nested features own their local providers and UI.
- Move Northline's agent workspace provider to `app/agents/layout.tsx`.
- Reject duplicate pages, ambiguous dynamic siblings, unsupported dynamic syntax, and framework-owned paths with actionable errors.
- Make route discovery deterministic and keep existing unambiguous flat routes compatible.
- Verify that Northline's dev bootstrap is connected to project `northline` before seeding data.
- Document the routing convention and add scanner, codegen, navigation, and startup regressions.

## Routing model

```text
app/layout.tsx                    global shell
└── app/agents/layout.tsx         feature shell
    └── framework agent routes   feature pages
```

## Why

- Feature shells no longer require pathname conditionals in the root layout.
- Providers stay mounted while navigating between sibling feature pages.
- Invalid route ownership fails at discovery time instead of depending on filesystem order.
- A Sixb server already using Northline's port now produces the real project-mismatch error.

## Verification

- `bun run build`
- `bun run typecheck`
- `bun run check`
- `bun test packages/app/tests examples/northline/tests` — 65 passing
