### PR TITLE
agents: resolve execution plans from the model catalog

### DIFF
--- a/docs/runtime/overview.md
+++ b/docs/runtime/overview.md
@@ -73,10 +73,11 @@ The two surfaces use distinct namespaces:
 | `host.scheduler`, `host.close*()` | Process lifecycle | `host.scheduler.start()` |
 | `sixb` | Execution-bound domain operations and visible definitions | `sixb.workflows.requestById(input)` |
 
-Definition catalogs consistently expose `list()` and `getById(id)`. The execution SDK may add
-authorized operations and history below the matching primitive; it does not expose process
-lifecycle. Execution code uses `sixb.blobs` and `sixb.connector(definition)`; connector client
-resolution remains private to the host.
+Definition catalogs expose `list()` and `getById(id)`. The model catalog uses `list()` and
+`getByRef({ provider, modelId })` because a model binding has a structured identity rather than a
+Sixb definition id. The execution SDK may add authorized operations and history below the matching
+primitive; it does not expose process lifecycle. Execution code uses `sixb.blobs` and
+`sixb.connector(definition)`; connector client resolution remains private to the host.
 
 ### Typed objects
 

--- a/packages/agent-worker/src/execution-plan.ts
+++ b/packages/agent-worker/src/execution-plan.ts
@@ -1,0 +1,49 @@
+import type {
+  AgentDefinition,
+  AgentReasoningLevel,
+  AgentToolDefinition,
+  LanguageModelCatalog,
+} from "@sixb/core"
+import { createSixbError } from "@sixb/core/internal/errors"
+
+/**
+ * Fully resolved inputs shared by the agent execution engines.
+ *
+ * This internal runtime value is neither a durable run nor a public API contract. Source-specific
+ * adapters resolve it before entering the shared execution path.
+ */
+export interface ResolvedAgentExecutionPlan {
+  readonly model: AgentDefinition["model"]
+  readonly reasoning?: AgentReasoningLevel
+  readonly caching?: "auto" | "off"
+  readonly instructions: string
+  readonly tools: readonly AgentToolDefinition[]
+  readonly maxSteps: number
+}
+
+/** Adapt today's registered-agent definition to the source-neutral execution contract. */
+export function resolveAgentExecutionPlan(input: {
+  readonly agent: AgentDefinition
+  readonly models?: LanguageModelCatalog
+  readonly defaultMaxSteps: number
+}): ResolvedAgentExecutionPlan {
+  const { agent, models } = input
+  const ref = { provider: agent.model.providerId, modelId: agent.model.modelId }
+  const model = models?.getByRef(ref)?.model ?? (models === undefined ? agent.model : null)
+  if (model === null) {
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbAgentWorker] Agent '${agent.id}' references language model '${ref.provider}/${ref.modelId}', which is missing from the runtime catalog.`,
+      { details: { agentId: agent.id } }
+    )
+  }
+
+  return Object.freeze({
+    model,
+    instructions: agent.instructions,
+    tools: agent.tools,
+    maxSteps: agent.loop?.stopWhen?.maxSteps ?? input.defaultMaxSteps,
+    ...(agent.reasoning === undefined ? {} : { reasoning: agent.reasoning }),
+    ...(agent.loop?.caching === undefined ? {} : { caching: agent.loop.caching }),
+  })
+}

--- a/packages/agent-worker/src/run-agent-turn.ts
+++ b/packages/agent-worker/src/run-agent-turn.ts
@@ -1,4 +1,4 @@
-import type { AgentDefinition, AgentMessage, AgentMessagePart, Storage } from "@sixb/core"
+import type { AgentMessage, AgentMessagePart, Storage } from "@sixb/core"
 import { createAgentMessageId, runModelLoop, toModelMessages } from "@sixb/core/internal/agents"
 import { createSixbError } from "@sixb/core/internal/errors"
 import { isAbortError, QueueDeliveryLeaseLostError } from "@sixb/core/internal/workers"
@@ -17,6 +17,7 @@ import {
   toolResultAttachmentKey,
 } from "./attachments"
 import { AgentTurnTimeoutError } from "./errors"
+import type { ResolvedAgentExecutionPlan } from "./execution-plan"
 import { type AgentRunFailure, toAgentExecutionFailure } from "./failure"
 import { appendMessageAndFinishRunOrThrow, finishRunOrThrow } from "./finalize"
 import { agentTraceFromModelSteps, agentTraceFromPartialModelLoop } from "./model-adapters"
@@ -31,7 +32,7 @@ export const DEFAULT_MAX_STEPS = 100
 export interface RunAgentTurnInput {
   /** The worker's stable execution context (storage, tools, stream sink, and turn limits). */
   readonly context: AgentTurnContext
-  readonly agent: AgentDefinition
+  readonly plan: ResolvedAgentExecutionPlan
   /** The run this delivery reserved or reclaimed with its execution token. */
   readonly run: AgentRunRecord
   /** The worker's shutdown signal. */
@@ -44,8 +45,8 @@ export interface RunAgentTurnInput {
 
 /** Drive one provider-neutral model/tool turn to completion and persist it. */
 export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRecord> {
-  const { context, agent, run, signal } = input
-  const { id: projectId, storage, tools, defaultMaxSteps, turnTimeoutMs } = context
+  const { context, plan, run, signal } = input
+  const { id: projectId, storage, tools, turnTimeoutMs } = context
   const runId = run.id
   const executionToken = run.execution?.token
   if (!executionToken) {
@@ -73,7 +74,7 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
           messages: threadContext.retainedMessages,
           blobStorage: context.blobStorage,
           apiBaseUrl: context.apiBaseUrl,
-          inlineImages: modelSupportsInlineImages(agent.model),
+          inlineImages: modelSupportsInlineImages(plan.model),
           signal,
         })
       : undefined)
@@ -94,7 +95,7 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
         : undefined,
   })
 
-  const maxSteps = agent.loop?.stopWhen?.maxSteps ?? defaultMaxSteps
+  const maxSteps = plan.maxSteps
   const sandboxReadiness = monitorSandboxReadiness(context.sandboxReady)
   // Preflight and the answer share accounting and one deadline. Direct callers own their runtime.
   const ownsRuntime = input.runtime === undefined
@@ -137,7 +138,7 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
         run,
         executionToken,
         projectId,
-        modelId: agent.model.modelId,
+        modelId: plan.model.modelId,
         status: "failed",
         finishReason: "timeout",
         error: toAgentExecutionFailure(new AgentTurnTimeoutError(runId, turnTimeoutMs), {
@@ -162,7 +163,7 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
       run,
       executionToken,
       projectId,
-      modelId: agent.model.modelId,
+      modelId: plan.model.modelId,
       status: "cancelled",
       parts: interruptedParts,
     })
@@ -173,7 +174,7 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
     let result: Awaited<ReturnType<typeof runModelLoop>>
     try {
       result = await runModelLoop({
-        model: usageRecorder.wrapModel(agent.model),
+        model: usageRecorder.wrapModel(plan.model),
         messages: [
           {
             role: "system",
@@ -182,8 +183,8 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
           ...modelMessages,
         ],
         tools,
-        ...(agent.reasoning === undefined ? {} : { reasoning: agent.reasoning }),
-        ...(agent.loop?.caching === undefined ? {} : { caching: agent.loop.caching }),
+        ...(plan.reasoning === undefined ? {} : { reasoning: plan.reasoning }),
+        ...(plan.caching === undefined ? {} : { caching: plan.caching }),
         maxSteps,
         finalStepInstruction: DEFAULT_AGENT_FINAL_STEP_INSTRUCTION,
         ...(context.prepareStep === undefined ? {} : { prepareStep: context.prepareStep }),
@@ -202,10 +203,10 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
     interruptedParts =
       result.status === "aborted"
         ? agentTraceFromPartialModelLoop(result.steps, result.partialContent, {
-            agentId: agent.id,
+            agentId: run.agentId,
             runId,
           })
-        : agentTraceFromModelSteps(result.steps, { agentId: agent.id, runId })
+        : agentTraceFromModelSteps(result.steps, { agentId: run.agentId, runId })
 
     const interruptedAfterModel = await finalizeIfInterrupted()
     if (interruptedAfterModel) return interruptedAfterModel
@@ -217,7 +218,7 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
         run,
         executionToken,
         projectId,
-        modelId: agent.model.modelId,
+        modelId: plan.model.modelId,
         status: "cancelled",
         parts: interruptedParts,
       })
@@ -268,7 +269,7 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
         id: runId,
         executionToken,
         status: "succeeded",
-        modelId: agent.model.modelId,
+        modelId: plan.model.modelId,
         finishReason,
         ...(outputAttachments.diagnostics.length === 0
           ? {}

--- a/packages/agent-worker/src/run-environment.ts
+++ b/packages/agent-worker/src/run-environment.ts
@@ -1,4 +1,4 @@
-import type { AgentDefinition, Sandbox } from "@sixb/core"
+import type { Sandbox } from "@sixb/core"
 import { resolveLoggingService } from "@sixb/core/internal/logging"
 import type { WorkflowIOSnapshot } from "@sixb/core/internal/workflows"
 import type { ModelTool } from "@sixb/core/models"
@@ -16,6 +16,7 @@ import {
   type PreparedAgentAttachmentContext,
   prepareAgentAttachments,
 } from "./attachments"
+import type { ResolvedAgentExecutionPlan } from "./execution-plan"
 import { modelToolsFromAgentDefinitions } from "./model-adapters"
 import { prepareAgentSandboxApiContext } from "./sandbox-api-context"
 import { AgentSandboxFileRegistry } from "./sandbox-file-registry"
@@ -35,7 +36,7 @@ export interface AgentExecutionEnvironment {
 
 interface CreateAgentEnvironmentInput {
   readonly context: AgentExecutionContext
-  readonly agent: AgentDefinition
+  readonly plan: ResolvedAgentExecutionPlan
   readonly signal?: AbortSignal
   /**
    * Sink for a sandbox teardown that outlives dispose() (the model answered before the boot
@@ -62,7 +63,7 @@ export interface CreateWorkflowAgentNodeEnvironmentInput extends CreateAgentEnvi
 export async function createConversationAgentEnvironment(
   input: CreateConversationAgentEnvironmentInput
 ): Promise<AgentExecutionEnvironment> {
-  const { context, agent, run } = input
+  const { context, plan, run } = input
 
   const apiBaseUrl = createAgentApiGatewayBaseUrl({
     apiBaseUrl: context.apiBaseUrl,
@@ -80,7 +81,7 @@ export async function createConversationAgentEnvironment(
           order: "asc",
         })
         .then((history) => history.messages),
-    modelSupportsInlineImages(agent.model),
+    modelSupportsInlineImages(plan.model),
   ])
   const attachmentContext = await prepareAgentAttachments({
     projectId: context.id,
@@ -95,7 +96,8 @@ export async function createConversationAgentEnvironment(
   return startAgentEnvironment({
     mode: "conversation",
     context,
-    agent,
+    agentId: run.agentId,
+    plan,
     runId: run.id,
     threadId: run.threadId,
     apiBaseUrl,
@@ -109,7 +111,7 @@ export async function createConversationAgentEnvironment(
 export async function createWorkflowAgentNodeEnvironment(
   input: CreateWorkflowAgentNodeEnvironmentInput
 ): Promise<AgentExecutionEnvironment> {
-  const { context, agent, run } = input
+  const { context, plan, run } = input
   const execution = run.execution
   if (!execution) {
     throw new Error(
@@ -128,7 +130,8 @@ export async function createWorkflowAgentNodeEnvironment(
   return startAgentEnvironment({
     mode: "workflow-task",
     context,
-    agent,
+    agentId: run.agentId,
+    plan,
     runId: run.nodeRunId,
     apiBaseUrl: createAgentApiGatewayBaseUrl({
       apiBaseUrl: context.apiBaseUrl,
@@ -143,6 +146,7 @@ export async function createWorkflowAgentNodeEnvironment(
 }
 
 interface AgentEnvironmentSetup extends CreateAgentEnvironmentInput {
+  readonly agentId: string
   readonly mode: AgentExecutionMode
   readonly runId: string
   readonly threadId?: string
@@ -156,14 +160,15 @@ interface AgentEnvironmentSetup extends CreateAgentEnvironmentInput {
  * Sandbox boot stays concurrent with the model call; sandbox tools await it only when used.
  */
 function startAgentEnvironment(input: AgentEnvironmentSetup): AgentExecutionEnvironment {
-  const { mode, context, agent, runId, threadId, apiBaseUrl, attachmentContext, skills } = input
+  const { mode, context, agentId, plan, runId, threadId, apiBaseUrl, attachmentContext, skills } =
+    input
 
   const logSession = resolveLoggingService(context.id, context.logging).startExecution({
     kind: "agent",
     id: runId,
   })
   const logger = logSession.logger.child({
-    agentId: agent.id,
+    agentId,
     ...(threadId ? { threadId } : {}),
   })
   let ready: Promise<AgentSandboxHandle>
@@ -187,17 +192,17 @@ function startAgentEnvironment(input: AgentEnvironmentSetup): AgentExecutionEnvi
     })
   const tools = [
     ...modelToolsFromAgentDefinitions({
-      definitions: agent.tools,
+      definitions: plan.tools,
       valueTypesById: context.valueTypesById,
-      run: { id: runId, agentId: agent.id, ...(threadId ? { threadId } : {}) },
+      run: { id: runId, agentId: agentId, ...(threadId ? { threadId } : {}) },
       connector: context.connector,
       logger,
       artifactsForToolCall,
       toolResultToModelOutput: (output) => mediaBridge.toModelOutput(output),
       errorDetails:
         mode === "conversation"
-          ? { agentId: agent.id, runId }
-          : { agentId: agent.id, nodeRunId: runId },
+          ? { agentId: agentId, runId }
+          : { agentId: agentId, nodeRunId: runId },
     }),
   ]
 
@@ -222,7 +227,7 @@ function startAgentEnvironment(input: AgentEnvironmentSetup): AgentExecutionEnvi
 
   ready = provisionSandbox({
     context,
-    agent,
+    agentId,
     run: { id: runId, ...(threadId ? { threadId } : {}) },
     apiBaseUrl,
     apiOrigin: new URL(apiBaseUrl).origin,
@@ -249,12 +254,11 @@ function startAgentEnvironment(input: AgentEnvironmentSetup): AgentExecutionEnvi
       attachmentContext,
       tools,
       prepareStep: mediaBridge.prepareStep,
-      systemPrompt: renderAgentSystemPrompt({ mode, instructions: agent.instructions, skills }),
+      systemPrompt: renderAgentSystemPrompt({ mode, instructions: plan.instructions, skills }),
       sandboxReady: ready,
       sandboxWasUsed: () => sandboxWasUsed,
       streamSink: context.streamSink,
       recoverAiModelCall: context.recoverAiModelCall,
-      defaultMaxSteps: context.defaultMaxSteps,
       turnTimeoutMs: context.turnTimeoutMs,
     },
     async dispose() {
@@ -268,7 +272,7 @@ function startAgentEnvironment(input: AgentEnvironmentSetup): AgentExecutionEnvi
 
 interface ProvisionSandboxInput {
   readonly context: AgentExecutionContext
-  readonly agent: AgentDefinition
+  readonly agentId: string
   readonly run: { readonly id: string; readonly threadId?: string }
   readonly apiBaseUrl: string
   readonly apiOrigin: string
@@ -277,7 +281,7 @@ interface ProvisionSandboxInput {
 }
 
 async function provisionSandbox(input: ProvisionSandboxInput): Promise<AgentSandboxHandle> {
-  const { context, agent, run, apiBaseUrl, apiOrigin, skills } = input
+  const { context, agentId, run, apiBaseUrl, apiOrigin, skills } = input
   let sandbox: Sandbox | null = null
   try {
     sandbox = await context.sandboxes.create({
@@ -287,7 +291,7 @@ async function provisionSandbox(input: ProvisionSandboxInput): Promise<AgentSand
       sandbox,
       apiBaseUrl,
       projectId: context.id,
-      agentId: agent.id,
+      agentId,
       ...(run.threadId ? { threadId: run.threadId } : {}),
       runId: run.id,
       attachments: input.attachmentContext,

--- a/packages/agent-worker/src/run-workflow-agent-node.ts
+++ b/packages/agent-worker/src/run-workflow-agent-node.ts
@@ -1,4 +1,4 @@
-import type { AgentDefinition, AgentMessagePart, SchemaOrRef, ValueType } from "@sixb/core"
+import type { AgentMessagePart, SchemaOrRef, ValueType } from "@sixb/core"
 import { runModelLoop } from "@sixb/core/internal/agents"
 import { createSixbError } from "@sixb/core/internal/errors"
 import { schemaRecordToJsonSchema } from "@sixb/core/internal/ontology"
@@ -15,6 +15,7 @@ import {
   DEFAULT_AGENT_FINAL_STEP_INSTRUCTION,
   renderWorkflowOutputFinalizerPrompt,
 } from "./agent-prompt"
+import type { ResolvedAgentExecutionPlan } from "./execution-plan"
 import { agentTraceFromModelSteps } from "./model-adapters"
 import type { AiModelCallRecorder } from "./model-call-recorder"
 import { monitorSandboxReadiness } from "./sandbox-readiness"
@@ -24,7 +25,8 @@ const WORKFLOW_OUTPUT_FINALIZATION_ATTEMPTS = 2
 
 export interface RunWorkflowAgentNodeInput {
   readonly context: AgentTurnContext
-  readonly agent: AgentDefinition
+  readonly agentId: string
+  readonly plan: ResolvedAgentExecutionPlan
   readonly agentStep: AgentStepDefinition
   readonly workflowId: string
   readonly workflowRunId: string
@@ -67,7 +69,7 @@ export class WorkflowAgentNodeExecutionError extends Error {
 export async function runWorkflowAgentNode(
   input: RunWorkflowAgentNodeInput
 ): Promise<WorkflowAgentNodeResult> {
-  const maxSteps = input.agent.loop?.stopWhen?.maxSteps ?? input.context.defaultMaxSteps
+  const maxSteps = input.plan.maxSteps
   const outputSchema = schemaRecordToJsonSchema({
     shape: input.agentStep.output as Readonly<Record<string, SchemaOrRef>>,
     valueTypesById: input.valueTypesById,
@@ -87,7 +89,7 @@ export async function runWorkflowAgentNode(
   const abortSignal = AbortSignal.any([input.signal, timeout.signal, sandboxReadiness.signal])
   const completedSteps: ModelStep[] = []
   const traceDetails = {
-    agentId: input.agent.id,
+    agentId: input.agentId,
     workflowId: input.workflowId,
     workflowRunId: input.workflowRunId,
     nodeRunId: input.nodeRunId,
@@ -96,7 +98,7 @@ export async function runWorkflowAgentNode(
   let finishReason: AgentRunFinishReason | undefined
   try {
     const research = await runModelLoop({
-      model: input.usageRecorder.wrapModel(input.agent.model),
+      model: input.usageRecorder.wrapModel(input.plan.model),
       messages: [
         {
           role: "system",
@@ -105,8 +107,8 @@ export async function runWorkflowAgentNode(
         { role: "user", content: [{ type: "text", text: input.prompt }] },
       ],
       tools: input.context.tools,
-      ...(input.agent.reasoning === undefined ? {} : { reasoning: input.agent.reasoning }),
-      ...(input.agent.loop?.caching === undefined ? {} : { caching: input.agent.loop.caching }),
+      ...(input.plan.reasoning === undefined ? {} : { reasoning: input.plan.reasoning }),
+      ...(input.plan.caching === undefined ? {} : { caching: input.plan.caching }),
       maxSteps,
       finalStepInstruction: DEFAULT_AGENT_FINAL_STEP_INSTRUCTION,
       ...(input.context.prepareStep === undefined
@@ -129,7 +131,7 @@ export async function runWorkflowAgentNode(
     if (researchText.trim().length === 0) {
       throw createSixbError(
         "agent.execution_failed",
-        `[SixbAgentWorker] Workflow agent '${input.agent.id}' produced no final answer to structure.`,
+        `[SixbAgentWorker] Workflow agent '${input.agentId}' produced no final answer to structure.`,
         { details: traceDetails }
       )
     }
@@ -138,7 +140,7 @@ export async function runWorkflowAgentNode(
     let finalizerMessages: ModelMessage[] = [
       {
         role: "system",
-        content: renderWorkflowOutputFinalizerPrompt({ instructions: input.agent.instructions }),
+        content: renderWorkflowOutputFinalizerPrompt({ instructions: input.plan.instructions }),
       },
       {
         role: "user",
@@ -159,7 +161,7 @@ export async function runWorkflowAgentNode(
     for (let attempt = 1; attempt <= WORKFLOW_OUTPUT_FINALIZATION_ATTEMPTS; attempt += 1) {
       try {
         const finalization = await runModelLoop({
-          model: input.usageRecorder.wrapModel(input.agent.model),
+          model: input.usageRecorder.wrapModel(input.plan.model),
           messages: finalizerMessages,
           output: {
             name: input.agentStep.id,
@@ -208,7 +210,7 @@ export async function runWorkflowAgentNode(
     if (structuredValue === undefined) {
       throw createSixbError(
         "internal.unexpected",
-        `[SixbAgentWorker] Workflow output finalization for agent '${input.agent.id}' ended without a value.`,
+        `[SixbAgentWorker] Workflow output finalization for agent '${input.agentId}' ended without a value.`,
         { details: traceDetails }
       )
     }
@@ -221,7 +223,7 @@ export async function runWorkflowAgentNode(
         value: structuredValue,
         valueTypesById: input.valueTypesById,
       }),
-      modelId: input.agent.model.modelId,
+      modelId: input.plan.model.modelId,
       finishReason,
       trace: agentTraceFromModelSteps(completedSteps, traceDetails),
     }

--- a/packages/agent-worker/src/types.ts
+++ b/packages/agent-worker/src/types.ts
@@ -50,16 +50,19 @@ export type RecoverAiModelCall = (input: RecoverAiModelCallInput) => Promise<voi
 
 /**
  * The host surface the agent worker is constructed with. `SixbHost` satisfies it structurally, so
- * cohosting passes the host directly. The worker resolves a run's model through
- * `definitions.agents.getById` (the model is a non-serialisable language model, never sent over the
- * wire).
+ * cohosting passes the host directly. Registered agents provide today's execution configuration;
+ * when configured, the model catalog provides the authoritative live model binding. Models are
+ * non-serialisable and never sent over the wire.
  */
 export interface AgentWorkerHost extends AgentExecutionHost {
   readonly broker: Broker
   readonly events: DomainEventLog
   readonly storage: Storage
   readonly queues: Queues
-  readonly definitions: Pick<SixbDefinitions, "agents" | "workflows" | "ontology" | "security">
+  readonly definitions: Pick<
+    SixbDefinitions,
+    "agents" | "workflows" | "ontology" | "security" | "models"
+  >
   readonly sandboxes?: SandboxFactory
   readonly projectRoot?: string
   readonly logging?: LoggingService
@@ -114,7 +117,6 @@ export interface AgentTurnContext {
   readonly sandboxWasUsed?: () => boolean
   readonly streamSink: StreamSink
   readonly recoverAiModelCall: RecoverAiModelCall
-  readonly defaultMaxSteps: number
   readonly turnTimeoutMs: number
 }
 

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -26,6 +26,7 @@ import {
   AgentUsageRecordingError,
 } from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
+import { resolveAgentExecutionPlan } from "./execution-plan"
 import { type AgentRunFailure, toAgentExecutionFailure, toAgentRunFailure } from "./failure"
 import { finishRunOrThrow } from "./finalize"
 import {
@@ -112,10 +113,21 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
   }
 
   override async start(): Promise<void> {
-    if (this.context) {
+    const context = this.context
+    if (context) {
+      // Resolve the project binding before pinning its metadata and output budget.
       const [prepared] = await Promise.all([
-        prepareAgentModels(this.agents),
-        this.context.agentSkills,
+        prepareAgentModels(
+          this.agents.map((agent) => ({
+            ...agent,
+            model: resolveAgentExecutionPlan({
+              agent,
+              models: this.host.definitions.models?.language,
+              defaultMaxSteps: context.defaultMaxSteps,
+            }).model,
+          }))
+        ),
+        context.agentSkills,
       ])
       this.contextBudgets = prepared.budgets
       this.models = prepared.models
@@ -237,6 +249,10 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
       }
       throw error
     }
+    const plan = resolveAgentExecutionPlan({
+      agent,
+      defaultMaxSteps: context.defaultMaxSteps,
+    })
 
     const durableExecution = await context.storage.executions.getById({
       projectId: context.id,
@@ -274,7 +290,7 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
 
     const reservation = await this.startOrReclaim(context, {
       run: queuedRun,
-      agent,
+      modelId: plan.model.modelId,
       execution: freshExecution(delivery.leaseExpiresAt),
     })
     if (reservation.kind === "skip") {
@@ -335,7 +351,7 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
       })
       environment = await createConversationAgentEnvironment({
         context: executionContext,
-        agent,
+        plan,
         run,
         signal: turnSignal,
         messages: prepared.threadContext.retainedMessages,
@@ -345,7 +361,7 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
       runtime.assertCanContinue()
       await runAgentTurn({
         context: environment.turnContext,
-        agent,
+        plan,
         run,
         signal: turnSignal,
         runtime,
@@ -582,7 +598,7 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
     context: AgentWorkerContext,
     input: {
       readonly run: AgentRunRecord
-      readonly agent: AgentDefinition
+      readonly modelId: string
       readonly execution: AgentRunExecution
     }
   ): Promise<Reservation> {
@@ -593,7 +609,7 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
         run: await context.storage.agents.runs.start({
           projectId: context.id,
           id: run.id,
-          modelId: input.agent.model.modelId,
+          modelId: input.modelId,
           execution: input.execution,
         }),
       }

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -40,6 +40,7 @@ import type {
 import { AGENT_RUN_FAILURE_CODES, WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import { AgentUsageRecordingError } from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
+import { resolveAgentExecutionPlan } from "./execution-plan"
 import { toAgentExecutionFailure } from "./failure"
 import { createAiModelCallLimitController } from "./model-call-limits"
 import { AiModelCallRecorder } from "./model-call-recorder"
@@ -98,6 +99,10 @@ export async function executeWorkflowAgentNode(
     durableExecution,
     valueTypesById,
   } = loaded
+  const plan = resolveAgentExecutionPlan({
+    agent,
+    defaultMaxSteps: context.defaultMaxSteps,
+  })
   const resolved = await resolveAgentExecutionAuthorization({
     auth: context.storage.auth,
     projectId: context.id,
@@ -118,7 +123,7 @@ export async function executeWorkflowAgentNode(
     runs,
     executionRecord,
     nodeRun,
-    agent,
+    modelId: plan.model.modelId,
     execution: freshWorkflowExecution(delivery.leaseExpiresAt),
   })
   const executionToken = reserved.execution?.token
@@ -168,7 +173,7 @@ export async function executeWorkflowAgentNode(
     })
     environment = await createWorkflowAgentNodeEnvironment({
       context: executionContext,
-      agent,
+      plan,
       run: reserved,
       nodeInput: nodeRun.input,
       signal: turnSignal,
@@ -176,7 +181,8 @@ export async function executeWorkflowAgentNode(
     })
     const result = await runWorkflowAgentNode({
       context: environment.turnContext,
-      agent,
+      agentId: agent.id,
+      plan,
       agentStep: node.agentStep,
       workflowId: workflow.id,
       workflowRunId: nodeRun.workflowRunId,
@@ -241,7 +247,8 @@ export async function executeWorkflowAgentNode(
     const failed = await finishWorkflowAgentNodeFailed({
       context,
       nodeRun,
-      agent,
+      agentId: agent.id,
+      modelId: plan.model.modelId,
       executionToken,
       status,
       error: executionError,
@@ -397,14 +404,14 @@ async function reserveWorkflowAgentNode(input: {
   readonly runs: WorkflowRunStorage
   readonly executionRecord: WorkflowAgentNodeRunRecord
   readonly nodeRun: WorkflowNodeRunRecord
-  readonly agent: AgentDefinition
+  readonly modelId: string
   readonly execution: WorkflowAgentNodeRunExecution
 }): Promise<WorkflowAgentNodeRunRecord> {
   if (input.executionRecord.status === "queued") {
     return input.runs.agentNodes.start({
       projectId: input.executionRecord.projectId,
       nodeRunId: input.nodeRun.id,
-      modelId: input.agent.model.modelId,
+      modelId: input.modelId,
       execution: input.execution,
     })
   }
@@ -482,7 +489,8 @@ async function finishWorkflowAgentNodeSucceeded(input: {
 async function finishWorkflowAgentNodeFailed(input: {
   readonly context: AgentWorkerContext
   readonly nodeRun: WorkflowNodeRunRecord
-  readonly agent: AgentDefinition
+  readonly agentId: string
+  readonly modelId: string
   readonly executionToken: string
   readonly status: "failed" | "cancelled"
   readonly error: unknown
@@ -496,7 +504,7 @@ async function finishWorkflowAgentNodeFailed(input: {
 }> {
   const at = new Date()
   const agentErrorDetails = {
-    ...workflowAgentErrorDetails(input.agent.id, input.nodeRun),
+    ...workflowAgentErrorDetails(input.agentId, input.nodeRun),
     ...(input.failurePhase === undefined ? {} : { failurePhase: input.failurePhase }),
   }
   const agentExecutionError =
@@ -512,7 +520,7 @@ async function finishWorkflowAgentNodeFailed(input: {
             workflowRunId: input.nodeRun.workflowRunId,
             nodeId: input.nodeRun.nodeId,
             nodeRunId: input.nodeRun.id,
-            child: { type: "agent", agentId: input.agent.id },
+            child: { type: "agent", agentId: input.agentId },
           })
       : createSixbError(
           "runtime.cancelled",
@@ -532,7 +540,7 @@ async function finishWorkflowAgentNodeFailed(input: {
       throw createSixbError(
         "internal.unexpected",
         "[SixbAgentWorker] Workflow storage disappeared during finalization.",
-        { details: workflowAgentErrorDetails(input.agent.id, input.nodeRun) }
+        { details: workflowAgentErrorDetails(input.agentId, input.nodeRun) }
       )
     }
     await runs.agentNodes.finish({
@@ -540,7 +548,7 @@ async function finishWorkflowAgentNodeFailed(input: {
       nodeRunId: input.nodeRun.id,
       executionToken: input.executionToken,
       status: input.status,
-      modelId: input.agent.model.modelId,
+      modelId: input.modelId,
       finishReason: input.finishReason,
       trace: input.trace,
       error: toAgentExecutionFailure(agentExecutionError, {

--- a/packages/agent-worker/tests/execution-plan.test.ts
+++ b/packages/agent-worker/tests/execution-plan.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test"
+import {
+  defineAgent,
+  defineAgentTool,
+  type LanguageModelCatalog,
+  type LanguageModelEntry,
+  type LanguageModelRef,
+} from "@sixb/core"
+import { resolveAgentExecutionPlan } from "../src/execution-plan"
+import { WorkerTestModel } from "./worker-model-fixture"
+
+describe("resolveAgentExecutionPlan", () => {
+  test("maps executable configuration and resolves the worker step default", () => {
+    const model = new WorkerTestModel({ modelId: "mock-model" })
+    const lookup = defineAgentTool("lookup")
+      .description("Look up a value.")
+      .input({ query: "string" })
+      .run(({ input }) => ({ result: input.query }))
+    const configured = defineAgent("configured", {
+      name: "Configured",
+      model,
+      reasoning: "high",
+      instructions: "Resolve the request.",
+      tools: [lookup],
+      loop: { stopWhen: { maxSteps: 12 }, caching: "off" },
+    })
+
+    const configuredPlan = resolveAgentExecutionPlan({
+      agent: configured,
+      defaultMaxSteps: 100,
+    })
+
+    expect(configuredPlan).toEqual({
+      model,
+      reasoning: "high",
+      instructions: "Resolve the request.",
+      tools: [lookup],
+      maxSteps: 12,
+      caching: "off",
+    })
+    expect(Object.isFrozen(configuredPlan)).toBe(true)
+    expect("agentId" in configuredPlan).toBe(false)
+    expect("groupIds" in configuredPlan).toBe(false)
+    expect("name" in configuredPlan).toBe(false)
+
+    const defaulted = defineAgent("defaulted", {
+      name: "Defaulted",
+      model,
+      instructions: "Use the worker default.",
+    })
+
+    expect(resolveAgentExecutionPlan({ agent: defaulted, defaultMaxSteps: 7 }).maxSteps).toBe(7)
+  })
+
+  test("uses the project catalog as the authoritative model binding", () => {
+    const declaredModel = new WorkerTestModel({ modelId: "shared-model" })
+    const catalogModel = new WorkerTestModel({ modelId: "shared-model" })
+    const agent = defineAgent("configured", {
+      name: "Configured",
+      model: declaredModel,
+      instructions: "Resolve the request.",
+    })
+    const entry: LanguageModelEntry = Object.freeze({
+      provider: catalogModel.providerId,
+      modelId: catalogModel.modelId,
+      model: catalogModel,
+    })
+    const models: LanguageModelCatalog = Object.freeze({
+      default: entry,
+      list: () => [entry],
+      getByRef: (ref: LanguageModelRef) =>
+        ref.provider === entry.provider && ref.modelId === entry.modelId ? entry : null,
+    })
+
+    const plan = resolveAgentExecutionPlan({ agent, models, defaultMaxSteps: 100 })
+
+    expect(plan.model).toBe(catalogModel)
+    expect(plan.model).not.toBe(declaredModel)
+  })
+
+  test("fails closed when an agent model is missing from a configured catalog", () => {
+    const model = new WorkerTestModel({ modelId: "missing-model" })
+    const agent = defineAgent("missing", {
+      name: "Missing",
+      model,
+      instructions: "Resolve the request.",
+    })
+    const otherModel = new WorkerTestModel({ modelId: "other-model" })
+    const entry: LanguageModelEntry = {
+      provider: otherModel.providerId,
+      modelId: otherModel.modelId,
+      model: otherModel,
+    }
+    const models: LanguageModelCatalog = {
+      default: entry,
+      list: () => [entry],
+      getByRef: () => null,
+    }
+
+    expect(() => resolveAgentExecutionPlan({ agent, models, defaultMaxSteps: 100 })).toThrow(
+      /missing from the runtime catalog/
+    )
+  })
+})

--- a/packages/agent-worker/tests/thread-context.test.ts
+++ b/packages/agent-worker/tests/thread-context.test.ts
@@ -3,6 +3,7 @@ import { defineAgent, InMemoryBlobStorage, InMemoryStorage, type Storage } from 
 import { toModelMessages } from "@sixb/core/internal/agents"
 import type { ModelMessage, ModelUsage } from "@sixb/core/models"
 import { createTestAgentExecution } from "@sixb/core/testing"
+import { resolveAgentExecutionPlan } from "../src/execution-plan"
 import { runAgentTurn } from "../src/run-agent-turn"
 import { NOOP_STREAM_SINK } from "../src/stream-sink"
 import type { AgentWorkerStorage } from "../src/types"
@@ -181,10 +182,9 @@ async function runAndCaptureModelPrompt(withCheckpoint: boolean) {
       systemPrompt: "Test system prompt.",
       streamSink: NOOP_STREAM_SINK,
       recoverAiModelCall: async () => {},
-      defaultMaxSteps: 4,
       turnTimeoutMs: 60_000,
     },
-    agent,
+    plan: resolveAgentExecutionPlan({ agent, defaultMaxSteps: 4 }),
     run: seeded.run,
     signal: new AbortController().signal,
   })

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -6,6 +6,7 @@ import { exa } from "@sixb/connector-exa"
 import { exaWebFetch, exaWebSearch } from "@sixb/connector-exa/agent-tools"
 import {
   type AgentContextConfig,
+  type AgentDefinition,
   type AgentReasoningLevel,
   AgentRequestError,
   type AgentsRuntime,
@@ -27,6 +28,7 @@ import {
   InMemoryLakeStorage,
   InMemoryQueues,
   InMemoryStorage,
+  type ModelCatalogInput,
   type RunCommandOptions,
   type Sandbox,
   type SandboxFactory,
@@ -74,6 +76,7 @@ import { loadAgentSkills } from "../src/agent-skills"
 import { normalizeApiBaseUrl } from "../src/api-url"
 import { prepareAgentAttachments } from "../src/attachments"
 import { AgentExecutionLostError, AgentFinalizationError } from "../src/errors"
+import { resolveAgentExecutionPlan } from "../src/execution-plan"
 import { finishRunOrThrow } from "../src/finalize"
 import { enqueueAiModelCallRecovery } from "../src/model-call-recovery"
 import { runAgentTurn } from "../src/run-agent-turn"
@@ -414,6 +417,23 @@ function structuredAnswerModel(): WorkerTestModel {
       usage: USAGE,
       warnings: [],
     }),
+  })
+}
+
+function trackedStructuredAnswerModel(onCall: (phase: "research" | "finalize") => void) {
+  return new WorkerTestModel({
+    modelId: "catalog-workflow-model",
+    generate: async (request) => {
+      onCall(request.responseFormat?.type === "json" ? "finalize" : "research")
+      expect(request.maxOutputTokens).toBe(16_384)
+      return {
+        content: [
+          { type: "text", text: JSON.stringify({ answer: "Project Alpha", confidence: 0.96 }) },
+        ],
+        finishReason: "stop",
+        usage: USAGE,
+      }
+    },
   })
 }
 
@@ -1009,6 +1029,7 @@ function buildSixb(
     readonly agentTools?: readonly AgentToolDefinition[]
     readonly connectors?: readonly ConnectorDefinition[]
     readonly context?: AgentContextConfig
+    readonly models?: ModelCatalogInput
   } = {}
 ): TestSixb {
   const agent = defineAgent("assistant", {
@@ -1035,6 +1056,7 @@ function buildSixb(
     blobStorage: new InMemoryBlobStorage(),
     queues: new InMemoryQueues(),
     sandboxes,
+    ...(options.models === undefined ? {} : { models: options.models }),
     ...(options.projectRoot === undefined ? {} : { projectRoot: options.projectRoot }),
   })
 }
@@ -1105,6 +1127,7 @@ async function seedRequesterUser(storage: Storage, principal = REQUESTER): Promi
 
 async function queueWorkflowAgentNode(input: {
   readonly model: LanguageModel
+  readonly models?: ModelCatalogInput
   readonly tools?: readonly AgentToolDefinition[]
   readonly storage?: Storage
   readonly sandboxes?: SandboxFactory
@@ -1136,6 +1159,7 @@ async function queueWorkflowAgentNode(input: {
     blobStorage: new InMemoryBlobStorage(),
     queues: new InMemoryQueues(),
     sandboxes: input.sandboxes ?? new RecordingSandboxFactory(),
+    ...(input.models === undefined ? {} : { models: input.models }),
   })
   const runs = sixb.storage.workflowRuns
   if (!runs) throw new Error("expected workflow run storage")
@@ -1286,6 +1310,16 @@ function workerStorageOf(storage: Storage): AgentWorkerStorage {
     throw new Error("expected AI cost storage")
   }
   return storage as AgentWorkerStorage
+}
+
+function executionPlanFor(agent: AgentDefinition, defaultMaxSteps = 4) {
+  return resolveAgentExecutionPlan({ agent, defaultMaxSteps })
+}
+
+function requiredAgent(sixb: TestSixb, agentId = "assistant"): AgentDefinition {
+  const agent = sixb.definitions.agents.getById(agentId)
+  if (!agent) throw new Error(`Expected test agent '${agentId}'.`)
+  return agent
 }
 
 async function buildAgentWorkerContext(
@@ -2548,6 +2582,33 @@ describe("AgentWorker", () => {
     }
   })
 
+  // Regression proof: prepare the definition's model instead of the catalog binding in worker.start.
+  test("executes workflow tasks with the authoritative model from the project catalog", async () => {
+    const declaredCalls: string[] = []
+    const catalogCalls: string[] = []
+    const { sixb, runs, nodeRunId } = await queueWorkflowAgentNode({
+      model: trackedStructuredAnswerModel((phase) => declaredCalls.push(phase)),
+      models: { language: [trackedStructuredAnswerModel((phase) => catalogCalls.push(phase))] },
+      runId: "workflow-catalog-model",
+    })
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+    await worker.start()
+    try {
+      const execution = await waitFor(
+        async () => {
+          const current = await runs.agentNodes.getByNodeRunId({ projectId: PROJECT_ID, nodeRunId })
+          return current?.status === "succeeded" ? current : null
+        },
+        { label: "catalog-backed workflow agent node" }
+      )
+      expect(execution.modelId).toBe("catalog-workflow-model")
+      expect(declaredCalls).toEqual([])
+      expect(catalogCalls).toEqual(["research", "finalize"])
+    } finally {
+      await worker.stop()
+    }
+  })
+
   // Regression proof: remove monitorSandboxReadiness from runWorkflowAgentNode.
   test.each([
     1, 2,
@@ -3388,8 +3449,16 @@ describe("AgentWorker", () => {
       apiBaseUrl: "http://sixb-api.local/api/",
     })
     const [firstEnvironment, secondEnvironment] = await Promise.all([
-      createConversationAgentEnvironment({ context, agent, run: firstRun }),
-      createConversationAgentEnvironment({ context, agent, run: secondRun }),
+      createConversationAgentEnvironment({
+        context,
+        plan: executionPlanFor(agent),
+        run: firstRun,
+      }),
+      createConversationAgentEnvironment({
+        context,
+        plan: executionPlanFor(agent),
+        run: secondRun,
+      }),
     ])
     let firstDisposed = false
     let secondDisposed = false
@@ -3476,7 +3545,11 @@ describe("AgentWorker", () => {
       apiBaseUrl: "http://sixb-api.local/api/",
     })
 
-    const environment = await createConversationAgentEnvironment({ context, agent, run })
+    const environment = await createConversationAgentEnvironment({
+      context,
+      plan: executionPlanFor(agent),
+      run,
+    })
     try {
       await environment.turnContext.sandboxReady
       const sandbox = sandboxes.sandboxes[0]
@@ -3535,15 +3608,16 @@ describe("AgentWorker", () => {
     })
     const run = await reserveRequestedRun(sixb, request)
     const context = await buildAgentWorkerContext(sixb)
+    const agent = requiredAgent(sixb)
     const environment = await createConversationAgentEnvironment({
       context,
-      agent: sixb.definitions.agents.getById("assistant")!,
+      plan: executionPlanFor(agent),
       run,
     })
     try {
       await runAgentTurn({
         context: environment.turnContext,
-        agent: sixb.definitions.agents.getById("assistant")!,
+        plan: executionPlanFor(agent),
         run,
         signal: new AbortController().signal,
       })
@@ -3593,15 +3667,16 @@ describe("AgentWorker", () => {
     })
     const run = await reserveRequestedRun(sixb, request)
     const context = await buildAgentWorkerContext(sixb)
+    const agent = requiredAgent(sixb)
     const environment = await createConversationAgentEnvironment({
       context,
-      agent: sixb.definitions.agents.getById("assistant")!,
+      plan: executionPlanFor(agent),
       run,
     })
     try {
       await runAgentTurn({
         context: environment.turnContext,
-        agent: sixb.definitions.agents.getById("assistant")!,
+        plan: executionPlanFor(agent),
         run,
         signal: new AbortController().signal,
       })
@@ -3655,15 +3730,16 @@ describe("AgentWorker", () => {
     })
     const run = await reserveRequestedRun(sixb, request)
     const context = await buildAgentWorkerContext(sixb)
+    const agent = requiredAgent(sixb)
     const environment = await createConversationAgentEnvironment({
       context,
-      agent: sixb.definitions.agents.getById("assistant")!,
+      plan: executionPlanFor(agent),
       run,
     })
     try {
       await runAgentTurn({
         context: environment.turnContext,
-        agent: sixb.definitions.agents.getById("assistant")!,
+        plan: executionPlanFor(agent),
         run,
         signal: new AbortController().signal,
       })
@@ -3746,7 +3822,11 @@ describe("AgentWorker", () => {
 
     // Resolves while create() is still gated: the system prompt is ready and the
     // sandbox has not been built yet.
-    const environment = await createConversationAgentEnvironment({ context, agent, run })
+    const environment = await createConversationAgentEnvironment({
+      context,
+      plan: executionPlanFor(agent),
+      run,
+    })
     expect(environment.turnContext.systemPrompt).toContain("<sixb_runtime_context>")
     expect(recording.sandboxes).toHaveLength(0)
 
@@ -3789,7 +3869,7 @@ describe("AgentWorker", () => {
     let detached: Promise<void> | null = null
     const environment = await createConversationAgentEnvironment({
       context,
-      agent,
+      plan: executionPlanFor(agent),
       run,
       onDetachedTeardown: (teardown) => {
         detached = teardown
@@ -5648,7 +5728,6 @@ describe("AgentWorker", () => {
         systemPrompt: "Test system prompt.",
         streamSink: NOOP_STREAM_SINK,
         recoverAiModelCall: recoverAiModelCall(sixb),
-        defaultMaxSteps: 4,
         turnTimeoutMs: 60_000,
         prepareStep: async ({ stepIndex, signal }): Promise<undefined> => {
           if (stepIndex !== 1) return
@@ -5656,7 +5735,7 @@ describe("AgentWorker", () => {
           signal.throwIfAborted()
         },
       },
-      agent: sixb.definitions.agents.getById("assistant")!,
+      plan: executionPlanFor(requiredAgent(sixb)),
       run,
       signal: abort.signal,
     })
@@ -6022,10 +6101,9 @@ describe("AgentWorker", () => {
         systemPrompt: "Test system prompt.",
         streamSink: NOOP_STREAM_SINK,
         recoverAiModelCall: recoverAiModelCall(sixb),
-        defaultMaxSteps: 4,
         turnTimeoutMs: 60_000,
       },
-      agent: sixb.definitions.agents.getById("assistant")!,
+      plan: executionPlanFor(requiredAgent(sixb)),
       run: staleRun,
       signal: new AbortController().signal,
     })
@@ -6077,10 +6155,9 @@ describe("AgentWorker", () => {
         systemPrompt: "<sixb_runtime_context>\nExtra sandbox context.\n</sixb_runtime_context>",
         streamSink: NOOP_STREAM_SINK,
         recoverAiModelCall: recoverAiModelCall(sixb),
-        defaultMaxSteps: 4,
         turnTimeoutMs: 60_000,
       },
-      agent: sixb.definitions.agents.getById("assistant")!,
+      plan: executionPlanFor(requiredAgent(sixb)),
       run,
       signal: new AbortController().signal,
     })
@@ -6123,15 +6200,71 @@ describe("AgentWorker", () => {
         systemPrompt: "Test system prompt.",
         streamSink: NOOP_STREAM_SINK,
         recoverAiModelCall: recoverAiModelCall(sixb),
-        defaultMaxSteps: 4,
         turnTimeoutMs: 60_000,
       },
-      agent: sixb.definitions.agents.getById("assistant")!,
+      plan: executionPlanFor(requiredAgent(sixb)),
       run,
       signal: new AbortController().signal,
     })
 
     expect(capturedReasoning).toBe("high")
+  })
+
+  test("executes the authoritative model instance from the project catalog", async () => {
+    let declaredCalls = 0
+    const declaredModel = new WorkerTestModel({
+      modelId: "shared-model",
+      stream: async () => {
+        declaredCalls += 1
+        return stream([
+          { type: "stream-start", warnings: [] },
+          { type: "text-start", id: "t" },
+          { type: "text-delta", id: "t", delta: "Wrong binding" },
+          { type: "text-end", id: "t" },
+          finish("stop"),
+        ])
+      },
+    })
+    let catalogCalls = 0
+    const catalogModel = new WorkerTestModel({
+      modelId: "shared-model",
+      stream: async (request) => {
+        expect(request.maxOutputTokens).toBe(16_384)
+        catalogCalls += 1
+        return stream([
+          { type: "stream-start", warnings: [] },
+          { type: "text-start", id: "t" },
+          { type: "text-delta", id: "t", delta: "Catalog binding" },
+          { type: "text-end", id: "t" },
+          finish("stop"),
+        ])
+      },
+    })
+    const sixb = buildSixb(declaredModel, new InMemoryBroker(), new RecordingSandboxFactory(), {
+      models: { language: [catalogModel] },
+    })
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+
+    await worker.start()
+    try {
+      const request = await requestAgent(sixb, { agentId: "assistant", text: "hello" })
+      const run = await waitFor(
+        async () => {
+          const current = await agentStorageOf(sixb).runs.getById({
+            projectId: PROJECT_ID,
+            id: request.run.id,
+          })
+          return current?.status === "succeeded" ? current : null
+        },
+        { label: "catalog-backed agent run" }
+      )
+
+      expect(run.modelId).toBe("shared-model")
+      expect(declaredCalls).toBe(0)
+      expect(catalogCalls).toBe(1)
+    } finally {
+      await worker.stop()
+    }
   })
 
   test("reports a terminal model failure exactly once with the original error", async () => {
@@ -6376,10 +6509,9 @@ describe("AgentWorker", () => {
             projectId: PROJECT_ID,
           }),
           recoverAiModelCall: recoverAiModelCall(sixb),
-          defaultMaxSteps: 4,
           turnTimeoutMs: 60_000,
         },
-        agent: sixb.definitions.agents.getById("assistant")!,
+        plan: executionPlanFor(requiredAgent(sixb)),
         run,
         signal: new AbortController().signal,
       })
@@ -6415,10 +6547,9 @@ describe("AgentWorker", () => {
           projectId: PROJECT_ID,
         }),
         recoverAiModelCall: recoverAiModelCall(sixb),
-        defaultMaxSteps: 4,
         turnTimeoutMs: 60_000,
       },
-      agent: sixb.definitions.agents.getById("assistant")!,
+      plan: executionPlanFor(requiredAgent(sixb)),
       run: reclaimed,
       signal: new AbortController().signal,
     })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1052,6 +1052,7 @@ export {
 export type {
   LanguageModelCatalog,
   LanguageModelEntry,
+  LanguageModelRef,
   ModelCatalog,
   ModelCatalogInput,
 } from "./models"

--- a/packages/core/src/models/catalog.ts
+++ b/packages/core/src/models/catalog.ts
@@ -1,30 +1,36 @@
-import { createDefinitionCatalog, type DefinitionCatalog } from "../runtime/definitions"
 import { RuntimeError } from "../runtime/errors"
-import type { LanguageModelDefinition, ModelDefinition } from "./definitions"
+import {
+  defineLanguageModel,
+  type LanguageModelDefinition,
+  type ModelDefinition,
+} from "./definitions"
 import type { LanguageModel } from "./language-model"
 
-/** Provider-owned metadata lookup for models available through that provider. */
-export interface ModelDefinitionCatalog<TDefinition extends ModelDefinition = ModelDefinition> {
-  get(modelId: string): Promise<TDefinition | undefined>
-  list(): Promise<readonly TDefinition[]>
-}
-
-export type LanguageModelDefinitionCatalog = ModelDefinitionCatalog<LanguageModelDefinition>
-
-/** One language-model binding configured by the project. */
-export interface LanguageModelEntry {
-  readonly ref: string
+/** Stable identity of one configured language-model binding. */
+export interface LanguageModelRef {
   readonly provider: string
   readonly modelId: string
+}
+
+/** The configured language models, with the project default. */
+export interface LanguageModelCatalog {
+  readonly default: LanguageModelEntry
+  list(): readonly LanguageModelEntry[]
+  getByRef(ref: LanguageModelRef): LanguageModelEntry | null
+}
+
+/**
+ * One configured language model.
+ *
+ * The identity describes the configured binding, not only a vendor model. For example,
+ * A gateway binding and a direct provider binding for the same vendor model are distinct because their
+ * `provider` values differ.
+ */
+export interface LanguageModelEntry extends LanguageModelRef {
   readonly model: LanguageModel
 }
 
-/** The project's configured language models, with the first entry as the default. */
-export interface LanguageModelCatalog extends DefinitionCatalog<LanguageModelEntry> {
-  readonly default: LanguageModelEntry
-}
-
-/** Models a project allows Sixb to use, organized by model kind. */
+/** Models a project allows Sixb to use, organized by technical model kind. */
 export interface ModelCatalog {
   readonly language: LanguageModelCatalog
 }
@@ -34,36 +40,98 @@ export interface ModelCatalogInput {
   readonly language: readonly LanguageModel[]
 }
 
-/** Identify a model by its provider and model ID. */
-export function modelRef(model: LanguageModel): string {
-  return `${model.providerId}/${model.modelId}`
-}
-
-/** Build the immutable project model catalog. Rejects duplicates and an empty catalog. */
+/** Build the immutable project model catalog. Rejects invalid, duplicate, and empty catalogs. */
 export function createModelCatalog(input: ModelCatalogInput): ModelCatalog {
-  const byRef = new Map<string, LanguageModelEntry>()
-
-  for (const model of input.language) {
-    const ref = modelRef(model)
-    if (byRef.has(ref)) {
-      throw new RuntimeError(
-        `[Sixb] Duplicate language model '${ref}' in 'models'. Each provider and model id pair may be configured once.`
-      )
-    }
-    byRef.set(
-      ref,
-      Object.freeze({ ref, provider: model.providerId, modelId: model.modelId, model })
-    )
+  if (!Array.isArray(input?.language)) {
+    throw new RuntimeError("[Sixb] 'models.language' must be an array of Sixb language models.")
   }
 
-  const [defaultEntry] = byRef.values()
+  const entries: LanguageModelEntry[] = []
+  const byProvider = new Map<string, Map<string, LanguageModelEntry>>()
+
+  for (const [index, model] of input.language.entries()) {
+    assertLanguageModel(model, index)
+
+    let byModelId = byProvider.get(model.providerId)
+    if (byModelId === undefined) {
+      byModelId = new Map()
+      byProvider.set(model.providerId, byModelId)
+    }
+    if (byModelId.has(model.modelId)) {
+      throw new RuntimeError(
+        `[Sixb] Duplicate language model '${model.providerId}/${model.modelId}' in 'models'. Each provider and model id pair may be configured once.`
+      )
+    }
+
+    const entry = Object.freeze({
+      provider: model.providerId,
+      modelId: model.modelId,
+      model,
+    })
+    byModelId.set(model.modelId, entry)
+    entries.push(entry)
+  }
+
+  const [defaultEntry] = entries
   if (defaultEntry === undefined) {
     throw new RuntimeError(
       "[Sixb] 'models.language' needs at least one model. Configure one or omit 'models' from createSixb()."
     )
   }
 
-  return Object.freeze({
-    language: Object.freeze({ ...createDefinitionCatalog(byRef), default: defaultEntry }),
+  const listed = Object.freeze(entries.slice())
+  const language: LanguageModelCatalog = Object.freeze({
+    default: defaultEntry,
+    list: () => listed,
+    getByRef: (ref: LanguageModelRef) => byProvider.get(ref.provider)?.get(ref.modelId) ?? null,
   })
+
+  return Object.freeze({ language })
 }
+
+function assertLanguageModel(model: unknown, index: number): asserts model is LanguageModel {
+  if ((typeof model !== "object" && typeof model !== "function") || model === null) {
+    throw invalidLanguageModel(index, "expected a Sixb LanguageModel instance")
+  }
+
+  const candidate = model as Record<string, unknown>
+  assertModelIdentifier(candidate.providerId, "provider", index)
+  assertModelIdentifier(candidate.modelId, "modelId", index)
+  if (typeof candidate.stream !== "function") {
+    throw invalidLanguageModel(index, "expected 'stream' to be a function")
+  }
+  try {
+    const definition = defineLanguageModel(candidate.definition as LanguageModelDefinition)
+    if (
+      definition.providerId !== candidate.providerId ||
+      definition.modelId !== candidate.modelId
+    ) {
+      throw new Error("definition identity does not match the binding")
+    }
+  } catch (error) {
+    throw invalidLanguageModel(index, error instanceof Error ? error.message : "invalid definition")
+  }
+}
+
+function assertModelIdentifier(value: unknown, field: "provider" | "modelId", index: number): void {
+  if (typeof value !== "string" || value.length === 0) {
+    throw invalidLanguageModel(index, `expected '${field}' to be a non-empty string`)
+  }
+  if (value.trim() !== value) {
+    throw invalidLanguageModel(index, `expected '${field}' not to have surrounding whitespace`)
+  }
+}
+
+function invalidLanguageModel(index: number, detail: string): RuntimeError {
+  return new RuntimeError(
+    `[Sixb] Invalid language model at 'models.language[${index}]': ${detail}.`
+  )
+}
+
+/** Provider-owned metadata lookup, independent from the project's configured bindings. */
+export interface ModelDefinitionCatalog<TDefinition extends ModelDefinition = ModelDefinition> {
+  get(modelId: string): Promise<TDefinition | undefined>
+  list(): Promise<readonly TDefinition[]>
+}
+
+export type LanguageModelDefinitionCatalog = ModelDefinitionCatalog<LanguageModelDefinition>

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -4,11 +4,12 @@ export type {
   LanguageModelCatalog,
   LanguageModelDefinitionCatalog,
   LanguageModelEntry,
+  LanguageModelRef,
   ModelCatalog,
   ModelCatalogInput,
   ModelDefinitionCatalog,
 } from "./catalog"
-export { createModelCatalog, modelRef } from "./catalog"
+export { createModelCatalog } from "./catalog"
 export type {
   LanguageModelDefinition,
   ModelDefinition,

--- a/packages/core/src/runtime/resolve-definitions.ts
+++ b/packages/core/src/runtime/resolve-definitions.ts
@@ -5,7 +5,7 @@ import { validateAgentGroupReferences, validateAgentToolsAtStartup } from "../ag
 import type { ConnectorDefinition } from "../connectors"
 import type { DatasetDefinition } from "../datasets/types"
 import { assertDatasetDefinition } from "../datasets/validation"
-import { createModelCatalog, type ModelCatalog, type ModelCatalogInput, modelRef } from "../models"
+import { createModelCatalog, type ModelCatalog, type ModelCatalogInput } from "../models"
 import { OntologyRegistry } from "../ontology"
 import type { PipelineDefinition } from "../pipelines/types"
 import { ProjectionRegistry } from "../projections"
@@ -256,10 +256,10 @@ function validateAgentModelReferences(
     return
   }
   for (const agent of agents) {
-    const ref = modelRef(agent.model)
-    if (models.language.getById(ref) === null) {
+    const ref = { provider: agent.model.providerId, modelId: agent.model.modelId }
+    if (models.language.getByRef(ref) === null) {
       throw new RuntimeError(
-        `[Sixb] Agent '${agent.id}' uses unknown language model '${ref}'. Add it to 'models.language' in createSixb().`
+        `[Sixb] Agent '${agent.id}' uses unknown language model '${ref.provider}/${ref.modelId}'. Add it to 'models.language' in createSixb().`
       )
     }
   }

--- a/packages/core/tests/models.test.ts
+++ b/packages/core/tests/models.test.ts
@@ -63,10 +63,12 @@ afterEach(async () => {
 })
 
 describe("createModelCatalog", () => {
-  test("derives an entry reference from provider and modelId", () => {
+  test("exposes the binding identity without creating another model id", () => {
     const catalog = createModelCatalog({ language: [gpt] })
 
-    expect(catalog.language.list().map((entry) => entry.ref)).toEqual(["gateway/openai/gpt-5.4"])
+    expect(catalog.language.list().map(({ provider, modelId }) => ({ provider, modelId }))).toEqual(
+      [{ provider: "gateway", modelId: "openai/gpt-5.4" }]
+    )
   })
 
   test("preserves the configured order", () => {
@@ -81,14 +83,16 @@ describe("createModelCatalog", () => {
   test("uses the first language model as the default", () => {
     const catalog = createModelCatalog({ language: [gpt, sonnet] })
 
-    expect(catalog.language.default.ref).toBe("gateway/openai/gpt-5.4")
+    expect(catalog.language.default.model).toBe(gpt)
   })
 
   test("resolves an entry by reference and returns null for an unknown one", () => {
     const catalog = createModelCatalog({ language: [gpt] })
 
-    expect(catalog.language.getById("gateway/openai/gpt-5.4")?.model).toBe(gpt)
-    expect(catalog.language.getById("gateway/openai/gpt-9")).toBeNull()
+    expect(
+      catalog.language.getByRef({ provider: "gateway", modelId: "openai/gpt-5.4" })?.model
+    ).toBe(gpt)
+    expect(catalog.language.getByRef({ provider: "gateway", modelId: "openai/gpt-9" })).toBeNull()
   })
 
   test("rejects two models that derive the same reference", () => {
@@ -104,10 +108,20 @@ describe("createModelCatalog", () => {
       language: [testModel("openai.chat", "gpt-5.4"), testModel("openai.responses", "gpt-5.4")],
     })
 
-    expect(catalog.language.list().map((entry) => entry.ref)).toEqual([
-      "openai.chat/gpt-5.4",
-      "openai.responses/gpt-5.4",
+    expect(catalog.language.list().map((entry) => entry.provider)).toEqual([
+      "openai.chat",
+      "openai.responses",
     ])
+  })
+
+  test("does not collide when delimiters appear in provider or modelId", () => {
+    // Proven by removal: a lookup keyed by `${provider}/${modelId}` makes these bindings collide.
+    const first = testModel("a/b", "c")
+    const second = testModel("a", "b/c")
+    const catalog = createModelCatalog({ language: [first, second] })
+
+    expect(catalog.language.getByRef({ provider: "a/b", modelId: "c" })?.model).toBe(first)
+    expect(catalog.language.getByRef({ provider: "a", modelId: "b/c" })?.model).toBe(second)
   })
 
   test("rejects an empty language catalog", () => {
@@ -116,6 +130,39 @@ describe("createModelCatalog", () => {
     expect(() => createModelCatalog({ language: [] })).toThrow(
       /'models.language' needs at least one model/
     )
+  })
+
+  test("rejects a malformed language catalog", () => {
+    expect(() =>
+      createModelCatalog({ language: null } as unknown as Parameters<typeof createModelCatalog>[0])
+    ).toThrow(/'models.language' must be an array/)
+  })
+
+  test.each([
+    ["stream", { stream: undefined }],
+    ["definition", { definition: undefined }],
+  ])("rejects an invalid %s field", (_field, override) => {
+    const invalid = { ...gpt, ...override } as unknown as LanguageModel
+    expect(() => createModelCatalog({ language: [invalid] })).toThrow(/Invalid language model/)
+  })
+
+  test.each([
+    ["providerId", ""],
+    ["providerId", " gateway"],
+    ["modelId", ""],
+    ["modelId", "openai/gpt-5.4 "],
+  ] as const)("rejects an invalid %s identity", (field, value) => {
+    const invalid = { ...gpt, [field]: value } as LanguageModel
+
+    expect(() => createModelCatalog({ language: [invalid] })).toThrow(/Invalid language model/)
+  })
+
+  test("does not freeze the provider-owned model", () => {
+    const model = testModel("gateway", "openai/gpt-5.4")
+
+    createModelCatalog({ language: [model] })
+
+    expect(Object.isFrozen(model)).toBe(false)
   })
 })
 
@@ -130,7 +177,7 @@ describe("createSixb models", () => {
       ...createTestRuntimeDeps(),
     })
 
-    expect(sixb.definitions.models?.language.default.ref).toBe("gateway/openai/gpt-5.4")
+    expect(sixb.definitions.models?.language.default.model).toBe(gpt)
   })
 
   test("leaves the catalog absent when models are not configured", async () => {

--- a/packages/core/tests/models.types.ts
+++ b/packages/core/tests/models.types.ts
@@ -1,0 +1,24 @@
+import type {
+  LanguageModelCatalog,
+  LanguageModelEntry,
+  LanguageModelRef,
+  ModelCatalogInput,
+} from "../src"
+
+declare const input: ModelCatalogInput
+declare const catalog: LanguageModelCatalog
+
+const ref: LanguageModelRef = {
+  provider: input.language[0]?.providerId ?? "vercel-ai-gateway",
+  modelId: input.language[0]?.modelId ?? "openai/gpt-5.4",
+}
+const entry: LanguageModelEntry | null = catalog.getByRef(ref)
+const listed: readonly LanguageModelEntry[] = catalog.list()
+const defaultEntry: LanguageModelEntry = catalog.default
+
+// @ts-expect-error model references are structured, never user-authored string aliases
+catalog.getByRef("gateway/openai/gpt-5.4")
+
+void entry
+void listed
+void defaultEntry

--- a/packages/server/src/routes/models.ts
+++ b/packages/server/src/routes/models.ts
@@ -3,8 +3,12 @@ import type { Elysia } from "elysia"
 import { OPENAPI_TAGS } from "../openapi/tags"
 import { ModelCatalogSchema } from "../schemas/models"
 
-function serializeLanguageModel(entry: LanguageModelEntry, defaultRef: string) {
-  return { provider: entry.provider, modelId: entry.modelId, isDefault: entry.ref === defaultRef }
+function serializeLanguageModel(entry: LanguageModelEntry, defaultEntry: LanguageModelEntry) {
+  return {
+    provider: entry.provider,
+    modelId: entry.modelId,
+    isDefault: entry.provider === defaultEntry.provider && entry.modelId === defaultEntry.modelId,
+  }
 }
 
 export function registerModelRoutes(app: Elysia, host: SixbHostView) {
@@ -16,7 +20,7 @@ export function registerModelRoutes(app: Elysia, host: SixbHostView) {
         language:
           language === undefined
             ? []
-            : language.list().map((entry) => serializeLanguageModel(entry, language.default.ref)),
+            : language.list().map((entry) => serializeLanguageModel(entry, language.default)),
       })
     },
     {


### PR DESCRIPTION
Part of #451.

## Why

- the model catalog used an ambiguous concatenated reference
- agent execution read live settings directly from `AgentDefinition` across multiple paths
- future main and sub-agent runs need one stable execution boundary

## What changes

- identifies models with `{ provider, modelId }`
- validates configured AI SDK models at startup
- resolves one internal execution plan for conversation and workflow runs
- uses the project catalog as the authoritative live model binding
- keeps identity and authorization on the durable run

```text
AgentDefinition ─┐
Model catalog ───┴─> execution plan ─> conversation / workflow runtime
Durable run ────────> identity + authorization
```

## Key choices

| Choice | Why |
| --- | --- |
| Structured model reference | avoids delimiter collisions without adding a user-defined model ID |
| Internal execution plan | creates a stable runtime seam without exposing a premature public API |
| Catalog-owned model instance | ensures configured model bindings are the ones actually executed |
| Run-owned identity | keeps model configuration out of authorization decisions |

## Compatibility

- no change to the `createSixb({ models })` DX
- no change to `GET /api/models`
- projects without a model catalog keep the existing `defineAgent` behavior

## Verification

- `bun run typecheck`
- `bun run build`
- `bun run check`
- `bun run test:publish`
- `bun run generate:client`
- `bun run test:ci` — 4,568 passed, 7 skipped
