### PR TITLE
objects: bound untrusted query admission

### DIFF
--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -23161,6 +23161,16 @@
               }
             }
           },
+          "413": {
+            "description": "Response for status 413",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Response for status 500",
             "content": {
@@ -23220,6 +23230,16 @@
           },
           "403": {
             "description": "Response for status 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Response for status 413",
             "content": {
               "application/json": {
                 "schema": {
@@ -23295,6 +23315,16 @@
               }
             }
           },
+          "413": {
+            "description": "Response for status 413",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Response for status 500",
             "content": {
@@ -23362,6 +23392,16 @@
               }
             }
           },
+          "413": {
+            "description": "Response for status 413",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Response for status 500",
             "content": {
@@ -23421,6 +23461,16 @@
           },
           "403": {
             "description": "Response for status 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Response for status 413",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -7771,6 +7771,10 @@ export type QueryObjectsErrors = {
    */
   403: ErrorResponse
   /**
+   * Response for status 413
+   */
+  413: ErrorResponse
+  /**
    * Response for status 500
    */
   500: ErrorResponse
@@ -7803,6 +7807,10 @@ export type QueryObjectLinksErrors = {
    * Response for status 403
    */
   403: ErrorResponse
+  /**
+   * Response for status 413
+   */
+  413: ErrorResponse
   /**
    * Response for status 500
    */
@@ -7837,6 +7845,10 @@ export type CountObjectsErrors = {
    */
   403: ErrorResponse
   /**
+   * Response for status 413
+   */
+  413: ErrorResponse
+  /**
    * Response for status 500
    */
   500: ErrorResponse
@@ -7870,6 +7882,10 @@ export type ExistsObjectsErrors = {
    */
   403: ErrorResponse
   /**
+   * Response for status 413
+   */
+  413: ErrorResponse
+  /**
    * Response for status 500
    */
   500: ErrorResponse
@@ -7902,6 +7918,10 @@ export type FacetObjectsErrors = {
    * Response for status 403
    */
   403: ErrorResponse
+  /**
+   * Response for status 413
+   */
+  413: ErrorResponse
   /**
    * Response for status 500
    */

--- a/packages/core/src/objects/query/complexity.ts
+++ b/packages/core/src/objects/query/complexity.ts
@@ -1,0 +1,384 @@
+import { ObjectQueryValidationError } from "./errors"
+import type { ObjectQuery, ObjectQueryPredicate } from "./ir"
+
+/** Shared admission bounds for authored and transport object-query trees. */
+export const OBJECT_QUERY_STRUCTURE_LIMITS = Object.freeze({
+  maxNodes: 512,
+  maxDepth: 32,
+  maxArrayEntries: 4_096,
+  maxJsonValueDepth: 64,
+  /** Cumulative children across every JSON container in predicate values. */
+  maxJsonValueEntries: 4_096,
+})
+
+export interface ObjectQueryStructureIssue {
+  readonly path: string
+  readonly code: string
+  readonly message: string
+}
+
+export type ObjectQueryStructureRoot = "query" | "predicate"
+
+interface StructureNodeWorkItem {
+  readonly kind: "query" | "predicate" | "expansion"
+  readonly value: unknown
+  readonly path: string
+  readonly depth: number
+}
+
+type StructureWorkItem = StructureNodeWorkItem | { readonly kind: "exit"; readonly value: object }
+
+interface ScanState {
+  arrayEntries: number
+  jsonValueEntries: number
+  issue: ObjectQueryStructureIssue | null
+}
+
+/**
+ * Inspect an unknown query-shaped value without recursive calls.
+ *
+ * This is deliberately structural only: malformed nodes are left to the schema and Core remains
+ * the semantic authority. The same walker can therefore protect both authored queries and the
+ * transport parser that runs before recursive Zod schemas.
+ */
+export function findObjectQueryStructureIssue(
+  value: unknown,
+  root: ObjectQueryStructureRoot = "query"
+): ObjectQueryStructureIssue | null {
+  const stack: StructureWorkItem[] = [{ kind: root, value, path: "$", depth: 0 }]
+  const active = new Set<object>()
+  const state: ScanState = { arrayEntries: 0, jsonValueEntries: 0, issue: null }
+  let nodes = 0
+
+  while (stack.length > 0) {
+    const item = stack.pop()
+    if (!item) continue
+    if (item.kind === "exit") {
+      active.delete(item.value)
+      continue
+    }
+    if (!isRecord(item.value)) continue
+
+    if (item.depth > OBJECT_QUERY_STRUCTURE_LIMITS.maxDepth) {
+      return issue(
+        item.path,
+        "query_depth_exceeded",
+        `Object query exceeds the maximum structural depth of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxDepth}`
+      )
+    }
+    if (active.has(item.value)) {
+      return issue(item.path, "cyclic_query", "Object query structure must not contain cycles")
+    }
+
+    nodes += 1
+    if (nodes > OBJECT_QUERY_STRUCTURE_LIMITS.maxNodes) {
+      return issue(
+        item.path,
+        "query_nodes_exceeded",
+        `Object query exceeds the maximum of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxNodes} structural nodes`
+      )
+    }
+
+    active.add(item.value)
+    stack.push({ kind: "exit", value: item.value })
+
+    if (item.kind === "query") enqueueQuery(item, stack, state)
+    else if (item.kind === "predicate") enqueuePredicate(item, stack, state)
+    else enqueueExpansion(item, stack, state)
+    if (state.issue) return state.issue
+  }
+
+  return null
+}
+
+/** Bound and cycle-check an authored query before recursive normalization or validation. */
+export function assertObjectQueryComplexity(query: ObjectQuery): void {
+  assertStructure(query, "query")
+}
+
+/** Bound the standalone predicate normalization entrypoint too. */
+export function assertObjectQueryPredicateComplexity(predicate: ObjectQueryPredicate): void {
+  assertStructure(predicate, "predicate")
+}
+
+function assertStructure(value: unknown, root: ObjectQueryStructureRoot): void {
+  const found = findObjectQueryStructureIssue(value, root)
+  if (found) throw new ObjectQueryValidationError([found])
+}
+
+function enqueueQuery(
+  item: StructureNodeWorkItem,
+  stack: StructureWorkItem[],
+  state: ScanState
+): void {
+  const query = item.value as Record<string, unknown>
+  switch (query.kind) {
+    case "refs":
+      readArray(query.refs, `${item.path}.refs`, state)
+      return
+    case "filter":
+      stack.push({
+        kind: "predicate",
+        value: query.predicate,
+        path: `${item.path}.predicate`,
+        depth: item.depth + 1,
+      })
+      pushQueryInput(query.input, item, stack)
+      return
+    case "text": {
+      readArray(query.fields, `${item.path}.fields`, state)
+      if (state.issue) return
+      if (isRecord(query.fieldsByObjectType)) {
+        for (const objectTypeId in query.fieldsByObjectType) {
+          if (!Object.hasOwn(query.fieldsByObjectType, objectTypeId)) continue
+          addArrayEntries(1, `${item.path}.fieldsByObjectType`, state)
+          if (state.issue) return
+          const fields = query.fieldsByObjectType[objectTypeId]
+          readArray(fields, `${item.path}.fieldsByObjectType.${objectTypeId}`, state)
+          if (state.issue) return
+        }
+      }
+      pushQueryInput(query.input, item, stack)
+      return
+    }
+    case "vector":
+      readArray(query.vector, `${item.path}.vector`, state)
+      if (state.issue) return
+      pushQueryInput(query.input, item, stack)
+      return
+    case "traverse":
+    case "limit":
+    case "page":
+      pushQueryInput(query.input, item, stack)
+      return
+    case "sort":
+      readArray(query.fields, `${item.path}.fields`, state)
+      if (state.issue) return
+      pushQueryInput(query.input, item, stack)
+      return
+    case "project":
+      readArray(query.properties, `${item.path}.properties`, state)
+      if (state.issue) return
+      pushQueryInput(query.input, item, stack)
+      return
+    case "set":
+      pushArrayChildren("query", query.inputs, `${item.path}.inputs`, item.depth, stack, state)
+      return
+    case "expand":
+      pushArrayChildren(
+        "expansion",
+        query.expansions,
+        `${item.path}.expansions`,
+        item.depth,
+        stack,
+        state
+      )
+      if (state.issue) return
+      pushQueryInput(query.input, item, stack)
+      return
+    default:
+      return
+  }
+}
+
+function enqueuePredicate(
+  item: StructureNodeWorkItem,
+  stack: StructureWorkItem[],
+  state: ScanState
+): void {
+  const predicate = item.value as Record<string, unknown>
+  // Predicate validation is a Zod union rather than a discriminated union. Inspect every field
+  // that any branch may recurse into even when `op` itself is malformed, otherwise the schema
+  // could still reach an attacker-controlled recursive child before reporting the bad literal.
+  pushArrayChildren("predicate", predicate.items, `${item.path}.items`, item.depth, stack, state)
+  if (state.issue) return
+  if (Object.hasOwn(predicate, "item")) {
+    stack.push({
+      kind: "predicate",
+      value: predicate.item,
+      path: `${item.path}.item`,
+      depth: item.depth + 1,
+    })
+  }
+
+  const values = readArray(predicate.values, `${item.path}.values`, state)
+  if (state.issue) return
+  for (const [index, value] of values.entries()) {
+    state.issue = findJsonValueIssue(value, `${item.path}.values[${index}]`, state)
+    if (state.issue) return
+  }
+  if (Object.hasOwn(predicate, "value")) {
+    state.issue = findJsonValueIssue(predicate.value, `${item.path}.value`, state)
+  }
+}
+
+function enqueueExpansion(
+  item: StructureNodeWorkItem,
+  stack: StructureWorkItem[],
+  state: ScanState
+): void {
+  const expansion = item.value as Record<string, unknown>
+  readArray(expansion.orderBy, `${item.path}.orderBy`, state)
+  if (state.issue) return
+  pushArrayChildren("expansion", expansion.expand, `${item.path}.expand`, item.depth, stack, state)
+}
+
+function pushQueryInput(
+  input: unknown,
+  parent: StructureNodeWorkItem,
+  stack: StructureWorkItem[]
+): void {
+  stack.push({
+    kind: "query",
+    value: input,
+    path: `${parent.path}.input`,
+    depth: parent.depth + 1,
+  })
+}
+
+function pushChildren(
+  kind: "query" | "predicate" | "expansion",
+  values: readonly unknown[],
+  path: string,
+  parentDepth: number,
+  stack: StructureWorkItem[]
+): void {
+  for (let index = values.length - 1; index >= 0; index -= 1) {
+    stack.push({ kind, value: values[index], path: `${path}[${index}]`, depth: parentDepth + 1 })
+  }
+}
+
+function pushArrayChildren(
+  kind: "query" | "predicate" | "expansion",
+  value: unknown,
+  path: string,
+  parentDepth: number,
+  stack: StructureWorkItem[],
+  state: ScanState
+): void {
+  const values = readArray(value, path, state)
+  if (state.issue) return
+  pushChildren(kind, values, path, parentDepth, stack)
+}
+
+function readArray(value: unknown, path: string, state: ScanState): readonly unknown[] {
+  if (!Array.isArray(value)) return []
+  addArrayEntries(value.length, path, state)
+  return value
+}
+
+function addArrayEntries(count: number, path: string, state: ScanState): void {
+  state.arrayEntries += count
+  if (state.arrayEntries > OBJECT_QUERY_STRUCTURE_LIMITS.maxArrayEntries) {
+    state.issue = issue(
+      path,
+      "query_array_entries_exceeded",
+      `Object query exceeds the maximum of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxArrayEntries} array entries`
+    )
+  }
+}
+
+function findJsonValueIssue(
+  value: unknown,
+  path: string,
+  state: ScanState
+): ObjectQueryStructureIssue | null {
+  type JsonWorkItem =
+    | {
+        readonly kind: "value"
+        readonly value: unknown
+        readonly path: string
+        readonly depth: number
+      }
+    | { readonly kind: "exit"; readonly value: object }
+
+  const stack: JsonWorkItem[] = [{ kind: "value", value, path, depth: 0 }]
+  const active = new Set<object>()
+  while (stack.length > 0) {
+    const item = stack.pop()
+    if (!item) continue
+    if (item.kind === "exit") {
+      active.delete(item.value)
+      continue
+    }
+    if (typeof item.value !== "object" || item.value === null) continue
+    if (item.depth > OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueDepth) {
+      return issue(
+        item.path,
+        "query_json_value_depth_exceeded",
+        `Object query JSON values exceed the maximum depth of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueDepth}`
+      )
+    }
+    if (active.has(item.value)) {
+      return issue(
+        item.path,
+        "cyclic_query_value",
+        "Object query JSON values must not contain cycles"
+      )
+    }
+
+    if (Array.isArray(item.value)) {
+      if (
+        state.jsonValueEntries + item.value.length >
+        OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueEntries
+      ) {
+        return jsonValueEntriesIssue(item.path)
+      }
+      state.jsonValueEntries += item.value.length
+      active.add(item.value)
+      stack.push({ kind: "exit", value: item.value })
+      for (let index = item.value.length - 1; index >= 0; index -= 1) {
+        stack.push({
+          kind: "value",
+          value: item.value[index],
+          path: `${item.path}[${index}]`,
+          depth: item.depth + 1,
+        })
+      }
+    } else {
+      const objectValue = item.value as Record<string, unknown>
+      let width = 0
+      for (const key in objectValue) {
+        if (!Object.hasOwn(objectValue, key)) continue
+        width += 1
+        if (state.jsonValueEntries + width > OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueEntries) {
+          return jsonValueEntriesIssue(item.path)
+        }
+      }
+      state.jsonValueEntries += width
+      active.add(item.value)
+      stack.push({ kind: "exit", value: item.value })
+
+      // Allocate keys only after proving the container is within the fixed bound. In particular,
+      // an object that exceeds the remaining cumulative budget never reads its values or allocates
+      // an entries array proportional to attacker-controlled input.
+      const keys = Object.keys(objectValue)
+      for (let index = keys.length - 1; index >= 0; index -= 1) {
+        const key = keys[index]!
+        stack.push({
+          kind: "value",
+          value: objectValue[key],
+          path: `${item.path}.${key}`,
+          depth: item.depth + 1,
+        })
+      }
+    }
+  }
+  return null
+}
+
+function jsonValueEntriesIssue(path: string): ObjectQueryStructureIssue {
+  return issue(
+    path,
+    "query_json_value_entries_exceeded",
+    `Object query JSON values exceed the maximum total of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueEntries} entries`
+  )
+}
+
+function issue(path: string, code: string, message: string): ObjectQueryStructureIssue {
+  return { path, code, message }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/packages/core/src/objects/query/index.ts
+++ b/packages/core/src/objects/query/index.ts
@@ -1,3 +1,11 @@
+export type {
+  ObjectQueryStructureIssue,
+  ObjectQueryStructureRoot,
+} from "./complexity"
+export {
+  findObjectQueryStructureIssue,
+  OBJECT_QUERY_STRUCTURE_LIMITS,
+} from "./complexity"
 export type { ObjectQueryPlanningIssue } from "./errors"
 export {
   ObjectQueryExecutionError,

--- a/packages/core/src/objects/query/normalize.ts
+++ b/packages/core/src/objects/query/normalize.ts
@@ -1,3 +1,4 @@
+import { assertObjectQueryComplexity, assertObjectQueryPredicateComplexity } from "./complexity"
 import type {
   ObjectExpansion,
   ObjectQuery,
@@ -15,6 +16,11 @@ import type {
  * same tree (and therefore the same cache key).
  */
 export function normalizeObjectQuery(query: ObjectQuery): ObjectQuery {
+  assertObjectQueryComplexity(query)
+  return normalizeObjectQueryUnchecked(query)
+}
+
+function normalizeObjectQueryUnchecked(query: ObjectQuery): ObjectQuery {
   return hoistExpand(normalizeNode(query))
 }
 
@@ -32,16 +38,20 @@ function normalizeNode(query: ObjectQuery): ObjectQuery {
     case "text":
       return {
         ...query,
-        input: normalizeObjectQuery(query.input),
+        input: normalizeObjectQueryUnchecked(query.input),
         fields: query.fields ? uniqueStrings(query.fields) : undefined,
         fieldsByObjectType: query.fieldsByObjectType
           ? uniqueStringRecord(query.fieldsByObjectType)
           : undefined,
       }
     case "vector":
-      return { ...query, input: normalizeObjectQuery(query.input), vector: [...query.vector] }
+      return {
+        ...query,
+        input: normalizeObjectQueryUnchecked(query.input),
+        vector: [...query.vector],
+      }
     case "traverse":
-      return { ...query, input: normalizeObjectQuery(query.input) }
+      return { ...query, input: normalizeObjectQueryUnchecked(query.input) }
     case "set":
       return normalizeSet(query)
     case "sort":
@@ -49,11 +59,11 @@ function normalizeNode(query: ObjectQuery): ObjectQuery {
     case "limit":
       return normalizeLimit(query.input, query.limit)
     case "page":
-      return { ...query, input: normalizeObjectQuery(query.input) }
+      return { ...query, input: normalizeObjectQueryUnchecked(query.input) }
     case "project":
       return {
         ...query,
-        input: normalizeObjectQuery(query.input),
+        input: normalizeObjectQueryUnchecked(query.input),
         properties: query.properties ? uniqueStrings(query.properties) : undefined,
       }
     case "expand":
@@ -79,7 +89,7 @@ function hoistExpand(query: ObjectQuery): ObjectQuery {
   if (query.input.kind !== "expand") return query
 
   const inner = query.input
-  const rebuilt = normalizeObjectQuery({ ...query, input: inner.input })
+  const rebuilt = normalizeObjectQueryUnchecked({ ...query, input: inner.input })
   if (rebuilt.kind === "expand") {
     return {
       kind: "expand",
@@ -91,7 +101,7 @@ function hoistExpand(query: ObjectQuery): ObjectQuery {
 }
 
 function normalizeExpand(input: ObjectQuery, expansions: readonly ObjectExpansion[]): ObjectQuery {
-  const normalizedInput = normalizeObjectQuery(input)
+  const normalizedInput = normalizeObjectQueryUnchecked(input)
   const normalizedExpansions = normalizeExpansions(expansions)
 
   // A directly-nested expand (`a.expand(X).expand(Y)` builds
@@ -152,18 +162,25 @@ function expansionKey(expansion: ObjectExpansion): string {
 export function normalizeObjectQueryPredicate(
   predicate: ObjectQueryPredicate
 ): ObjectQueryPredicate {
+  assertObjectQueryPredicateComplexity(predicate)
+  return normalizeObjectQueryPredicateUnchecked(predicate)
+}
+
+function normalizeObjectQueryPredicateUnchecked(
+  predicate: ObjectQueryPredicate
+): ObjectQueryPredicate {
   switch (predicate.op) {
     case "and":
     case "or": {
       const items = predicate.items.flatMap((item) => {
-        const normalized = normalizeObjectQueryPredicate(item)
+        const normalized = normalizeObjectQueryPredicateUnchecked(item)
         if (normalized.op === predicate.op) return normalized.items
         return [normalized]
       })
       return items.length === 1 ? items[0] : { op: predicate.op, items }
     }
     case "not":
-      return { op: "not", item: normalizeObjectQueryPredicate(predicate.item) }
+      return { op: "not", item: normalizeObjectQueryPredicateUnchecked(predicate.item) }
     case "in":
       return { ...predicate, values: [...predicate.values] }
     default:
@@ -172,13 +189,13 @@ export function normalizeObjectQueryPredicate(
 }
 
 function normalizeFilter(input: ObjectQuery, predicate: ObjectQueryPredicate): ObjectQuery {
-  const normalizedInput = normalizeObjectQuery(input)
-  const normalizedPredicate = normalizeObjectQueryPredicate(predicate)
+  const normalizedInput = normalizeObjectQueryUnchecked(input)
+  const normalizedPredicate = normalizeObjectQueryPredicateUnchecked(predicate)
 
   // Adjacent filters are equivalent to a single conjunction and are easier for
   // capability checks and providers to inspect.
   if (normalizedInput.kind === "filter") {
-    return normalizeObjectQuery({
+    return normalizeObjectQueryUnchecked({
       kind: "filter",
       input: normalizedInput.input,
       predicate: {
@@ -197,7 +214,7 @@ function normalizeFilter(input: ObjectQuery, predicate: ObjectQueryPredicate): O
 
 function normalizeSet(query: ObjectQuerySet): ObjectQuery {
   const inputs = query.inputs.flatMap((input) => {
-    const normalized = normalizeObjectQuery(input)
+    const normalized = normalizeObjectQueryUnchecked(input)
     if (normalized.kind === "set" && normalized.op === query.op) return normalized.inputs
     return [normalized]
   })
@@ -206,7 +223,7 @@ function normalizeSet(query: ObjectQuerySet): ObjectQuery {
 }
 
 function normalizeSort(input: ObjectQuery, fields: readonly ObjectQuerySortField[]): ObjectQuery {
-  const normalizedInput = normalizeObjectQuery(input)
+  const normalizedInput = normalizeObjectQueryUnchecked(input)
   const normalizedFields = fields.map((field) => ({ ...field }))
 
   // A later sort fully determines result order, so it replaces an adjacent sort.
@@ -226,7 +243,7 @@ function normalizeSort(input: ObjectQuery, fields: readonly ObjectQuerySortField
 }
 
 function normalizeLimit(input: ObjectQuery, limit: number): ObjectQuery {
-  const normalizedInput = normalizeObjectQuery(input)
+  const normalizedInput = normalizeObjectQueryUnchecked(input)
 
   // Adjacent limits collapse to the stricter bound.
   if (normalizedInput.kind === "limit") {

--- a/packages/core/src/objects/query/validate.ts
+++ b/packages/core/src/objects/query/validate.ts
@@ -9,6 +9,7 @@ import type {
 import { normalizeDecimalValue } from "../../ontology"
 import { formatUnknownObjectTypeMessage } from "../../ontology/errors"
 import { validatePropertyValue, validateSchemaValue } from "../../ontology/validation"
+import { assertObjectQueryComplexity } from "./complexity"
 import { ObjectQueryValidationError } from "./errors"
 import type {
   ObjectExpansion,
@@ -67,6 +68,7 @@ export function validateObjectQuery(
   query: ObjectQuery,
   options: ObjectQueryValidationOptions
 ): ValidatedObjectQuery {
+  if (options.normalize === false) assertObjectQueryComplexity(query)
   const normalized = options.normalize === false ? query : normalizeObjectQuery(query)
   const ctx = createValidationContext(options)
   const validation = validateQueryNode(normalized, "$", ctx)
@@ -86,7 +88,14 @@ export function collectObjectQueryValidationIssues(
   query: ObjectQuery,
   options: ObjectQueryValidationOptions
 ): readonly ObjectQueryValidationIssue[] {
-  const normalized = options.normalize === false ? query : normalizeObjectQuery(query)
+  let normalized: ObjectQuery
+  try {
+    if (options.normalize === false) assertObjectQueryComplexity(query)
+    normalized = options.normalize === false ? query : normalizeObjectQuery(query)
+  } catch (error) {
+    if (error instanceof ObjectQueryValidationError) return error.issues
+    throw error
+  }
   const ctx = createValidationContext(options)
   validateQueryNode(normalized, "$", ctx)
   return ctx.issues

--- a/packages/core/tests/object-query-complexity.test.ts
+++ b/packages/core/tests/object-query-complexity.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test"
+import type { ObjectQuery, ObjectQueryPredicate } from "../src/objects/query"
+import {
+  collectObjectQueryValidationIssues,
+  findObjectQueryStructureIssue,
+  normalizeObjectQuery,
+  normalizeObjectQueryPredicate,
+  OBJECT_QUERY_STRUCTURE_LIMITS,
+} from "../src/objects/query"
+
+describe("object query structural bounds", () => {
+  test("rejects cyclic queries and predicates before recursive normalization", () => {
+    const query = { kind: "limit", limit: 1 } as ObjectQuery & { input?: ObjectQuery }
+    query.input = query
+    expect(() => normalizeObjectQuery(query)).toThrow("must not contain cycles")
+
+    const predicate = { op: "not" } as ObjectQueryPredicate & { item?: ObjectQueryPredicate }
+    predicate.item = predicate
+    expect(() => normalizeObjectQueryPredicate(predicate)).toThrow("must not contain cycles")
+  })
+
+  test("bounds depth, total nodes, and cumulative raw array entries", () => {
+    let deep: ObjectQuery = { kind: "start", objectTypeId: "Thing" }
+    for (let index = 0; index < OBJECT_QUERY_STRUCTURE_LIMITS.maxDepth + 1; index += 1) {
+      deep = { kind: "limit", limit: 1, input: deep }
+    }
+    expect(() => normalizeObjectQuery(deep)).toThrow(
+      `maximum structural depth of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxDepth}`
+    )
+
+    const tooManyNodes: ObjectQuery = {
+      kind: "set",
+      op: "union",
+      inputs: Array.from({ length: OBJECT_QUERY_STRUCTURE_LIMITS.maxNodes }, () => ({
+        kind: "start" as const,
+        objectTypeId: "Thing",
+      })),
+    }
+    expect(() => normalizeObjectQuery(tooManyNodes)).toThrow(
+      `maximum of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxNodes} structural nodes`
+    )
+
+    const tooManyRefs: ObjectQuery = {
+      kind: "refs",
+      refs: Array.from(
+        { length: OBJECT_QUERY_STRUCTURE_LIMITS.maxArrayEntries + 1 },
+        (_, index) => ({ objectTypeId: "Thing", primaryId: `thing-${index}` })
+      ),
+    }
+    expect(() => normalizeObjectQuery(tooManyRefs)).toThrow(
+      `maximum of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxArrayEntries} array entries`
+    )
+
+    const tooManyTextTypeEntries: ObjectQuery = {
+      kind: "text",
+      input: { kind: "start", objectTypeId: "Thing" },
+      query: "needle",
+      fieldsByObjectType: Object.fromEntries(
+        Array.from({ length: OBJECT_QUERY_STRUCTURE_LIMITS.maxArrayEntries + 1 }, (_, index) => [
+          `Thing${index}`,
+          [],
+        ])
+      ),
+    }
+    expect(() => normalizeObjectQuery(tooManyTextTypeEntries)).toThrow(
+      `maximum of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxArrayEntries} array entries`
+    )
+  })
+
+  test("bounds nested JSON predicate values without assigning them semantics", () => {
+    let value: unknown = "leaf"
+    for (let depth = 0; depth < OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueDepth + 2; depth += 1) {
+      value = { child: value }
+    }
+
+    const issue = findObjectQueryStructureIssue({
+      kind: "filter",
+      input: { kind: "start", objectTypeId: "Thing" },
+      predicate: { op: "eq", propertyId: "payload", value },
+    })
+
+    expect(issue).toMatchObject({ code: "query_json_value_depth_exceeded" })
+  })
+
+  test("stops before enqueueing an over-limit structural fan-out", () => {
+    const inputs: unknown[] = []
+    inputs.length = OBJECT_QUERY_STRUCTURE_LIMITS.maxArrayEntries + 1
+    Object.defineProperty(inputs, OBJECT_QUERY_STRUCTURE_LIMITS.maxArrayEntries, {
+      configurable: true,
+      get(): never {
+        throw new Error("The rejected fan-out must not be read.")
+      },
+    })
+
+    expect(findObjectQueryStructureIssue({ kind: "set", op: "union", inputs })).toMatchObject({
+      code: "query_array_entries_exceeded",
+    })
+  })
+
+  test("bounds JSON array and object width before reading their children", () => {
+    const arrayValue: unknown[] = []
+    arrayValue.length = OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueEntries + 1
+    Object.defineProperty(arrayValue, OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueEntries, {
+      configurable: true,
+      get(): never {
+        throw new Error("The rejected JSON array must not be read.")
+      },
+    })
+
+    const objectValue: Record<string, unknown> = {}
+    Object.defineProperty(objectValue, "guard", {
+      configurable: true,
+      enumerable: true,
+      get(): never {
+        throw new Error("The rejected JSON object must not be read.")
+      },
+    })
+    for (let index = 0; index < OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueEntries; index += 1) {
+      objectValue[`field${index}`] = index
+    }
+
+    for (const value of [arrayValue, objectValue]) {
+      expect(
+        findObjectQueryStructureIssue({
+          kind: "filter",
+          input: { kind: "start", objectTypeId: "Thing" },
+          predicate: { op: "eq", propertyId: "payload", value },
+        })
+      ).toMatchObject({ code: "query_json_value_entries_exceeded" })
+    }
+  })
+
+  test("applies one cumulative JSON-entry budget across predicate values", () => {
+    const first = Array.from(
+      { length: OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueEntries - 1 },
+      () => null
+    )
+    const second: unknown[] = [null, null]
+    Object.defineProperty(second, 1, {
+      configurable: true,
+      get(): never {
+        throw new Error("A container outside the remaining JSON budget must not be read.")
+      },
+    })
+
+    expect(
+      findObjectQueryStructureIssue({
+        kind: "filter",
+        input: { kind: "start", objectTypeId: "Thing" },
+        predicate: { op: "in", propertyId: "payload", values: [first, second] },
+      })
+    ).toMatchObject({ code: "query_json_value_entries_exceeded" })
+  })
+
+  test("accepts exact boundaries and reports complexity through issue collection", () => {
+    const atNodeBoundary: ObjectQuery = {
+      kind: "set",
+      op: "union",
+      inputs: Array.from({ length: OBJECT_QUERY_STRUCTURE_LIMITS.maxNodes - 1 }, () => ({
+        kind: "start" as const,
+        objectTypeId: "Thing",
+      })),
+    }
+    expect(normalizeObjectQuery(atNodeBoundary).kind).toBe("set")
+
+    const cyclic = { kind: "limit", limit: 1 } as ObjectQuery & { input?: ObjectQuery }
+    cyclic.input = cyclic
+    expect(
+      collectObjectQueryValidationIssues(cyclic, {
+        ontology: {} as never,
+        normalize: false,
+      })
+    ).toMatchObject([{ code: "cyclic_query" }])
+  })
+})

--- a/packages/server/src/routes/objects.ts
+++ b/packages/server/src/routes/objects.ts
@@ -40,6 +40,10 @@ import {
   UpsertObjectBodySchema,
 } from "../schemas/objects"
 import { handleRouteError, parseOptionalInt, toIsoString } from "../utils/http"
+import {
+  mapObjectQueryRequestParseError,
+  parseBoundedObjectQueryBody,
+} from "../utils/object-query-request-admission"
 
 const ObjectFileContentQuerySchema = FileContentQuerySchema.extend({
   path: z
@@ -47,6 +51,15 @@ const ObjectFileContentQuerySchema = FileContentQuerySchema.extend({
     .min(1)
     .regex(/^\/properties(?:\/|$)/, "Object file content paths must start with /properties/"),
 })
+
+const OBJECT_QUERY_REQUEST_TOO_LARGE_RESPONSE = {
+  description: "Response for status 413",
+  content: {
+    "application/json": {
+      schema: { $ref: "#/components/schemas/ErrorResponse" },
+    },
+  },
+} as const
 
 function serializeObject(row: {
   primaryId: string
@@ -422,6 +435,8 @@ export function registerObjectRoutes(app: Elysia, host: SixbHostView) {
         }
       },
       {
+        parse: parseBoundedObjectQueryBody,
+        error: mapObjectQueryRequestParseError,
         detail: {
           summary: "Query objects",
           tags: [OPENAPI_TAGS.objects.name],
@@ -460,6 +475,7 @@ export function registerObjectRoutes(app: Elysia, host: SixbHostView) {
                 },
               },
             },
+            413: OBJECT_QUERY_REQUEST_TOO_LARGE_RESPONSE,
             500: {
               description: "Response for status 500",
               content: {
@@ -498,6 +514,8 @@ export function registerObjectRoutes(app: Elysia, host: SixbHostView) {
         }
       },
       {
+        parse: parseBoundedObjectQueryBody,
+        error: mapObjectQueryRequestParseError,
         detail: {
           summary: "Query object links",
           tags: [OPENAPI_TAGS.links.name],
@@ -536,6 +554,7 @@ export function registerObjectRoutes(app: Elysia, host: SixbHostView) {
                 },
               },
             },
+            413: OBJECT_QUERY_REQUEST_TOO_LARGE_RESPONSE,
             500: {
               description: "Response for status 500",
               content: {
@@ -567,6 +586,8 @@ export function registerObjectRoutes(app: Elysia, host: SixbHostView) {
         }
       },
       {
+        parse: parseBoundedObjectQueryBody,
+        error: mapObjectQueryRequestParseError,
         detail: {
           summary: "Count objects",
           tags: [OPENAPI_TAGS.objects.name],
@@ -605,6 +626,7 @@ export function registerObjectRoutes(app: Elysia, host: SixbHostView) {
                 },
               },
             },
+            413: OBJECT_QUERY_REQUEST_TOO_LARGE_RESPONSE,
             500: {
               description: "Response for status 500",
               content: {
@@ -636,6 +658,8 @@ export function registerObjectRoutes(app: Elysia, host: SixbHostView) {
         }
       },
       {
+        parse: parseBoundedObjectQueryBody,
+        error: mapObjectQueryRequestParseError,
         detail: {
           summary: "Check object existence",
           tags: [OPENAPI_TAGS.objects.name],
@@ -674,6 +698,7 @@ export function registerObjectRoutes(app: Elysia, host: SixbHostView) {
                 },
               },
             },
+            413: OBJECT_QUERY_REQUEST_TOO_LARGE_RESPONSE,
             500: {
               description: "Response for status 500",
               content: {
@@ -709,6 +734,8 @@ export function registerObjectRoutes(app: Elysia, host: SixbHostView) {
         }
       },
       {
+        parse: parseBoundedObjectQueryBody,
+        error: mapObjectQueryRequestParseError,
         detail: {
           summary: "Facet objects",
           tags: [OPENAPI_TAGS.objects.name],
@@ -747,6 +774,7 @@ export function registerObjectRoutes(app: Elysia, host: SixbHostView) {
                 },
               },
             },
+            413: OBJECT_QUERY_REQUEST_TOO_LARGE_RESPONSE,
             500: {
               description: "Response for status 500",
               content: {

--- a/packages/server/src/utils/object-query-request-admission.ts
+++ b/packages/server/src/utils/object-query-request-admission.ts
@@ -1,0 +1,90 @@
+import { findObjectQueryStructureIssue } from "@sixb/core/internal/query"
+import { RequestBodyTooLargeError, readRequestBodyWithLimit } from "./request-body"
+
+/** Hard transport ceiling for object-query control payloads. */
+export const OBJECT_QUERY_REQUEST_BODY_LIMIT_BYTES = 1024 * 1024
+
+class InvalidObjectQueryRequestBodyError extends Error {
+  readonly name = "InvalidObjectQueryRequestBodyError"
+}
+
+/** Parse and structurally bound an object-query request before Elysia reaches recursive Zod. */
+export async function parseBoundedObjectQueryBody(context: {
+  readonly request: Request
+}): Promise<unknown> {
+  const bytes = await readBoundedBody(context.request)
+  if (!hasJsonContentType(context.request)) {
+    // Elysia parses text/plain as text. The object-query schema will reject it; importantly, a
+    // JSON-looking string must not gain JSON semantics merely because this route has a custom cap.
+    return new TextDecoder().decode(bytes)
+  }
+
+  const body = parseJsonBody(bytes)
+  if (!isRecord(body)) return body
+
+  const found = findObjectQueryStructureIssue(body.query)
+  if (found) throw invalid(`${found.message}.`)
+  return body
+}
+
+export function mapObjectQueryRequestParseError(context: {
+  readonly error: unknown
+  readonly set: { status?: number | string }
+}): { error: string } | undefined {
+  const tooLarge = findCause(context.error, RequestBodyTooLargeError)
+  if (tooLarge) {
+    context.set.status = 413
+    return { error: tooLarge.message }
+  }
+
+  const invalidBody = findCause(context.error, InvalidObjectQueryRequestBodyError)
+  if (invalidBody) {
+    context.set.status = 400
+    return { error: invalidBody.message }
+  }
+
+  return undefined
+}
+
+function readBoundedBody(request: Request): Promise<Uint8Array> {
+  return readRequestBodyWithLimit(
+    request,
+    OBJECT_QUERY_REQUEST_BODY_LIMIT_BYTES,
+    `[SixbServer] Object query request body exceeds the ${OBJECT_QUERY_REQUEST_BODY_LIMIT_BYTES}-byte limit.`
+  )
+}
+
+function parseJsonBody(bytes: Uint8Array): unknown {
+  try {
+    const json = new TextDecoder("utf-8", { fatal: true }).decode(bytes)
+    return JSON.parse(json) as unknown
+  } catch {
+    throw invalid("Object query request body must contain valid UTF-8 JSON.")
+  }
+}
+
+function hasJsonContentType(request: Request): boolean {
+  const contentType = request.headers.get("content-type")
+  if (!contentType) return false
+  return contentType.split(";", 1)[0]?.trim().toLowerCase() === "application/json"
+}
+
+function findCause<TError extends Error>(
+  error: unknown,
+  errorType: new (...args: never[]) => TError
+): TError | undefined {
+  let current: unknown = error
+  for (let depth = 0; depth < 3; depth += 1) {
+    if (current instanceof errorType) return current
+    current = (current as { cause?: unknown } | null | undefined)?.cause
+  }
+  return undefined
+}
+
+function invalid(message: string): InvalidObjectQueryRequestBodyError {
+  return new InvalidObjectQueryRequestBodyError(`[SixbServer] ${message}`)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/packages/server/src/utils/object-query-request-admission.ts
+++ b/packages/server/src/utils/object-query-request-admission.ts
@@ -1,4 +1,7 @@
-import { findObjectQueryStructureIssue } from "@sixb/core/internal/query"
+import {
+  findObjectQueryStructureIssue,
+  type ObjectQueryStructureIssue,
+} from "@sixb/core/internal/query"
 import { RequestBodyTooLargeError, readRequestBodyWithLimit } from "./request-body"
 
 /** Hard transport ceiling for object-query control payloads. */
@@ -6,6 +9,13 @@ export const OBJECT_QUERY_REQUEST_BODY_LIMIT_BYTES = 1024 * 1024
 
 class InvalidObjectQueryRequestBodyError extends Error {
   readonly name = "InvalidObjectQueryRequestBodyError"
+
+  constructor(
+    message: string,
+    readonly issues?: readonly ObjectQueryStructureIssue[]
+  ) {
+    super(message)
+  }
 }
 
 /** Parse and structurally bound an object-query request before Elysia reaches recursive Zod. */
@@ -23,14 +33,16 @@ export async function parseBoundedObjectQueryBody(context: {
   if (!isRecord(body)) return body
 
   const found = findObjectQueryStructureIssue(body.query)
-  if (found) throw invalid(`${found.message}.`)
+  if (found) {
+    throw new InvalidObjectQueryRequestBodyError(`[SixbServer] ${found.message}.`, [found])
+  }
   return body
 }
 
 export function mapObjectQueryRequestParseError(context: {
   readonly error: unknown
   readonly set: { status?: number | string }
-}): { error: string } | undefined {
+}): { error: string; issues?: readonly ObjectQueryStructureIssue[] } | undefined {
   const tooLarge = findCause(context.error, RequestBodyTooLargeError)
   if (tooLarge) {
     context.set.status = 413
@@ -40,7 +52,10 @@ export function mapObjectQueryRequestParseError(context: {
   const invalidBody = findCause(context.error, InvalidObjectQueryRequestBodyError)
   if (invalidBody) {
     context.set.status = 400
-    return { error: invalidBody.message }
+    return {
+      error: invalidBody.message,
+      ...(invalidBody.issues === undefined ? {} : { issues: invalidBody.issues }),
+    }
   }
 
   return undefined

--- a/packages/server/tests/object-query-request-admission.test.ts
+++ b/packages/server/tests/object-query-request-admission.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test"
+import type { SixbHostView } from "@sixb/core"
+import { OBJECT_QUERY_STRUCTURE_LIMITS } from "@sixb/core/internal/query"
+import { Elysia } from "elysia"
+import { registerObjectRoutes } from "../src/routes/objects"
+import {
+  OBJECT_QUERY_REQUEST_BODY_LIMIT_BYTES,
+  parseBoundedObjectQueryBody,
+} from "../src/utils/object-query-request-admission"
+
+const queryPaths = [
+  "/api/objects/query",
+  "/api/objects/query/links",
+  "/api/objects/query/count",
+  "/api/objects/query/exists",
+  "/api/objects/query/facets",
+] as const
+
+describe("object query request admission", () => {
+  test("rejects recursive query structure on all five query routes before Zod", async () => {
+    const app = createObjectRoutesApp()
+    let query: unknown = { kind: "start", objectTypeId: "Thing" }
+    for (let depth = 0; depth < OBJECT_QUERY_STRUCTURE_LIMITS.maxDepth + 2; depth += 1) {
+      query = { kind: "limit", limit: 1, input: query }
+    }
+
+    for (const path of queryPaths) {
+      const response = await postJson(app, path, { query })
+      expect(response.status, path).toBe(400)
+      expect(await response.json(), path).toEqual({
+        error: `[SixbServer] Object query exceeds the maximum structural depth of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxDepth}.`,
+      })
+    }
+  })
+
+  test("bounds exact-reference arrays before recursive schema validation", async () => {
+    const app = createObjectRoutesApp()
+    const response = await postJson(app, "/api/objects/query/links", {
+      query: {
+        kind: "refs",
+        refs: Array.from(
+          { length: OBJECT_QUERY_STRUCTURE_LIMITS.maxArrayEntries + 1 },
+          (_, index) => ({ objectTypeId: "Thing", primaryId: `thing-${index}` })
+        ),
+      },
+      direction: "outgoing",
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: `[SixbServer] Object query exceeds the maximum of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxArrayEntries} array entries.`,
+    })
+  })
+
+  test("rejects deeply nested predicate JSON before recursive schema validation", async () => {
+    const app = createObjectRoutesApp()
+    let value: unknown = "leaf"
+    for (let depth = 0; depth < OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueDepth + 2; depth += 1) {
+      value = [value]
+    }
+
+    const response = await postJson(app, "/api/objects/query", {
+      query: {
+        kind: "filter",
+        input: { kind: "start", objectTypeId: "Thing" },
+        predicate: { op: "eq", propertyId: "value", value },
+      },
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: `[SixbServer] Object query JSON values exceed the maximum depth of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueDepth}.`,
+    })
+  })
+
+  test("bounds recursive predicate fields even when the discriminator is invalid", async () => {
+    const app = createObjectRoutesApp()
+    let predicate: unknown = { op: "exists", propertyId: "value", value: true }
+    for (let depth = 0; depth < OBJECT_QUERY_STRUCTURE_LIMITS.maxDepth + 2; depth += 1) {
+      predicate = { op: "invalid", item: predicate }
+    }
+
+    const response = await postJson(app, "/api/objects/query/exists", {
+      query: {
+        kind: "filter",
+        input: { kind: "start", objectTypeId: "Thing" },
+        predicate,
+      },
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: `[SixbServer] Object query exceeds the maximum structural depth of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxDepth}.`,
+    })
+  })
+
+  test("rejects an oversized body independently of its declared content type", async () => {
+    const app = createObjectRoutesApp()
+    const body = JSON.stringify({ padding: "x".repeat(OBJECT_QUERY_REQUEST_BODY_LIMIT_BYTES) })
+    const response = await postRaw(app, "/api/objects/query/facets", body, "text/plain")
+
+    expect(response.status).toBe(413)
+    expect(await response.json()).toEqual({
+      error: `[SixbServer] Object query request body exceeds the ${OBJECT_QUERY_REQUEST_BODY_LIMIT_BYTES}-byte limit.`,
+    })
+  })
+
+  test("maps malformed JSON to a stable response", async () => {
+    const app = createObjectRoutesApp()
+    const response = await postRaw(app, "/api/objects/query/count", '{"query":')
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: "[SixbServer] Object query request body must contain valid UTF-8 JSON.",
+    })
+  })
+
+  test("does not give JSON semantics to a text/plain body", async () => {
+    const app = createObjectRoutesApp()
+    const response = await postRaw(
+      app,
+      "/api/objects/query",
+      JSON.stringify({ query: { kind: "start", objectTypeId: "Thing" } }),
+      "text/plain; charset=utf-8"
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({ error: "Invalid object query request" })
+  })
+
+  test("preserves a refs-based query-links envelope", async () => {
+    const envelope = {
+      query: {
+        kind: "refs",
+        refs: [{ objectTypeId: "Thing", primaryId: "thing-1" }],
+      },
+      direction: "both",
+      includeObjects: true,
+    }
+    const request = new Request("http://localhost/api/objects/query/links", {
+      method: "POST",
+      headers: { "content-type": "application/json; charset=utf-8" },
+      body: JSON.stringify(envelope),
+    })
+
+    expect(await parseBoundedObjectQueryBody({ request })).toEqual(envelope)
+  })
+})
+
+function createObjectRoutesApp() {
+  return registerObjectRoutes(new Elysia(), {} as SixbHostView)
+}
+
+function postJson(app: ReturnType<typeof createObjectRoutesApp>, path: string, body: unknown) {
+  return postRaw(app, path, JSON.stringify(body))
+}
+
+function postRaw(
+  app: ReturnType<typeof createObjectRoutesApp>,
+  path: string,
+  body: string,
+  contentType = "application/json"
+) {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "content-type": contentType },
+      body,
+    })
+  )
+}

--- a/packages/server/tests/object-query-request-admission.test.ts
+++ b/packages/server/tests/object-query-request-admission.test.ts
@@ -17,6 +17,8 @@ const queryPaths = [
 ] as const
 
 describe("object query request admission", () => {
+  // Regression check: omit issues in mapObjectQueryRequestParseError's response.
+  // The structural rejection tests below must fail while their HTTP status stays 400.
   test("rejects recursive query structure on all five query routes before Zod", async () => {
     const app = createObjectRoutesApp()
     let query: unknown = { kind: "start", objectTypeId: "Thing" }
@@ -29,6 +31,13 @@ describe("object query request admission", () => {
       expect(response.status, path).toBe(400)
       expect(await response.json(), path).toEqual({
         error: `[SixbServer] Object query exceeds the maximum structural depth of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxDepth}.`,
+        issues: [
+          {
+            path: `$${".input".repeat(OBJECT_QUERY_STRUCTURE_LIMITS.maxDepth + 1)}`,
+            code: "query_depth_exceeded",
+            message: `Object query exceeds the maximum structural depth of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxDepth}`,
+          },
+        ],
       })
     }
   })
@@ -49,6 +58,13 @@ describe("object query request admission", () => {
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({
       error: `[SixbServer] Object query exceeds the maximum of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxArrayEntries} array entries.`,
+      issues: [
+        {
+          path: "$.refs",
+          code: "query_array_entries_exceeded",
+          message: `Object query exceeds the maximum of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxArrayEntries} array entries`,
+        },
+      ],
     })
   })
 
@@ -70,6 +86,13 @@ describe("object query request admission", () => {
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({
       error: `[SixbServer] Object query JSON values exceed the maximum depth of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueDepth}.`,
+      issues: [
+        {
+          path: `$.predicate.value${"[0]".repeat(OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueDepth + 1)}`,
+          code: "query_json_value_depth_exceeded",
+          message: `Object query JSON values exceed the maximum depth of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxJsonValueDepth}`,
+        },
+      ],
     })
   })
 
@@ -91,6 +114,13 @@ describe("object query request admission", () => {
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({
       error: `[SixbServer] Object query exceeds the maximum structural depth of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxDepth}.`,
+      issues: [
+        {
+          path: `$.predicate${".item".repeat(OBJECT_QUERY_STRUCTURE_LIMITS.maxDepth)}`,
+          code: "query_depth_exceeded",
+          message: `Object query exceeds the maximum structural depth of ${OBJECT_QUERY_STRUCTURE_LIMITS.maxDepth}`,
+        },
+      ],
     })
   })
 

--- a/packages/server/tests/openapi-docs.test.ts
+++ b/packages/server/tests/openapi-docs.test.ts
@@ -239,4 +239,19 @@ describe("OpenAPI docs", () => {
       }
     }
   })
+
+  test("documents bounded object-query request bodies", async () => {
+    const app = createDocsApi()
+    const spec = await fetchDocsJsonWithoutWarnings(app)
+
+    for (const path of [
+      "/api/objects/query",
+      "/api/objects/query/links",
+      "/api/objects/query/count",
+      "/api/objects/query/exists",
+      "/api/objects/query/facets",
+    ]) {
+      expect(spec.paths?.[path]?.post?.responses, path).toHaveProperty("413")
+    }
+  })
 })


### PR DESCRIPTION
Deferred · Part of #269 · Excluded from the active Shared Links stack #547.

## Why

Object queries can nest filters, link traversals, and expansions. Excessively large or deep inputs can exhaust resources or overflow the call stack **during validation, before any database query runs**.

Shared Links expose queries to visitors whose inputs cannot be trusted. These safeguards protect ordinary object queries too.

## How it works

```text
HTTP body → streaming size cap → structural scan → existing validation → execution
Core SDK                      → structural scan → existing normalization / validation
```

- **Server:** stop reading bodies above **1 MiB** on all five object-query routes, including `query/links` (`413`).
- **Core + Server:** reject excessively deep or large query structures before recursive processing (`400` over HTTP; validation error in Core).
- **Iterative scanner:** avoids recursive calls itself and rejects cyclic SDK inputs.

| Structural bound | Limit |
| --- | ---: |
| Query nodes / depth | 512 / 32 |
| Cumulative query array entries | 4,096 |
| JSON value depth / cumulative entries | 64 / 4,096 |

## Scope

- Normal query syntax and permissions are unchanged; no new API for app authors to adopt.
- This bounds **input structure**, not SQL execution cost or which objects a caller may access.
- Tests cover the guards; OpenAPI and the generated client document the new `413` responses.
