### PR TITLE
app: preserve superclass imports in production bundles

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -551,6 +551,8 @@
       "devDependencies": {
         "@types/bun": "latest",
         "@types/react": "^19.0.0",
+        "happy-dom": "^20.11.6",
+        "libphonenumber-js": "1.13.9",
         "typescript": "^5.7.0",
       },
       "peerDependencies": {
@@ -1989,6 +1991,8 @@
     "libbase64": ["libbase64@1.3.0", "", {}, "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg=="],
 
     "libmime": ["libmime@5.4.1", "", { "dependencies": { "encoding-japanese": "2.2.0", "iconv-lite": "0.7.3", "libbase64": "1.3.0", "libqp": "2.1.1" } }, "sha512-0wHGhsofo9IdQPenr3BBHXuxcwMq4atFUTsZ9Ogc1OvI5h4rUdDIrBQEN9JHjCXfDMrE59LUMJWsTD82wTYk8A=="],
+
+    "libphonenumber-js": ["libphonenumber-js@1.13.9", "", {}, "sha512-VNS5vWMM7r0P66BYv+TQJATxExEgLxN+34hfHDVhDkUsGAE4cRg0shCNSLTXNKm7nIUscC7AfB51TjxEeF7msQ=="],
 
     "libqp": ["libqp@2.1.1", "", {}, "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow=="],
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -43,6 +43,7 @@
   },
   "scripts": {
     "build": "bun ../../scripts/build-package.ts",
+    "test:e2e": "bun test ./tests/build-browser.e2e.ts",
     "typecheck": "tsc --noEmit",
     "prepack": "bun run build"
   },
@@ -62,6 +63,8 @@
   "devDependencies": {
     "@types/bun": "latest",
     "@types/react": "^19.0.0",
+    "happy-dom": "^20.11.6",
+    "libphonenumber-js": "1.13.9",
     "typescript": "^5.7.0"
   },
   "license": "MIT",

--- a/packages/app/src/build.ts
+++ b/packages/app/src/build.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs"
 import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises"
