### PR TITLE
execution: bind runtime authority to one exact execution

### DIFF
--- a/packages/core/src/actions/request.ts
+++ b/packages/core/src/actions/request.ts
@@ -1,4 +1,5 @@
 import { assertAuthorized } from "../authorization"
+import { resolveExecutionScopeAuthorization } from "../execution/authorization"
 import {
   createPrimitiveExecutionRecord,
   ensureExecutionRecord,
@@ -83,6 +84,10 @@ export async function requestAction(
   execution: ExecutionContext,
   input: RequestActionInput
 ): Promise<RequestActionResult> {
+  resolveExecutionScopeAuthorization(runtime.projectId, {
+    execution,
+    authorization: runtime.runtimeAuthorization,
+  })
   requireActionRunStorage(runtime)
   const action = getActionDefinition(runtime, input.actionId)
   const actionId = action.id

--- a/packages/core/src/agents/authority.ts
+++ b/packages/core/src/agents/authority.ts
@@ -13,6 +13,7 @@ import type {
   UserRecord,
 } from "../storage/auth"
 import { AuthStorageError } from "../storage/auth"
+import { agentServiceAccountId } from "./identity"
 
 export type AgentExecutionAuthorization =
   | { readonly type: "principal"; readonly context: AuthorizationContext }
@@ -28,14 +29,12 @@ interface CredentialedUserAuthorizationRef {
   readonly credential: UserCredentialRef
 }
 
+export { agentServiceAccountId } from "./identity"
+
 export interface AgentExecutionIdentity {
   readonly serviceAccount: ServiceAccountRecord
   readonly principal: Extract<AuthorizablePrincipal, { readonly type: "serviceAccount" }>
   readonly groupMemberships: readonly ServiceAccountGroupMembershipRecord[]
-}
-
-export function agentServiceAccountId(actorId: string): string {
-  return `svc_agent_${actorId}`
 }
 
 /** Ensure a framework-managed Agent actor exists with exactly its declared group memberships. */

--- a/packages/core/src/agents/identity.ts
+++ b/packages/core/src/agents/identity.ts
@@ -1,0 +1,4 @@
+/** Deterministic managed service-account id owned by one framework Agent actor. */
+export function agentServiceAccountId(actorId: string): string {
+  return `svc_agent_${actorId}`
+}

--- a/packages/core/src/agents/request.ts
+++ b/packages/core/src/agents/request.ts
@@ -8,6 +8,7 @@ import {
   canInheritAgentRequestAuthorization,
   createInheritedAgentExecutionRecord,
 } from "../execution/agent"
+import { resolveExecutionScopeAuthorization } from "../execution/authorization"
 import { ensureExecutionRecord, executionRecordInputFromRuntime } from "../execution/durable"
 import type { ExecutionContext } from "../execution/types"
 import type { LanguageModelCatalog, LanguageModelRef } from "../models"
@@ -81,6 +82,10 @@ export async function requestAgentRun(
   models: LanguageModelCatalog | undefined,
   input: RequestAgentRunInput
 ): Promise<RequestAgentRunResult> {
+  const authority = resolveExecutionScopeAuthorization(runtime.projectId, {
+    execution,
+    authorization: runtime.runtimeAuthorization,
+  })
   assertNoAgentSelector(input)
   assertAuthorized(runtime, { kind: "agent.run" })
   assertRequestAuthorityCanRunAgent(runtime)
@@ -92,9 +97,13 @@ export async function requestAgentRun(
 
   const agents = requireAgentStorage(runtime)
   const projectId = runtime.projectId
-  // A scoped runtime is authoritative for caller identity. `input.principal` remains available to
-  // privileged server integrations that have already authenticated their request.
-  const principal = runtime.authorization?.principal ?? input.principal ?? SYSTEM_PRINCIPAL
+  // Attribution comes from the exact capability/execution pair, never the optional context cache
+  // on the runtime. `input.principal` remains available to unrestricted server integrations that
+  // have already authenticated their request.
+  const principal =
+    authority.type === "principal"
+      ? authority.context.principal
+      : (input.principal ?? SYSTEM_PRINCIPAL)
   const runId = createAgentRunId()
   const durableExecution = await prepareDurableAgentExecution(runtime, execution, runId)
   const requesterGroupIds = durableExecution.requestedBy
@@ -179,6 +188,10 @@ export async function retryAgentRun(
   models: LanguageModelCatalog | undefined,
   failedRun: ConversationAgentRunRecord
 ): Promise<RequestAgentRunResult> {
+  resolveExecutionScopeAuthorization(runtime.projectId, {
+    execution,
+    authorization: runtime.runtimeAuthorization,
+  })
   assertAuthorized(runtime, { kind: "agent.run" })
   assertRequestAuthorityCanRunAgent(runtime)
   if (failedRun.status !== "failed") {

--- a/packages/core/src/authorization/decision.ts
+++ b/packages/core/src/authorization/decision.ts
@@ -13,7 +13,8 @@
 import type { AuthSessionAudience } from "../auth/audience"
 import {
   type ResolvedRuntimeAuthorization,
-  resolveRuntimeAuthorization,
+  resolveExecutionScopeAuthorization,
+  resolveRuntimeAuthorizationForProject,
 } from "../execution/authorization"
 import type { ExecutionContext, RuntimeAuthorization } from "../execution/types"
 import { AuthorizationError } from "./errors"
@@ -47,6 +48,7 @@ export interface AuthzDecision {
 }
 
 interface AuthorizedRuntime {
+  readonly projectId: string
   readonly runtimeAuthorization?: RuntimeAuthorization
   readonly authorization?: AuthorizationContext
 }
@@ -149,7 +151,7 @@ export function assertAuthorized(runtime: AuthorizedRuntime, request: AuthzReque
 export function assertRuntimeAuthorizationBound(
   runtime: AuthorizedRuntime
 ): Exclude<ResolvedRuntimeAuthorization, { readonly type: "denied" }> {
-  const resolved = resolveRuntimeAuthorization(runtime.runtimeAuthorization)
+  const resolved = resolveRuntimeAuthorizationForProject(runtime)
   if (resolved.type === "denied") {
     throw new AuthorizationError(
       "runtime:unbound",
@@ -218,27 +220,22 @@ export function assertPrivileged(runtime: AuthorizedRuntime, operation: string):
  * Assert access to process providers that trusted executions and genuine agent runs may use.
  *
  * Agent provenance alone is not authority: the registered capability must be bound to the exact
- * same execution identity and run before this check succeeds.
+ * same immutable execution before this check succeeds.
  */
 export function assertProviderAccess(
-  runtime: AuthorizedRuntime,
+  runtime: AuthorizedRuntime & { readonly runtimeAuthorization: RuntimeAuthorization },
   execution: ExecutionContext,
   operation: string
 ): void {
-  const resolved = assertRuntimeAuthorizationBound(runtime)
+  const resolved = resolveExecutionScopeAuthorization(runtime.projectId, {
+    execution,
+    authorization: runtime.runtimeAuthorization,
+  })
   if (resolved.type === "unrestricted") {
     return
   }
 
-  const binding = resolved.executionBinding
-  const executor = execution.executor
-  if (
-    binding?.type === "agent" &&
-    executor.type === "agent" &&
-    binding.executionId === execution.id &&
-    binding.actorId === executor.actorId &&
-    binding.runId === executor.runId
-  ) {
+  if (execution.executor.type === "agent") {
     return
   }
 

--- a/packages/core/src/execution/agent.ts
+++ b/packages/core/src/execution/agent.ts
@@ -131,10 +131,7 @@ export function restoreAgentExecutionScope(input: {
   return Object.freeze({
     execution: context,
     authorization: createAgentRuntimeAuthorization({
-      projectId: input.execution.projectId,
-      executionId: input.execution.id,
-      ...(input.actorId === undefined ? {} : { actorId: input.actorId }),
-      runId: input.runId,
+      execution: context,
       authority:
         input.authorization.type === "principal"
           ? {

--- a/packages/core/src/execution/authorization.ts
+++ b/packages/core/src/execution/authorization.ts
@@ -1,11 +1,14 @@
+import { isDeepStrictEqual } from "node:util"
+import { agentServiceAccountId } from "../agents/identity"
 import type { Principal } from "../auth"
-import { emptyGrantSets, TARGETED_GRANT_KIND_KEYS } from "../authorization/grant-kinds"
+import { TARGETED_GRANT_KIND_KEYS, type TargetedGrantKind } from "../authorization/grant-kinds"
 import type { AuthorizationContext, GrantIndex } from "../authorization/types"
 import { createSixbError } from "../errors/internal"
 import {
   type AuthorizablePrincipal,
   type AuthorizationRef,
   createRuntimeAuthorizationCapability,
+  type ExecutionContext,
   type ExecutionScope,
   isRuntimeAuthorizationCapability,
   type KernelOperation,
@@ -20,15 +23,11 @@ export type ResolvedRuntimeAuthorization =
       readonly projectId: string
       readonly context: AuthorizationContext
       readonly ref: Extract<AuthorizationRef, { readonly type: "principal" }>
-      /** Process-local binding used by provider façades that explicitly support agent runs. */
-      readonly executionBinding?: AgentExecutionBinding
     }
   | {
       readonly type: "unrestricted"
       readonly projectId: string
       readonly ref: Exclude<AuthorizationRef, { readonly type: "principal" }>
-      /** Process-local binding used by provider façades that explicitly support agent runs. */
-      readonly executionBinding?: AgentExecutionBinding
     }
   | { readonly type: "denied" }
 
@@ -41,29 +40,30 @@ type PrincipalAuthorizationContext = Omit<AuthorizationContext, "principal"> & {
   readonly principal: AuthorizablePrincipal
 }
 
-interface AgentExecutionBinding {
-  readonly type: "agent"
-  readonly executionId: string
-  readonly actorId?: string
-  readonly runId: string
+interface RuntimeAuthorizationRegistration {
+  readonly resolved: RegisteredRuntimeAuthorization
+  readonly execution: ExecutionContext
 }
 
-const registeredAuthorizations = new WeakMap<RuntimeAuthorization, RegisteredRuntimeAuthorization>()
+const registeredAuthorizations = new WeakMap<
+  RuntimeAuthorization,
+  RuntimeAuthorizationRegistration
+>()
 
 export function createPrincipalRuntimeAuthorization(input: {
-  readonly projectId: string
+  readonly execution: ExecutionContext
   readonly context: AuthorizationContext
   readonly credential?: Extract<AuthorizationRef, { readonly type: "principal" }>["credential"]
 }): RuntimeAuthorization {
+  if (input.execution.executor.type !== "request") {
+    throw new Error("[Sixb] Principal runtime authorization requires a request execution.")
+  }
   return createRegisteredPrincipalAuthorization(input)
 }
 
 /** Register restored authority bound to one exact agent run. */
 export function createAgentRuntimeAuthorization(input: {
-  readonly projectId: string
-  readonly executionId: string
-  readonly actorId?: string
-  readonly runId: string
+  readonly execution: ExecutionContext
   readonly authority:
     | {
         readonly type: "principal"
@@ -75,45 +75,32 @@ export function createAgentRuntimeAuthorization(input: {
       }
     | { readonly type: "disabled" }
 }): RuntimeAuthorization {
-  assertNonEmpty(input.executionId, "Execution id")
-  if (input.actorId !== undefined) assertNonEmpty(input.actorId, "Agent actor id")
-  assertNonEmpty(input.runId, "Agent run id")
-  const executionBinding: AgentExecutionBinding = {
-    type: "agent",
-    executionId: input.executionId,
-    ...(input.actorId === undefined ? {} : { actorId: input.actorId }),
-    runId: input.runId,
+  if (input.execution.executor.type !== "agent") {
+    throw new Error("[Sixb] Agent runtime authorization requires an Agent execution.")
   }
 
   if (input.authority.type === "principal") {
-    return createRegisteredPrincipalAuthorization(
-      {
-        projectId: input.projectId,
-        context: input.authority.context,
-        ...(input.authority.credential === undefined
-          ? {}
-          : { credential: input.authority.credential }),
-      },
-      executionBinding
-    )
+    return createRegisteredPrincipalAuthorization({
+      execution: input.execution,
+      context: input.authority.context,
+      ...(input.authority.credential === undefined
+        ? {}
+        : { credential: input.authority.credential }),
+    })
   }
 
-  return register({
+  return register(input.execution, {
     type: "unrestricted",
-    projectId: input.projectId,
+    projectId: input.execution.projectId,
     ref: Object.freeze({ type: "disabled" }),
-    executionBinding: Object.freeze(executionBinding),
   })
 }
 
-function createRegisteredPrincipalAuthorization(
-  input: {
-    readonly projectId: string
-    readonly context: AuthorizationContext
-    readonly credential?: Extract<AuthorizationRef, { readonly type: "principal" }>["credential"]
-  },
-  executionBinding?: AgentExecutionBinding
-): RuntimeAuthorization {
+function createRegisteredPrincipalAuthorization(input: {
+  readonly execution: ExecutionContext
+  readonly context: AuthorizationContext
+  readonly credential?: Extract<AuthorizationRef, { readonly type: "principal" }>["credential"]
+}): RuntimeAuthorization {
   const context = snapshotAuthorizationContext(input.context)
   const credential = input.credential ? snapshotCredential(input.credential) : undefined
   assertCredentialMatchesContext(context, credential)
@@ -122,41 +109,44 @@ function createRegisteredPrincipalAuthorization(
     principal: context.principal,
     ...(credential === undefined ? {} : { credential }),
   })
-  return register({
+  return register(input.execution, {
     type: "principal",
-    projectId: input.projectId,
+    projectId: input.execution.projectId,
     context,
     ref,
-    ...(executionBinding === undefined
-      ? {}
-      : { executionBinding: Object.freeze({ ...executionBinding }) }),
   })
 }
 
-export function createDisabledRuntimeAuthorization(projectId: string): RuntimeAuthorization {
-  return register({ type: "unrestricted", projectId, ref: Object.freeze({ type: "disabled" }) })
+export function createDisabledRuntimeAuthorization(
+  execution: ExecutionContext
+): RuntimeAuthorization {
+  return register(execution, {
+    type: "unrestricted",
+    projectId: execution.projectId,
+    ref: Object.freeze({ type: "disabled" }),
+  })
 }
 
 export function createTrustedPrimitiveRuntimeAuthorization(input: {
-  readonly projectId: string
+  readonly execution: ExecutionContext
   readonly primitive: TrustedPrimitiveRef
 }): RuntimeAuthorization {
   const primitive = snapshotTrustedPrimitive(input.primitive)
-  return register({
+  return register(input.execution, {
     type: "unrestricted",
-    projectId: input.projectId,
+    projectId: input.execution.projectId,
     ref: Object.freeze({ type: "trustedPrimitive", primitive }),
   })
 }
 
 export function createKernelRuntimeAuthorization(input: {
-  readonly projectId: string
+  readonly execution: ExecutionContext
   readonly operation: KernelOperation
 }): RuntimeAuthorization {
   const operation = snapshotKernelOperation(input.operation)
-  return register({
+  return register(input.execution, {
     type: "unrestricted",
-    projectId: input.projectId,
+    projectId: input.execution.projectId,
     ref: Object.freeze({ type: "kernel", operation }),
   })
 }
@@ -165,7 +155,28 @@ export function resolveRuntimeAuthorization(authorization: unknown): ResolvedRun
   if (!isRuntimeAuthorizationCapability(authorization)) {
     return { type: "denied" }
   }
-  return registeredAuthorizations.get(authorization) ?? { type: "denied" }
+  return registeredAuthorizations.get(authorization)?.resolved ?? { type: "denied" }
+}
+
+/**
+ * Resolve authority from a runtime already admitted by `SixbHost.withScope`.
+ *
+ * Bound runtime facades carry no second execution value to recombine. Any lower-level boundary
+ * that receives an `ExecutionContext` separately must use `resolveExecutionScopeAuthorization`.
+ */
+export function resolveRuntimeAuthorizationForProject(input: {
+  readonly projectId: unknown
+  readonly runtimeAuthorization?: unknown
+}): ResolvedRuntimeAuthorization {
+  const resolved = resolveRuntimeAuthorization(input.runtimeAuthorization)
+  if (
+    resolved.type === "denied" ||
+    typeof input.projectId !== "string" ||
+    resolved.projectId !== input.projectId
+  ) {
+    return { type: "denied" }
+  }
+  return resolved
 }
 
 export function getAuthorizationRef(authorization: RuntimeAuthorization): AuthorizationRef {
@@ -230,7 +241,22 @@ export function resolveExecutionScopeAuthorization(
     )
   }
 
-  const { execution } = scope
+  const registration = registeredAuthorizations.get(scope.authorization)
+  if (!registration || !executionMatchesBinding(registration.execution, scope.execution)) {
+    throw invalidExecutionAuthority(
+      scope.execution.id,
+      "authority is bound to different execution provenance"
+    )
+  }
+
+  assertResolvedAuthorizationMatchesExecution(resolved, scope.execution)
+  return resolved
+}
+
+function assertResolvedAuthorizationMatchesExecution(
+  resolved: RegisteredRuntimeAuthorization,
+  execution: ExecutionContext
+): void {
   switch (execution.executor.type) {
     case "request":
       if (
@@ -242,7 +268,6 @@ export function resolveExecutionScopeAuthorization(
       if (resolved.ref.type === "principal") {
         if (
           resolved.type !== "principal" ||
-          resolved.executionBinding !== undefined ||
           !principalsEqual(execution.requestedBy, resolved.ref.principal)
         ) {
           throw invalidExecutionAuthority(
@@ -250,9 +275,9 @@ export function resolveExecutionScopeAuthorization(
             "request authority does not match its requested-by principal"
           )
         }
-        return resolved
+        return
       }
-      if (resolved.ref.type === "disabled" && execution.requestedBy === undefined) return resolved
+      if (resolved.ref.type === "disabled" && execution.requestedBy === undefined) return
       throw invalidExecutionAuthority(
         execution.id,
         "request execution requires principal or explicitly disabled authority"
@@ -270,22 +295,37 @@ export function resolveExecutionScopeAuthorization(
           "trusted primitive authority does not match its executor"
         )
       }
-      return resolved
+      return
 
     case "agent":
-      if (
-        resolved.executionBinding?.type !== "agent" ||
-        resolved.executionBinding.executionId !== execution.id ||
-        resolved.executionBinding.actorId !== execution.executor.actorId ||
-        resolved.executionBinding.runId !== execution.executor.runId
-      ) {
+      if (execution.source.type !== "execution") {
         throw invalidExecutionAuthority(
           execution.id,
-          "agent authority does not match its execution binding"
+          "agent execution requires an execution source"
         )
       }
-      if (resolved.type === "principal" && resolved.ref.type === "principal") return resolved
-      if (resolved.type === "unrestricted" && resolved.ref.type === "disabled") return resolved
+      if (resolved.type === "principal" && resolved.ref.type === "principal") {
+        if (resolved.ref.principal.type === "serviceAccount") {
+          const actorId = execution.executor.actorId
+          if (
+            actorId === undefined ||
+            resolved.ref.principal.id !== agentServiceAccountId(actorId) ||
+            resolved.ref.credential !== undefined
+          ) {
+            throw invalidExecutionAuthority(
+              execution.id,
+              "agent authority must reference its managed service account"
+            )
+          }
+        } else if (resolved.ref.credential === undefined) {
+          throw invalidExecutionAuthority(
+            execution.id,
+            "inherited user agent authority requires a credential"
+          )
+        }
+        return
+      }
+      if (resolved.type === "unrestricted" && resolved.ref.type === "disabled") return
       throw invalidExecutionAuthority(
         execution.id,
         "agent authority must be principal or explicitly disabled"
@@ -303,7 +343,7 @@ export function resolveExecutionScopeAuthorization(
           "kernel authority does not match its executor"
         )
       }
-      return resolved
+      return
   }
 }
 
@@ -322,23 +362,122 @@ function invalidExecutionAuthority(executionId: string, reason: string): Error {
   )
 }
 
-function register(input: RegisteredRuntimeAuthorization): RuntimeAuthorization {
+function register(
+  execution: ExecutionContext,
+  input: RegisteredRuntimeAuthorization
+): RuntimeAuthorization {
   assertNonEmpty(input.projectId, "Authorization project id")
+  const executionBinding = snapshotExecutionContext(execution)
+  if (input.projectId !== executionBinding.projectId) {
+    throw new Error(
+      `[Sixb] Runtime authorization belongs to project '${input.projectId}', not execution project '${executionBinding.projectId}'.`
+    )
+  }
+  assertResolvedAuthorizationMatchesExecution(input, executionBinding)
   const authorization = createRuntimeAuthorizationCapability()
-  registeredAuthorizations.set(authorization, Object.freeze(input))
+  registeredAuthorizations.set(
+    authorization,
+    Object.freeze({ resolved: Object.freeze(input), execution: executionBinding })
+  )
   return authorization
+}
+
+function executionMatchesBinding(binding: ExecutionContext, execution: ExecutionContext): boolean {
+  try {
+    return isDeepStrictEqual(binding, snapshotExecutionContext(execution))
+  } catch {
+    return false
+  }
+}
+
+function snapshotExecutionContext(execution: ExecutionContext): ExecutionContext {
+  assertNonEmpty(execution.id, "Execution id")
+  assertNonEmpty(execution.projectId, "Execution project id")
+  assertNonEmpty(execution.correlationId, "Execution correlation id")
+  return Object.freeze({
+    id: execution.id,
+    projectId: execution.projectId,
+    ...(execution.requestedBy === undefined
+      ? {}
+      : { requestedBy: snapshotAuthorizablePrincipal(execution.requestedBy) }),
+    executor: snapshotExecutionExecutor(execution.executor),
+    source: snapshotExecutionSource(execution.source),
+    correlationId: execution.correlationId,
+  })
+}
+
+function snapshotExecutionExecutor(
+  executor: ExecutionContext["executor"]
+): ExecutionContext["executor"] {
+  switch (executor.type) {
+    case "request":
+      assertNonEmpty(executor.requestId, "Execution request id")
+      return Object.freeze({ type: "request", requestId: executor.requestId })
+    case "primitive": {
+      const primitive = snapshotTrustedPrimitive(executor)
+      return Object.freeze({ type: "primitive", ...primitive })
+    }
+    case "agent":
+      if (executor.actorId !== undefined)
+        assertNonEmpty(executor.actorId, "Execution Agent actor id")
+      assertNonEmpty(executor.runId, "Execution Agent run id")
+      return Object.freeze({
+        type: "agent",
+        ...(executor.actorId === undefined ? {} : { actorId: executor.actorId }),
+        runId: executor.runId,
+      })
+    case "kernel":
+      return Object.freeze({
+        type: "kernel",
+        operation: snapshotKernelOperation(executor.operation),
+      })
+  }
+  throw new Error(
+    `[Sixb] Unknown execution executor type '${String((executor as { type?: unknown }).type)}'.`
+  )
+}
+
+function snapshotExecutionSource(source: ExecutionContext["source"]): ExecutionContext["source"] {
+  switch (source.type) {
+    case "http":
+      assertNonEmpty(source.requestId, "Execution source request id")
+      return Object.freeze({ type: "http", requestId: source.requestId })
+    case "webhook":
+      assertNonEmpty(source.deliveryId, "Execution source delivery id")
+      return Object.freeze({ type: "webhook", deliveryId: source.deliveryId })
+    case "schedule":
+    case "event":
+      assertNonEmpty(source.eventId, "Execution source event id")
+      return Object.freeze({ type: source.type, eventId: source.eventId })
+    case "datasetVersion":
+      assertNonEmpty(source.datasetId, "Execution source dataset id")
+      assertNonEmpty(source.versionId, "Execution source dataset version id")
+      return Object.freeze({
+        type: "datasetVersion",
+        datasetId: source.datasetId,
+        versionId: source.versionId,
+      })
+    case "execution":
+      assertNonEmpty(source.executionId, "Execution source execution id")
+      return Object.freeze({ type: "execution", executionId: source.executionId })
+  }
+  throw new Error(
+    `[Sixb] Unknown execution source type '${String((source as { type?: unknown }).type)}'.`
+  )
 }
 
 function snapshotAuthorizationContext(
   context: AuthorizationContext
 ): PrincipalAuthorizationContext {
   const principal = snapshotAuthorizablePrincipal(context.principal)
-  const grants = emptyGrantSets()
-  grants["run:agent"] = context.grants["run:agent"]
+  const grants = {} as Record<TargetedGrantKind, ReadonlySet<string>>
   for (const kind of TARGETED_GRANT_KIND_KEYS) {
-    grants[kind] = new Set(context.grants[kind])
+    grants[kind] = new ImmutableGrantSet(context.grants[kind])
   }
-  const frozenGrants: GrantIndex = Object.freeze(grants)
+  const frozenGrants: GrantIndex = Object.freeze({
+    ...grants,
+    "run:agent": context.grants["run:agent"],
+  })
   return Object.freeze({
     principal,
     ...(context.sessionId === undefined ? {} : { sessionId: context.sessionId }),
@@ -346,6 +485,68 @@ function snapshotAuthorizationContext(
     roleIds: Object.freeze([...context.roleIds]),
     grants: frozenGrants,
   })
+}
+
+/** Read-only Set semantics with no mutable handle hidden behind the TypeScript interface. */
+class ImmutableGrantSet implements ReadonlySet<string> {
+  readonly #values: Set<string>
+  readonly [Symbol.toStringTag] = "Set"
+
+  constructor(values: Iterable<string>) {
+    this.#values = new Set(values)
+    Object.freeze(this)
+  }
+
+  get size(): number {
+    return this.#values.size
+  }
+
+  has(value: string): boolean {
+    return this.#values.has(value)
+  }
+
+  entries(): ReturnType<Set<string>["entries"]> {
+    return this.#values.entries()
+  }
+
+  keys(): ReturnType<Set<string>["keys"]> {
+    return this.#values.keys()
+  }
+
+  values(): ReturnType<Set<string>["values"]> {
+    return this.#values.values()
+  }
+
+  [Symbol.iterator](): ReturnType<Set<string>[typeof Symbol.iterator]> {
+    return this.#values[Symbol.iterator]()
+  }
+
+  forEach(
+    callback: (value: string, valueAgain: string, set: ReadonlySet<string>) => void,
+    thisArg?: unknown
+  ): void {
+    for (const value of this.#values) {
+      callback.call(thisArg, value, value, this)
+    }
+  }
+
+  add(_value: string): never {
+    throw immutableGrantSetMutation()
+  }
+
+  delete(_value: string): never {
+    throw immutableGrantSetMutation()
+  }
+
+  clear(): never {
+    throw immutableGrantSetMutation()
+  }
+}
+
+Object.freeze(ImmutableGrantSet.prototype)
+
+function immutableGrantSetMutation(): Error {
+  return new Error("[Sixb] Runtime authorization grants are immutable.")
 }
 
 function snapshotAuthorizablePrincipal(principal: Principal): AuthorizablePrincipal {

--- a/packages/core/src/execution/durable.ts
+++ b/packages/core/src/execution/durable.ts
@@ -5,7 +5,11 @@ import {
   type ExecutionStorage,
   ExecutionStorageError,
 } from "../storage/executions"
-import { createTrustedPrimitiveRuntimeAuthorization, getAuthorizationRef } from "./authorization"
+import {
+  createTrustedPrimitiveRuntimeAuthorization,
+  getAuthorizationRef,
+  resolveExecutionScopeAuthorization,
+} from "./authorization"
 import type {
   ExecutionContext,
   ExecutionScope,
@@ -19,6 +23,10 @@ export function executionRecordInputFromRuntime(input: {
   readonly runtimeAuthorization: RuntimeAuthorization
 }): CreateExecutionInput {
   const execution = input.execution
+  resolveExecutionScopeAuthorization(execution.projectId, {
+    execution,
+    authorization: input.runtimeAuthorization,
+  })
   return {
     id: execution.id,
     projectId: execution.projectId,
@@ -135,7 +143,7 @@ export function restoreTrustedPrimitiveExecutionScope(input: {
   return Object.freeze({
     execution: context,
     authorization: createTrustedPrimitiveRuntimeAuthorization({
-      projectId: input.execution.projectId,
+      execution: context,
       primitive: input.primitive,
     }),
   })

--- a/packages/core/src/execution/scopes.ts
+++ b/packages/core/src/execution/scopes.ts
@@ -31,7 +31,7 @@ export function createPrincipalRequestScope(input: {
   return Object.freeze({
     execution,
     authorization: createPrincipalRuntimeAuthorization({
-      projectId: input.projectId,
+      execution,
       context: input.context,
       ...(input.credential === undefined ? {} : { credential: input.credential }),
     }),
@@ -43,9 +43,10 @@ export function createDisabledRequestScope(input: {
   readonly requestId: string
   readonly correlationId: string
 }): ExecutionScope {
+  const execution = createRequestExecution(input)
   return Object.freeze({
-    execution: createRequestExecution(input),
-    authorization: createDisabledRuntimeAuthorization(input.projectId),
+    execution,
+    authorization: createDisabledRuntimeAuthorization(execution),
   })
 }
 
@@ -64,7 +65,7 @@ export function createKernelScope(input: {
   })
   return Object.freeze({
     execution,
-    authorization: createKernelRuntimeAuthorization({ projectId: input.projectId, operation }),
+    authorization: createKernelRuntimeAuthorization({ execution, operation }),
   })
 }
 
@@ -110,8 +111,8 @@ export function createTestingScope(input: {
   return Object.freeze({
     execution,
     authorization: context
-      ? createPrincipalRuntimeAuthorization({ projectId: input.projectId, context })
-      : createDisabledRuntimeAuthorization(input.projectId),
+      ? createPrincipalRuntimeAuthorization({ execution, context })
+      : createDisabledRuntimeAuthorization(execution),
   })
 }
 

--- a/packages/core/src/objects/link/authorization.ts
+++ b/packages/core/src/objects/link/authorization.ts
@@ -1,7 +1,8 @@
 /**
  * The authorization rule for writing a link, in one place because all three link leaves need it.
  */
-import { type AuthorizationContext, assertAuthorized, assertCanEdit } from "../../authorization"
+import { assertAuthorized, assertCanEdit } from "../../authorization"
+import type { SixbRuntimeContext } from "../../runtime/types"
 
 /**
  * Assert a principal may create or remove a link.
@@ -18,7 +19,7 @@ import { type AuthorizationContext, assertAuthorized, assertCanEdit } from "../.
  * Call this *before* any endpoint lookup, for that second reason.
  */
 export function assertCanWriteLink(
-  ctx: { readonly authorization?: AuthorizationContext },
+  ctx: Pick<SixbRuntimeContext, "projectId" | "runtimeAuthorization" | "authorization">,
   endpoints: { readonly sourceTypeId: string; readonly targetTypeId: string }
 ): void {
   assertCanEdit(ctx, endpoints.sourceTypeId)

--- a/packages/core/src/objects/query/executor.ts
+++ b/packages/core/src/objects/query/executor.ts
@@ -138,7 +138,7 @@ export async function executeObjectQuery(
     maxRefs: options.maxRefs,
     normalize: false,
   })
-  assertQueryViewable(validated, options)
+  assertQueryViewable(input.projectId, validated, options)
   const capabilities = options.storage.queryCapabilities()
   const hasQueryObjects = typeof options.storage.queryObjects === "function"
   const hasCountObjects = typeof options.storage.countObjects === "function"
@@ -206,7 +206,7 @@ export async function countObjects(
     maxRefs: options.maxRefs,
     normalize: false,
   })
-  assertQueryViewable(validated, options)
+  assertQueryViewable(input.projectId, validated, options)
   const capabilities = options.storage.queryCapabilities()
   const hasQueryObjects = typeof options.storage.queryObjects === "function"
   const hasCountObjects = typeof options.storage.countObjects === "function"
@@ -267,7 +267,7 @@ export async function existsObjects(
     maxRefs: options.maxRefs,
     normalize: false,
   })
-  assertQueryViewable(validated, options)
+  assertQueryViewable(input.projectId, validated, options)
   const capabilities = options.storage.queryCapabilities()
   const hasQueryObjects = typeof options.storage.queryObjects === "function"
   const hasCountObjects = typeof options.storage.countObjects === "function"
@@ -328,7 +328,7 @@ export async function facetObjects(
     maxRefs: options.maxRefs,
     normalize: false,
   })
-  assertQueryViewable(validated, options)
+  assertQueryViewable(input.projectId, validated, options)
   const facets = validateFacetRequests(input.facets, validated.result.objectTypeIds, options)
   const aggregateQuery = stripOuterRowShape(validated.query)
   const capabilities = options.storage.queryCapabilities()
@@ -388,16 +388,20 @@ export async function facetObjects(
 // Authorization happens at planning time: a scoped query must hold a view
 // grant for every object type it touches, before any storage call runs.
 function assertQueryViewable(
+  projectId: string,
   validated: ValidatedObjectQuery,
   authorization: Pick<QueryExecutorOptions, "authorization" | "runtimeAuthorization">
 ): void {
   // The query engine is also a storage-level utility. Authorization is activated by a runtime
   // context; execution SDKs always provide a registered capability, including auth-disabled ones.
   if (!authorization.runtimeAuthorization && !authorization.authorization) return
-  assertAuthorized(authorization, {
-    kind: "object.query",
-    touchedObjectTypeIds: validated.touchedObjectTypeIds,
-  })
+  assertAuthorized(
+    { projectId, ...authorization },
+    {
+      kind: "object.query",
+      touchedObjectTypeIds: validated.touchedObjectTypeIds,
+    }
+  )
 }
 
 interface ExpansionResolutionContext {

--- a/packages/core/src/objects/telemetry/history.ts
+++ b/packages/core/src/objects/telemetry/history.ts
@@ -17,17 +17,19 @@ export async function getTelemetryHistoryBatch(
   input: TimeseriesHistoryBatchInput,
   options: TelemetryHistoryOptions
 ): Promise<readonly TimeseriesHistoryBatchResult[]> {
-  assertTelemetrySeriesViewable(input.series, options)
+  assertTelemetrySeriesViewable(input.projectId, input.series, options)
   return options.storage.getHistoryBatch(input)
 }
 
 function assertTelemetrySeriesViewable(
+  projectId: string,
   series: readonly TimeseriesHistorySeriesInput[],
   authorization: Pick<TelemetryHistoryOptions, "authorization" | "runtimeAuthorization">
 ): void {
   for (const objectTypeId of new Set(series.map((entry) => entry.objectTypeId))) {
     assertAuthorized(
       {
+        projectId,
         runtimeAuthorization: authorization.runtimeAuthorization,
         authorization: authorization.authorization ?? undefined,
       },

--- a/packages/core/src/pipelines/request.ts
+++ b/packages/core/src/pipelines/request.ts
@@ -1,4 +1,5 @@
 import { assertAuthorized } from "../authorization"
+import { resolveExecutionScopeAuthorization } from "../execution/authorization"
 import {
   createPrimitiveExecutionRecord,
   ensureExecutionRecord,
@@ -42,6 +43,10 @@ export async function requestPipelineRun(
   pipeline: PipelineDefinition,
   options: PipelineRunRequestOptions = {}
 ): Promise<PipelineRunRequestResult> {
+  resolveExecutionScopeAuthorization(runtime.projectId, {
+    execution,
+    authorization: runtime.runtimeAuthorization,
+  })
   assertAuthorized(runtime, { kind: "pipeline.run", pipelineId: pipeline.id })
   if (!runtime.storage.pipelineRuns) {
     throw new PipelineError("[Sixb] Pipeline run storage is not configured.")

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -11,6 +11,7 @@ import type { ConnectorService } from "../connectors/service"
 import { createDatasetsRuntime, type DatasetsRuntime } from "../datasets/execution"
 import { createEventsRuntime, type EventsRuntime } from "../events/execution"
 import type { ExecutionContext } from "../execution"
+import { resolveExecutionScopeAuthorization } from "../execution/authorization"
 import type { LakeStorage } from "../lake-storage/types"
 import { createLogsRuntime, type LogsRuntime } from "../logging/execution"
 import type { LoggingService } from "../logging/service"
@@ -63,6 +64,10 @@ export function createBoundSixb<TOntologySources extends readonly OntologySource
   dependencies: SixbDependencies,
   execution: ExecutionContext
 ): Sixb<TOntologySources> {
+  resolveExecutionScopeAuthorization(runtime.projectId, {
+    execution,
+    authorization: runtime.runtimeAuthorization,
+  })
   const sixb: Sixb<TOntologySources> = {
     execution,
     ...createExecutionFacades<TOntologySources>(runtime, execution, dependencies),

--- a/packages/core/src/syncs/request.ts
+++ b/packages/core/src/syncs/request.ts
@@ -1,4 +1,5 @@
 import { assertAuthorized } from "../authorization"
+import { resolveExecutionScopeAuthorization } from "../execution/authorization"
 import {
   createPrimitiveExecutionRecord,
   ensureExecutionRecord,
@@ -45,6 +46,10 @@ export async function requestSyncRun(
   sync: SyncDefinition,
   options: SyncRunRequestOptions = {}
 ): Promise<SyncRunRequestResult> {
+  resolveExecutionScopeAuthorization(runtime.projectId, {
+    execution,
+    authorization: runtime.runtimeAuthorization,
+  })
   assertAuthorized(runtime, { kind: "sync.run", syncId: sync.id })
   if (!runtime.storage.syncRuns) {
     throw new SyncValidationError("[Sixb] Sync run storage is not configured.")

--- a/packages/core/src/workflows/request.ts
+++ b/packages/core/src/workflows/request.ts
@@ -1,5 +1,6 @@
 import { snapshotRequesterGroupIds } from "../auth/attribution"
 import { assertAuthorized } from "../authorization"
+import { resolveExecutionScopeAuthorization } from "../execution/authorization"
 import {
   createPrimitiveExecutionRecord,
   ensureExecutionRecord,
@@ -44,6 +45,10 @@ export async function requestWorkflowRun(
   workflow: WorkflowDefinition,
   options: WorkflowRunRequestOptions = {}
 ): Promise<WorkflowRunRequestResult> {
+  resolveExecutionScopeAuthorization(runtime.projectId, {
+    execution,
+    authorization: runtime.runtimeAuthorization,
+  })
   assertAuthorized(runtime, { kind: "workflow.run", workflowId: workflow.id })
   const requesterGroupIds = execution.requestedBy
     ? await snapshotRequesterGroupIds({

--- a/packages/core/tests/authorization-decision.test.ts
+++ b/packages/core/tests/authorization-decision.test.ts
@@ -18,10 +18,7 @@ import type {
   StoredTelemetryAppendedEvent,
   StoredWorkflowRunStartedEvent,
 } from "../src/events"
-import {
-  createDisabledRuntimeAuthorization,
-  createPrincipalRuntimeAuthorization,
-} from "../src/execution/authorization"
+import { createTestingScope } from "../src/execution/scopes"
 
 function context(grants: {
   applications?: readonly string[]
@@ -58,16 +55,20 @@ function context(grants: {
 }
 
 function principalRuntime(grants: Parameters<typeof context>[0]) {
+  const scope = createTestingScope({
+    projectId: "decision-test",
+    context: context(grants),
+  })
   return {
-    runtimeAuthorization: createPrincipalRuntimeAuthorization({
-      projectId: "decision-test",
-      context: context(grants),
-    }),
+    projectId: "decision-test",
+    runtimeAuthorization: scope.authorization,
   }
 }
 
+const unrestrictedScope = createTestingScope({ projectId: "decision-test" })
 const unrestrictedRuntime = {
-  runtimeAuthorization: createDisabledRuntimeAuthorization("decision-test"),
+  projectId: "decision-test",
+  runtimeAuthorization: unrestrictedScope.authorization,
 }
 
 describe("evaluate", () => {
@@ -259,8 +260,12 @@ describe("write asserts", () => {
   })
 
   test("both asserts fail closed without registered execution authority", () => {
-    expect(() => assertCanEdit({}, "quote")).toThrow("registered execution scope")
-    expect(() => assertCanAppendTelemetry({}, "sensor")).toThrow("registered execution scope")
+    expect(() => assertCanEdit({ projectId: "decision-test" }, "quote")).toThrow(
+      "registered execution scope"
+    )
+    expect(() => assertCanAppendTelemetry({ projectId: "decision-test" }, "sensor")).toThrow(
+      "registered execution scope"
+    )
   })
 })
 

--- a/packages/core/tests/connector-connection-execution.test.ts
+++ b/packages/core/tests/connector-connection-execution.test.ts
@@ -32,17 +32,22 @@ describe("connector connection execution boundary", () => {
       source: { type: "execution", executionId: "request-a" },
       correlationId: "correlation-a",
     } as const
+    const authorizedExecution = {
+      ...execution,
+      id: "execution-b",
+      executor: { type: "primitive", kind: "action", id: "publish", runId: "run-b" },
+    } as const
     const runtime = {
       projectId: "project",
       runtimeAuthorization: createTrustedPrimitiveRuntimeAuthorization({
-        projectId: "project",
+        execution: authorizedExecution,
         primitive: { kind: "action", id: "publish", runId: "run-b" },
       }),
     } as SixbRuntimeContext
     const connector = createConnectorRuntime(runtime, execution, harness.service)
 
     expect(() => connector(harness.connector, { owner: projectOwner, slot: "social" })).toThrow(
-      "does not match its executor"
+      "bound to different execution provenance"
     )
   })
 
@@ -207,7 +212,7 @@ describe("connector connection execution boundary", () => {
     const runtime = {
       projectId: "project",
       runtimeAuthorization: createTrustedPrimitiveRuntimeAuthorization({
-        projectId: "project",
+        execution,
         primitive,
       }),
     } as SixbRuntimeContext

--- a/packages/core/tests/execution-authority-boundaries.test.ts
+++ b/packages/core/tests/execution-authority-boundaries.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test"
+import { requestAction } from "../src/actions/request"
+import { requestAgentRun, retryAgentRun } from "../src/agents/request"
+import { type AuthorizationContext, emptyGrantIndex } from "../src/authorization"
+import { createTestingScope } from "../src/execution/scopes"
+import { requestPipelineRun } from "../src/pipelines/request"
+import type { PipelineDefinition } from "../src/pipelines/types"
+import type { SixbRuntimeContext } from "../src/runtime/types"
+import type { ConversationAgentRunRecord } from "../src/storage/agents"
+import { requestSyncRun } from "../src/syncs/request"
+import type { SyncDefinition } from "../src/syncs/types"
+import { requestWorkflowRun } from "../src/workflows/request"
+import type { WorkflowDefinition } from "../src/workflows/types"
+
+describe("execution authority boundaries", () => {
+  test("run requests reject another same-principal execution before dependencies", async () => {
+    const context: AuthorizationContext = {
+      principal: { type: "user", id: "same-principal" },
+      groupIds: [],
+      roleIds: [],
+      grants: emptyGrantIndex(),
+    }
+    const authorityScope = createTestingScope({
+      projectId: "project-1",
+      executionId: "execution-authorized",
+      context,
+    })
+    const foreignExecution = createTestingScope({
+      projectId: "project-1",
+      executionId: "execution-foreign",
+      context,
+    }).execution
+    const runtime = {
+      projectId: "project-1",
+      runtimeAuthorization: authorityScope.authorization,
+    } as SixbRuntimeContext
+    const expected = "authority is bound to different execution provenance"
+
+    await expect(
+      requestAction(runtime, foreignExecution, { actionId: "action-1" })
+    ).rejects.toThrow(expected)
+    await expect(
+      requestAgentRun(runtime, foreignExecution, undefined, { text: "hello" })
+    ).rejects.toThrow(expected)
+    await expect(
+      retryAgentRun(runtime, foreignExecution, undefined, {
+        id: "run-1",
+      } as ConversationAgentRunRecord)
+    ).rejects.toThrow(expected)
+    await expect(
+      requestPipelineRun(runtime, foreignExecution, { id: "pipeline-1" } as PipelineDefinition)
+    ).rejects.toThrow(expected)
+    await expect(
+      requestSyncRun(runtime, foreignExecution, { id: "sync-1" } as SyncDefinition)
+    ).rejects.toThrow(expected)
+    await expect(
+      requestWorkflowRun(runtime, foreignExecution, { id: "workflow-1" } as WorkflowDefinition)
+    ).rejects.toThrow(expected)
+  })
+})

--- a/packages/core/tests/execution-authorization.test.ts
+++ b/packages/core/tests/execution-authorization.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../src/execution/agent"
 import {
   assertExecutionScopeProject,
+  createAgentRuntimeAuthorization,
   createPrincipalRuntimeAuthorization,
   createTrustedPrimitiveRuntimeAuthorization,
   getAuthorizationRef,
@@ -17,6 +18,7 @@ import {
 } from "../src/execution/authorization"
 import {
   createPrimitiveExecutionRecord,
+  executionRecordInputFromRuntime,
   restoreTrustedPrimitiveExecutionScope,
 } from "../src/execution/durable"
 import {
@@ -27,6 +29,7 @@ import {
 } from "../src/execution/scopes"
 import {
   createRuntimeAuthorizationCapability,
+  type ExecutionContext,
   type ExecutionScope,
   type RuntimeAuthorization,
 } from "../src/execution/types"
@@ -36,8 +39,9 @@ describe("runtime authorization capabilities", () => {
     const context = authorizationContext({ type: "user", id: "user-1" }, "session-1")
     const groups = context.groupIds as string[]
     const workflowGrants = context.grants["run:workflow"] as Set<string>
+    workflowGrants.add("original-workflow")
     const authorization = createPrincipalRuntimeAuthorization({
-      projectId: "project-1",
+      execution: requestExecution("principal-snapshot", { type: "user", id: "user-1" }),
       context,
       credential: { type: "session", id: "session-1" },
     })
@@ -50,6 +54,18 @@ describe("runtime authorization capabilities", () => {
     if (resolved.type !== "principal") throw new Error("expected principal authorization")
     expect(resolved.context.groupIds).toEqual(["group-1"])
     expect(resolved.context.grants["run:workflow"].has("late-workflow")).toBe(false)
+    expect(resolved.context.grants["run:workflow"].has("original-workflow")).toBe(true)
+
+    const runtimeGrants = resolved.context.grants["run:workflow"] as Set<string>
+    expect(() => runtimeGrants.add("injected-workflow")).toThrow(
+      "Runtime authorization grants are immutable"
+    )
+    expect(() => runtimeGrants.delete("original-workflow")).toThrow(
+      "Runtime authorization grants are immutable"
+    )
+    expect(() => runtimeGrants.clear()).toThrow("Runtime authorization grants are immutable")
+    expect(runtimeGrants.has("injected-workflow")).toBe(false)
+    expect(runtimeGrants.has("original-workflow")).toBe(true)
 
     const firstRef = getAuthorizationRef(authorization)
     expect(firstRef).toEqual({
@@ -103,7 +119,7 @@ describe("runtime authorization capabilities", () => {
   test("rejects system principals and invalid authority identifiers", () => {
     expect(() =>
       createPrincipalRuntimeAuthorization({
-        projectId: "project-1",
+        execution: requestExecution("system-principal"),
         context: authorizationContext({ type: "system", id: "system" }),
       })
     ).toThrow("Principal type 'system' cannot hold runtime authorization")
@@ -115,21 +131,129 @@ describe("runtime authorization capabilities", () => {
   test("rejects inconsistent session credential references", () => {
     expect(() =>
       createPrincipalRuntimeAuthorization({
-        projectId: "project-1",
+        execution: requestExecution("missing-session-credential", {
+          type: "user",
+          id: "user-1",
+        }),
         context: authorizationContext({ type: "user", id: "user-1" }, "session-1"),
       })
     ).toThrow("Authorization context session requires a matching session credential")
     expect(() =>
       createPrincipalRuntimeAuthorization({
-        projectId: "project-1",
+        execution: requestExecution("mismatched-session-credential", {
+          type: "user",
+          id: "user-1",
+        }),
         context: authorizationContext({ type: "user", id: "user-1" }),
         credential: { type: "session", id: "session-1" },
       })
     ).toThrow("Session credential id must match the authorization context session id")
   })
+
+  test("binds managed Agent authority to its actor-owned service account", () => {
+    const execution: ExecutionContext = {
+      id: "execution-agent-identity",
+      projectId: "project-1",
+      executor: { type: "agent", actorId: "research", runId: "run-1" },
+      source: { type: "execution", executionId: "execution-parent" },
+      correlationId: "correlation-1",
+    }
+
+    expect(() =>
+      createAgentRuntimeAuthorization({
+        execution,
+        authority: {
+          type: "principal",
+          context: authorizationContext({ type: "serviceAccount", id: "svc_agent_other" }),
+        },
+      })
+    ).toThrow("agent authority must reference its managed service account")
+    expect(() =>
+      createAgentRuntimeAuthorization({
+        execution: { ...execution, source: { type: "event", eventId: "event-forged" } },
+        authority: {
+          type: "principal",
+          context: authorizationContext({
+            type: "serviceAccount",
+            id: agentServiceAccountId("research"),
+          }),
+        },
+      })
+    ).toThrow("agent execution requires an execution source")
+  })
 })
 
 describe("execution scopes", () => {
+  // Regression check: bypass executionMatchesBinding in resolveExecutionScopeAuthorization;
+  // changing only the parent source or correlation must then make these rejection checks fail.
+  test.each([
+    "principal",
+    "disabled",
+  ] as const)("pins inherited %s Agent authority to its exact execution provenance", (type) => {
+    const execution: ExecutionContext = {
+      id: "execution-conversation",
+      projectId: "project-1",
+      ...(type === "principal" ? { requestedBy: { type: "user" as const, id: "user-1" } } : {}),
+      executor: { type: "agent", runId: "run-conversation" },
+      source: { type: "execution", executionId: "execution-parent" },
+      correlationId: "correlation-original",
+    }
+    const authorization = createAgentRuntimeAuthorization({
+      execution,
+      authority:
+        type === "principal"
+          ? {
+              type: "principal",
+              context: authorizationContext({ type: "user", id: "user-1" }, "session-1"),
+              credential: { type: "session", id: "session-1" },
+            }
+          : { type: "disabled" },
+    })
+    expect(() =>
+      resolveExecutionScopeAuthorization("project-1", { execution, authorization })
+    ).not.toThrow()
+    for (const changed of [
+      { ...execution, correlationId: "correlation-other" },
+      { ...execution, source: { type: "execution" as const, executionId: "other-parent" } },
+    ]) {
+      expect(() =>
+        resolveExecutionScopeAuthorization("project-1", { execution: changed, authorization })
+      ).toThrow("authority is bound to different execution provenance")
+    }
+  })
+
+  test("durable serialization rejects a mismatched execution and authority pair", () => {
+    const projectOne = createTestingScope({ projectId: "project-1" })
+    const projectTwo = createTestingScope({ projectId: "project-2" })
+    const principalOne = createTestingScope({
+      projectId: "project-1",
+      context: authorizationContext({ type: "user", id: "user-1" }),
+    })
+    const principalTwo = createTestingScope({
+      projectId: "project-1",
+      context: authorizationContext({ type: "user", id: "user-2" }),
+    })
+
+    expect(() =>
+      executionRecordInputFromRuntime({
+        execution: projectTwo.execution,
+        runtimeAuthorization: projectOne.authorization,
+      })
+    ).toThrow("belongs to project 'project-1', not 'project-2'")
+    expect(() =>
+      executionRecordInputFromRuntime({
+        execution: principalTwo.execution,
+        runtimeAuthorization: principalOne.authorization,
+      })
+    ).toThrow("authority is bound to different execution provenance")
+    expect(
+      executionRecordInputFromRuntime({
+        execution: projectOne.execution,
+        runtimeAuthorization: projectOne.authorization,
+      })
+    ).toMatchObject({ projectId: "project-1", authorizationRef: { type: "disabled" } })
+  })
+
   test("rejects mixing an execution with authority from another scope", () => {
     const principalScope = createTestingScope({
       projectId: "project-1",
@@ -153,6 +277,89 @@ describe("execution scopes", () => {
       "message",
       expect.stringContaining("incompatible with its authority")
     )
+  })
+
+  test("binds request authority to exact id, source, and correlation provenance", () => {
+    const context = authorizationContext({ type: "user", id: "user-1" })
+    const scope = createTestingScope({
+      projectId: "project-1",
+      executionId: "execution-request-1",
+      requestId: "request-1",
+      correlationId: "correlation-1",
+      context,
+    })
+    const anotherExecution = createTestingScope({
+      projectId: "project-1",
+      executionId: "execution-request-2",
+      requestId: "request-1",
+      correlationId: "correlation-1",
+      context,
+    }).execution
+    const forgedCorrelation: ExecutionContext = {
+      ...scope.execution,
+      correlationId: "correlation-forged",
+    }
+    const forgedSourceAndExecutor: ExecutionContext = {
+      ...scope.execution,
+      executor: { type: "request", requestId: "request-forged" },
+      source: { type: "http", requestId: "request-forged" },
+    }
+    const forgedRequestedBy: ExecutionContext = {
+      ...scope.execution,
+      requestedBy: { type: "user", id: "user-forged" },
+    }
+
+    for (const execution of [
+      anotherExecution,
+      forgedCorrelation,
+      forgedSourceAndExecutor,
+      forgedRequestedBy,
+    ]) {
+      expect(() =>
+        resolveExecutionScopeAuthorization("project-1", {
+          execution,
+          authorization: scope.authorization,
+        })
+      ).toThrow("authority is bound to different execution provenance")
+    }
+
+    expect(() =>
+      executionRecordInputFromRuntime({
+        execution: forgedCorrelation,
+        runtimeAuthorization: scope.authorization,
+      })
+    ).toThrow("authority is bound to different execution provenance")
+  })
+
+  test("binds primitive and kernel authority to their complete execution provenance", () => {
+    const primitive = { kind: "action", id: "send-email", runId: "action-run-1" } as const
+    const primitiveScope = restoreTrustedPrimitiveExecutionScope({
+      execution: {
+        id: "execution-action-binding",
+        projectId: "project-1",
+        executor: { type: "primitive", kind: primitive.kind, runId: primitive.runId },
+        source: { type: "event", eventId: "event-1" },
+        correlationId: "correlation-1",
+        authorizationRef: { type: "trustedPrimitive", primitive },
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+      primitive,
+    })
+    const kernelScope = createKernelScope({
+      projectId: "project-1",
+      operation: { type: "ontology.recover", recoveryId: "recovery-1" },
+      source: { type: "event", eventId: "event-1" },
+      correlationId: "correlation-1",
+    })
+
+    for (const scope of [primitiveScope, kernelScope]) {
+      expect(() =>
+        resolveExecutionScopeAuthorization("project-1", {
+          execution: { ...scope.execution, correlationId: "correlation-forged" },
+          authorization: scope.authorization,
+        })
+      ).toThrow("authority is bound to different execution provenance")
+    }
   })
 
   test("creates a principal request scope with explicit request provenance", () => {
@@ -303,7 +510,7 @@ describe("execution scopes", () => {
     ).toThrow("does not authorize Agent run")
     expect(() =>
       createTrustedPrimitiveRuntimeAuthorization({
-        projectId: "project-1",
+        execution: requestExecution("invalid-trusted-primitive"),
         primitive: { kind: "agent", id: "research", runId: "agent-run-2" } as never,
       })
     ).toThrow("Unknown trusted primitive kind 'agent'")
@@ -403,5 +610,19 @@ function authorizationContext(principal: Principal, sessionId?: string): Authori
     groupIds: ["group-1"],
     roleIds: ["role-1"],
     grants: emptyGrantIndex(),
+  }
+}
+
+function requestExecution(
+  id: string,
+  requestedBy?: ExecutionContext["requestedBy"]
+): ExecutionContext {
+  return {
+    id,
+    projectId: "project-1",
+    ...(requestedBy === undefined ? {} : { requestedBy }),
+    executor: { type: "request", requestId: `request-${id}` },
+    source: { type: "http", requestId: `request-${id}` },
+    correlationId: `correlation-${id}`,
   }
 }

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -1146,14 +1146,14 @@ describe("bound Sixb fails closed on ungranted surfaces", () => {
           executor: { type: "agent", actorId: "contract-agent", runId: "agent-run-2" },
         },
       })
-    ).toThrow("agent authority does not match its execution binding")
+    ).toThrow("authority is bound to different execution provenance")
 
     expect(() =>
       host.withScope({
         authorization: scope.authorization,
         execution: { ...scope.execution, id: "exec_forged" },
       })
-    ).toThrow("agent authority does not match its execution binding")
+    ).toThrow("authority is bound to different execution provenance")
   })
 })
 


### PR DESCRIPTION
Part of #269 · Stack #547 · Base: main · Next: #490

## Why

Execution context records **who is acting, in which project, and what triggered the work**. Runtime authorization carries **the permissions used to perform it**.

Those two must stay together. Valid permissions must not be reusable with a different request, Agent run, or execution origin.

## How it works

```text
Register permissions for execution A
  → capture immutable permissions + execution context
  → validate the pair before reads or effects

Permissions A + execution A  → continue with permission checks
Permissions A + execution B  → reject
```

The binding covers the execution ID, project, requester, executor, source and correlation ID—not just the user or project.

## Guarantees

- Captured permissions cannot be widened through mutation.
- Managed Agent actors retain their own service account; conversations preserve inherited user or auth-disabled authority.
- Mismatched authority/context pairs fail before provider access or effects.

## Why this comes first

Shared Links will introduce narrowly delegated permissions. This PR secures **which execution may use those permissions**; later PRs enforce **which objects and links it may access**.

No Shared Link behavior or object-level scoping yet. No new application-facing API.

