### PR TITLE
linkedin: tighten campaign and creative write contracts

### DIFF
--- a/connectors/linkedin/src/resources/campaigns.ts
+++ b/connectors/linkedin/src/resources/campaigns.ts
@@ -61,8 +61,9 @@ export function createCampaignsResource(http: LinkedinHttp, accountId: string): 
     searchAll(options) {
       return listAllCursor(resource.search, options)
     },
-    create(input) {
+    async create(input) {
       assertNonEmpty(input.name, "campaign name")
+      assertRunSchedule(input.runSchedule)
       return http.create(path, input)
     },
     update(id, input, deleteFields) {
@@ -82,6 +83,16 @@ export function createCampaignsResource(http: LinkedinHttp, accountId: string): 
     },
   }
   return resource
+}
+
+function assertRunSchedule(
+  runSchedule: LinkedinCreateCampaignInput["runSchedule"] | undefined
+): void {
+  if (!runSchedule || !Number.isFinite(runSchedule.start)) {
+    throw new Error(
+      "[SixbLinkedin] campaign runSchedule.start is required and must be a finite timestamp."
+    )
+  }
 }
 
 function assertSearch(options: LinkedinCampaignSearchOptions): void {

--- a/connectors/linkedin/src/resources/creatives.ts
+++ b/connectors/linkedin/src/resources/creatives.ts
@@ -14,6 +14,7 @@ import type {
   LinkedinCursorPage,
   LinkedinSponsoredCreativeUrn,
 } from "../types/common"
+import { sponsoredCreativeUrn } from "../urns"
 
 export interface CreativesResource {
   get<TContent extends LinkedinCreativeContent = LinkedinCreativeContent>(
@@ -23,9 +24,11 @@ export interface CreativesResource {
   searchAll(options?: LinkedinCreativeSearchOptions): AsyncIterable<LinkedinCreative>
   create<TContent extends LinkedinCreativeContent = LinkedinCreativeContent>(
     input: LinkedinCreateCreativeInput<TContent>
-  ): Promise<LinkedinCreatedEntity>
+  ): Promise<LinkedinCreatedEntity<LinkedinSponsoredCreativeUrn>>
   /** Create a creative and its post in one `action=createInline` request. */
-  createInline(input: LinkedinCreateInlineCreativeInput): Promise<LinkedinCreatedEntity>
+  createInline(
+    input: LinkedinCreateInlineCreativeInput
+  ): Promise<LinkedinCreatedEntity<LinkedinSponsoredCreativeUrn>>
   update(id: LinkedinSponsoredCreativeUrn, input: LinkedinUpdateCreativeInput): Promise<void>
   deleteDraft(id: LinkedinSponsoredCreativeUrn): Promise<void>
 }
@@ -73,11 +76,13 @@ export function createCreativesResource(http: LinkedinHttp, accountId: string): 
     searchAll(options) {
       return listAllCursor(resource.search, options)
     },
-    create(input) {
-      return http.create(path, input)
+    async create(input) {
+      const created = await http.create(path, input)
+      return { id: sponsoredCreativeUrn(created.id) }
     },
-    createInline(input) {
-      return http.create(withQuery(path, { action: "createInline" }), input)
+    async createInline(input) {
+      const created = await http.create(withQuery(path, { action: "createInline" }), input)
+      return { id: sponsoredCreativeUrn(created.id) }
     },
     update(id, input) {
       if (Object.keys(input).length === 0) {

--- a/connectors/linkedin/src/types/advertising.ts
+++ b/connectors/linkedin/src/types/advertising.ts
@@ -299,11 +299,14 @@ export type LinkedinCreateCampaignInput = Omit<
   | "totalBudget"
   | "status"
   | "politicalIntent"
+  | "runSchedule"
 > &
   LinkedinCampaignBudget & {
     readonly status: "ACTIVE" | "DRAFT"
     /** Required by current LinkedIn Marketing API versions. */
     readonly politicalIntent: LinkedinPoliticalIntent
+    /** Required when creating a campaign, even though older read payloads may omit it. */
+    readonly runSchedule: LinkedinRunSchedule
   }
 
 export type LinkedinUpdateCampaignInput = Partial<

--- a/connectors/linkedin/src/types/common.ts
+++ b/connectors/linkedin/src/types/common.ts
@@ -85,12 +85,13 @@ export interface LinkedinOffsetOptions {
   readonly count?: number
 }
 
-export interface LinkedinCreatedEntity {
+export interface LinkedinCreatedEntity<TId extends string = string> {
   /** Value returned by LinkedIn in the `x-restli-id` response header. */
-  readonly id: string
+  readonly id: TId
 }
 
-export interface LinkedinCreatedResource<TResource> extends LinkedinCreatedEntity {
+export interface LinkedinCreatedResource<TResource, TId extends string = string>
+  extends LinkedinCreatedEntity<TId> {
   /** Parsed response body returned alongside the Rest.li identifier. */
   readonly data: TResource
 }

--- a/connectors/linkedin/src/urns.ts
+++ b/connectors/linkedin/src/urns.ts
@@ -35,5 +35,17 @@ export function sponsoredCampaignUrn(id: LinkedinId): LinkedinSponsoredCampaignU
 }
 
 export function sponsoredCreativeUrn(id: LinkedinId): LinkedinSponsoredCreativeUrn {
-  return `urn:li:sponsoredCreative:${pathId(id, "creative id")}`
+  const value = String(id)
+  const prefix = "urn:li:sponsoredCreative:"
+
+  if (value.startsWith(prefix)) {
+    pathId(value.slice(prefix.length), "creative id")
+    return value as LinkedinSponsoredCreativeUrn
+  }
+  if (value.startsWith("urn:li:")) {
+    throw new Error(
+      "[SixbLinkedin] creative id must be a positive numeric ID or a sponsored creative URN."
+    )
+  }
+  return `${prefix}${pathId(value, "creative id")}`
 }

--- a/connectors/linkedin/tests/campaigns.test.ts
+++ b/connectors/linkedin/tests/campaigns.test.ts
@@ -1,6 +1,32 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import type { LinkedinCreateCampaignInput } from "../src"
 import { sponsoredAccountUrn, sponsoredCampaignGroupUrn, sponsoredCampaignUrn } from "../src"
 import { createTestClient, empty, json, recorder } from "./helpers"
+
+// Regression guard: making runSchedule optional again must fail the connector test typecheck.
+const campaignRunScheduleIsRequired: undefined extends LinkedinCreateCampaignInput["runSchedule"]
+  ? false
+  : true = true
+
+const validCampaignInput = {
+  account: sponsoredAccountUrn(123),
+  campaignGroup: sponsoredCampaignGroupUrn(456),
+  name: "Awareness",
+  costType: "CPM",
+  locale: { country: "US", language: "en" },
+  offsiteDeliveryEnabled: false,
+  targetingCriteria: {
+    include: {
+      and: [{ or: { "urn:li:adTargetingFacet:locations": ["urn:li:geo:103644278"] } }],
+    },
+  },
+  type: "SPONSORED_UPDATES",
+  unitCost: { amount: "15", currencyCode: "USD" },
+  dailyBudget: { amount: "50", currencyCode: "USD" },
+  runSchedule: { start: 1_788_134_400_000 },
+  status: "ACTIVE",
+  politicalIntent: "NOT_POLITICAL",
+} as const satisfies LinkedinCreateCampaignInput
 
 const originalFetch = globalThis.fetch
 afterEach(() => {
@@ -22,34 +48,33 @@ describe("linkedin campaigns", () => {
   test("creates a campaign faithfully and returns the response id", async () => {
     const calls = recorder([empty(201, { "x-restli-id": "987" })])
     const client = await createTestClient()
-    const account = sponsoredAccountUrn(123)
 
-    const result = await client.adAccount(123).campaigns.create({
-      account,
-      campaignGroup: sponsoredCampaignGroupUrn(456),
-      name: "Awareness",
-      costType: "CPM",
-      locale: { country: "US", language: "en" },
-      offsiteDeliveryEnabled: false,
-      targetingCriteria: {
-        include: {
-          and: [{ or: { "urn:li:adTargetingFacet:locations": ["urn:li:geo:103644278"] } }],
-        },
-      },
-      type: "SPONSORED_UPDATES",
-      unitCost: { amount: "15", currencyCode: "USD" },
-      dailyBudget: { amount: "50", currencyCode: "USD" },
-      status: "ACTIVE",
-      politicalIntent: "NOT_POLITICAL",
-    })
+    const result = await client.adAccount(123).campaigns.create(validCampaignInput)
 
     const body = JSON.parse(calls[0]?.body ?? "{}")
     expect(result.id).toBe("987")
     expect(body.campaignGroup).toBe("urn:li:sponsoredCampaignGroup:456")
     expect(body.politicalIntent).toBe("NOT_POLITICAL")
+    expect(body.runSchedule).toEqual({ start: 1_788_134_400_000 })
+    expect(campaignRunScheduleIsRequired).toBe(true)
     expect(body.targetingCriteria.include.and[0].or).toEqual({
       "urn:li:adTargetingFacet:locations": ["urn:li:geo:103644278"],
     })
+  })
+
+  // Regression guard: remove assertRunSchedule from createCampaignsResource to reproduce failure.
+  test("rejects a campaign without a run schedule before calling LinkedIn", async () => {
+    const calls = recorder([])
+    const client = await createTestClient()
+    const { runSchedule, ...withoutRunSchedule } = validCampaignInput
+    expect(runSchedule).toBeDefined()
+
+    await expect(
+      client
+        .adAccount(123)
+        .campaigns.create(withoutRunSchedule as unknown as LinkedinCreateCampaignInput)
+    ).rejects.toThrow("campaign runSchedule.start is required")
+    expect(calls).toHaveLength(0)
   })
 
   test("updates and deletes campaigns with the documented wire methods", async () => {

--- a/connectors/linkedin/tests/creatives.test.ts
+++ b/connectors/linkedin/tests/creatives.test.ts
@@ -47,7 +47,8 @@ describe("linkedin creatives", () => {
     expect(page.totalCount).toBe(42)
   })
 
-  test("creates and updates creatives without reshaping content", async () => {
+  // Regression guard: widen create's result back to a string and the test typecheck fails at update.
+  test("returns a created creative URN that can be passed directly to update", async () => {
     const id = sponsoredCreativeUrn(789)
     const calls = recorder([empty(201, { "x-restli-id": id }), empty()])
     const client = await createTestClient()
@@ -57,11 +58,30 @@ describe("linkedin creatives", () => {
       intendedStatus: "DRAFT",
       content: { reference: "urn:li:ugcPost:42" },
     })
-    await client.adAccount(123).creatives.update(id, { intendedStatus: "ACTIVE" })
+    await client.adAccount(123).creatives.update(created.id, { intendedStatus: "ACTIVE" })
 
     expect(created.id).toBe(id)
     expect(JSON.parse(calls[0]?.body ?? "{}").content).toEqual({ reference: "urn:li:ugcPost:42" })
     expect(calls[1]?.headers.get("x-restli-method")).toBe("PARTIAL_UPDATE")
+    expect(new URL(calls[1]?.url ?? "").pathname).toEndWith(
+      "/creatives/urn%3Ali%3AsponsoredCreative%3A789"
+    )
+  })
+
+  // Regression guard: bypass sponsoredCreativeUrn in createInline to reproduce failure.
+  test("normalizes legacy numeric create ids and rejects invalid creative URNs", async () => {
+    recorder([
+      empty(201, { "x-restli-id": "789" }),
+      empty(201, { "x-restli-id": "urn:li:sponsoredCampaign:789" }),
+    ])
+    const client = await createTestClient()
+
+    const created = await client.adAccount(123).creatives.createInline({ creative: {} })
+    expect(created.id).toBe("urn:li:sponsoredCreative:789")
+
+    await expect(client.adAccount(123).creatives.createInline({ creative: {} })).rejects.toThrow(
+      "positive numeric ID or a sponsored creative URN"
+    )
   })
 
   test("enforces LinkedIn's creative page-size limit", async () => {

--- a/connectors/linkedin/tests/linkedin.test.ts
+++ b/connectors/linkedin/tests/linkedin.test.ts
@@ -77,6 +77,12 @@ describe("linkedin connector", () => {
     expect(sponsoredCampaignGroupUrn("456")).toBe("urn:li:sponsoredCampaignGroup:456")
     expect(sponsoredCampaignUrn(789)).toBe("urn:li:sponsoredCampaign:789")
     expect(sponsoredCreativeUrn(321)).toBe("urn:li:sponsoredCreative:321")
+    expect(sponsoredCreativeUrn("urn:li:sponsoredCreative:321")).toBe(
+      "urn:li:sponsoredCreative:321"
+    )
+    expect(() => sponsoredCreativeUrn("urn:li:sponsoredCampaign:321")).toThrow(
+      "positive numeric ID or a sponsored creative URN"
+    )
   })
 
   test("rejects an empty token returned by the managed token source", async () => {


### PR DESCRIPTION
## What changed

- Require `runSchedule` when creating an Ads campaign.
- Reject a missing or invalid `runSchedule.start` before sending the request.
- Return `LinkedinSponsoredCreativeUrn` from `creatives.create` and `createInline`.
- Accept numeric IDs and complete sponsored-creative URNs in `sponsoredCreativeUrn`.

## Why

| Issue | Result |
|---|---|
| Optional campaign schedule | Prevents LinkedIn sandbox rejection when `runSchedule` is omitted |
| Generic creative creation ID | Allows the returned ID to flow directly into `get`, `update`, and `deleteDraft` |
| Full URN rejected by helper | Supports the exact `x-restli-id` format returned by LinkedIn |

## Design choices

- Keep `runSchedule` optional on campaign reads and updates; require it only on creation.
- Validate creative IDs at the resource boundary instead of relying on a type cast.
- Keep `LinkedinCreatedEntity` backward compatible through a default generic ID type.

## Validation

- 53 LinkedIn connector tests
- Source and test typechecks
- Connector build
- Biome checks