-import { basename, dirname, extname, join, resolve } from "node:path"
+import { basename, dirname, join, resolve } from "node:path"
 import { promisify } from "node:util"
 import {
   brotliCompress as brotliCompressCallback,
@@ -229,9 +229,11 @@ const extensionlessSourceImportPlugin: Bun.BunPlugin = {
     // A direct TypeScript entry with splitting exposes a Bun 1.3 resolver edge in linked workspace
     // packages: extensionless relative imports such as `../json` can fail even though `json.ts`
     // exists. HTML entries masked it, but HTML splitting can point at the wrong dynamic chunk.
-    build.onResolve({ filter: /^\.\.?\// }, (args) => {
-      if (extname(args.path)) return undefined
-
+    // Let Bun resolve already-explicit imports without entering this hook. On affected Bun
+    // releases (including 1.3.14 and 1.4.0), merely intercepting a package's explicit `.js`
+    // imports and returning `undefined` can corrupt DCE: subclass wrappers remain in the bundle
+    // while their imported superclass is removed.
+    build.onResolve({ filter: /^\.\.?\/(?:.*\/)?[^/.]+$/ }, (args) => {
       const base = resolve(dirname(args.importer), args.path)
       for (const candidate of [
         `${base}.ts`,

--- a/packages/app/tests/build-browser.e2e.ts
+++ b/packages/app/tests/build-browser.e2e.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+
+const packageRoot = resolve(import.meta.dir, "..")
+const repoRoot = resolve(packageRoot, "..", "..")
+
+describe("custom app production browser bundle", () => {
+  const roots: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+  })
+
+  test("executes subclass-based package exports and mounts React", async () => {
+    const root = await mkdtemp(join(tmpdir(), "sixb-app-browser-build-"))
+    roots.push(root)
+    await mkdir(join(root, "app"), { recursive: true })
+    await linkFixtureDependencies(root)
+    await writeFile(
+      join(root, "app", "page.tsx"),
+      `import { AsYouType, parsePhoneNumberFromString } from "libphonenumber-js"
+
+export default function Page() {
+  const formatted = new AsYouType("US").input("2125551234")
+  const parsed = parsePhoneNumberFromString("2125551234", "US")?.number
+  return <main data-testid="phone-result">{formatted}|{parsed}</main>
+}
+`
+    )
+
+    const buildScript = join(root, "build.ts")
+    await writeFile(
+      buildScript,
+      `import { createCustomApp } from ${JSON.stringify(join(packageRoot, "src", "createCustomApp.ts"))}
+
+const app = await createCustomApp({
+  rootDir: ${JSON.stringify(root)},
+  apiBaseUrl: "http://127.0.0.1:3000",
+  authEnabled: false,
+  agentRoutes: false,
+})
+const result = await app.build()
+if (!result.success) throw new Error((result.logs ?? []).join("\\n"))
+`
+    )
+    const build = await runBunScript(buildScript, root)
+    expect(build.exitCode, build.stderr).toBe(0)
+
+    const outdir = join(root, ".sixb", "dist", "app")
+    const html = await readFile(join(outdir, "index.html"), "utf-8")
+    const entryFile = html.match(/src="\/(app-[a-z0-9]+\.js)"/)?.[1]
+    expect(entryFile).toBeDefined()
+    expect(html).toContain('class="sixb-loading-shell"')
+
+    const executeScript = join(root, "execute.ts")
+    await writeFile(
+      executeScript,
+      `import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+import { GlobalWindow } from "happy-dom"
+
+const outdir = ${JSON.stringify(outdir)}
+const html = await readFile(join(outdir, "index.html"), "utf-8")
+const runtime = html.match(/window\\.__SIXB_RUNTIME__ = (.*);<\\/script>/)?.[1]
+if (!runtime) throw new Error("Built app runtime config is missing")
+
+const window = new GlobalWindow({ url: "http://127.0.0.1/" })
+Object.assign(window, { __SIXB_RUNTIME__: JSON.parse(runtime) })
+window.document.body.innerHTML = '<div id="root">loading</div>'
+Object.assign(globalThis, {
+  window,
+  self: window,
+  document: window.document,
+  navigator: window.navigator,
+  location: window.location,
+  history: window.history,
+  Node: window.Node,
+  Element: window.Element,
+  HTMLElement: window.HTMLElement,
+  HTMLAnchorElement: window.HTMLAnchorElement,
+  Event: window.Event,
+  MouseEvent: window.MouseEvent,
+  MutationObserver: window.MutationObserver,
+  getComputedStyle: window.getComputedStyle.bind(window),
+  requestAnimationFrame: window.requestAnimationFrame.bind(window),
+  cancelAnimationFrame: window.cancelAnimationFrame.bind(window),
+})
+
+await import(pathToFileURL(join(outdir, ${JSON.stringify(entryFile)})).href)
+await window.happyDOM.waitUntilComplete()
+await new Promise((resolve) => window.setTimeout(resolve, 0))
+
+const result = window.document.querySelector('[data-testid="phone-result"]')
+if (!result) throw new Error("React did not replace the production loading shell")
+console.log(result.textContent)
+`
+    )
+
+    const execution = await runBunScript(executeScript, root)
+    expect(execution.exitCode, execution.stderr).toBe(0)
+    expect(execution.stdout.trim()).toBe("(212) 555-1234|+12125551234")
+    // Regression proof: on Bun 1.3.14, restoring the resolver hook's old /^\.\.?\// filter
+    // makes this child fail with an undefined superclass before React can mount, while the build
+    // child still exits successfully.
+  }, 30_000)
+})
+
+async function linkFixtureDependencies(root: string): Promise<void> {
+  const dependencies = new Map([
+    ["react", join(packageRoot, "node_modules", "react")],
+    ["react-dom", join(packageRoot, "node_modules", "react-dom")],
+    ["react-router-dom", join(packageRoot, "node_modules", "react-router-dom")],
+    ["@tanstack/react-query", join(packageRoot, "node_modules", "@tanstack", "react-query")],
+    ["@sixb/client", join(repoRoot, "packages", "client")],
+    ["happy-dom", join(packageRoot, "node_modules", "happy-dom")],
+    ["libphonenumber-js", join(packageRoot, "node_modules", "libphonenumber-js")],
+  ])
+
+  for (const [name, source] of dependencies) {
+    const target = join(root, "node_modules", ...name.split("/"))
+    await mkdir(dirname(target), { recursive: true })
+    await symlink(source, target, "dir")
+  }
+}
+
+async function runBunScript(
+  scriptPath: string,
+  cwd: string
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn([process.execPath, "run", scriptPath], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const stdoutPromise = new Response(proc.stdout).text()
+  const stderrPromise = new Response(proc.stderr).text()
+  let timedOut = false
+  const timeout = setTimeout(() => {
+    timedOut = true
+    proc.kill()
+  }, 15_000)
+  const exitCode = await proc.exited
+  clearTimeout(timeout)
+  const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise])
+  if (timedOut) {
+    throw new Error(`Timed out running ${scriptPath}\n${stderr}`)
+  }
+  return { exitCode, stdout, stderr }
+}


### PR DESCRIPTION
## What changed

Production custom-app bundles could build successfully but fail immediately in the browser with an undefined superclass:

```text
ReferenceError: <minified superclass> is not defined
```

This was triggered by subclass-based package exports such as:

```ts
import { AsYouType, parsePhoneNumberFromString } from "libphonenumber-js"
```

## Root cause

The extensionless import plugin was registered for every relative import:

```ts
build.onResolve({ filter: /^\.\.?\// }, ...)
```

The callback returned `undefined` for explicit `.js` imports, but merely passing those imports through the plugin can corrupt dead-code elimination on affected Bun releases. The subclass wrapper remains in the output while its imported superclass is removed.

## Fix

Limit the plugin to relative imports whose final path segment has no extension:

```ts
build.onResolve({ filter: /^\.\.?\/(?:.*\/)?[^/.]+$/ }, ...)
```

This preserves Sixb’s extensionless workspace-import workaround while leaving explicit package imports entirely to Bun.

The regression test builds a production custom app with the original `libphonenumber-js` imports, executes the emitted bundle, and confirms React replaces the loading shell with the expected phone-number output. `libphonenumber-js@1.13.9` is pinned as a test-only development dependency.

Closes #485