### PR TITLE
storage: separate safe object-read primitives

### DIFF
--- a/packages/core/src/objects/query/executor.ts
+++ b/packages/core/src/objects/query/executor.ts
@@ -10,11 +10,10 @@ import type {
   ObjectBatchKey,
   ObjectFacetRequest,
   ObjectFacetResult,
-  ObjectLinkRow,
   ObjectQueryCapabilities,
+  ObjectReadStorage,
   ObjectRow,
   ObjectRowLinks,
-  ObjectStorage,
   QueryObjectsResult,
 } from "../../storage"
 import { linkBatchKey, objectBatchKey } from "../../storage"
@@ -51,7 +50,7 @@ export interface QueryExecutorOptions
     | "hasFacetObjects"
   > {
   ontology: OntologyRegistry
-  storage: ObjectStorage
+  storage: ObjectReadStorage
   maxLimit?: number
   maxPageSize?: number
   maxRefs?: number
@@ -820,35 +819,32 @@ async function collectIncomingEdges(
   expansion: ObjectExpansion,
   options: QueryExecutorOptions
 ): Promise<ExpansionEdge[][]> {
-  const incident = await options.storage.listIncidentLinksBatch({
+  const linksByKey = await options.storage.listLinksBatch({
     projectId,
+    direction: "incoming",
     items: parents.map((parent) => ({
       objectTypeId: parent.objectTypeId,
       objectId: parent.primaryId,
+      linkId: expansion.linkId,
     })),
   })
 
-  // Index links that point AT a parent (incoming) by that parent. The incident
-  // batch also returns outgoing links, so filter on the parent being the target.
-  const byTarget = new Map<string, ObjectLinkRow[]>()
-  for (const link of incident) {
-    if (link.linkId !== expansion.linkId) continue
-    if (expansion.sourceObjectTypeId && link.sourceTypeId !== expansion.sourceObjectTypeId) continue
-    const key = targetKey(link.targetTypeId, link.targetId)
-    const bucket = byTarget.get(key)
-    if (bucket) bucket.push(link)
-    else byTarget.set(key, [link])
-  }
-
   return parents.map((parent) => {
-    const links = byTarget.get(targetKey(parent.objectTypeId, parent.primaryId))
+    const links = linksByKey.get(
+      linkBatchKey(parent.objectTypeId, parent.primaryId, expansion.linkId)
+    )
     if (!links) return []
     // For an incoming expansion the hydrated object is the link's source.
-    return links.map((link) => ({
-      neighborTypeId: link.sourceTypeId,
-      neighborId: link.sourceId,
-      edgeProperties: link.properties,
-    }))
+    return links
+      .filter(
+        (link) =>
+          !expansion.sourceObjectTypeId || link.sourceTypeId === expansion.sourceObjectTypeId
+      )
+      .map((link) => ({
+        neighborTypeId: link.sourceTypeId,
+        neighborId: link.sourceId,
+        edgeProperties: link.properties,
+      }))
   })
 }
 

--- a/packages/core/src/objects/query/links.ts
+++ b/packages/core/src/objects/query/links.ts
@@ -6,8 +6,8 @@ import {
   type ObjectBatchKey,
   type ObjectLinkCursor,
   type ObjectLinkRow,
+  type ObjectReadStorage,
   type ObjectRow,
-  type ObjectStorage,
   objectBatchKey,
   objectLinkCursor,
 } from "../../storage"
@@ -271,7 +271,7 @@ async function hydrateLinkQueryObjects(
   projectId: string,
   selected: readonly ObjectRow[],
   links: readonly ObjectLinkRow[],
-  storage: ObjectStorage
+  storage: ObjectReadStorage
 ): Promise<ObjectRow[]> {
   const byIdentity = new Map(
     selected.map((row) => [objectIdentity(row.objectTypeId, row.primaryId), row])

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -415,6 +415,7 @@ export type {
   ObjectQueryCapabilityMap,
   ObjectQueryScalarOperation,
   ObjectQueryScalarOperations,
+  ObjectReadStorage,
   ObjectRow,
   ObjectRowLinks,
   ObjectStorage,

--- a/packages/core/src/storage/objects/in-memory.ts
+++ b/packages/core/src/storage/objects/in-memory.ts
@@ -21,6 +21,7 @@ import type {
   ObjectFacetResult,
   ObjectLinkRow,
   ObjectQueryCapabilities,
+  ObjectReadStorage,
   ObjectRow,
   ObjectStorage,
   QueryObjectLinksInput,
@@ -614,6 +615,18 @@ export class InMemoryObjectStorage implements ObjectStorage {
     return bucket.get(params.primaryId) ?? null
   }
 
+  async selectsObjectProperties(
+    params: Parameters<ObjectReadStorage["selectsObjectProperties"]>[0]
+  ): Promise<readonly boolean[]> {
+    const objects = await this.getByPrimaryIdBatch({
+      projectId: params.projectId,
+      items: params.items,
+    })
+    return params.items.map((item) =>
+      objects.has(objectBatchKey(item.objectTypeId, item.primaryId))
+    )
+  }
+
   async listLinks(params: {
     projectId: string
     objectTypeId: string
@@ -671,6 +684,7 @@ export class InMemoryObjectStorage implements ObjectStorage {
 
   async listLinksBatch(params: {
     projectId: string
+    direction?: LinkDirection
     items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
   }): Promise<Map<LinkBatchKey, ObjectLinkRow[]>> {
     const result = new Map<LinkBatchKey, ObjectLinkRow[]>()
@@ -680,6 +694,7 @@ export class InMemoryObjectStorage implements ObjectStorage {
         objectTypeId: item.objectTypeId,
         objectId: item.objectId,
         linkId: item.linkId,
+        direction: params.direction,
       })
       if (rows.length > 0) {
         result.set(linkBatchKey(item.objectTypeId, item.objectId, item.linkId), [...rows])

--- a/packages/core/src/storage/objects/index.ts
+++ b/packages/core/src/storage/objects/index.ts
@@ -23,6 +23,7 @@ export type {
   ObjectQueryCapabilityMap,
   ObjectQueryScalarOperation,
   ObjectQueryScalarOperations,
+  ObjectReadStorage,
   ObjectRow,
   ObjectRowLinks,
   ObjectStorage,

--- a/packages/core/src/storage/objects/keys.ts
+++ b/packages/core/src/storage/objects/keys.ts
@@ -13,7 +13,7 @@ export function objectBatchKey(objectTypeId: string, primaryId: string): ObjectB
   return JSON.stringify([objectTypeId, primaryId]) as ObjectBatchKey
 }
 
-/** Collision-safe key for outgoing-link batch-read results. */
+/** Collision-safe key for directional link batch-read results, keyed by the requested object. */
 export function linkBatchKey(objectTypeId: string, objectId: string, linkId: string): LinkBatchKey {
   return JSON.stringify([objectTypeId, objectId, linkId]) as LinkBatchKey
 }

--- a/packages/core/src/storage/objects/types.ts
+++ b/packages/core/src/storage/objects/types.ts
@@ -189,7 +189,8 @@ export interface FacetObjectsResult {
   facets: readonly ObjectFacetResult[]
 }
 
-export interface ObjectStorage {
+/** Provider-facing read-only surface for effective objects and links. */
+export interface ObjectReadStorage {
   queryCapabilities(): ObjectQueryCapabilities
 
   queryObjects?(params: QueryObjectsInput): Promise<QueryObjectsResult>
@@ -202,6 +203,22 @@ export interface ObjectStorage {
     objectTypeId: string
     primaryId: string
   }): Promise<ObjectRow | null>
+
+  /**
+   * Check whether each requested property belongs to the reader's selection.
+   *
+   * Results align exactly with `items`, including duplicates. Selection is independent from the
+   * property's current materialized value: an unrestricted reader selects every property of an
+   * existing object even when that property has no stored value.
+   */
+  selectsObjectProperties(params: {
+    projectId: string
+    items: readonly {
+      objectTypeId: string
+      primaryId: string
+      propertyId: string
+    }[]
+  }): Promise<readonly boolean[]>
 
   listLinks(params: {
     projectId: string
@@ -221,11 +238,13 @@ export interface ObjectStorage {
   }): Promise<ReadonlyMap<ObjectBatchKey, ObjectRow>>
 
   /**
-   * Batch fetch outgoing links by (objectTypeId, objectId, linkId) tuples.
+   * Batch fetch links by (objectTypeId, objectId, linkId) tuples in the requested direction.
+   * Direction defaults to outgoing.
    * Returns a Map keyed by {@link linkBatchKey}. Missing entries are absent.
    */
   listLinksBatch(params: {
     projectId: string
+    direction?: LinkDirection
     items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
   }): Promise<ReadonlyMap<LinkBatchKey, ObjectLinkRow[]>>
 
@@ -235,25 +254,6 @@ export interface ObjectStorage {
    * bounded response never requires loading every incident link into the runtime.
    */
   queryLinks(params: QueryObjectLinksInput): Promise<QueryObjectLinksResult>
-
-  /**
-   * Batch fetch every link incident to any of the given objects, in BOTH directions (the object as
-   * link source or target). Returns a flat, de-duplicated list: a physical link incident to two
-   * listed objects appears once. This unpaged primitive exists for internal materialization and
-   * per-parent expansion work; interactive reads use {@link queryLinks}.
-   */
-  listIncidentLinksBatch(params: {
-    projectId: string
-    items: readonly { objectTypeId: string; objectId: string }[]
-  }): Promise<readonly ObjectLinkRow[]>
-
-  /** Stable keyset page used by background reconciliation without a total-count scan. */
-  listByPrimaryIdPage(params: {
-    projectId: string
-    objectTypeId: string
-    afterPrimaryId?: string
-    limit: number
-  }): Promise<{ objects: readonly ObjectRow[]; nextPrimaryId?: string }>
 
   list(params: {
     projectId: string
@@ -269,4 +269,26 @@ export interface ObjectStorage {
     orderBy?: "createdAt" | "updatedAt" | "primaryId"
     order?: "asc" | "desc"
   }): Promise<{ objects: readonly ObjectRow[]; hasMore: boolean; total: number }>
+}
+
+/** Latest-state projection storage, including trusted internal read primitives. */
+export interface ObjectStorage extends ObjectReadStorage {
+  /**
+   * Batch fetch every link incident to any of the given objects, in BOTH directions (the object as
+   * link source or target). Returns a flat, de-duplicated list: a physical link incident to two
+   * listed objects appears once. This unpaged primitive is reserved for trusted internal work and
+   * deliberately absent from {@link ObjectReadStorage}; interactive reads use {@link queryLinks}.
+   */
+  listIncidentLinksBatch(params: {
+    projectId: string
+    items: readonly { objectTypeId: string; objectId: string }[]
+  }): Promise<readonly ObjectLinkRow[]>
+
+  /** Stable keyset page used by background reconciliation without a total-count scan. */
+  listByPrimaryIdPage(params: {
+    projectId: string
+    objectTypeId: string
+    afterPrimaryId?: string
+    limit: number
+  }): Promise<{ objects: readonly ObjectRow[]; nextPrimaryId?: string }>
 }

--- a/packages/core/src/testing/effective-storage-contract.ts
+++ b/packages/core/src/testing/effective-storage-contract.ts
@@ -75,6 +75,17 @@ export function runEffectiveStorageContractSuite<TStorage extends Storage>(
           ],
         })
         expect([...batch.keys()]).toEqual([objectBatchKey(Device.id, "a")])
+
+        const selectedProperties = await storage.objects.selectsObjectProperties({
+          projectId,
+          items: [
+            { objectTypeId: Device.id, primaryId: "a", propertyId: "name" },
+            { objectTypeId: Device.id, primaryId: "a", propertyId: "not-materialized" },
+            { objectTypeId: Device.id, primaryId: "missing", propertyId: "name" },
+            { objectTypeId: Device.id, primaryId: "a", propertyId: "name" },
+          ],
+        })
+        expect(selectedProperties).toEqual([true, true, false, true])
       })
     })
 
@@ -100,6 +111,28 @@ export function runEffectiveStorageContractSuite<TStorage extends Storage>(
           items: [{ objectTypeId: Device.id, objectId: "a", linkId: "peers" }],
         })
         expect(linksByScope.get(linkBatchKey(Device.id, "a", "peers"))).toHaveLength(2)
+
+        const incomingByScope = await storage.objects.listLinksBatch({
+          projectId,
+          direction: "incoming",
+          items: [{ objectTypeId: Device.id, objectId: "b", linkId: "peers" }],
+        })
+        expect(incomingByScope.get(linkBatchKey(Device.id, "b", "peers"))).toMatchObject([
+          { sourceId: "a", targetId: "b" },
+        ])
+
+        const bothDirectionsByScope = await storage.objects.listLinksBatch({
+          projectId,
+          direction: "both",
+          items: [
+            { objectTypeId: Device.id, objectId: "a", linkId: "peers" },
+            { objectTypeId: Device.id, objectId: "b", linkId: "peers" },
+          ],
+        })
+        expect(bothDirectionsByScope.get(linkBatchKey(Device.id, "a", "peers"))).toHaveLength(2)
+        expect(bothDirectionsByScope.get(linkBatchKey(Device.id, "b", "peers"))).toMatchObject([
+          { sourceId: "a", targetId: "b" },
+        ])
       })
     })
 
@@ -222,6 +255,7 @@ export function runEffectiveStorageContractSuite<TStorage extends Storage>(
 
         const links = await storage.objects.listLinksBatch({
           projectId: opaqueProjectId,
+          direction: "both",
           items: [
             { objectTypeId: OpaqueA.id, objectId: "B:C", linkId: "D" },
             { objectTypeId: OpaqueAB.id, objectId: "C", linkId: "D" },

--- a/packages/core/tests/storage.types.ts
+++ b/packages/core/tests/storage.types.ts
@@ -2,6 +2,7 @@ import type {
   ConsumeConnectorAuthorizationAttemptInput,
   InMemoryConnectorConnectionStorageSnapshot,
   ObjectQueryCapabilities,
+  ObjectReadStorage,
   ObjectStorage,
   OntologyOutboxFailureCode,
   OntologyOutboxRecord,
@@ -76,3 +77,12 @@ const providerQuerySurface: Pick<ObjectStorage, "queryCapabilities" | "queryObje
 }
 
 void providerQuerySurface
+
+const objectReader = {} as ObjectReadStorage
+void objectReader.selectsObjectProperties
+void objectReader.listLinksBatch
+void objectReader.queryLinks
+// @ts-expect-error Internal materialization reads are deliberately absent from the safe reader.
+void objectReader.listIncidentLinksBatch
+// @ts-expect-error Background reconciliation reads are deliberately absent from the safe reader.
+void objectReader.listByPrimaryIdPage

--- a/storage/pg/src/pg-object-storage.ts
+++ b/storage/pg/src/pg-object-storage.ts
@@ -13,6 +13,7 @@ import type {
   ObjectBatchKey,
   ObjectLinkRow,
   ObjectQueryCapabilities,
+  ObjectReadStorage,
   ObjectRow,
   ObjectRowLinks,
   ObjectStorage,
@@ -241,6 +242,18 @@ export class PgObjectStorage implements ObjectStorage {
     return row ? rowToObject(row) : null
   }
 
+  async selectsObjectProperties(
+    params: Parameters<ObjectReadStorage["selectsObjectProperties"]>[0]
+  ): Promise<readonly boolean[]> {
+    const objects = await this.getByPrimaryIdBatch({
+      projectId: params.projectId,
+      items: params.items,
+    })
+    return params.items.map((item) =>
+      objects.has(objectBatchKey(item.objectTypeId, item.primaryId))
+    )
+  }
+
   async listLinks(params: {
     projectId: string
     objectTypeId: string
@@ -289,26 +302,37 @@ export class PgObjectStorage implements ObjectStorage {
 
   async listLinksBatch(params: {
     projectId: string
+    direction?: LinkDirection
     items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
   }): Promise<Map<LinkBatchKey, ObjectLinkRow[]>> {
-    const result = new Map<LinkBatchKey, ObjectLinkRow[]>()
-    if (params.items.length === 0) return result
-    const rows = await valuesJoin<LinkDatabaseRow>(
-      this.sql,
-      "SELECT l.* FROM links l",
-      ["source_type_id", "source_id", "link_id"],
-      params.items.map((i) => [i.objectTypeId, i.objectId, i.linkId]),
-      `WHERE l.project_id = $1`,
-      [params.projectId]
-    )
+    const result = new Map<LinkBatchKey, Map<string, ObjectLinkRow>>()
+    if (params.items.length === 0) return new Map()
 
-    for (const row of rows) {
-      const key = linkBatchKey(row.source_type_id, row.source_id, row.link_id)
-      const existing = result.get(key) ?? []
-      existing.push(rowToLink(row))
-      result.set(key, existing)
+    const readSide = async (side: "source" | "target"): Promise<void> => {
+      const rows = await valuesJoin<LinkDatabaseRow>(
+        this.sql,
+        "SELECT l.* FROM links l",
+        [`${side}_type_id`, `${side}_id`, "link_id"],
+        params.items.map((item) => [item.objectTypeId, item.objectId, item.linkId]),
+        `WHERE l.project_id = $1`,
+        [params.projectId]
+      )
+      for (const row of rows) {
+        const link = rowToLink(row)
+        const objectTypeId = side === "source" ? row.source_type_id : row.target_type_id
+        const objectId = side === "source" ? row.source_id : row.target_id
+        const key = linkBatchKey(objectTypeId, objectId, row.link_id)
+        const bucket = result.get(key) ?? new Map<string, ObjectLinkRow>()
+        bucket.set(linkIdentity(link), link)
+        result.set(key, bucket)
+      }
     }
-    return result
+
+    const direction = params.direction ?? "outgoing"
+    if (direction === "outgoing" || direction === "both") await readSide("source")
+    if (direction === "incoming" || direction === "both") await readSide("target")
+
+    return new Map([...result].map(([key, links]) => [key, [...links.values()]] as const))
   }
 
   async queryLinks(params: QueryObjectLinksInput): Promise<QueryObjectLinksResult> {

--- a/storage/sqlite/src/object-storage.ts
+++ b/storage/sqlite/src/object-storage.ts
@@ -15,6 +15,7 @@ import type {
   ObjectFacetRequest,
   ObjectLinkRow,
   ObjectQueryCapabilities,
+  ObjectReadStorage,
   ObjectRow,
   ObjectRowLinks,
   ObjectStorage,
@@ -186,6 +187,18 @@ export class SqliteObjectStorage implements ObjectStorage {
     return row ? this.rowToObject(row) : null
   }
 
+  async selectsObjectProperties(
+    params: Parameters<ObjectReadStorage["selectsObjectProperties"]>[0]
+  ): Promise<readonly boolean[]> {
+    const objects = await this.getByPrimaryIdBatch({
+      projectId: params.projectId,
+      items: params.items,
+    })
+    return params.items.map((item) =>
+      objects.has(objectBatchKey(item.objectTypeId, item.primaryId))
+    )
+  }
+
   async listLinks(params: {
     projectId: string
     objectTypeId: string
@@ -249,26 +262,22 @@ export class SqliteObjectStorage implements ObjectStorage {
 
   async listLinksBatch(params: {
     projectId: string
+    direction?: LinkDirection
     items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
   }): Promise<Map<LinkBatchKey, ObjectLinkRow[]>> {
     const result = new Map<LinkBatchKey, ObjectLinkRow[]>()
     if (params.items.length === 0) return result
 
-    const stmt = this.db.query(
-      "SELECT * FROM links WHERE project_id = ? AND source_type_id = ? AND source_id = ? AND link_id = ?"
-    )
     for (const item of params.items) {
-      const rows = stmt.all(
-        params.projectId,
-        item.objectTypeId,
-        item.objectId,
-        item.linkId
-      ) as LinkDatabaseRow[]
+      const rows = await this.listLinks({
+        projectId: params.projectId,
+        objectTypeId: item.objectTypeId,
+        objectId: item.objectId,
+        linkId: item.linkId,
+        ...(params.direction === undefined ? {} : { direction: params.direction }),
+      })
       if (rows.length > 0) {
-        result.set(
-          linkBatchKey(item.objectTypeId, item.objectId, item.linkId),
-          rows.map((r) => this.rowToLink(r))
-        )
+        result.set(linkBatchKey(item.objectTypeId, item.objectId, item.linkId), [...rows])
       }
     }
     return result


### PR DESCRIPTION
Part of #269 · Stack #547 · Parent: #489 · Next: #480

## Why

The query executor currently depends on `ObjectStorage`, which combines application reads with internal reconciliation reads. Shared access needs a restricted reader that can serve ordinary queries without exposing those internal operations.

This PR extracts the common application-read contract:

- `ObjectReadStorage`: object lookup, listing, queries, aggregates, links and property-selection checks.
- `ObjectStorage extends ObjectReadStorage`: also exposes `listIncidentLinksBatch` and `listByPrimaryIdPage` for trusted internal work.

Both interfaces remain over the same data. This is not a second database or a read/write split. Existing providers satisfy both; later PRs add restricted readers implementing `ObjectReadStorage`.

## Request flow once the stack is complete

SQLite example for a list query at the end of the stack. Boxes represent classes, functions or objects; `ObjectReadStorage` and `ObjectStorage` are interfaces, not additional layers.

```mermaid
flowchart TB
  subgraph ordinary["Ordinary authority"]
    A["Application query<br/>Query on Proposal"]
    B["AuthorizedObjectReader<br/>Ordinary authorization checks"]
    C["executeObjectQuery()<br/>Common query executor"]
    D["SqliteObjectStorage<br/>Implements ObjectStorage<br/>and therefore ObjectReadStorage"]
    E["compileObjectQuery()<br/>Source: objects / links"]
    A --> B --> C --> D --> E
  end

  subgraph shared["Delegated authority"]
    F["Same application query<br/>Same query on Proposal"]
    G["AuthorizedObjectReader<br/>Delegated authorization checks<br/>and property / path admission"]
    H["executeObjectQuery()<br/>Same query executor"]
    I["Restricted reader<br/>Implements ObjectReadStorage<br/>Created by createSelectedReadScope()"]
    J["SqliteObjectStorage<br/>queryObjectsFromSource()"]
    K["compileObjectQuery()<br/>Source: _sixb_scope_objects<br/>and _sixb_scope_links"]
    F --> G --> H --> I --> J --> K
  end

  E --> DB[("Same SQLite database")]
  K --> DB

  style I fill:#e0f2e9,stroke:#36835b
  style K fill:#e0f2e9,stroke:#36835b
```

`AuthorizedObjectReader` binds the reader at construction: the ordinary provider for ordinary authority, or `provider.createSelectedReadScope(...)` for delegated authority. Both satisfy `ObjectReadStorage`. The restricted reader is an object of methods created by the provider; it applies scope before sorting, limits and aggregates.

## What changes here

- The query executor now accepts `ObjectReadStorage`.
- Incoming-link expansion uses `listLinksBatch({ direction: "incoming", ... })` instead of the internal `listIncidentLinksBatch`. Batches support outgoing, incoming and both directions while preserving collision-safe keys.
- `selectsObjectProperties` checks whether each exact object/property tuple belongs to the reader's selection. It distinguishes an unselected property from a selected property with no stored value—needed later to authorize reads from separate stores such as telemetry. Results preserve input order and duplicates; this is not ontology validation.
- InMemory, SQLite and PostgreSQL implement the same contract; `queryLinks` remains available.

This PR prepares the interface only. Restricted scopes, `AuthorizedObjectReader` integration and Shared Link activation follow later in the stack.

