### PR TITLE
storage: activate selected object readers

### DIFF
--- a/packages/core/src/storage/in-memory/index.ts
+++ b/packages/core/src/storage/in-memory/index.ts
@@ -21,6 +21,7 @@ import { ProviderMaterializationTransactionLifecycle } from "../ontology/provide
 import {
   createAgentOperationScope,
   createAuthOperationScope,
+  createObjectOperationScope,
   createOntologyOperationScope,
   createOperationScopedFacade,
   createStorageOperationScope,
@@ -118,7 +119,7 @@ export class InMemoryStorage implements Storage {
       (run) => this.withStorageOperation(run),
       () => this.assertRootOperationAvailable()
     )
-    this.objects = createOperationScopedFacade(this.objectStorage, scope)
+    this.objects = createObjectOperationScope(this.objectStorage, scope)
     this.timeseries = createOperationScopedFacade(this.timeseriesStorage, scope)
     this.auth = createAuthOperationScope(this.authStorage, scope)
     this.executions = createOperationScopedFacade(this.executionStorage, scope)

--- a/packages/core/src/storage/objects/guard.ts
+++ b/packages/core/src/storage/objects/guard.ts
@@ -1,0 +1,55 @@
+import type { ObjectReadScopeFactory, ObjectReadStorage, ObjectStorage } from "./types"
+
+export interface ObjectReadStorageCallGuard {
+  assertAvailable(): void
+  run<TResult>(operation: () => Promise<TResult>): Promise<TResult>
+}
+
+/** Validate the required runtime capability before any facade can expose broad object reads. */
+export function requireObjectReadScopeFactory(storage: ObjectStorage): ObjectReadScopeFactory {
+  if (typeof storage.createSelectedReadScope !== "function") {
+    throw new Error(
+      "[Sixb] Object storage provider must implement ObjectReadScopeFactory to create selected object readers."
+    )
+  }
+  return storage
+}
+
+/**
+ * Guard every selected-reader terminal without proxying the provider reader.
+ *
+ * First-party providers freeze their readers. A Proxy cannot substitute a frozen own method
+ * without violating JavaScript's invariants, so operation and lifetime guards use this explicit
+ * facade instead.
+ */
+export function createGuardedObjectReadStorage(
+  reader: ObjectReadStorage,
+  guard: ObjectReadStorageCallGuard
+): ObjectReadStorage {
+  const guarded: ObjectReadStorage = {
+    queryCapabilities: () => {
+      guard.assertAvailable()
+      return reader.queryCapabilities()
+    },
+    getByPrimaryId: (input) => guard.run(() => reader.getByPrimaryId(input)),
+    selectsObjectProperties: (input) => guard.run(() => reader.selectsObjectProperties(input)),
+    listLinks: (input) => guard.run(() => reader.listLinks(input)),
+    getByPrimaryIdBatch: (input) => guard.run(() => reader.getByPrimaryIdBatch(input)),
+    listLinksBatch: (input) => guard.run(() => reader.listLinksBatch(input)),
+    queryLinks: (input) => guard.run(() => reader.queryLinks(input)),
+    list: (input) => guard.run(() => reader.list(input)),
+  }
+  if (reader.queryObjects) {
+    guarded.queryObjects = (input) => guard.run(() => reader.queryObjects!(input))
+  }
+  if (reader.countObjects) {
+    guarded.countObjects = (input) => guard.run(() => reader.countObjects!(input))
+  }
+  if (reader.existsObjects) {
+    guarded.existsObjects = (input) => guard.run(() => reader.existsObjects!(input))
+  }
+  if (reader.facetObjects) {
+    guarded.facetObjects = (input) => guard.run(() => reader.facetObjects!(input))
+  }
+  return Object.freeze(guarded)
+}

--- a/packages/core/src/storage/objects/in-memory.ts
+++ b/packages/core/src/storage/objects/in-memory.ts
@@ -32,7 +32,6 @@ import type {
   ObjectFacetResult,
   ObjectLinkRow,
   ObjectQueryCapabilities,
-  ObjectReadScopeFactory,
   ObjectReadStorage,
   ObjectRow,
   ObjectStorage,
@@ -218,7 +217,7 @@ export function getInMemoryObjectMaterializerAdapter(
   return adapter
 }
 
-export class InMemoryObjectStorage implements ObjectStorage, ObjectReadScopeFactory {
+export class InMemoryObjectStorage implements ObjectStorage {
   private readonly rows = new Map<string, Map<string, ObjectRow>>()
   private readonly links = new Map<string, Map<string, ObjectLinkRow>>()
 

--- a/packages/core/src/storage/objects/types.ts
+++ b/packages/core/src/storage/objects/types.ts
@@ -344,7 +344,7 @@ export interface ObjectReadStorage {
   }): Promise<{ objects: readonly ObjectRow[]; hasMore: boolean; total: number }>
 }
 
-/** Optional provider capability for enforcing a finite, precompiled object-read selection. */
+/** Provider capability for enforcing a finite, precompiled object-read selection. */
 export interface ObjectReadScopeFactory {
   createSelectedReadScope(params: {
     projectId: string
@@ -353,8 +353,8 @@ export interface ObjectReadScopeFactory {
   }): ObjectReadStorage
 }
 
-/** Latest-state projection storage, including trusted internal read primitives. */
-export interface ObjectStorage extends ObjectReadStorage {
+/** Latest-state projection storage, including selected reads and trusted internal primitives. */
+export interface ObjectStorage extends ObjectReadStorage, ObjectReadScopeFactory {
   /**
    * Batch fetch every link incident to any of the given objects, in BOTH directions (the object as
    * link source or target). Returns a flat, de-duplicated list: a physical link incident to two

--- a/packages/core/src/storage/operation-scope.ts
+++ b/packages/core/src/storage/operation-scope.ts
@@ -1,6 +1,8 @@
 import { AsyncLocalStorage } from "node:async_hooks"
 import type { AgentStorage } from "./agents"
 import type { AuthStorage } from "./auth"
+import type { ObjectStorage } from "./objects"
+import { createGuardedObjectReadStorage, requireObjectReadScopeFactory } from "./objects/guard"
 import type { OntologyStorage } from "./ontology"
 import type { WorkflowRunStorage } from "./workflow-runs"
 
@@ -228,6 +230,20 @@ export function createOntologyOperationScope<T extends OntologyStorage>(
     sources: createOperationScopedFacade(target.sources, scope),
     materializations: createOperationScopedFacade(target.materializations, scope),
     outbox: createOperationScopedFacade(target.outbox, scope),
+  }) as T
+}
+
+/** Keep synchronously created selected readers inside the provider's root operation scope. */
+export function createObjectOperationScope<T extends ObjectStorage>(
+  target: T,
+  scope: StorageOperationScope
+): T {
+  const factory = requireObjectReadScopeFactory(target)
+  return createOperationScopedFacade<ObjectStorage>(target, scope, {
+    createSelectedReadScope: (params) => {
+      scope.assertAvailable()
+      return createGuardedObjectReadStorage(factory.createSelectedReadScope(params), scope)
+    },
   }) as T
 }
 

--- a/packages/core/src/storage/transaction.ts
+++ b/packages/core/src/storage/transaction.ts
@@ -1,12 +1,21 @@
 import { StorageTransactionError } from "./errors"
+import { createObjectOperationScope } from "./operation-scope"
+import type { Storage } from "./types"
 
 type ObjectLike = Record<PropertyKey, unknown>
 
-export function createTransactionStorageProxy<T extends object>(
+export function createTransactionStorageProxy<T extends Storage>(
   target: T,
   isActive: () => boolean
 ): T {
   const proxies = new WeakMap<object, object>()
+  const objectStorage = createObjectOperationScope(target.objects, {
+    assertAvailable: () => assertTransactionActive(isActive),
+    run: async <TResult>(operation: () => Promise<TResult> | TResult): Promise<TResult> => {
+      assertTransactionActive(isActive)
+      return operation()
+    },
+  })
 
   const wrap = <TValue extends object>(value: TValue): TValue => {
     const existing = proxies.get(value)
@@ -19,7 +28,10 @@ export function createTransactionStorageProxy<T extends object>(
       // from `tx` are wrapped (a handful), not the row/link data graph, and never per-record.
       get(current, property, receiver) {
         assertTransactionActive(isActive)
-        const result = Reflect.get(current, property, receiver)
+        const result =
+          current === target && property === "objects"
+            ? objectStorage
+            : Reflect.get(current, property, receiver)
         if (typeof result === "function") {
           return (...args: unknown[]) => {
             assertTransactionActive(isActive)

--- a/packages/core/tests/in-memory-object-read-scope.test.ts
+++ b/packages/core/tests/in-memory-object-read-scope.test.ts
@@ -6,7 +6,6 @@ import {
   getInMemoryObjectMaterializerAdapter,
   InMemoryObjectStorage,
 } from "../src/storage/objects/in-memory"
-import type { ObjectReadScopeFactory, ObjectStorage } from "../src/storage/objects/types"
 import {
   createMaterializerTestFixture,
   objectReadScopeContractOntology,
@@ -16,7 +15,7 @@ import {
 runObjectReadScopeContractSuite("InMemoryStorage selected object-read scope contract", {
   createHarness: () => {
     const storage = new InMemoryStorage()
-    return { storage, objectReadScopeFactory: requireScopeFactory(storage.objects) }
+    return { storage, objectReadScopeFactory: storage.objects }
   },
 })
 
@@ -82,7 +81,7 @@ describe("InMemoryObjectStorage selected read behavior", () => {
       ],
     })
 
-    const reader = requireScopeFactory(storage.objects).createSelectedReadScope({
+    const reader = storage.objects.createSelectedReadScope({
       projectId: "in-memory-vector-scope",
       scope: compileSelectedObjectReadScope({
         kind: "selected",
@@ -188,14 +187,3 @@ describe("InMemoryObjectStorage selected read behavior", () => {
     ).toMatchObject({ properties: { id: "prototype-1" } })
   })
 })
-
-function requireScopeFactory(storage: ObjectStorage): ObjectReadScopeFactory {
-  if (!("createSelectedReadScope" in storage)) {
-    throw new Error("[Sixb] Expected the in-memory object-read scope factory.")
-  }
-  const factory = storage as ObjectStorage & Partial<ObjectReadScopeFactory>
-  if (typeof factory.createSelectedReadScope !== "function") {
-    throw new Error("[Sixb] Expected the in-memory object-read scope factory.")
-  }
-  return factory as ObjectReadScopeFactory
-}

--- a/packages/core/tests/object-read-storage-guard.test.ts
+++ b/packages/core/tests/object-read-storage-guard.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test"
+import type { ObjectReadStorage } from "../src/storage"
+import { createGuardedObjectReadStorage } from "../src/storage/objects/guard"
+
+describe("selected object reader guards", () => {
+  test("forwards every terminal from a frozen provider reader through one guard", async () => {
+    const provider = fullReader()
+    let availabilityChecks = 0
+    let guardedRuns = 0
+    const reader = createGuardedObjectReadStorage(provider, {
+      assertAvailable: () => {
+        availabilityChecks += 1
+      },
+      run: async (operation) => {
+        guardedRuns += 1
+        return operation()
+      },
+    })
+
+    expect(reader.queryCapabilities()).toEqual({ queryObjects: true })
+    const query = { kind: "start", objectTypeId: "GuardedObject" } as const
+    await reader.queryObjects?.({ projectId: "guard-project", query })
+    await reader.countObjects?.({ projectId: "guard-project", query })
+    await reader.existsObjects?.({ projectId: "guard-project", query })
+    await reader.facetObjects?.({
+      projectId: "guard-project",
+      query,
+      facets: [{ propertyId: "id", limit: 10 }],
+    })
+    await reader.getByPrimaryId({
+      projectId: "guard-project",
+      objectTypeId: "GuardedObject",
+      primaryId: "root",
+    })
+    await reader.selectsObjectProperties({ projectId: "guard-project", items: [] })
+    await reader.listLinks({
+      projectId: "guard-project",
+      objectTypeId: "GuardedObject",
+      objectId: "root",
+    })
+    await reader.getByPrimaryIdBatch({ projectId: "guard-project", items: [] })
+    await reader.listLinksBatch({ projectId: "guard-project", items: [] })
+    await reader.queryLinks({
+      projectId: "guard-project",
+      objectRefs: [],
+      direction: "outgoing",
+      limit: 1,
+    })
+    await reader.list({ projectId: "guard-project" })
+
+    expect(Object.isFrozen(provider)).toBe(true)
+    expect(Object.isFrozen(reader)).toBe(true)
+    expect(availabilityChecks).toBe(1)
+    expect(guardedRuns).toBe(11)
+  })
+
+  test("does not invent optional query terminals", () => {
+    const provider = requiredReader()
+    const reader = createGuardedObjectReadStorage(provider, {
+      assertAvailable: () => undefined,
+      run: (operation) => operation(),
+    })
+
+    expect(reader.queryObjects).toBeUndefined()
+    expect(reader.countObjects).toBeUndefined()
+    expect(reader.existsObjects).toBeUndefined()
+    expect(reader.facetObjects).toBeUndefined()
+  })
+})
+
+function fullReader(): ObjectReadStorage {
+  return Object.freeze({
+    ...requiredReader(),
+    queryCapabilities: () => ({ queryObjects: true }),
+    queryObjects: async () => ({ objects: [], hasMore: false, total: 0 }),
+    countObjects: async () => ({ count: 0 }),
+    existsObjects: async () => ({ exists: false }),
+    facetObjects: async () => ({ facets: [] }),
+  })
+}
+
+function requiredReader(): ObjectReadStorage {
+  return Object.freeze({
+    queryCapabilities: () => ({ queryObjects: false }),
+    getByPrimaryId: async () => null,
+    selectsObjectProperties: async () => [],
+    listLinks: async () => [],
+    getByPrimaryIdBatch: async () => new Map(),
+    listLinksBatch: async () => new Map(),
+    queryLinks: async () => ({ links: [], hasMore: false }),
+    list: async () => ({ objects: [], hasMore: false, total: 0 }),
+  })
+}

--- a/packages/core/tests/storage-operation-scope.test.ts
+++ b/packages/core/tests/storage-operation-scope.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import {
+  compileSelectedObjectReadScope,
+  type ObjectReadStorage,
+  type ObjectStorage,
+  StorageTransactionError,
+} from "../src/storage"
+import { InMemoryStorage } from "../src/storage/in-memory"
+import {
+  createObjectOperationScope,
   createOperationScopedFacade,
   createStorageOperationScope,
 } from "../src/storage/operation-scope"
@@ -11,6 +19,17 @@ class TestStorage {
 }
 
 describe("storage operation scope", () => {
+  test("fails closed when object storage omits the selected-read factory", () => {
+    const malformed = { createSelectedReadScope: undefined } as unknown as ObjectStorage
+
+    expect(() =>
+      createObjectOperationScope(
+        malformed,
+        createStorageOperationScope(async (run) => run())
+      )
+    ).toThrow("must implement ObjectReadScopeFactory")
+  })
+
   test("keeps decorated provider methods inside their operation scope", async () => {
     const target = new TestStorage()
     let scopeRuns = 0
@@ -82,4 +101,93 @@ describe("storage operation scope", () => {
 
     await expect(facade.read()).rejects.toThrow("scope became unavailable")
   })
+
+  test("runs selected-reader terminals through the same root operation lock", async () => {
+    const storage = new InMemoryStorage()
+    const input = selectedReaderInput()
+    const reader = storage.objects.createSelectedReadScope(input)
+    let transactionEntered!: () => void
+    const entered = new Promise<void>((resolve) => {
+      transactionEntered = resolve
+    })
+    let releaseTransaction!: () => void
+    const blocked = new Promise<void>((resolve) => {
+      releaseTransaction = resolve
+    })
+    const transaction = storage.transaction(async () => {
+      transactionEntered()
+      await blocked
+    })
+    await entered
+
+    let readFinished = false
+    const read = reader.list({ projectId: input.projectId }).then((result) => {
+      readFinished = true
+      return result
+    })
+    try {
+      await Bun.sleep(0)
+      expect(readFinished).toBe(false)
+    } finally {
+      releaseTransaction()
+      await transaction
+    }
+    await expect(read).resolves.toEqual({ objects: [], hasMore: false, total: 0 })
+  })
+
+  test("guards transaction-created readers and captured factory methods after completion", async () => {
+    const storage = new InMemoryStorage()
+    const input = selectedReaderInput()
+    let escapedReader: ObjectReadStorage | undefined
+    let escapedRead: ObjectReadStorage["list"] | undefined
+    let escapedFactory: ObjectStorage["createSelectedReadScope"] | undefined
+
+    await storage.transaction(async (tx) => {
+      expect(() => storage.objects.createSelectedReadScope(input)).toThrow(
+        "use the provided tx storage"
+      )
+
+      const reader = tx.objects.createSelectedReadScope(input)
+      await expect(reader.list({ projectId: input.projectId })).resolves.toEqual({
+        objects: [],
+        hasMore: false,
+        total: 0,
+      })
+      escapedReader = reader
+      escapedRead = reader.list
+      escapedFactory = tx.objects.createSelectedReadScope
+    })
+
+    if (!escapedReader || !escapedRead || !escapedFactory) {
+      throw new Error("Expected transaction reader handles to be captured.")
+    }
+    const reader = escapedReader
+    const read = escapedRead
+    const createReader = escapedFactory
+    expect(() => reader.queryCapabilities()).toThrow(StorageTransactionError)
+    expect(() => createReader(input)).toThrow(StorageTransactionError)
+    await expect(
+      Promise.resolve().then(() => read({ projectId: input.projectId }))
+    ).rejects.toMatchObject({ code: "transaction_inactive" })
+  })
 })
+
+function selectedReaderInput() {
+  const projectId = "operation-scope-project"
+  return {
+    projectId,
+    scope: compileSelectedObjectReadScope({
+      kind: "selected",
+      roots: [
+        {
+          anchor: { objectTypeId: "OperationScopeObject", primaryId: "root" },
+          node: {
+            objects: [{ objectTypeId: "OperationScopeObject", propertyIds: ["id"] }],
+            links: [],
+          },
+        },
+      ],
+    }),
+    limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 10_000 },
+  }
+}

--- a/storage/pg/src/index.ts
+++ b/storage/pg/src/index.ts
@@ -13,6 +13,7 @@ import { ProviderMaterializationTransactionLifecycle } from "@sixb/core/internal
 import {
   createAgentOperationScope,
   createAuthOperationScope,
+  createObjectOperationScope,
   createOntologyOperationScope,
   createOperationScopedFacade,
   createStorageOperationScope,
@@ -208,7 +209,7 @@ export class PostgresStorage implements MigrationCapableStorage {
       },
       () => this.assertRootOperationAvailable()
     )
-    this.objects = createOperationScopedFacade(stores.objects, scope)
+    this.objects = createObjectOperationScope(stores.objects, scope)
     this.ontology = createOntologyOperationScope(stores.ontology, scope)
     this.auth = createAuthOperationScope(stores.auth, scope)
     this.executions = createOperationScopedFacade(stores.executions, scope)

--- a/storage/pg/src/pg-object-query-compiler.ts
+++ b/storage/pg/src/pg-object-query-compiler.ts
@@ -45,6 +45,7 @@ interface CompiledHasMoreProbe {
 
 interface CompileContext {
   probeLimit: boolean
+  source: PgObjectQuerySource
 }
 
 interface CompiledPredicate {
@@ -89,7 +90,6 @@ interface EncodedCursorValue {
 }
 
 const PAGE_TOKEN_PREFIX = "keyset:"
-const exactContext: CompileContext = { probeLimit: false }
 // Per-parent fanout the core executor bakes into every pushed-down expansion;
 // this default only guards a malformed (un-baked) IR and mirrors the core cap.
 const DEFAULT_EXPANSION_FANOUT = 1_000
@@ -97,11 +97,15 @@ const DEFAULT_EXPANSION_FANOUT = 1_000
 export function compilePgObjectQuery(
   projectId: string,
   query: ObjectQuery,
-  options: { includeTotal?: boolean } = {}
+  options: { includeTotal?: boolean; source?: PgObjectQuerySource } = {}
 ): CompiledPgObjectQuery {
-  const compiled = compileObjectQueryInternal(projectId, query, {
-    probeLimit: options.includeTotal === false,
-  })
+  const source = options.source ?? DEFAULT_OBJECT_QUERY_SOURCE
+  const compiled = source.wrapQuery(
+    compileObjectQueryInternal(projectId, query, {
+      probeLimit: options.includeTotal === false,
+      source,
+    })
+  )
   return {
     ...compiled,
     sql: numberPlaceholders(compiled.sql),
@@ -115,44 +119,90 @@ export function compilePgObjectQuery(
   }
 }
 
+/** Physical relations used by the PostgreSQL object-query compiler. */
+export interface PgObjectQuerySource {
+  readonly objectsTable: string
+  readonly linksTable: string
+  /** Wrap a terminal SELECT without its own WITH clause; the selected source owns the only WITH. */
+  wrapStatement(
+    sql: string,
+    args?: readonly unknown[]
+  ): {
+    readonly sql: string
+    readonly args: unknown[]
+  }
+  wrapQuery(query: CompiledPgObjectQuery): CompiledPgObjectQuery
+}
+
+/** Prefix an optional query source, then assign PostgreSQL positional placeholders. */
+export function compilePgObjectStatement(
+  sql: string,
+  args: readonly unknown[] = [],
+  source?: PgObjectQuerySource
+): CompiledPgScalarQuery {
+  return numberCompiledQuery((source ?? DEFAULT_OBJECT_QUERY_SOURCE).wrapStatement(sql, args))
+}
+
+const DEFAULT_OBJECT_QUERY_SOURCE: PgObjectQuerySource = {
+  objectsTable: "objects",
+  linksTable: "links",
+  wrapStatement: (sql, args = []) => ({ sql, args: [...args] }),
+  wrapQuery: (query) => query,
+}
+
+function exactContext(ctx: CompileContext): CompileContext {
+  return ctx.probeLimit ? { ...ctx, probeLimit: false } : ctx
+}
+
 export function compilePgObjectCountQuery(
   projectId: string,
-  query: ObjectQuery
+  query: ObjectQuery,
+  options: { source?: PgObjectQuerySource } = {}
 ): CompiledPgScalarQuery {
-  const source = compileAggregateSource(projectId, query)
-  return numberCompiledQuery({
-    sql: `
+  const querySource = options.source ?? DEFAULT_OBJECT_QUERY_SOURCE
+  const source = compileAggregateSource(projectId, query, querySource)
+  return numberCompiledQuery(
+    querySource.wrapStatement(
+      `
       SELECT COUNT(*)::bigint AS count
       FROM (${source.sql}) AS input
     `,
-    args: source.args,
-  })
+      source.args
+    )
+  )
 }
 
 export function compilePgObjectExistsQuery(
   projectId: string,
-  query: ObjectQuery
+  query: ObjectQuery,
+  options: { source?: PgObjectQuerySource } = {}
 ): CompiledPgScalarQuery {
-  const source = compileAggregateSource(projectId, query)
-  return numberCompiledQuery({
-    sql: `
+  const querySource = options.source ?? DEFAULT_OBJECT_QUERY_SOURCE
+  const source = compileAggregateSource(projectId, query, querySource)
+  return numberCompiledQuery(
+    querySource.wrapStatement(
+      `
       SELECT 1
       FROM (${source.sql}) AS input
       LIMIT 1
     `,
-    args: source.args,
-  })
+      source.args
+    )
+  )
 }
 
 export function compilePgObjectFacetQuery(
   projectId: string,
   query: ObjectQuery,
   propertyId: string,
-  limit: number
+  limit: number,
+  options: { source?: PgObjectQuerySource } = {}
 ): CompiledPgFacetQuery {
-  const source = compileAggregateSource(projectId, query)
-  return numberCompiledQuery({
-    sql: `
+  const querySource = options.source ?? DEFAULT_OBJECT_QUERY_SOURCE
+  const source = compileAggregateSource(projectId, query, querySource)
+  return numberCompiledQuery(
+    querySource.wrapStatement(
+      `
       SELECT facet.value_type, facet.value_text, COUNT(*)::bigint AS count
       FROM (
         SELECT
@@ -165,8 +215,9 @@ export function compilePgObjectFacetQuery(
       ORDER BY count DESC, facet.value_text ASC
       LIMIT ?
     `,
-    args: [propertyId, propertyId, ...source.args, propertyId, limit],
-  })
+      [propertyId, propertyId, ...source.args, propertyId, limit]
+    )
+  )
 }
 
 function compileObjectQueryInternal(
@@ -176,27 +227,28 @@ function compileObjectQueryInternal(
 ): CompiledPgObjectQuery {
   switch (query.kind) {
     case "start":
-      return compileStart(projectId, query)
+      return compileStart(projectId, query, ctx)
     case "refs":
-      return compileRefs(projectId, query)
+      return compileRefs(projectId, query, ctx)
     case "filter":
-      return compileFilter(projectId, query.input, query.predicate)
+      return compileFilter(projectId, query.input, query.predicate, ctx)
     case "sort":
       return compileSort(projectId, query.input, query.fields, ctx)
     case "limit":
       return compileLimit(projectId, query.input, query.limit, ctx)
     case "page":
-      return compilePage(projectId, query.input, query.pageSize, query.pageToken)
+      return compilePage(projectId, query.input, query.pageSize, query.pageToken, ctx)
     case "traverse":
       return compileTraversal(
         projectId,
         query.input,
         query.linkId,
         query.direction,
-        query.sourceObjectTypeId
+        query.sourceObjectTypeId,
+        ctx
       )
     case "set":
-      return compileSet(projectId, query.op, query.inputs)
+      return compileSet(projectId, query.op, query.inputs, ctx)
     case "project":
       return compileProject(projectId, query.input, query.properties, ctx)
     case "text":
@@ -205,10 +257,11 @@ function compileObjectQueryInternal(
         query.input,
         query.query,
         query.fields,
-        query.fieldsByObjectType
+        query.fieldsByObjectType,
+        ctx
       )
     case "expand":
-      return compileExpand(projectId, query.input, query.expansions)
+      return compileExpand(projectId, query.input, query.expansions, ctx)
     case "vector":
       throw new Error(
         `[SixbPg] PostgreSQL object storage does not support query node '${query.kind}'`
@@ -218,7 +271,8 @@ function compileObjectQueryInternal(
 
 function compileStart(
   projectId: string,
-  query: Extract<ObjectQuery, { kind: "start" }>
+  query: Extract<ObjectQuery, { kind: "start" }>,
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
   if (query.includeSubtypes === true) {
     throw new Error("[SixbPg] PostgreSQL object storage does not support start.includeSubtypes")
@@ -227,7 +281,7 @@ function compileStart(
   const order = compileOrder(identityOrderFields())
   const sql = `
     SELECT *, properties AS _cursor_properties
-    FROM objects
+    FROM ${ctx.source.objectsTable}
     WHERE project_id = ? AND object_type_id = ?
     ORDER BY ${order.sql}
   `
@@ -235,8 +289,7 @@ function compileStart(
   return {
     sql,
     args: [projectId, query.objectTypeId, ...order.args],
-    totalSql:
-      "SELECT COUNT(*)::bigint AS total FROM objects WHERE project_id = ? AND object_type_id = ?",
+    totalSql: `SELECT COUNT(*)::bigint AS total FROM ${ctx.source.objectsTable} WHERE project_id = ? AND object_type_id = ?`,
     totalArgs: [projectId, query.objectTypeId],
     order,
     hasMore: () => false,
@@ -247,7 +300,8 @@ function compileStart(
 
 function compileRefs(
   projectId: string,
-  query: Extract<ObjectQuery, { kind: "refs" }>
+  query: Extract<ObjectQuery, { kind: "refs" }>,
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
   if (query.refs.length === 0) {
     throw new Error("[SixbPg] PostgreSQL object storage requires at least one ref")
@@ -263,10 +317,9 @@ function compileRefs(
     FROM jsonb_array_elements(?::text::jsonb) AS ref(value)
   `
   const sql = `
-    WITH requested AS (${requested})
     SELECT selected.*, selected.properties AS _cursor_properties
-    FROM requested
-    JOIN objects AS selected
+    FROM (${requested}) AS requested
+    JOIN ${ctx.source.objectsTable} AS selected
       ON selected.project_id = ?
      AND selected.object_type_id = requested.object_type_id
      AND selected.primary_id = requested.primary_id
@@ -277,10 +330,9 @@ function compileRefs(
     sql,
     args: [refsJson, projectId, ...selectedOrder.args],
     totalSql: `
-      WITH requested AS (${requested})
       SELECT COUNT(*)::bigint AS total
-      FROM requested
-      JOIN objects AS selected
+      FROM (${requested}) AS requested
+      JOIN ${ctx.source.objectsTable} AS selected
         ON selected.project_id = ?
        AND selected.object_type_id = requested.object_type_id
        AND selected.primary_id = requested.primary_id
@@ -296,17 +348,19 @@ function compileRefs(
 function compileFilter(
   projectId: string,
   inputQuery: ObjectQuery,
-  predicateNode: ObjectQueryPredicate
+  predicateNode: ObjectQueryPredicate,
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
-  return compileWhere(projectId, inputQuery, compilePredicate(predicateNode))
+  return compileWhere(projectId, inputQuery, compilePredicate(predicateNode), ctx)
 }
 
 function compileWhere(
   projectId: string,
   inputQuery: ObjectQuery,
-  predicate: CompiledPredicate
+  predicate: CompiledPredicate,
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const sql = `
     SELECT *
     FROM (${input.sql}) AS input
@@ -335,12 +389,14 @@ function compileText(
   inputQuery: ObjectQuery,
   query: string,
   fields: readonly string[] | undefined,
-  fieldsByObjectType: Readonly<Record<string, readonly string[]>> | undefined
+  fieldsByObjectType: Readonly<Record<string, readonly string[]>> | undefined,
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
   return compileWhere(
     projectId,
     inputQuery,
-    compileTextSearchPredicate(query, fields, fieldsByObjectType)
+    compileTextSearchPredicate(query, fields, fieldsByObjectType),
+    ctx
   )
 }
 
@@ -350,7 +406,7 @@ function compileSort(
   fields: readonly ObjectQuerySortField[],
   ctx: CompileContext
 ): CompiledPgObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const probeInput =
     ctx.probeLimit && needsLimitProbe(inputQuery)
       ? compileObjectQueryInternal(projectId, inputQuery, ctx)
@@ -389,7 +445,7 @@ function compileLimit(
   rawLimit: number,
   ctx: CompileContext
 ): CompiledPgObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const limit = Math.max(0, rawLimit)
   const rowLimit = ctx.probeLimit ? limit + 1 : limit
 
@@ -418,9 +474,10 @@ function compilePage(
   projectId: string,
   inputQuery: ObjectQuery,
   rawPageSize: number,
-  pageToken: string | undefined
+  pageToken: string | undefined,
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const pageSize = Math.max(0, rawPageSize)
   const cursor = pageToken ? decodePageToken(pageToken, input.order.fields) : undefined
   const cursorPredicate = cursor
@@ -457,30 +514,31 @@ function compileTraversal(
   inputQuery: ObjectQuery,
   linkId: string,
   direction: "outgoing" | "incoming",
-  sourceObjectTypeId?: string
+  sourceObjectTypeId: string | undefined,
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const outputAlias = direction === "outgoing" ? "target_object" : "source_object"
   const joinSql =
     direction === "outgoing"
       ? `
-        JOIN links AS edge
+        JOIN ${ctx.source.linksTable} AS edge
           ON edge.project_id = input.project_id
          AND edge.source_type_id = input.object_type_id
          AND edge.source_id = input.primary_id
          AND edge.link_id = ?
-        JOIN objects AS target_object
+        JOIN ${ctx.source.objectsTable} AS target_object
           ON target_object.project_id = edge.project_id
          AND target_object.object_type_id = edge.target_type_id
          AND target_object.primary_id = edge.target_id
       `
       : `
-        JOIN links AS edge
+        JOIN ${ctx.source.linksTable} AS edge
           ON edge.project_id = input.project_id
          AND edge.target_type_id = input.object_type_id
          AND edge.target_id = input.primary_id
          AND edge.link_id = ?${sourceObjectTypeId === undefined ? "" : "\n         AND edge.source_type_id = ?"}
-        JOIN objects AS source_object
+        JOIN ${ctx.source.objectsTable} AS source_object
           ON source_object.project_id = edge.project_id
          AND source_object.object_type_id = edge.source_type_id
          AND source_object.primary_id = edge.source_id
@@ -527,13 +585,15 @@ interface ExpansionParent {
 function compileExpand(
   projectId: string,
   inputQuery: ObjectQuery,
-  expansions: readonly ObjectExpansion[]
+  expansions: readonly ObjectExpansion[],
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const expand = compileExpansionsObject(
     expansions,
     { project: "input.project_id", type: "input.object_type_id", id: "input.primary_id" },
-    ""
+    "",
+    ctx
   )
   const inputOrder = compileOrder(input.order.fields, "input", "input._cursor_properties")
   const sql = `
@@ -561,13 +621,14 @@ function compileExpand(
 function compileExpansionsObject(
   expansions: readonly ObjectExpansion[],
   parent: ExpansionParent,
-  pathPrefix: string
+  pathPrefix: string,
+  ctx: CompileContext
 ): CompiledPredicate {
   const parts: string[] = []
   const args: unknown[] = []
   expansions.forEach((expansion, index) => {
     const path = pathPrefix === "" ? `${index}` : `${pathPrefix}_${index}`
-    const value = compileExpansionValue(expansion, parent, path)
+    const value = compileExpansionValue(expansion, parent, path, ctx)
     parts.push("?::text", value.sql)
     args.push(expansion.linkId, ...value.args)
   })
@@ -583,7 +644,8 @@ function compileExpansionsObject(
 function compileExpansionValue(
   expansion: ObjectExpansion,
   parent: ExpansionParent,
-  path: string
+  path: string,
+  ctx: CompileContext
 ): CompiledPredicate {
   const edge = `edge_${path}`
   const target = `tgt_${path}`
@@ -596,7 +658,7 @@ function compileExpansionValue(
   const parentType = incoming ? `${edge}.target_type_id` : `${edge}.source_type_id`
   const parentId = incoming ? `${edge}.target_id` : `${edge}.source_id`
 
-  const child = compileExpansionChildJson(expansion, edge, target, path)
+  const child = compileExpansionChildJson(expansion, edge, target, path, ctx)
   const order = compileExpansionOrder(expansion, target, neighborType, neighborId)
 
   const whereParts = [
@@ -613,8 +675,8 @@ function compileExpansionValue(
 
   const inner = `
     SELECT ${child.sql} AS elem, row_number() OVER (ORDER BY ${order.sql}) AS _ord
-    FROM links AS ${edge}
-    JOIN objects AS ${target}
+    FROM ${ctx.source.linksTable} AS ${edge}
+    JOIN ${ctx.source.objectsTable} AS ${target}
       ON ${target}.project_id = ${edge}.project_id
      AND ${target}.object_type_id = ${neighborType}
      AND ${target}.primary_id = ${neighborId}
@@ -644,7 +706,8 @@ function compileExpansionChildJson(
   expansion: ObjectExpansion,
   edge: string,
   target: string,
-  path: string
+  path: string,
+  ctx: CompileContext
 ): CompiledPredicate {
   const fields = [
     `'projectId', ${target}.project_id`,
@@ -667,7 +730,8 @@ function compileExpansionChildJson(
         type: `${target}.object_type_id`,
         id: `${target}.primary_id`,
       },
-      path
+      path,
+      ctx
     )
     fields.push(`'links', ${nested.sql}`)
     args.push(...nested.args)
@@ -711,14 +775,15 @@ function compileExpansionOrder(
 function compileSet(
   projectId: string,
   op: ObjectQuerySetOperation,
-  inputs: readonly ObjectQuery[]
+  inputs: readonly ObjectQuery[],
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
   if (inputs.length === 0) {
     const order = compileOrder(identityOrderFields())
     return {
       sql: `
         SELECT *, properties AS _cursor_properties
-        FROM objects
+        FROM ${ctx.source.objectsTable}
         WHERE 1 = 0
         ORDER BY ${order.sql}
       `,
@@ -733,7 +798,7 @@ function compileSet(
   }
 
   const compiledInputs = inputs.map((input) =>
-    compileObjectQueryInternal(projectId, input, exactContext)
+    compileObjectQueryInternal(projectId, input, exactContext(ctx))
   )
   const identities = compileSetIdentities(op, compiledInputs)
   const order = compileOrder(identityOrderFields())
@@ -741,7 +806,7 @@ function compileSet(
   const sql = `
     SELECT selected.*, selected.properties AS _cursor_properties
     FROM (${identities.sql}) AS ids
-    JOIN objects AS selected
+    JOIN ${ctx.source.objectsTable} AS selected
       ON selected.project_id = ?
      AND selected.object_type_id = ids.object_type_id
      AND selected.primary_id = ids.primary_id
@@ -799,19 +864,29 @@ function compileProject(
   }
 }
 
-function compileAggregateSource(projectId: string, query: ObjectQuery): CompiledAggregateSource {
+function compileAggregateSource(
+  projectId: string,
+  query: ObjectQuery,
+  source: PgObjectQuerySource
+): CompiledAggregateSource {
   switch (query.kind) {
     case "start":
-      return compileAggregateStart(projectId, query)
+      return compileAggregateStart(projectId, query, source)
     case "refs":
-      return compileAggregateRefs(projectId, query)
+      return compileAggregateRefs(projectId, query, source)
     case "filter":
-      return compileAggregateWhere(projectId, query.input, compilePredicate(query.predicate))
+      return compileAggregateWhere(
+        projectId,
+        query.input,
+        compilePredicate(query.predicate),
+        source
+      )
     case "text": {
       return compileAggregateWhere(
         projectId,
         query.input,
-        compileTextSearchPredicate(query.query, query.fields, query.fieldsByObjectType)
+        compileTextSearchPredicate(query.query, query.fields, query.fieldsByObjectType),
+        source
       )
     }
     case "traverse":
@@ -820,18 +895,19 @@ function compileAggregateSource(projectId: string, query: ObjectQuery): Compiled
         query.input,
         query.linkId,
         query.direction,
-        query.sourceObjectTypeId
+        query.sourceObjectTypeId,
+        source
       )
     case "set":
-      return compileAggregateSet(projectId, query.op, query.inputs)
+      return compileAggregateSet(projectId, query.op, query.inputs, source)
     case "sort":
     case "project":
     // `expand` is output-shaping, like sort/project: aggregates ignore it.
     case "expand":
-      return compileAggregateSource(projectId, query.input)
+      return compileAggregateSource(projectId, query.input, source)
     case "limit":
     case "page":
-      return compileRowQueryAggregateSource(projectId, query)
+      return compileRowQueryAggregateSource(projectId, query, source)
     case "vector":
       throw new Error(
         `[SixbPg] PostgreSQL object storage does not support query node '${query.kind}'`
@@ -841,7 +917,8 @@ function compileAggregateSource(projectId: string, query: ObjectQuery): Compiled
 
 function compileAggregateStart(
   projectId: string,
-  query: Extract<ObjectQuery, { kind: "start" }>
+  query: Extract<ObjectQuery, { kind: "start" }>,
+  source: PgObjectQuerySource
 ): CompiledAggregateSource {
   if (query.includeSubtypes === true) {
     throw new Error("[SixbPg] PostgreSQL object storage does not support start.includeSubtypes")
@@ -850,7 +927,7 @@ function compileAggregateStart(
   return {
     sql: `
       SELECT project_id, object_type_id, primary_id, properties
-      FROM objects
+      FROM ${source.objectsTable}
       WHERE project_id = ? AND object_type_id = ?
     `,
     args: [projectId, query.objectTypeId],
@@ -859,7 +936,8 @@ function compileAggregateStart(
 
 function compileAggregateRefs(
   projectId: string,
-  query: Extract<ObjectQuery, { kind: "refs" }>
+  query: Extract<ObjectQuery, { kind: "refs" }>,
+  source: PgObjectQuerySource
 ): CompiledAggregateSource {
   if (query.refs.length === 0) {
     throw new Error("[SixbPg] PostgreSQL object storage requires at least one ref")
@@ -874,7 +952,7 @@ function compileAggregateRefs(
           ref.value ->> 'primaryId' AS primary_id
         FROM jsonb_array_elements(?::text::jsonb) AS ref(value)
       ) AS requested
-      JOIN objects AS selected
+      JOIN ${source.objectsTable} AS selected
         ON selected.project_id = ?
        AND selected.object_type_id = requested.object_type_id
        AND selected.primary_id = requested.primary_id
@@ -886,9 +964,10 @@ function compileAggregateRefs(
 function compileAggregateWhere(
   projectId: string,
   inputQuery: ObjectQuery,
-  predicate: CompiledPredicate
+  predicate: CompiledPredicate,
+  source: PgObjectQuerySource
 ): CompiledAggregateSource {
-  const input = compileAggregateSource(projectId, inputQuery)
+  const input = compileAggregateSource(projectId, inputQuery, source)
   return {
     sql: `
       SELECT input.project_id, input.object_type_id, input.primary_id, input.properties
@@ -904,30 +983,31 @@ function compileAggregateTraversal(
   inputQuery: ObjectQuery,
   linkId: string,
   direction: "outgoing" | "incoming",
-  sourceObjectTypeId?: string
+  sourceObjectTypeId: string | undefined,
+  source: PgObjectQuerySource
 ): CompiledAggregateSource {
-  const input = compileAggregateSource(projectId, inputQuery)
+  const input = compileAggregateSource(projectId, inputQuery, source)
   const outputAlias = direction === "outgoing" ? "target_object" : "source_object"
   const joinSql =
     direction === "outgoing"
       ? `
-        JOIN links AS edge
+        JOIN ${source.linksTable} AS edge
           ON edge.project_id = input.project_id
          AND edge.source_type_id = input.object_type_id
          AND edge.source_id = input.primary_id
          AND edge.link_id = ?
-        JOIN objects AS target_object
+        JOIN ${source.objectsTable} AS target_object
           ON target_object.project_id = edge.project_id
          AND target_object.object_type_id = edge.target_type_id
          AND target_object.primary_id = edge.target_id
       `
       : `
-        JOIN links AS edge
+        JOIN ${source.linksTable} AS edge
           ON edge.project_id = input.project_id
          AND edge.target_type_id = input.object_type_id
          AND edge.target_id = input.primary_id
          AND edge.link_id = ?${sourceObjectTypeId === undefined ? "" : "\n         AND edge.source_type_id = ?"}
-        JOIN objects AS source_object
+        JOIN ${source.objectsTable} AS source_object
           ON source_object.project_id = edge.project_id
          AND source_object.object_type_id = edge.source_type_id
          AND source_object.primary_id = edge.source_id
@@ -954,26 +1034,27 @@ function compileAggregateTraversal(
 function compileAggregateSet(
   projectId: string,
   op: ObjectQuerySetOperation,
-  inputs: readonly ObjectQuery[]
+  inputs: readonly ObjectQuery[],
+  source: PgObjectQuerySource
 ): CompiledAggregateSource {
   if (inputs.length === 0) {
     return {
       sql: `
         SELECT project_id, object_type_id, primary_id, properties
-        FROM objects
+        FROM ${source.objectsTable}
         WHERE 1 = 0
       `,
       args: [],
     }
   }
 
-  const compiledInputs = inputs.map((input) => compileAggregateSource(projectId, input))
+  const compiledInputs = inputs.map((input) => compileAggregateSource(projectId, input, source))
   const identities = compileSetIdentities(op, compiledInputs)
   return {
     sql: `
       SELECT selected.project_id, selected.object_type_id, selected.primary_id, selected.properties
       FROM (${identities.sql}) AS ids
-      JOIN objects AS selected
+      JOIN ${source.objectsTable} AS selected
         ON selected.project_id = ?
        AND selected.object_type_id = ids.object_type_id
        AND selected.primary_id = ids.primary_id
@@ -984,9 +1065,13 @@ function compileAggregateSet(
 
 function compileRowQueryAggregateSource(
   projectId: string,
-  query: ObjectQuery
+  query: ObjectQuery,
+  source: PgObjectQuerySource
 ): CompiledAggregateSource {
-  const rowQuery = compileObjectQueryInternal(projectId, query, exactContext)
+  const rowQuery = compileObjectQueryInternal(projectId, query, {
+    probeLimit: false,
+    source,
+  })
   return {
     sql: `
       SELECT input.project_id, input.object_type_id, input.primary_id, input.properties

--- a/storage/pg/src/pg-object-read-scope.ts
+++ b/storage/pg/src/pg-object-read-scope.ts
@@ -1,0 +1,324 @@
+import type { CompiledSelectedObjectReadScope } from "@sixb/core/storage"
+import {
+  type CompiledPgObjectQuery,
+  compilePgObjectStatement,
+  type PgObjectQuerySource,
+} from "./pg-object-query-compiler"
+
+export interface PgSelectedObjectReadSource extends PgObjectQuerySource {
+  readonly objectPropertyPermissionsTable: string
+  readonly traversalProbe: {
+    readonly sql: string
+    readonly args: readonly unknown[]
+  }
+}
+
+/**
+ * Prepare one immutable selected scope as live, path-sensitive PostgreSQL relations.
+ *
+ * The complete compiled scope is serialized once. Every statement receives that one JSONB
+ * document and the bound project id, keeping the parameter count constant as selections grow.
+ */
+export function compilePgSelectedObjectReadSource(
+  projectId: string,
+  scope: CompiledSelectedObjectReadScope,
+  maxTraversalFacts: number
+): PgSelectedObjectReadSource {
+  const scopeJson = JSON.stringify({
+    roots: scope.roots,
+    objects: scope.objects,
+    steps: scope.steps,
+  })
+  const compiled = compileSelectedReadScopeCte(scopeJson, projectId)
+  const wrapStatement = (sql: string, args: readonly unknown[] = []) => ({
+    sql: `${compiled.sql}\n${sql}`,
+    args: [...compiled.args, ...args],
+  })
+
+  const source: PgSelectedObjectReadSource = {
+    objectsTable: "_sixb_scope_objects",
+    linksTable: "_sixb_scope_links",
+    objectPropertyPermissionsTable: "_sixb_scope_object_permissions",
+    wrapStatement,
+    wrapQuery: (query: CompiledPgObjectQuery): CompiledPgObjectQuery => ({
+      ...query,
+      ...wrapStatement(query.sql, query.args),
+      totalSql: `${compiled.sql}\n${query.totalSql}`,
+      totalArgs: [...compiled.args, ...query.totalArgs],
+      ...(query.hasMoreProbe
+        ? {
+            hasMoreProbe: {
+              ...query.hasMoreProbe,
+              ...wrapStatement(query.hasMoreProbe.sql, query.hasMoreProbe.args),
+            },
+          }
+        : {}),
+    }),
+    traversalProbe: { sql: "", args: [] },
+  }
+
+  const traversalProbe = compilePgObjectStatement(
+    `
+      SELECT COUNT(*)::bigint AS total
+      FROM (
+        SELECT 1 AS traversal_fact
+        FROM _sixb_scope_root_facts
+
+        UNION ALL
+
+        SELECT 1 AS traversal_fact
+        FROM _sixb_scope_reached_links
+
+        LIMIT ?
+      ) AS bounded_traversal_facts
+    `,
+    [BigInt(maxTraversalFacts) + 1n],
+    source
+  )
+
+  return Object.freeze({ ...source, traversalProbe })
+}
+
+interface CompiledReadScopeCte {
+  readonly sql: string
+  readonly args: readonly unknown[]
+}
+
+function compileSelectedReadScopeCte(scopeJson: string, projectId: string): CompiledReadScopeCte {
+  return {
+    sql: `
+      WITH RECURSIVE
+      _sixb_scope_document(scope) AS (
+        SELECT ?::text::jsonb
+      ),
+      _sixb_scope_roots(root_id, node_id, object_type_id, primary_id) AS (
+        SELECT
+          (root.ordinality - 1)::integer,
+          (root.value ->> 'nodeId')::integer,
+          root.value ->> 'objectTypeId',
+          root.value ->> 'primaryId'
+        FROM _sixb_scope_document AS document
+        CROSS JOIN LATERAL jsonb_array_elements(document.scope -> 'roots')
+          WITH ORDINALITY AS root(value, ordinality)
+      ),
+      _sixb_scope_root_facts(project_id, root_id, node_id, object_type_id, primary_id) AS (
+        SELECT anchor.project_id, root.root_id, root.node_id, root.object_type_id, root.primary_id
+        FROM _sixb_scope_roots AS root
+        JOIN objects AS anchor
+          ON anchor.project_id = ?
+         AND anchor.object_type_id = root.object_type_id
+         AND anchor.primary_id = root.primary_id
+      ),
+      _sixb_scope_object_selections(node_id, object_type_id, property_ids) AS (
+        SELECT
+          (selection.value ->> 'nodeId')::integer,
+          selection.value ->> 'objectTypeId',
+          selection.value -> 'propertyIds'
+        FROM _sixb_scope_document AS document
+        CROSS JOIN LATERAL jsonb_array_elements(document.scope -> 'objects') AS selection(value)
+      ),
+      _sixb_scope_link_selections(
+        step_id,
+        node_id,
+        parent_node_id,
+        source_object_type_id,
+        link_id,
+        target_object_type_id,
+        property_ids
+      ) AS (
+        SELECT
+          (step.ordinality - 1)::integer,
+          (step.value ->> 'nodeId')::integer,
+          (step.value ->> 'parentNodeId')::integer,
+          step.value ->> 'sourceObjectTypeId',
+          step.value ->> 'linkId',
+          step.value ->> 'targetObjectTypeId',
+          step.value -> 'propertyIds'
+        FROM _sixb_scope_document AS document
+        CROSS JOIN LATERAL jsonb_array_elements(document.scope -> 'steps')
+          WITH ORDINALITY AS step(value, ordinality)
+      ),
+      _sixb_scope_reachable(project_id, node_id, object_type_id, primary_id) AS (
+        SELECT root.project_id, root.node_id, root.object_type_id, root.primary_id
+        FROM _sixb_scope_root_facts AS root
+
+        UNION
+
+        SELECT edge.project_id, selection.node_id, edge.target_type_id, edge.target_id
+        FROM _sixb_scope_reachable AS parent
+        JOIN _sixb_scope_link_selections AS selection
+          ON selection.parent_node_id = parent.node_id
+         AND selection.source_object_type_id = parent.object_type_id
+        JOIN links AS edge
+          ON edge.project_id = parent.project_id
+         AND edge.source_type_id = parent.object_type_id
+         AND edge.source_id = parent.primary_id
+         AND edge.link_id = selection.link_id
+         AND edge.target_type_id = selection.target_object_type_id
+        JOIN objects AS target
+          ON target.project_id = edge.project_id
+         AND target.object_type_id = edge.target_type_id
+         AND target.primary_id = edge.target_id
+      ),
+      _sixb_scope_object_permissions(project_id, object_type_id, primary_id, property_id) AS (
+        SELECT DISTINCT
+          reachable.project_id,
+          reachable.object_type_id,
+          reachable.primary_id,
+          selected_property.value
+        FROM _sixb_scope_reachable AS reachable
+        JOIN _sixb_scope_object_selections AS selection
+          ON selection.node_id = reachable.node_id
+         AND selection.object_type_id = reachable.object_type_id
+        CROSS JOIN LATERAL jsonb_array_elements_text(selection.property_ids)
+          AS selected_property(value)
+      ),
+      _sixb_scope_object_ids(project_id, object_type_id, primary_id) AS (
+        SELECT DISTINCT project_id, object_type_id, primary_id
+        FROM _sixb_scope_reachable
+      ),
+      _sixb_scope_objects AS (
+        SELECT
+          stored.project_id,
+          stored.object_type_id,
+          stored.primary_id,
+          COALESCE(
+            (
+              SELECT jsonb_object_agg(property.key, property.value)
+              FROM jsonb_each(stored.properties) AS property(key, value)
+              JOIN _sixb_scope_object_permissions AS permission
+                ON permission.project_id = stored.project_id
+               AND permission.object_type_id = stored.object_type_id
+               AND permission.primary_id = stored.primary_id
+               AND permission.property_id = property.key
+            ),
+            '{}'::jsonb
+          ) AS properties,
+          stored.created_at,
+          stored.updated_at,
+          stored.version,
+          stored.last_commit_id
+        FROM objects AS stored
+        JOIN _sixb_scope_object_ids AS visible
+          ON visible.project_id = stored.project_id
+         AND visible.object_type_id = stored.object_type_id
+         AND visible.primary_id = stored.primary_id
+      ),
+      _sixb_scope_reached_links(
+        project_id,
+        step_id,
+        node_id,
+        parent_node_id,
+        source_type_id,
+        source_id,
+        link_id,
+        target_type_id,
+        target_id,
+        property_ids
+      ) AS (
+        SELECT
+          edge.project_id,
+          selection.step_id,
+          selection.node_id,
+          selection.parent_node_id,
+          edge.source_type_id,
+          edge.source_id,
+          edge.link_id,
+          edge.target_type_id,
+          edge.target_id,
+          selection.property_ids
+        FROM _sixb_scope_reachable AS parent
+        JOIN _sixb_scope_link_selections AS selection
+          ON selection.parent_node_id = parent.node_id
+         AND selection.source_object_type_id = parent.object_type_id
+        JOIN links AS edge
+          ON edge.project_id = parent.project_id
+         AND edge.source_type_id = parent.object_type_id
+         AND edge.source_id = parent.primary_id
+         AND edge.link_id = selection.link_id
+         AND edge.target_type_id = selection.target_object_type_id
+        JOIN objects AS target
+          ON target.project_id = edge.project_id
+         AND target.object_type_id = edge.target_type_id
+         AND target.primary_id = edge.target_id
+      ),
+      _sixb_scope_link_permissions(
+        project_id,
+        source_type_id,
+        source_id,
+        link_id,
+        target_type_id,
+        target_id,
+        property_id
+      ) AS (
+        SELECT DISTINCT
+          reached.project_id,
+          reached.source_type_id,
+          reached.source_id,
+          reached.link_id,
+          reached.target_type_id,
+          reached.target_id,
+          selected_property.value
+        FROM _sixb_scope_reached_links AS reached
+        CROSS JOIN LATERAL jsonb_array_elements_text(reached.property_ids)
+          AS selected_property(value)
+      ),
+      _sixb_scope_link_ids(
+        project_id,
+        source_type_id,
+        source_id,
+        link_id,
+        target_type_id,
+        target_id
+      ) AS (
+        SELECT DISTINCT
+          project_id,
+          source_type_id,
+          source_id,
+          link_id,
+          target_type_id,
+          target_id
+        FROM _sixb_scope_reached_links
+      ),
+      _sixb_scope_links AS (
+        SELECT
+          stored.project_id,
+          stored.source_type_id,
+          stored.source_id,
+          stored.link_id,
+          stored.target_type_id,
+          stored.target_id,
+          CASE
+            WHEN stored.properties IS NULL THEN NULL
+            ELSE NULLIF(
+              (
+                SELECT jsonb_object_agg(property.key, property.value)
+                FROM jsonb_each(stored.properties) AS property(key, value)
+                JOIN _sixb_scope_link_permissions AS permission
+                  ON permission.project_id = stored.project_id
+                 AND permission.source_type_id = stored.source_type_id
+                 AND permission.source_id = stored.source_id
+                 AND permission.link_id = stored.link_id
+                 AND permission.target_type_id = stored.target_type_id
+                 AND permission.target_id = stored.target_id
+                 AND permission.property_id = property.key
+              ),
+              '{}'::jsonb
+            )
+          END AS properties,
+          stored.created_at,
+          stored.updated_at,
+          stored.last_commit_id
+        FROM links AS stored
+        JOIN _sixb_scope_link_ids AS visible
+          ON visible.project_id = stored.project_id
+         AND visible.source_type_id = stored.source_type_id
+         AND visible.source_id = stored.source_id
+         AND visible.link_id = stored.link_id
+         AND visible.target_type_id = stored.target_type_id
+         AND visible.target_id = stored.target_id
+      )
+    `,
+    args: [scopeJson, projectId],
+  }
+}

--- a/storage/pg/src/pg-object-storage.ts
+++ b/storage/pg/src/pg-object-storage.ts
@@ -1,5 +1,6 @@
 import type { ObjectQuery } from "@sixb/core"
 import type {
+  CompiledSelectedObjectReadScope,
   CountObjectsInput,
   CountObjectsResult,
   ExistsObjectsInput,
@@ -11,8 +12,11 @@ import type {
   LinkBatchKey,
   LinkDirection,
   ObjectBatchKey,
+  ObjectFacetResult,
   ObjectLinkRow,
   ObjectQueryCapabilities,
+  ObjectReadExecutionLimits,
+  ObjectReadScopeFactory,
   ObjectReadStorage,
   ObjectRow,
   ObjectRowLinks,
@@ -22,7 +26,15 @@ import type {
   QueryObjectsInput,
   QueryObjectsResult,
 } from "@sixb/core/storage"
-import { linkBatchKey, objectBatchKey } from "@sixb/core/storage"
+import {
+  assertObjectReaderProject,
+  assertObjectReadFacetCount,
+  assertObjectReadOutputWithinLimit,
+  linkBatchKey,
+  ObjectReadLimitExceededError,
+  objectBatchKey,
+  snapshotObjectReadExecutionLimits,
+} from "@sixb/core/storage"
 import type { SQLClient, SqlParameter } from "./pg-client"
 import {
   type CompiledPgObjectQuery,
@@ -30,8 +42,14 @@ import {
   compilePgObjectExistsQuery,
   compilePgObjectFacetQuery,
   compilePgObjectQuery,
+  compilePgObjectStatement,
+  type PgObjectQuerySource,
 } from "./pg-object-query-compiler"
-import type { PgStoreClient } from "./transactions"
+import {
+  compilePgSelectedObjectReadSource,
+  type PgSelectedObjectReadSource,
+} from "./pg-object-read-scope"
+import { type PgStoreClient, runPgRepeatableReadTransaction } from "./transactions"
 
 const PG_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
   queryObjects: true,
@@ -156,19 +174,110 @@ function valuesJoin<Row = unknown>(
  * - Reads return JSONB as native JS types (objects, numbers, booleans) when
  *   the data was stored correctly.
  */
-export class PgObjectStorage implements ObjectStorage {
+export class PgObjectStorage implements ObjectStorage, ObjectReadScopeFactory {
   constructor(private readonly sql: PgStoreClient) {}
 
   queryCapabilities(): ObjectQueryCapabilities {
     return PG_OBJECT_QUERY_CAPABILITIES
   }
 
+  createSelectedReadScope(params: {
+    projectId: string
+    scope: CompiledSelectedObjectReadScope
+    limits: ObjectReadExecutionLimits
+  }): ObjectReadStorage {
+    const projectId = params.projectId
+    const limits = snapshotObjectReadExecutionLimits(params.limits)
+    const source = compilePgSelectedObjectReadSource(
+      projectId,
+      params.scope,
+      limits.maxTraversalFacts
+    )
+    const assertProject = (actualProjectId: string): void =>
+      assertObjectReaderProject(projectId, actualProjectId)
+    const read = <T>(run: (sql: SQLClient) => Promise<T>): Promise<T> =>
+      runPgRepeatableReadTransaction(this.sql, async (sql) => {
+        await assertTraversalBudget(sql, source, limits.maxTraversalFacts)
+        const value = await run(sql)
+        assertObjectReadOutputWithinLimit(value, limits)
+        return value
+      })
+    const readMap = <TKey, TValue>(
+      run: (sql: SQLClient) => Promise<Map<TKey, TValue>>
+    ): Promise<Map<TKey, TValue>> =>
+      runPgRepeatableReadTransaction(this.sql, async (sql) => {
+        await assertTraversalBudget(sql, source, limits.maxTraversalFacts)
+        const value = await run(sql)
+        assertObjectReadOutputWithinLimit([...value.entries()], limits)
+        return value
+      })
+
+    return Object.freeze({
+      queryCapabilities: () => this.queryCapabilities(),
+      queryObjects: async (input) => {
+        assertProject(input.projectId)
+        return read((sql) => this.queryObjectsFromSource(sql, input, source))
+      },
+      countObjects: async (input) => {
+        assertProject(input.projectId)
+        return read((sql) => this.countObjectsFromSource(sql, input, source))
+      },
+      existsObjects: async (input) => {
+        assertProject(input.projectId)
+        return read((sql) => this.existsObjectsFromSource(sql, input, source))
+      },
+      facetObjects: async (input) => {
+        assertProject(input.projectId)
+        assertObjectReadFacetCount(input.facets.length)
+        return read((sql) => this.facetObjectsFromSource(sql, input, source))
+      },
+      getByPrimaryId: async (input) => {
+        assertProject(input.projectId)
+        return read((sql) => this.getByPrimaryIdFromSource(sql, input, source))
+      },
+      selectsObjectProperties: async (input) => {
+        assertProject(input.projectId)
+        return read((sql) => this.selectsObjectPropertiesFromSource(sql, input, source))
+      },
+      listLinks: async (input) => {
+        assertProject(input.projectId)
+        return read((sql) => this.listLinksFromSource(sql, input, source))
+      },
+      getByPrimaryIdBatch: async (input) => {
+        assertProject(input.projectId)
+        return readMap((sql) => this.getByPrimaryIdBatchFromSource(sql, input, source))
+      },
+      listLinksBatch: async (input) => {
+        assertProject(input.projectId)
+        return readMap((sql) => this.listLinksBatchFromSource(sql, input, source))
+      },
+      queryLinks: async (input) => {
+        assertProject(input.projectId)
+        assertLinkQueryLimit(input.limit)
+        return read((sql) => this.queryLinksFromSource(sql, input, source))
+      },
+      list: async (input) => {
+        assertProject(input.projectId)
+        return read((sql) => this.listFromSource(sql, input, source))
+      },
+    } satisfies ObjectReadStorage)
+  }
+
   async queryObjects(params: QueryObjectsInput): Promise<QueryObjectsResult> {
+    return this.queryObjectsFromSource(this.sql, params)
+  }
+
+  private async queryObjectsFromSource(
+    sql: SQLClient,
+    params: QueryObjectsInput,
+    source?: PgObjectQuerySource
+  ): Promise<QueryObjectsResult> {
     const compiled = compilePgObjectQuery(params.projectId, params.query, {
       includeTotal: params.includeTotal,
+      ...(source ? { source } : {}),
     })
-    const total = params.includeTotal === false ? undefined : await readTotal(this.sql, compiled)
-    const rawRows = await this.sql.unsafe<ObjectQueryDatabaseRow[]>(
+    const total = params.includeTotal === false ? undefined : await readTotal(sql, compiled)
+    const rawRows = await sql.unsafe<ObjectQueryDatabaseRow[]>(
       compiled.sql,
       compiled.args as SqlParameter[]
     )
@@ -177,7 +286,7 @@ export class PgObjectStorage implements ObjectStorage {
       total === undefined && compiled.hasMoreProbe
         ? compiled.hasMoreProbe.hasMore(
             (
-              await this.sql.unsafe(
+              await sql.unsafe(
                 compiled.hasMoreProbe.sql,
                 compiled.hasMoreProbe.args as SqlParameter[]
               )
@@ -194,8 +303,18 @@ export class PgObjectStorage implements ObjectStorage {
   }
 
   async countObjects(params: CountObjectsInput): Promise<CountObjectsResult> {
-    const compiled = compilePgObjectCountQuery(params.projectId, stripOuterRowShape(params.query))
-    const [row] = await this.sql.unsafe<{ count: string | number | bigint }[]>(
+    return this.countObjectsFromSource(this.sql, params)
+  }
+
+  private async countObjectsFromSource(
+    sql: SQLClient,
+    params: CountObjectsInput,
+    source?: PgObjectQuerySource
+  ): Promise<CountObjectsResult> {
+    const compiled = compilePgObjectCountQuery(params.projectId, stripOuterRowShape(params.query), {
+      ...(source ? { source } : {}),
+    })
+    const [row] = await sql.unsafe<{ count: string | number | bigint }[]>(
       compiled.sql,
       compiled.args as SqlParameter[]
     )
@@ -203,28 +322,49 @@ export class PgObjectStorage implements ObjectStorage {
   }
 
   async existsObjects(params: ExistsObjectsInput): Promise<ExistsObjectsResult> {
-    const compiled = compilePgObjectExistsQuery(params.projectId, stripOuterRowShape(params.query))
-    const [row] = await this.sql.unsafe<unknown[]>(compiled.sql, compiled.args as SqlParameter[])
+    return this.existsObjectsFromSource(this.sql, params)
+  }
+
+  private async existsObjectsFromSource(
+    sql: SQLClient,
+    params: ExistsObjectsInput,
+    source?: PgObjectQuerySource
+  ): Promise<ExistsObjectsResult> {
+    const compiled = compilePgObjectExistsQuery(
+      params.projectId,
+      stripOuterRowShape(params.query),
+      { ...(source ? { source } : {}) }
+    )
+    const [row] = await sql.unsafe<unknown[]>(compiled.sql, compiled.args as SqlParameter[])
     return { exists: row !== undefined }
   }
 
   async facetObjects(params: FacetObjectsInput): Promise<FacetObjectsResult> {
-    return {
-      facets: await Promise.all(
-        params.facets.map(async (facet) => ({
-          propertyId: facet.propertyId,
-          buckets: await readFacetBuckets(
-            this.sql,
-            compilePgObjectFacetQuery(
-              params.projectId,
-              stripOuterRowShape(params.query),
-              facet.propertyId,
-              facet.limit
-            )
-          ),
-        }))
-      ),
+    return this.facetObjectsFromSource(this.sql, params)
+  }
+
+  private async facetObjectsFromSource(
+    sql: SQLClient,
+    params: FacetObjectsInput,
+    source?: PgObjectQuerySource
+  ): Promise<FacetObjectsResult> {
+    const facets: ObjectFacetResult[] = []
+    for (const facet of params.facets) {
+      facets.push({
+        propertyId: facet.propertyId,
+        buckets: await readFacetBuckets(
+          sql,
+          compilePgObjectFacetQuery(
+            params.projectId,
+            stripOuterRowShape(params.query),
+            facet.propertyId,
+            facet.limit,
+            { ...(source ? { source } : {}) }
+          )
+        ),
+      })
     }
+    return { facets }
   }
 
   async getByPrimaryId(params: {
@@ -232,12 +372,31 @@ export class PgObjectStorage implements ObjectStorage {
     objectTypeId: string
     primaryId: string
   }): Promise<ObjectRow | null> {
-    const [row] = await this.sql<ObjectDatabaseRow[]>`
-      SELECT * FROM objects
-      WHERE project_id = ${params.projectId}
-        AND object_type_id = ${params.objectTypeId}
-        AND primary_id = ${params.primaryId}
-    `
+    return this.getByPrimaryIdFromSource(this.sql, params)
+  }
+
+  private async getByPrimaryIdFromSource(
+    sql: SQLClient,
+    params: {
+      projectId: string
+      objectTypeId: string
+      primaryId: string
+    },
+    source?: PgObjectQuerySource
+  ): Promise<ObjectRow | null> {
+    const statement = compilePgObjectStatement(
+      `
+        SELECT *
+        FROM ${source?.objectsTable ?? "objects"}
+        WHERE project_id = ? AND object_type_id = ? AND primary_id = ?
+      `,
+      [params.projectId, params.objectTypeId, params.primaryId],
+      source
+    )
+    const [row] = await sql.unsafe<ObjectDatabaseRow[]>(
+      statement.sql,
+      statement.args as SqlParameter[]
+    )
 
     return row ? rowToObject(row) : null
   }
@@ -245,13 +404,45 @@ export class PgObjectStorage implements ObjectStorage {
   async selectsObjectProperties(
     params: Parameters<ObjectReadStorage["selectsObjectProperties"]>[0]
   ): Promise<readonly boolean[]> {
-    const objects = await this.getByPrimaryIdBatch({
-      projectId: params.projectId,
-      items: params.items,
-    })
-    return params.items.map((item) =>
-      objects.has(objectBatchKey(item.objectTypeId, item.primaryId))
+    return this.selectsObjectPropertiesFromSource(this.sql, params)
+  }
+
+  private async selectsObjectPropertiesFromSource(
+    sql: SQLClient,
+    params: Parameters<ObjectReadStorage["selectsObjectProperties"]>[0],
+    source?: PgSelectedObjectReadSource
+  ): Promise<readonly boolean[]> {
+    const result = params.items.map(() => false)
+    if (params.items.length === 0) return result
+
+    const items = params.items.map((item, batchIndex) => ({ ...item, batchIndex }))
+    const storedTable = source?.objectPropertyPermissionsTable ?? "objects"
+    const propertyJoin = source ? 'AND stored.property_id = requested."propertyId"' : ""
+    const statement = compilePgObjectStatement(
+      `
+        SELECT DISTINCT requested."batchIndex" AS _batch_index
+        FROM ${storedTable} AS stored
+        JOIN jsonb_to_recordset(?::text::jsonb)
+          AS requested(
+            "objectTypeId" text,
+            "primaryId" text,
+            "propertyId" text,
+            "batchIndex" integer
+          )
+          ON stored.object_type_id = requested."objectTypeId"
+         AND stored.primary_id = requested."primaryId"
+         ${propertyJoin}
+        WHERE stored.project_id = ?
+      `,
+      [JSON.stringify(items), params.projectId],
+      source
     )
+    const rows = await sql.unsafe<PropertyPermissionBatchDatabaseRow[]>(
+      statement.sql,
+      statement.args as SqlParameter[]
+    )
+    for (const row of rows) result[row._batch_index] = true
+    return result
   }
 
   async listLinks(params: {
@@ -261,20 +452,46 @@ export class PgObjectStorage implements ObjectStorage {
     linkId?: string
     direction?: LinkDirection
   }): Promise<readonly ObjectLinkRow[]> {
+    return this.listLinksFromSource(this.sql, params)
+  }
+
+  private async listLinksFromSource(
+    sql: SQLClient,
+    params: {
+      projectId: string
+      objectTypeId: string
+      objectId: string
+      linkId?: string
+      direction?: LinkDirection
+    },
+    source?: PgObjectQuerySource
+  ): Promise<readonly ObjectLinkRow[]> {
     const direction = params.direction ?? "outgoing"
     const directionWhere =
       direction === "incoming"
-        ? "target_type_id = $2 AND target_id = $3"
+        ? "target_type_id = ? AND target_id = ?"
         : direction === "both"
-          ? "((source_type_id = $2 AND source_id = $3) OR (target_type_id = $2 AND target_id = $3))"
-          : "source_type_id = $2 AND source_id = $3"
-    const query = `SELECT * FROM links WHERE project_id = $1 AND ${directionWhere}${
-      params.linkId ? " AND link_id = $4" : ""
+          ? "((source_type_id = ? AND source_id = ?) OR (target_type_id = ? AND target_id = ?))"
+          : "source_type_id = ? AND source_id = ?"
+    const args: unknown[] =
+      direction === "both"
+        ? [
+            params.projectId,
+            params.objectTypeId,
+            params.objectId,
+            params.objectTypeId,
+            params.objectId,
+          ]
+        : [params.projectId, params.objectTypeId, params.objectId]
+    const query = `SELECT * FROM ${source?.linksTable ?? "links"} WHERE project_id = ? AND ${directionWhere}${
+      params.linkId ? " AND link_id = ?" : ""
     }`
-    const args = params.linkId
-      ? [params.projectId, params.objectTypeId, params.objectId, params.linkId]
-      : [params.projectId, params.objectTypeId, params.objectId]
-    const rows = await this.sql.unsafe<LinkDatabaseRow[]>(query, args)
+    if (params.linkId) args.push(params.linkId)
+    const statement = compilePgObjectStatement(query, args, source)
+    const rows = await sql.unsafe<LinkDatabaseRow[]>(
+      statement.sql,
+      statement.args as SqlParameter[]
+    )
 
     return rows.map((row) => rowToLink(row))
   }
@@ -283,19 +500,41 @@ export class PgObjectStorage implements ObjectStorage {
     projectId: string
     items: readonly { objectTypeId: string; primaryId: string }[]
   }): Promise<Map<ObjectBatchKey, ObjectRow>> {
+    return this.getByPrimaryIdBatchFromSource(this.sql, params)
+  }
+
+  private async getByPrimaryIdBatchFromSource(
+    sql: SQLClient,
+    params: {
+      projectId: string
+      items: readonly { objectTypeId: string; primaryId: string }[]
+    },
+    source?: PgObjectQuerySource
+  ): Promise<Map<ObjectBatchKey, ObjectRow>> {
     const result = new Map<ObjectBatchKey, ObjectRow>()
     if (params.items.length === 0) return result
-    const rows = await valuesJoin<ObjectDatabaseRow>(
-      this.sql,
-      "SELECT o.* FROM objects o",
-      ["object_type_id", "primary_id"],
-      params.items.map((i) => [i.objectTypeId, i.primaryId]),
-      `WHERE o.project_id = $1`,
-      [params.projectId]
+    const items = params.items.map((item, batchIndex) => ({ ...item, batchIndex }))
+    const statement = compilePgObjectStatement(
+      `
+        SELECT object.*, requested."batchIndex" AS _batch_index
+        FROM jsonb_to_recordset(?::text::jsonb)
+          AS requested("objectTypeId" text, "primaryId" text, "batchIndex" integer)
+        JOIN ${source?.objectsTable ?? "objects"} AS object
+          ON object.project_id = ?
+         AND object.object_type_id = requested."objectTypeId"
+         AND object.primary_id = requested."primaryId"
+      `,
+      [JSON.stringify(items), params.projectId],
+      source
     )
-
-    for (const row of rows) {
-      result.set(objectBatchKey(row.object_type_id, row.primary_id), rowToObject(row))
+    const rows = await sql.unsafe<ObjectBatchDatabaseRow[]>(
+      statement.sql,
+      statement.args as SqlParameter[]
+    )
+    const rowsByIndex = new Map(rows.map((row) => [row._batch_index, row]))
+    for (const [index, item] of params.items.entries()) {
+      const row = rowsByIndex.get(index)
+      if (row) result.set(objectBatchKey(item.objectTypeId, item.primaryId), rowToObject(row))
     }
     return result
   }
@@ -305,105 +544,204 @@ export class PgObjectStorage implements ObjectStorage {
     direction?: LinkDirection
     items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
   }): Promise<Map<LinkBatchKey, ObjectLinkRow[]>> {
-    const result = new Map<LinkBatchKey, Map<string, ObjectLinkRow>>()
-    if (params.items.length === 0) return new Map()
+    return this.listLinksBatchFromSource(this.sql, params)
+  }
 
-    const readSide = async (side: "source" | "target"): Promise<void> => {
-      const rows = await valuesJoin<LinkDatabaseRow>(
-        this.sql,
-        "SELECT l.* FROM links l",
-        [`${side}_type_id`, `${side}_id`, "link_id"],
-        params.items.map((item) => [item.objectTypeId, item.objectId, item.linkId]),
-        `WHERE l.project_id = $1`,
-        [params.projectId]
-      )
-      for (const row of rows) {
-        const link = rowToLink(row)
-        const objectTypeId = side === "source" ? row.source_type_id : row.target_type_id
-        const objectId = side === "source" ? row.source_id : row.target_id
-        const key = linkBatchKey(objectTypeId, objectId, row.link_id)
-        const bucket = result.get(key) ?? new Map<string, ObjectLinkRow>()
-        bucket.set(linkIdentity(link), link)
-        result.set(key, bucket)
-      }
-    }
+  private async listLinksBatchFromSource(
+    sql: SQLClient,
+    params: {
+      projectId: string
+      direction?: LinkDirection
+      items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
+    },
+    source?: PgObjectQuerySource
+  ): Promise<Map<LinkBatchKey, ObjectLinkRow[]>> {
+    const result = new Map<LinkBatchKey, ObjectLinkRow[]>()
+    if (params.items.length === 0) return result
 
     const direction = params.direction ?? "outgoing"
-    if (direction === "outgoing" || direction === "both") await readSide("source")
-    if (direction === "incoming" || direction === "both") await readSide("target")
+    const outgoing =
+      'stored.source_type_id = requested."objectTypeId" AND stored.source_id = requested."objectId"'
+    const incoming =
+      'stored.target_type_id = requested."objectTypeId" AND stored.target_id = requested."objectId"'
+    const items = params.items.map((item, batchIndex) => ({ ...item, batchIndex }))
+    const requestedSql = `
+      jsonb_to_recordset(?::text::jsonb)
+        AS requested(
+          "objectTypeId" text,
+          "objectId" text,
+          "linkId" text,
+          "batchIndex" integer
+        )
+    `
+    const table = source?.linksTable ?? "links"
+    const selectedSql =
+      direction === "both"
+        ? `
+          SELECT stored.*, requested."batchIndex" AS _batch_index
+          FROM ${requestedSql}
+          CROSS JOIN LATERAL (
+            SELECT outgoing_link.*
+            FROM ${table} AS outgoing_link
+            WHERE outgoing_link.project_id = ?
+              AND outgoing_link.source_type_id = requested."objectTypeId"
+              AND outgoing_link.source_id = requested."objectId"
+              AND outgoing_link.link_id = requested."linkId"
 
-    return new Map([...result].map(([key, links]) => [key, [...links.values()]] as const))
+            UNION
+
+            SELECT incoming_link.*
+            FROM ${table} AS incoming_link
+            WHERE incoming_link.project_id = ?
+              AND incoming_link.target_type_id = requested."objectTypeId"
+              AND incoming_link.target_id = requested."objectId"
+              AND incoming_link.link_id = requested."linkId"
+          ) AS stored
+        `
+        : `
+          SELECT stored.*, requested."batchIndex" AS _batch_index
+          FROM ${requestedSql}
+          JOIN ${table} AS stored
+            ON ${direction === "incoming" ? incoming : outgoing}
+           AND stored.link_id = requested."linkId"
+          WHERE stored.project_id = ?
+        `
+    const statement = compilePgObjectStatement(
+      `
+        ${selectedSql}
+        ORDER BY
+          _batch_index,
+          source_type_id COLLATE "C",
+          source_id COLLATE "C",
+          link_id COLLATE "C",
+          target_type_id COLLATE "C",
+          target_id COLLATE "C"
+      `,
+      direction === "both"
+        ? [JSON.stringify(items), params.projectId, params.projectId]
+        : [JSON.stringify(items), params.projectId],
+      source
+    )
+    const rows = await sql.unsafe<LinkBatchDatabaseRow[]>(
+      statement.sql,
+      statement.args as SqlParameter[]
+    )
+    const rowsByIndex = params.items.map(() => new Map<string, ObjectLinkRow>())
+    for (const row of rows) {
+      const link = rowToLink(row)
+      rowsByIndex[row._batch_index]?.set(linkIdentity(link), link)
+    }
+    for (const [index, item] of params.items.entries()) {
+      const links = [...(rowsByIndex[index]?.values() ?? [])]
+      if (links.length > 0) {
+        result.set(linkBatchKey(item.objectTypeId, item.objectId, item.linkId), links)
+      }
+    }
+    return result
   }
 
   async queryLinks(params: QueryObjectLinksInput): Promise<QueryObjectLinksResult> {
     assertLinkQueryLimit(params.limit)
+    return this.queryLinksFromSource(this.sql, params)
+  }
+
+  private async queryLinksFromSource(
+    sql: SQLClient,
+    params: QueryObjectLinksInput,
+    source?: PgObjectQuerySource
+  ): Promise<QueryObjectLinksResult> {
     if (params.objectRefs.length === 0 || params.endpointObjectTypeIds?.length === 0) {
       return { links: [], hasMore: false }
     }
 
-    const args: SqlParameter[] = [JSON.stringify(params.objectRefs), params.projectId]
-    const addArg = (value: SqlParameter): string => {
+    const requestedJson = JSON.stringify(params.objectRefs)
+    const args: unknown[] =
+      params.direction === "both"
+        ? [requestedJson, params.projectId, params.projectId]
+        : [requestedJson, params.projectId]
+    const addArg = (value: unknown): string => {
       args.push(value)
-      return `$${args.length}`
+      return "?"
     }
-    const sourceJoin = `
-      SELECT link.*
-      FROM links AS link
-      JOIN requested
-        ON requested.object_type_id = link.source_type_id
-       AND requested.object_id = link.source_id
-      WHERE link.project_id = $2
+    const requestedSql = `
+      jsonb_to_recordset(?::text::jsonb)
+        AS requested("objectTypeId" text, "primaryId" text)
     `
-    const targetJoin = `
-      SELECT link.*
-      FROM links AS link
-      JOIN requested
-        ON requested.object_type_id = link.target_type_id
-       AND requested.object_id = link.target_id
-      WHERE link.project_id = $2
-    `
+    const table = source?.linksTable ?? "links"
     const incidentSql =
-      params.direction === "outgoing"
-        ? sourceJoin
-        : params.direction === "incoming"
-          ? targetJoin
-          : `${sourceJoin} UNION ${targetJoin}`
+      params.direction === "both"
+        ? `
+          SELECT DISTINCT link.*
+          FROM ${requestedSql}
+          CROSS JOIN LATERAL (
+            SELECT outgoing_link.*
+            FROM ${table} AS outgoing_link
+            WHERE outgoing_link.project_id = ?
+              AND outgoing_link.source_type_id = requested."objectTypeId"
+              AND outgoing_link.source_id = requested."primaryId"
+
+            UNION
+
+            SELECT incoming_link.*
+            FROM ${table} AS incoming_link
+            WHERE incoming_link.project_id = ?
+              AND incoming_link.target_type_id = requested."objectTypeId"
+              AND incoming_link.target_id = requested."primaryId"
+          ) AS link
+        `
+        : `
+          SELECT DISTINCT link.*
+          FROM ${requestedSql}
+          JOIN ${table} AS link
+            ON requested."objectTypeId" = link.${params.direction === "incoming" ? "target_type_id" : "source_type_id"}
+           AND requested."primaryId" = link.${params.direction === "incoming" ? "target_id" : "source_id"}
+          WHERE link.project_id = ?
+        `
 
     const predicates: string[] = []
     if (params.linkId !== undefined) {
       predicates.push(`link_id = ${addArg(params.linkId)}::text`)
     }
     if (params.endpointObjectTypeIds !== undefined) {
-      const allowedTypes = addArg(JSON.stringify([...new Set(params.endpointObjectTypeIds)]))
+      const allowedTypes = JSON.stringify([...new Set(params.endpointObjectTypeIds)])
       predicates.push(
-        `source_type_id IN (SELECT jsonb_array_elements_text(${allowedTypes}::text::jsonb))`,
-        `target_type_id IN (SELECT jsonb_array_elements_text(${allowedTypes}::text::jsonb))`
+        `source_type_id IN (SELECT jsonb_array_elements_text(${addArg(allowedTypes)}::text::jsonb))`,
+        `target_type_id IN (SELECT jsonb_array_elements_text(${addArg(allowedTypes)}::text::jsonb))`
       )
     }
     if (params.after) {
-      const cursor = params.after.map((value) => `${addArg(value)}::text`)
+      const cursor = params.after.map((value) => `${addArg(value)}::text COLLATE "C"`)
       predicates.push(
-        `(source_type_id, source_id, link_id, target_type_id, target_id) > (${cursor.join(", ")})`
+        `(
+          source_type_id COLLATE "C",
+          source_id COLLATE "C",
+          link_id COLLATE "C",
+          target_type_id COLLATE "C",
+          target_id COLLATE "C"
+        ) > (${cursor.join(", ")})`
       )
     }
     const limit = addArg(params.limit + 1)
     const whereSql = predicates.length > 0 ? `WHERE ${predicates.join(" AND ")}` : ""
-    const rows = await this.sql.unsafe<LinkDatabaseRow[]>(
+    const statement = compilePgObjectStatement(
       `
-        WITH requested AS (
-          SELECT DISTINCT
-            requested."objectTypeId" AS object_type_id,
-            requested."primaryId" AS object_id
-          FROM jsonb_to_recordset($1::text::jsonb)
-            AS requested("objectTypeId" text, "primaryId" text)
-        ), incident AS (${incidentSql})
         SELECT *
-        FROM incident
+        FROM (${incidentSql}) AS incident
         ${whereSql}
-        ORDER BY source_type_id, source_id, link_id, target_type_id, target_id
+        ORDER BY
+          source_type_id COLLATE "C",
+          source_id COLLATE "C",
+          link_id COLLATE "C",
+          target_type_id COLLATE "C",
+          target_id COLLATE "C"
         LIMIT ${limit}
       `,
-      args
+      args,
+      source
+    )
+    const rows = await sql.unsafe<LinkDatabaseRow[]>(
+      statement.sql,
+      statement.args as SqlParameter[]
     )
 
     return {
@@ -487,81 +825,103 @@ export class PgObjectStorage implements ObjectStorage {
     orderBy?: "createdAt" | "updatedAt" | "primaryId"
     order?: "asc" | "desc"
   }): Promise<{ objects: readonly ObjectRow[]; hasMore: boolean; total: number }> {
+    return this.listFromSource(this.sql, params)
+  }
+
+  private async listFromSource(
+    sql: SQLClient,
+    params: Parameters<ObjectReadStorage["list"]>[0],
+    source?: PgObjectQuerySource
+  ): Promise<{ objects: readonly ObjectRow[]; hasMore: boolean; total: number }> {
     const queryOffset = params.offset ?? 0
     const limit = params.limit ?? 50
     const orderBy = params.orderBy ?? "updatedAt"
     const order = params.order ?? "desc"
     const orderColumn =
       orderBy === "primaryId" ? "primary_id" : orderBy === "createdAt" ? "created_at" : "updated_at"
+    const filters = ["project_id = ?"]
+    const args: unknown[] = [params.projectId]
+    if (typeof params.objectTypeId === "string") {
+      filters.push("object_type_id = ?")
+      args.push(params.objectTypeId)
+    } else if (params.objectTypeId !== undefined) {
+      filters.push("object_type_id IN (SELECT jsonb_array_elements_text(?::text::jsonb))")
+      args.push(JSON.stringify(params.objectTypeId))
+    }
+    if (params.primaryIdPrefix) {
+      filters.push("primary_id LIKE ?")
+      args.push(`${params.primaryIdPrefix}%`)
+    }
+    if (params.primaryIdSuffix) {
+      filters.push("primary_id LIKE ?")
+      args.push(`%${params.primaryIdSuffix}`)
+    }
+    if (params.updatedAfter) {
+      filters.push("updated_at >= ?")
+      args.push(params.updatedAfter)
+    }
+    if (params.updatedBefore) {
+      filters.push("updated_at <= ?")
+      args.push(params.updatedBefore)
+    }
+    if (params.createdAfter) {
+      filters.push("created_at >= ?")
+      args.push(params.createdAfter)
+    }
+    if (params.createdBefore) {
+      filters.push("created_at <= ?")
+      args.push(params.createdBefore)
+    }
 
-    // Build WHERE conditions using conditional fragments
-    const typeFilter =
-      params.objectTypeId === undefined
-        ? this.sql``
-        : typeof params.objectTypeId === "string"
-          ? this.sql`AND object_type_id = ${params.objectTypeId}`
-          : this.sql`AND object_type_id IN ${this.sql(params.objectTypeId as string[])}`
-
-    const primaryIdPrefixFilter = params.primaryIdPrefix
-      ? this.sql`AND primary_id LIKE ${`${params.primaryIdPrefix}%`}`
-      : this.sql``
-
-    const primaryIdSuffixFilter = params.primaryIdSuffix
-      ? this.sql`AND primary_id LIKE ${`%${params.primaryIdSuffix}`}`
-      : this.sql``
-
-    const updatedAfterFilter = params.updatedAfter
-      ? this.sql`AND updated_at >= ${params.updatedAfter}`
-      : this.sql``
-
-    const updatedBeforeFilter = params.updatedBefore
-      ? this.sql`AND updated_at <= ${params.updatedBefore}`
-      : this.sql``
-
-    const createdAfterFilter = params.createdAfter
-      ? this.sql`AND created_at >= ${params.createdAfter}`
-      : this.sql``
-
-    const createdBeforeFilter = params.createdBefore
-      ? this.sql`AND created_at <= ${params.createdBefore}`
-      : this.sql``
-
-    const filters = this.sql`
-      ${typeFilter}
-      ${primaryIdPrefixFilter}
-      ${primaryIdSuffixFilter}
-      ${updatedAfterFilter}
-      ${updatedBeforeFilter}
-      ${createdAfterFilter}
-      ${createdBeforeFilter}
-    `
-
-    // Get total count
-    const [countResult] = await this.sql<{ total: number }[]>`
-      SELECT COUNT(*)::int AS total FROM objects
-      WHERE project_id = ${params.projectId}
-      ${filters}
-    `
-    const total = countResult.total
+    const objectsTable = source?.objectsTable ?? "objects"
+    const whereSql = filters.join(" AND ")
+    const countStatement = compilePgObjectStatement(
+      `SELECT COUNT(*)::int AS total FROM ${objectsTable} WHERE ${whereSql}`,
+      args,
+      source
+    )
+    const [countResult] = await sql.unsafe<{ total: number }[]>(
+      countStatement.sql,
+      countStatement.args as SqlParameter[]
+    )
+    const total = countResult?.total ?? 0
 
     if (limit === 0) return { objects: [], hasMore: queryOffset < total, total }
 
-    // Get paginated results (+1 for hasMore check)
-    // Column and direction derived from a fixed mapping — safe to use as identifiers
     const fetchLimit = limit + 1
-    const rows = await this.sql<ObjectDatabaseRow[]>`
-      SELECT * FROM objects
-      WHERE project_id = ${params.projectId}
-      ${filters}
-      ORDER BY ${this.sql(orderColumn)} ${order === "asc" ? this.sql`ASC` : this.sql`DESC`}
-      LIMIT ${fetchLimit}
-      OFFSET ${queryOffset}
-    `
+    const rowsStatement = compilePgObjectStatement(
+      `
+        SELECT * FROM ${objectsTable}
+        WHERE ${whereSql}
+        ORDER BY ${orderColumn} ${order === "asc" ? "ASC" : "DESC"}
+        LIMIT ? OFFSET ?
+      `,
+      [...args, fetchLimit, queryOffset],
+      source
+    )
+    const rows = await sql.unsafe<ObjectDatabaseRow[]>(
+      rowsStatement.sql,
+      rowsStatement.args as SqlParameter[]
+    )
 
     const hasMore = rows.length > limit
     const objects = rows.slice(0, limit).map((row) => rowToObject(row))
 
     return { objects, hasMore, total }
+  }
+}
+
+async function assertTraversalBudget(
+  sql: SQLClient,
+  source: PgSelectedObjectReadSource,
+  maxTraversalFacts: number
+): Promise<void> {
+  const [row] = await sql.unsafe<{ total: string | number | bigint }[]>(
+    source.traversalProbe.sql,
+    source.traversalProbe.args as SqlParameter[]
+  )
+  if (BigInt(row?.total ?? 0) > BigInt(maxTraversalFacts)) {
+    throw new ObjectReadLimitExceededError("traversalFacts", maxTraversalFacts)
   }
 }
 
@@ -698,7 +1058,7 @@ function rowToLink(row: LinkDatabaseRow): ObjectLinkRow {
     linkId: row.link_id,
     targetTypeId: row.target_type_id,
     targetId: row.target_id,
-    properties: row.properties ? (row.properties as Record<string, unknown>) : undefined,
+    ...(row.properties === null ? {} : { properties: row.properties as Record<string, unknown> }),
     createdAt: new Date(row.created_at),
     updatedAt: new Date(row.updated_at),
     lastCommitId: row.last_commit_id,
@@ -738,6 +1098,14 @@ interface ObjectQueryDatabaseRow extends ObjectDatabaseRow {
   _expand?: unknown
 }
 
+interface ObjectBatchDatabaseRow extends ObjectDatabaseRow {
+  _batch_index: number
+}
+
+interface PropertyPermissionBatchDatabaseRow {
+  _batch_index: number
+}
+
 interface FacetDatabaseRow {
   value_type: string | null
   value_text: string | null
@@ -755,4 +1123,8 @@ interface LinkDatabaseRow {
   created_at: Date | string
   updated_at: Date | string
   last_commit_id: string
+}
+
+interface LinkBatchDatabaseRow extends LinkDatabaseRow {
+  _batch_index: number
 }

--- a/storage/pg/src/pg-object-storage.ts
+++ b/storage/pg/src/pg-object-storage.ts
@@ -16,7 +16,6 @@ import type {
   ObjectLinkRow,
   ObjectQueryCapabilities,
   ObjectReadExecutionLimits,
-  ObjectReadScopeFactory,
   ObjectReadStorage,
   ObjectRow,
   ObjectRowLinks,
@@ -174,7 +173,7 @@ function valuesJoin<Row = unknown>(
  * - Reads return JSONB as native JS types (objects, numbers, booleans) when
  *   the data was stored correctly.
  */
-export class PgObjectStorage implements ObjectStorage, ObjectReadScopeFactory {
+export class PgObjectStorage implements ObjectStorage {
   constructor(private readonly sql: PgStoreClient) {}
 
   queryCapabilities(): ObjectQueryCapabilities {

--- a/storage/pg/src/transactions.ts
+++ b/storage/pg/src/transactions.ts
@@ -4,9 +4,13 @@ import type { SQL, SQLClient } from "./pg-client"
 export type PgStoreClient = SQL | SQLClient
 
 export interface RunPgTransactionOptions {
-  /** Open the transaction at `SERIALIZABLE`; omit for the server default (`READ COMMITTED`). */
-  readonly isolation?: "serializable"
+  /** Open the transaction at an explicit isolation; omit for the server default. */
+  readonly isolation?: "repeatableRead" | "serializable"
 }
+
+type PgTransactionIsolation = "unverifiedDefault" | "repeatableRead" | "serializable"
+
+const activePgTransactions = new WeakMap<PgStoreClient, PgTransactionIsolation>()
 
 export async function runPgTransaction<T>(
   sql: PgStoreClient,
@@ -24,10 +28,47 @@ export async function runPgTransaction<T>(
   // The isolation level is folded into `BEGIN` (`BEGIN ISOLATION LEVEL SERIALIZABLE`) rather than
   // a separate `SET TRANSACTION` statement: one round-trip instead of two, and the level is
   // guaranteed to take effect before any data statement of the transaction runs.
-  if (options.isolation === "serializable") {
-    return sql.begin("isolation level serializable", run) as Promise<T>
+  const isolation = options.isolation ?? "unverifiedDefault"
+  const trackedRun = async (tx: SQLClient): Promise<T> => {
+    activePgTransactions.set(tx, isolation)
+    try {
+      return await run(tx)
+    } finally {
+      activePgTransactions.delete(tx)
+    }
   }
-  return sql.begin(run) as Promise<T>
+
+  if (isolation === "serializable") {
+    return sql.begin("isolation level serializable", trackedRun) as Promise<T>
+  }
+  if (isolation === "repeatableRead") {
+    return sql.begin("isolation level repeatable read", trackedRun) as Promise<T>
+  }
+  return sql.begin(trackedRun) as Promise<T>
+}
+
+/**
+ * Run a multi-statement read against one proven PostgreSQL snapshot.
+ *
+ * A provider-owned repeatable-read or serializable transaction may be reused. An external
+ * transaction client is rejected because postgres.js does not expose its current isolation.
+ */
+export async function runPgRepeatableReadTransaction<T>(
+  sql: PgStoreClient,
+  run: (tx: SQLClient) => Promise<T>
+): Promise<T> {
+  if (canStartPgTransaction(sql)) {
+    return runPgTransaction(sql, run, { isolation: "repeatableRead" })
+  }
+
+  const isolation = activePgTransactions.get(sql)
+  if (isolation === "repeatableRead" || isolation === "serializable") {
+    return run(sql)
+  }
+
+  throw new Error(
+    "[SixbPg] Selected object reads cannot join an unverified PostgreSQL transaction."
+  )
 }
 
 export function authLockKey(kind: string, ...parts: readonly string[]): string {

--- a/storage/pg/src/transactions.ts
+++ b/storage/pg/src/transactions.ts
@@ -67,7 +67,7 @@ export async function runPgRepeatableReadTransaction<T>(
   }
 
   throw new Error(
-    "[SixbPg] Selected object reads cannot join an unverified PostgreSQL transaction."
+    '[SixbPg] Selected object reads cannot join an unverified PostgreSQL transaction. Use storage.transaction(..., { isolation: "serializable" }) when reading through tx.objects.'
   )
 }
 

--- a/storage/pg/tests/pg-object-read-scope-provider.e2e.ts
+++ b/storage/pg/tests/pg-object-read-scope-provider.e2e.ts
@@ -1,0 +1,486 @@
+import { describe, expect, test } from "bun:test"
+import {
+  compileSelectedObjectReadScope,
+  linkBatchKey,
+  type ObjectReadExecutionLimits,
+  type ObjectReadScopeFactory,
+  type ObjectReadStorage,
+  type ObjectStorage,
+  objectBatchKey,
+  type SelectedObjectReadScope,
+} from "@sixb/core/storage"
+import type { PostgresStorage } from "../src"
+import type { SQL, SQLClient, SqlParameter } from "../src/pg-client"
+import { PgObjectStorage } from "../src/pg-object-storage"
+import type { PgStoreClient } from "../src/transactions"
+import { createTestStorage } from "./helpers"
+
+const projectId = "pg-selected-reader"
+const otherProjectId = `${projectId}-other`
+const RootType = "PgScopeRoot"
+const TargetType = "PgScopeTarget"
+const timestamp = "2026-08-31T00:00:00.000Z"
+const generousLimits: ObjectReadExecutionLimits = {
+  maxTraversalFacts: 100_000,
+  maxOutputJsonBytes: 10_000_000,
+}
+
+describe("PgObjectStorage selected reader invariants", () => {
+  test("counts exact path facts and preserves redacted JSONB within one project", async () => {
+    const { storage } = await createTestStorage()
+    try {
+      const sql = sqlOf(storage)
+      await insertObject(sql, RootType, "root-1", {
+        id: "root-1",
+        nested: { key: "value" },
+        values: [1, true, null],
+        enabled: true,
+        disabled: false,
+        nullable: null,
+        amount: 2.5,
+        "clé:🧪": { 值: true },
+        hidden: "root-secret",
+      })
+      await insertObject(sql, TargetType, "target-1", {
+        id: "target-1",
+        label: "visible",
+        hidden: "target-secret",
+      })
+      await insertLink(sql, "root-1", "items", "target-1", {
+        nested: { edge: true },
+        values: [false, null, 3],
+        enabled: true,
+        disabled: false,
+        nullable: null,
+        amount: 7.5,
+        hidden: "edge-secret",
+      })
+      await insertLink(sql, "root-1", "items", "target-missing", { enabled: true })
+      await insertObject(sql, RootType, "root-1", { id: "other-root" }, otherProjectId)
+      await insertObject(sql, TargetType, "target-1", { id: "other-target" }, otherProjectId)
+      await insertObject(
+        sql,
+        TargetType,
+        "target-missing",
+        { id: "other-project-only-target" },
+        otherProjectId
+      )
+      await insertLink(sql, "root-1", "items", "target-1", { enabled: false }, otherProjectId)
+
+      const exact = createReader(storage, repeatedPathScope(), {
+        ...generousLimits,
+        maxTraversalFacts: 3,
+      })
+      const listed = await exact.list({ projectId, orderBy: "primaryId", order: "asc" })
+      expect(listed.objects.map((row) => row.primaryId)).toEqual(["root-1", "target-1"])
+      expect(listed.objects.every((row) => row.projectId === projectId)).toBe(true)
+      expect(
+        await exact.getByPrimaryId({ projectId, objectTypeId: RootType, primaryId: "root-1" })
+      ).toMatchObject({
+        properties: {
+          id: "root-1",
+          nested: { key: "value" },
+          values: [1, true, null],
+          enabled: true,
+          disabled: false,
+          nullable: null,
+          amount: 2.5,
+          "clé:🧪": { 值: true },
+        },
+      })
+      const links = await exact.listLinks({
+        projectId,
+        objectTypeId: RootType,
+        objectId: "root-1",
+        linkId: "items",
+      })
+      expect(links).toHaveLength(1)
+      expect(links[0]?.properties).toEqual({
+        nested: { edge: true },
+        values: [false, null, 3],
+        enabled: true,
+        disabled: false,
+        nullable: null,
+        amount: 7.5,
+      })
+
+      const batch = await exact.getByPrimaryIdBatch({
+        projectId,
+        items: [
+          { objectTypeId: TargetType, primaryId: "target-1" },
+          { objectTypeId: RootType, primaryId: "root-1" },
+          { objectTypeId: TargetType, primaryId: "target-1" },
+        ],
+      })
+      expect([...batch.keys()]).toEqual([
+        objectBatchKey(TargetType, "target-1"),
+        objectBatchKey(RootType, "root-1"),
+      ])
+      const linkBatch = await exact.listLinksBatch({
+        projectId,
+        direction: "both",
+        items: [
+          { objectTypeId: TargetType, objectId: "target-1", linkId: "items" },
+          { objectTypeId: RootType, objectId: "root-1", linkId: "items" },
+        ],
+      })
+      expect([...linkBatch.keys()]).toEqual([
+        linkBatchKey(TargetType, "target-1", "items"),
+        linkBatchKey(RootType, "root-1", "items"),
+      ])
+
+      const overBudget = createReader(storage, repeatedPathScope(), {
+        ...generousLimits,
+        maxTraversalFacts: 2,
+      })
+      await expect(overBudget.list({ projectId })).rejects.toMatchObject({
+        code: "object_read_limit_exceeded",
+        metric: "traversalFacts",
+        limit: 2,
+      })
+    } finally {
+      await storage.dropSchema()
+      await storage.close()
+    }
+  })
+
+  test("keeps 22k-item batches bounded and link cursors deterministic", async () => {
+    const { storage } = await createTestStorage()
+    try {
+      const sql = sqlOf(storage)
+      await insertObject(sql, RootType, "root-1", { id: "root-1" })
+      for (const targetId of ["target-a", "target-é", `target-${String.fromCodePoint(0xe000)}`]) {
+        await insertObject(sql, TargetType, targetId, { id: targetId, hidden: "secret" })
+        await insertLink(sql, "root-1", "items", targetId)
+      }
+      const reader = createReader(storage, singlePathScope())
+      const targetIds = ["target-a", "target-é", `target-${String.fromCodePoint(0xe000)}`]
+      const objectItems = Array.from({ length: 22_000 }, (_, index) => {
+        if (index < targetIds.length) {
+          return { objectTypeId: TargetType, primaryId: targetIds[index] as string }
+        }
+        if (index === targetIds.length) {
+          return { objectTypeId: RootType, primaryId: "root-1" }
+        }
+        return { objectTypeId: TargetType, primaryId: `missing-${index}` }
+      })
+      const objects = await reader.getByPrimaryIdBatch({ projectId, items: objectItems })
+      expect([...objects.keys()]).toEqual([
+        ...targetIds.map((targetId) => objectBatchKey(TargetType, targetId)),
+        objectBatchKey(RootType, "root-1"),
+      ])
+
+      const linkItems = objectItems.map((item) => ({
+        objectTypeId: item.objectTypeId,
+        objectId: item.primaryId,
+        linkId: "items",
+      }))
+      const links = await reader.listLinksBatch({
+        projectId,
+        direction: "both",
+        items: linkItems,
+      })
+      expect([...links.keys()]).toEqual([
+        ...targetIds.map((targetId) => linkBatchKey(TargetType, targetId, "items")),
+        linkBatchKey(RootType, "root-1", "items"),
+      ])
+      expect([...links.values()].flat().every((link) => !Object.hasOwn(link, "properties"))).toBe(
+        true
+      )
+
+      const firstPage = await reader.queryLinks({
+        projectId,
+        objectRefs: [
+          { objectTypeId: RootType, primaryId: "root-1" },
+          { objectTypeId: RootType, primaryId: "root-1" },
+          { objectTypeId: TargetType, primaryId: "target-a" },
+        ],
+        direction: "both",
+        endpointObjectTypeIds: [RootType, TargetType],
+        limit: 2,
+      })
+      expect(firstPage.links.map((link) => link.targetId)).toEqual(targetIds.slice(0, 2))
+      expect(firstPage.hasMore).toBe(true)
+
+      const secondPage = await reader.queryLinks({
+        projectId,
+        objectRefs: [{ objectTypeId: RootType, primaryId: "root-1" }],
+        direction: "outgoing",
+        endpointObjectTypeIds: [RootType, TargetType],
+        after: [RootType, "root-1", "items", TargetType, targetIds[1] as string],
+        limit: 2,
+      })
+      expect(secondPage).toMatchObject({
+        hasMore: false,
+        links: [{ targetId: targetIds[2] }],
+      })
+    } finally {
+      await storage.dropSchema()
+      await storage.close()
+    }
+  }, 30_000)
+
+  test("keeps traversal probe and terminal reads on one repeatable-read snapshot", async () => {
+    const { storage } = await createTestStorage()
+    try {
+      const sql = sqlOf(storage)
+      await insertObject(sql, RootType, "root-1", { id: "root-1" })
+      await insertObject(sql, TargetType, "target-1", { id: "target-1" })
+      let writerCommitted = false
+      const beginModes: string[] = []
+      const intercepted = {
+        begin: (mode: string, run: (client: SQLClient) => Promise<unknown>): Promise<unknown> =>
+          sql.begin(mode, async (tx) => {
+            beginModes.push(mode)
+            const client = {
+              unsafe: async (query: string, args: SqlParameter[]) => {
+                const result = await tx.unsafe(query, args)
+                if (!writerCommitted && query.includes("bounded_traversal_facts")) {
+                  writerCommitted = true
+                  await insertLink(sql, "root-1", "items", "target-1")
+                }
+                return result
+              },
+            } as unknown as SQLClient
+            return run(client)
+          }) as Promise<unknown>,
+      } as unknown as PgStoreClient
+      const reader = createReader(new PgObjectStorage(intercepted), singlePathScope(), {
+        ...generousLimits,
+        maxTraversalFacts: 1,
+      })
+
+      expect(await reader.list({ projectId, orderBy: "primaryId", order: "asc" })).toEqual({
+        objects: [expect.objectContaining({ primaryId: "root-1" })],
+        hasMore: false,
+        total: 1,
+      })
+      expect(beginModes).toEqual(["isolation level repeatable read"])
+      expect(writerCommitted).toBe(true)
+
+      const freshReader = createReader(storage, singlePathScope(), {
+        ...generousLimits,
+        maxTraversalFacts: 1,
+      })
+      await expect(freshReader.list({ projectId })).rejects.toMatchObject({
+        code: "object_read_limit_exceeded",
+        metric: "traversalFacts",
+        limit: 1,
+      })
+    } finally {
+      await storage.dropSchema()
+      await storage.close()
+    }
+  })
+
+  test("rejects a transaction client whose isolation was not opened by the provider", async () => {
+    const { storage } = await createTestStorage()
+    try {
+      const sql = sqlOf(storage)
+      await insertObject(sql, RootType, "root-1", { id: "root-1" })
+      await sql.begin(async (tx) => {
+        const reader = createReader(new PgObjectStorage(tx), rootOnlyScope())
+        await expect(reader.list({ projectId })).rejects.toThrow(
+          "cannot join an unverified PostgreSQL transaction"
+        )
+      })
+    } finally {
+      await storage.dropSchema()
+      await storage.close()
+    }
+  })
+
+  test("reuses a serializable PostgresStorage transaction end to end", async () => {
+    const { storage } = await createTestStorage()
+    try {
+      await insertObject(sqlOf(storage), RootType, "root-1", { id: "root-1", hidden: "secret" })
+
+      const row = await storage.transaction(
+        async (tx) => {
+          const factory = tx.objects as ObjectStorage & ObjectReadScopeFactory
+          const reader = factory.createSelectedReadScope({
+            projectId,
+            scope: compileSelectedObjectReadScope(rootOnlyScope()),
+            limits: generousLimits,
+          })
+          return reader.getByPrimaryId({
+            projectId,
+            objectTypeId: RootType,
+            primaryId: "root-1",
+          })
+        },
+        { isolation: "serializable" }
+      )
+      expect(row).toMatchObject({ primaryId: "root-1", properties: { id: "root-1" } })
+
+      await expect(
+        storage.transaction(async (tx) => {
+          const factory = tx.objects as ObjectStorage & ObjectReadScopeFactory
+          const reader = factory.createSelectedReadScope({
+            projectId,
+            scope: compileSelectedObjectReadScope(rootOnlyScope()),
+            limits: generousLimits,
+          })
+          return reader.list({ projectId })
+        })
+      ).rejects.toThrow("cannot join an unverified PostgreSQL transaction")
+    } finally {
+      await storage.dropSchema()
+      await storage.close()
+    }
+  })
+})
+
+function createReader(
+  storage: PostgresStorage | PgObjectStorage,
+  scope: SelectedObjectReadScope,
+  limits: ObjectReadExecutionLimits = generousLimits
+): ObjectReadStorage {
+  const factory =
+    storage instanceof PgObjectStorage
+      ? storage
+      : (storage.objects as ObjectStorage & ObjectReadScopeFactory)
+  return factory.createSelectedReadScope({
+    projectId,
+    scope: compileSelectedObjectReadScope(scope),
+    limits,
+  })
+}
+
+function rootOnlyScope(): SelectedObjectReadScope {
+  return { kind: "selected", roots: [rootSelection("root-1")] }
+}
+
+function singlePathScope(): SelectedObjectReadScope {
+  return {
+    kind: "selected",
+    roots: [
+      {
+        ...rootSelection("root-1"),
+        node: {
+          objects: [{ objectTypeId: RootType, propertyIds: ["id"] }],
+          links: [targetPath()],
+        },
+      },
+    ],
+  }
+}
+
+function repeatedPathScope(): SelectedObjectReadScope {
+  return {
+    kind: "selected",
+    roots: [
+      {
+        ...rootSelection("root-1"),
+        node: {
+          objects: [
+            {
+              objectTypeId: RootType,
+              propertyIds: [
+                "id",
+                "nested",
+                "values",
+                "enabled",
+                "disabled",
+                "nullable",
+                "amount",
+                "clé:🧪",
+              ],
+            },
+          ],
+          links: [targetPath(true), targetPath(true)],
+        },
+      },
+      rootSelection("root-missing"),
+    ],
+  }
+}
+
+function rootSelection(primaryId: string) {
+  return {
+    anchor: { objectTypeId: RootType, primaryId },
+    node: {
+      objects: [{ objectTypeId: RootType, propertyIds: ["id"] }],
+      links: [],
+    },
+  }
+}
+
+function targetPath(selectLinkValues = false) {
+  return {
+    definitions: [
+      {
+        sourceObjectTypeId: RootType,
+        linkId: "items",
+        targetObjectTypeIds: [TargetType],
+        propertyIds: selectLinkValues
+          ? ["nested", "values", "enabled", "disabled", "nullable", "amount"]
+          : [],
+      },
+    ],
+    target: {
+      objects: [{ objectTypeId: TargetType, propertyIds: ["id", "label", "enabled"] }],
+      links: [],
+    },
+  }
+}
+
+function sqlOf(storage: PostgresStorage): SQL {
+  return (storage as unknown as { sql: SQL }).sql
+}
+
+async function insertObject(
+  sql: SQLClient,
+  objectTypeId: string,
+  primaryId: string,
+  properties: Readonly<Record<string, unknown>>,
+  rowProjectId = projectId
+): Promise<void> {
+  await sql.unsafe(
+    `
+      INSERT INTO objects (
+        project_id, object_type_id, primary_id, properties,
+        created_at, updated_at, version, last_commit_id
+      ) VALUES ($1, $2, $3, $4::text::jsonb, $5, $6, 1, $7)
+    `,
+    [
+      rowProjectId,
+      objectTypeId,
+      primaryId,
+      JSON.stringify(properties),
+      timestamp,
+      timestamp,
+      "scope-test",
+    ]
+  )
+}
+
+async function insertLink(
+  sql: SQLClient,
+  sourceId: string,
+  linkId: string,
+  targetId: string,
+  properties?: Readonly<Record<string, unknown>>,
+  rowProjectId = projectId
+): Promise<void> {
+  await sql.unsafe(
+    `
+      INSERT INTO links (
+        project_id, source_type_id, source_id, link_id, target_type_id, target_id,
+        properties, created_at, updated_at, last_commit_id
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7::text::jsonb, $8, $9, $10)
+    `,
+    [
+      rowProjectId,
+      RootType,
+      sourceId,
+      linkId,
+      TargetType,
+      targetId,
+      properties === undefined ? null : JSON.stringify(properties),
+      timestamp,
+      timestamp,
+      "scope-test",
+    ]
+  )
+}

--- a/storage/pg/tests/pg-object-read-scope-provider.e2e.ts
+++ b/storage/pg/tests/pg-object-read-scope-provider.e2e.ts
@@ -3,9 +3,7 @@ import {
   compileSelectedObjectReadScope,
   linkBatchKey,
   type ObjectReadExecutionLimits,
-  type ObjectReadScopeFactory,
   type ObjectReadStorage,
-  type ObjectStorage,
   objectBatchKey,
   type SelectedObjectReadScope,
 } from "@sixb/core/storage"
@@ -292,17 +290,20 @@ describe("PgObjectStorage selected reader invariants", () => {
 
   test("reuses a serializable PostgresStorage transaction end to end", async () => {
     const { storage } = await createTestStorage()
+    let escapedReader: ObjectReadStorage | undefined
+    let escapedList: ObjectReadStorage["list"] | undefined
     try {
       await insertObject(sqlOf(storage), RootType, "root-1", { id: "root-1", hidden: "secret" })
 
       const row = await storage.transaction(
         async (tx) => {
-          const factory = tx.objects as ObjectStorage & ObjectReadScopeFactory
-          const reader = factory.createSelectedReadScope({
+          const reader = tx.objects.createSelectedReadScope({
             projectId,
             scope: compileSelectedObjectReadScope(rootOnlyScope()),
             limits: generousLimits,
           })
+          escapedReader = reader
+          escapedList = reader.list
           return reader.getByPrimaryId({
             projectId,
             objectTypeId: RootType,
@@ -312,18 +313,24 @@ describe("PgObjectStorage selected reader invariants", () => {
         { isolation: "serializable" }
       )
       expect(row).toMatchObject({ primaryId: "root-1", properties: { id: "root-1" } })
+      if (!escapedReader || !escapedList) throw new Error("expected escaped selected reader")
+      const reader = escapedReader
+      const list = escapedList
+      expect(() => reader.queryCapabilities()).toThrow("after transaction completion")
+      await expect(Promise.resolve().then(() => list({ projectId }))).rejects.toMatchObject({
+        code: "transaction_inactive",
+      })
 
       await expect(
         storage.transaction(async (tx) => {
-          const factory = tx.objects as ObjectStorage & ObjectReadScopeFactory
-          const reader = factory.createSelectedReadScope({
+          const reader = tx.objects.createSelectedReadScope({
             projectId,
             scope: compileSelectedObjectReadScope(rootOnlyScope()),
             limits: generousLimits,
           })
           return reader.list({ projectId })
         })
-      ).rejects.toThrow("cannot join an unverified PostgreSQL transaction")
+      ).rejects.toThrow('{ isolation: "serializable" }')
     } finally {
       await storage.dropSchema()
       await storage.close()
@@ -336,10 +343,7 @@ function createReader(
   scope: SelectedObjectReadScope,
   limits: ObjectReadExecutionLimits = generousLimits
 ): ObjectReadStorage {
-  const factory =
-    storage instanceof PgObjectStorage
-      ? storage
-      : (storage.objects as ObjectStorage & ObjectReadScopeFactory)
+  const factory = storage instanceof PgObjectStorage ? storage : storage.objects
   return factory.createSelectedReadScope({
     projectId,
     scope: compileSelectedObjectReadScope(scope),

--- a/storage/pg/tests/pg-object-read-scope-provider.test.ts
+++ b/storage/pg/tests/pg-object-read-scope-provider.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test } from "bun:test"
+import {
+  compileSelectedObjectReadScope,
+  type ObjectReadExecutionLimits,
+  type SelectedObjectReadScope,
+} from "@sixb/core/storage"
+import type { SQLClient, SqlParameter } from "../src/pg-client"
+import {
+  compilePgObjectCountQuery,
+  compilePgObjectExistsQuery,
+  compilePgObjectFacetQuery,
+  compilePgObjectQuery,
+  compilePgObjectStatement,
+} from "../src/pg-object-query-compiler"
+import { compilePgSelectedObjectReadSource } from "../src/pg-object-read-scope"
+import { PgObjectStorage } from "../src/pg-object-storage"
+import type { PgStoreClient } from "../src/transactions"
+
+const projectId = "pg-selected-reader"
+const RootType = "PgScopeRoot"
+const limits: ObjectReadExecutionLimits = {
+  maxTraversalFacts: 100,
+  maxOutputJsonBytes: 1_000_000,
+}
+
+describe("PgObjectStorage selected reader compilation", () => {
+  test("serializes a large compiled scope into one bounded statement parameter", () => {
+    const scope = compileSelectedObjectReadScope({
+      kind: "selected",
+      roots: Array.from({ length: 400 }, (_, index) => rootSelection(`root-${index}`)),
+    })
+    const source = compilePgSelectedObjectReadSource(projectId, scope, Number.MAX_SAFE_INTEGER)
+    const statement = compilePgObjectStatement("SELECT ?::text AS terminal", ["value"], source)
+
+    expect(statement.args).toHaveLength(3)
+    expect(statement.args[0]).toBeString()
+    expect(statement.args[1]).toBe(projectId)
+    expect(statement.args[2]).toBe("value")
+    expect(statement.sql.match(/\$1::text::jsonb/g)).toHaveLength(1)
+    expect(highestPlaceholder(statement.sql)).toBe(statement.args.length)
+    expect(source.traversalProbe.args.at(-1)).toBe(BigInt(Number.MAX_SAFE_INTEGER) + 1n)
+  })
+
+  test("wraps main, total, and has-more query statements in the selected source", () => {
+    const source = compilePgSelectedObjectReadSource(
+      projectId,
+      compileSelectedObjectReadScope(rootOnlyScope()),
+      limits.maxTraversalFacts
+    )
+    const compiled = compilePgObjectQuery(
+      projectId,
+      {
+        kind: "sort",
+        fields: [{ kind: "property", propertyId: "id", direction: "asc" }],
+        input: {
+          kind: "limit",
+          limit: 1,
+          input: { kind: "start", objectTypeId: RootType },
+        },
+      },
+      { includeTotal: false, source }
+    )
+
+    for (const statement of [
+      { sql: compiled.sql, args: compiled.args },
+      { sql: compiled.totalSql, args: compiled.totalArgs },
+      compiled.hasMoreProbe,
+    ]) {
+      if (!statement) throw new Error("expected a has-more probe")
+      expect(statement.sql).toContain("WITH RECURSIVE")
+      expect(statement.sql).toContain("_sixb_scope_objects")
+      expect(statement.args[0]).toBeString()
+      expect(statement.args[1]).toBe(projectId)
+      expect(highestPlaceholder(statement.sql)).toBe(statement.args.length)
+    }
+  })
+
+  test("wraps aggregate query statements in the selected source", () => {
+    const source = compilePgSelectedObjectReadSource(
+      projectId,
+      compileSelectedObjectReadScope(rootOnlyScope()),
+      limits.maxTraversalFacts
+    )
+    const query = { kind: "start", objectTypeId: RootType } as const
+
+    for (const statement of [
+      compilePgObjectCountQuery(projectId, query, { source }),
+      compilePgObjectExistsQuery(projectId, query, { source }),
+      compilePgObjectFacetQuery(projectId, query, "id", 10, { source }),
+    ]) {
+      expect(statement.sql).toContain("WITH RECURSIVE")
+      expect(statement.sql).toContain("_sixb_scope_objects")
+      expect(statement.args[0]).toBeString()
+      expect(statement.args[1]).toBe(projectId)
+      expect(highestPlaceholder(statement.sql)).toBe(statement.args.length)
+    }
+  })
+
+  test("compiles endpoint-filtered link reads with exact args and canonical collation", async () => {
+    const { sql, calls, beginCalls } = recordingPool()
+    const storage = new PgObjectStorage(sql)
+    const reader = storage.createSelectedReadScope({
+      projectId,
+      scope: compileSelectedObjectReadScope(rootOnlyScope()),
+      limits,
+    })
+    const allowedTypes = [RootType, "PgScopeTarget"]
+
+    expect(
+      await reader.queryLinks({
+        projectId,
+        objectRefs: [
+          { objectTypeId: RootType, primaryId: "root-1" },
+          { objectTypeId: RootType, primaryId: "root-1" },
+        ],
+        direction: "both",
+        linkId: "items",
+        endpointObjectTypeIds: allowedTypes,
+        after: [RootType, "root-0", "items", "PgScopeTarget", "target-é"],
+        limit: 20,
+      })
+    ).toEqual({ links: [], hasMore: false })
+
+    expect(beginCalls).toEqual(["isolation level repeatable read"])
+    expect(calls).toHaveLength(2)
+    const terminal = calls[1]
+    if (!terminal) throw new Error("expected a terminal query")
+    expect(terminal.sql).toContain("CROSS JOIN LATERAL")
+    expect(terminal.sql).toContain("SELECT DISTINCT link.*")
+    expect(terminal.sql).toContain('COLLATE "C"')
+    expect(terminal.sql).toContain("_sixb_scope_links")
+    expect(highestPlaceholder(terminal.sql)).toBe(terminal.args.length)
+    expect(terminal.args.filter((value) => value === JSON.stringify(allowedTypes))).toHaveLength(2)
+    expect(terminal.args.at(-1)).toBe(21)
+  })
+
+  test("rejects an invalid link-query limit before opening a transaction or probing", async () => {
+    const { sql, calls, beginCalls } = recordingPool()
+    const reader = new PgObjectStorage(sql).createSelectedReadScope({
+      projectId,
+      scope: compileSelectedObjectReadScope(rootOnlyScope()),
+      limits,
+    })
+
+    await expect(
+      reader.queryLinks({
+        projectId,
+        objectRefs: [{ objectTypeId: RootType, primaryId: "root-1" }],
+        direction: "outgoing",
+        limit: 0,
+      })
+    ).rejects.toThrow("positive safe integer")
+    expect(beginCalls).toHaveLength(0)
+    expect(calls).toHaveLength(0)
+  })
+
+  test("wraps every interactive terminal in the selected source", async () => {
+    const { sql, calls } = recordingPool()
+    const reader = new PgObjectStorage(sql).createSelectedReadScope({
+      projectId,
+      scope: compileSelectedObjectReadScope(rootOnlyScope()),
+      limits,
+    })
+    const operations: readonly (() => Promise<unknown>)[] = [
+      () =>
+        reader.queryObjects?.({
+          projectId,
+          query: { kind: "start", objectTypeId: RootType },
+        }) ?? Promise.reject(new Error("queryObjects missing")),
+      () =>
+        reader.countObjects?.({
+          projectId,
+          query: { kind: "start", objectTypeId: RootType },
+        }) ?? Promise.reject(new Error("countObjects missing")),
+      () =>
+        reader.existsObjects?.({
+          projectId,
+          query: { kind: "start", objectTypeId: RootType },
+        }) ?? Promise.reject(new Error("existsObjects missing")),
+      () =>
+        reader.facetObjects?.({
+          projectId,
+          query: { kind: "start", objectTypeId: RootType },
+          facets: [{ propertyId: "id", limit: 10 }],
+        }) ?? Promise.reject(new Error("facetObjects missing")),
+      () => reader.getByPrimaryId({ projectId, objectTypeId: RootType, primaryId: "root-1" }),
+      () =>
+        reader.selectsObjectProperties({
+          projectId,
+          items: [{ objectTypeId: RootType, primaryId: "root-1", propertyId: "id" }],
+        }),
+      () =>
+        reader.listLinks({
+          projectId,
+          objectTypeId: RootType,
+          objectId: "root-1",
+          direction: "both",
+        }),
+      () =>
+        reader.getByPrimaryIdBatch({
+          projectId,
+          items: [{ objectTypeId: RootType, primaryId: "root-1" }],
+        }),
+      () =>
+        reader.listLinksBatch({
+          projectId,
+          direction: "both",
+          items: [{ objectTypeId: RootType, objectId: "root-1", linkId: "items" }],
+        }),
+      () =>
+        reader.queryLinks({
+          projectId,
+          objectRefs: [{ objectTypeId: RootType, primaryId: "root-1" }],
+          direction: "both",
+          limit: 10,
+        }),
+      () => reader.list({ projectId }),
+    ]
+
+    for (const operation of operations) {
+      const start = calls.length
+      await operation()
+      const operationCalls = calls.slice(start)
+      expect(operationCalls.length).toBeGreaterThanOrEqual(2)
+      for (const call of operationCalls) {
+        expect(call.sql).toContain("WITH RECURSIVE")
+        expect(call.sql).toContain("_sixb_scope_document")
+        expect(call.args[0]).toBeString()
+        expect(call.args[1]).toBe(projectId)
+        expect(highestPlaceholder(call.sql)).toBe(call.args.length)
+      }
+    }
+  })
+})
+
+function recordingPool(): {
+  readonly sql: PgStoreClient
+  readonly calls: { readonly sql: string; readonly args: readonly SqlParameter[] }[]
+  readonly beginCalls: string[]
+} {
+  const calls: { sql: string; args: readonly SqlParameter[] }[] = []
+  const beginCalls: string[] = []
+  const tx = {
+    unsafe: async <T extends readonly unknown[]>(sql: string, args: SqlParameter[]): Promise<T> => {
+      calls.push({ sql, args })
+      if (sql.includes("bounded_traversal_facts")) {
+        return [{ total: "0" }] as unknown as T
+      }
+      return [] as unknown as T
+    },
+  } as unknown as SQLClient
+  const sql = {
+    begin: async (mode: string, run: (client: SQLClient) => Promise<unknown>) => {
+      beginCalls.push(mode)
+      return run(tx)
+    },
+  } as unknown as PgStoreClient
+  return { sql, calls, beginCalls }
+}
+
+function highestPlaceholder(sql: string): number {
+  return Math.max(0, ...[...sql.matchAll(/\$(\d+)/g)].map((match) => Number(match[1])))
+}
+
+function rootOnlyScope(): SelectedObjectReadScope {
+  return { kind: "selected", roots: [rootSelection("root-1")] }
+}
+
+function rootSelection(primaryId: string) {
+  return {
+    anchor: { objectTypeId: RootType, primaryId },
+    node: {
+      objects: [{ objectTypeId: RootType, propertyIds: ["id"] }],
+      links: [],
+    },
+  }
+}

--- a/storage/pg/tests/pg-object-read-scope.e2e.ts
+++ b/storage/pg/tests/pg-object-read-scope.e2e.ts
@@ -1,4 +1,3 @@
-import type { ObjectReadScopeFactory, ObjectStorage } from "@sixb/core/storage"
 import { runObjectReadScopeContractSuite } from "@sixb/core/testing"
 import { createTestStorage } from "./helpers"
 
@@ -7,7 +6,7 @@ runObjectReadScopeContractSuite("PostgresStorage selected object-read scope cont
     const { storage } = await createTestStorage()
     return {
       storage,
-      objectReadScopeFactory: storage.objects as ObjectStorage & ObjectReadScopeFactory,
+      objectReadScopeFactory: storage.objects,
     }
   },
   teardown: async ({ storage }) => {

--- a/storage/pg/tests/pg-object-read-scope.e2e.ts
+++ b/storage/pg/tests/pg-object-read-scope.e2e.ts
@@ -1,0 +1,17 @@
+import type { ObjectReadScopeFactory, ObjectStorage } from "@sixb/core/storage"
+import { runObjectReadScopeContractSuite } from "@sixb/core/testing"
+import { createTestStorage } from "./helpers"
+
+runObjectReadScopeContractSuite("PostgresStorage selected object-read scope contract", {
+  createHarness: async () => {
+    const { storage } = await createTestStorage()
+    return {
+      storage,
+      objectReadScopeFactory: storage.objects as ObjectStorage & ObjectReadScopeFactory,
+    }
+  },
+  teardown: async ({ storage }) => {
+    await storage.dropSchema()
+    await storage.close()
+  },
+})

--- a/storage/pg/tests/pg-transactions.test.ts
+++ b/storage/pg/tests/pg-transactions.test.ts
@@ -80,7 +80,7 @@ describe("runPgTransaction isolation", () => {
   test("rejects unverified, read-committed, and escaped transaction clients", async () => {
     await expect(
       runPgRepeatableReadTransaction({} as PgStoreClient, async () => "unverified")
-    ).rejects.toThrow("cannot join an unverified PostgreSQL transaction")
+    ).rejects.toThrow('{ isolation: "serializable" }')
 
     const readCommitted = fakeSql()
     await runPgTransaction(readCommitted.sql, async (tx) => {

--- a/storage/pg/tests/pg-transactions.test.ts
+++ b/storage/pg/tests/pg-transactions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { PgStoreClient } from "../src/transactions"
-import { runPgTransaction } from "../src/transactions"
+import { runPgRepeatableReadTransaction, runPgTransaction } from "../src/transactions"
 
 /**
  * A minimal stand-in for porsager's pool that records how `begin` was invoked. `runPgTransaction`
@@ -8,16 +8,17 @@ import { runPgTransaction } from "../src/transactions"
  * live database — this is the CI-runnable check that the `serializable` path actually reaches the
  * driver (the full provider path is exercised by the Docker-gated e2e).
  */
-function fakeSql(): { sql: PgStoreClient; beginCalls: unknown[][] } {
+function fakeSql(): { sql: PgStoreClient; client: PgStoreClient; beginCalls: unknown[][] } {
   const beginCalls: unknown[][] = []
+  const client = {} as PgStoreClient
   const sql = {
     begin: (...args: unknown[]) => {
       beginCalls.push(args)
       const run = args[args.length - 1] as (client: unknown) => Promise<unknown>
-      return run({})
+      return run(client)
     },
   }
-  return { sql: sql as unknown as PgStoreClient, beginCalls }
+  return { sql: sql as unknown as PgStoreClient, client, beginCalls }
 }
 
 describe("runPgTransaction isolation", () => {
@@ -40,5 +41,66 @@ describe("runPgTransaction isolation", () => {
     expect(beginCalls).toHaveLength(1)
     expect(beginCalls[0]).toHaveLength(1)
     expect(typeof beginCalls[0]?.[0]).toBe("function")
+  })
+
+  test("opens selected reads at repeatable-read isolation", async () => {
+    const { sql, beginCalls } = fakeSql()
+
+    const result = await runPgRepeatableReadTransaction(sql, async () => "ok")
+
+    expect(result).toBe("ok")
+    expect(beginCalls).toHaveLength(1)
+    expect(beginCalls[0]?.[0]).toBe("isolation level repeatable read")
+  })
+
+  test("reuses only provider-owned repeatable-read or serializable transactions", async () => {
+    const repeatable = fakeSql()
+    const serializable = fakeSql()
+
+    await runPgTransaction(
+      repeatable.sql,
+      async (tx) => {
+        expect(await runPgRepeatableReadTransaction(tx, async () => "repeatable")).toBe(
+          "repeatable"
+        )
+      },
+      { isolation: "repeatableRead" }
+    )
+    await runPgTransaction(
+      serializable.sql,
+      async (tx) => {
+        expect(await runPgRepeatableReadTransaction(tx, async () => "serializable")).toBe(
+          "serializable"
+        )
+      },
+      { isolation: "serializable" }
+    )
+  })
+
+  test("rejects unverified, read-committed, and escaped transaction clients", async () => {
+    await expect(
+      runPgRepeatableReadTransaction({} as PgStoreClient, async () => "unverified")
+    ).rejects.toThrow("cannot join an unverified PostgreSQL transaction")
+
+    const readCommitted = fakeSql()
+    await runPgTransaction(readCommitted.sql, async (tx) => {
+      await expect(runPgRepeatableReadTransaction(tx, async () => "unsafe")).rejects.toThrow(
+        "cannot join an unverified PostgreSQL transaction"
+      )
+    })
+
+    const escaped = fakeSql()
+    let escapedClient: PgStoreClient | undefined
+    await runPgTransaction(
+      escaped.sql,
+      async (tx) => {
+        escapedClient = tx
+      },
+      { isolation: "serializable" }
+    )
+    if (!escapedClient) throw new Error("expected a transaction client")
+    await expect(
+      runPgRepeatableReadTransaction(escapedClient, async () => "escaped")
+    ).rejects.toThrow("cannot join an unverified PostgreSQL transaction")
   })
 })

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -13,6 +13,7 @@ import { ProviderMaterializationTransactionLifecycle } from "@sixb/core/internal
 import {
   createAgentOperationScope,
   createAuthOperationScope,
+  createObjectOperationScope,
   createOntologyOperationScope,
   createOperationScopedFacade,
   createStorageOperationScope,
@@ -143,7 +144,7 @@ export class SqliteStorage implements MigrationCapableStorage {
     const readTimeseries = path
       ? new SqliteTimeseriesStorage({ connection: this.readConnection })
       : stores.timeseries
-    this.objects = createOperationScopedFacade(readObjects, readScope)
+    this.objects = createObjectOperationScope(readObjects, readScope)
     this.ontology = createOntologyOperationScope(stores.ontology, ontologyScope)
     this.auth = createAuthOperationScope(stores.auth, scope)
     this.executions = createOperationScopedFacade(stores.executions, scope)

--- a/storage/sqlite/src/object-query-compiler.ts
+++ b/storage/sqlite/src/object-query-compiler.ts
@@ -36,6 +36,7 @@ interface CompiledHasMoreProbe {
 
 interface CompileContext {
   probeLimit: boolean
+  source: SqliteObjectQuerySource
 }
 
 interface CompiledPredicate {
@@ -74,7 +75,6 @@ interface EncodedCursorValue {
 }
 
 const PAGE_TOKEN_PREFIX = "keyset:"
-const exactContext: CompileContext = { probeLimit: false }
 
 // Fallback fanout cap for a "many" expansion that arrives without an explicit
 // limit. The core executor normally bakes a limit in before pushdown; this only
@@ -84,10 +84,37 @@ const DEFAULT_EXPANSION_FANOUT = 1_000
 export function compileObjectQuery(
   projectId: string,
   query: ObjectQuery,
-  options: { includeTotal?: boolean } = {}
+  options: { includeTotal?: boolean; source?: SqliteObjectQuerySource } = {}
 ): CompiledObjectQuery {
-  const ctx: CompileContext = { probeLimit: options.includeTotal === false }
-  return compileObjectQueryInternal(projectId, query, ctx)
+  const source = options.source ?? DEFAULT_OBJECT_QUERY_SOURCE
+  const ctx: CompileContext = { probeLimit: options.includeTotal === false, source }
+  return source.wrapQuery(compileObjectQueryInternal(projectId, query, ctx))
+}
+
+/** Physical relations used by the object-query compiler. */
+export interface SqliteObjectQuerySource {
+  readonly objectsTable: string
+  readonly linksTable: string
+  /** Wrap a terminal SELECT without its own WITH clause; the selected source owns the only WITH. */
+  wrapStatement(
+    sql: string,
+    args?: readonly SqliteValue[]
+  ): {
+    readonly sql: string
+    readonly args: readonly SqliteValue[]
+  }
+  wrapQuery(query: CompiledObjectQuery): CompiledObjectQuery
+}
+
+const DEFAULT_OBJECT_QUERY_SOURCE: SqliteObjectQuerySource = {
+  objectsTable: "objects",
+  linksTable: "links",
+  wrapStatement: (sql, args = []) => ({ sql, args: [...args] }),
+  wrapQuery: (query) => query,
+}
+
+function exactContext(ctx: CompileContext): CompileContext {
+  return ctx.probeLimit ? { ...ctx, probeLimit: false } : ctx
 }
 
 function compileObjectQueryInternal(
@@ -97,27 +124,28 @@ function compileObjectQueryInternal(
 ): CompiledObjectQuery {
   switch (query.kind) {
     case "start":
-      return compileStart(projectId, query)
+      return compileStart(projectId, query, ctx)
     case "refs":
-      return compileRefs(projectId, query)
+      return compileRefs(projectId, query, ctx)
     case "filter":
-      return compileFilter(projectId, query.input, query.predicate)
+      return compileFilter(projectId, query.input, query.predicate, ctx)
     case "sort":
       return compileSort(projectId, query.input, query.fields, ctx)
     case "limit":
       return compileLimit(projectId, query.input, query.limit, ctx)
     case "page":
-      return compilePage(projectId, query.input, query.pageSize, query.pageToken)
+      return compilePage(projectId, query.input, query.pageSize, query.pageToken, ctx)
     case "traverse":
       return compileTraversal(
         projectId,
         query.input,
         query.linkId,
         query.direction,
-        query.sourceObjectTypeId
+        query.sourceObjectTypeId,
+        ctx
       )
     case "set":
-      return compileSet(projectId, query.op, query.inputs)
+      return compileSet(projectId, query.op, query.inputs, ctx)
     case "project":
       return compileProject(projectId, query.input, query.properties, ctx)
     case "text":
@@ -126,10 +154,11 @@ function compileObjectQueryInternal(
         query.input,
         query.query,
         query.fields,
-        query.fieldsByObjectType
+        query.fieldsByObjectType,
+        ctx
       )
     case "expand":
-      return compileExpand(projectId, query.input, query.expansions)
+      return compileExpand(projectId, query.input, query.expansions, ctx)
     case "vector":
       throw new Error(`[Sixb] SQLite object storage does not support query node '${query.kind}'`)
   }
@@ -137,7 +166,8 @@ function compileObjectQueryInternal(
 
 function compileStart(
   projectId: string,
-  query: Extract<ObjectQuery, { kind: "start" }>
+  query: Extract<ObjectQuery, { kind: "start" }>,
+  ctx: CompileContext
 ): CompiledObjectQuery {
   if (query.includeSubtypes === true) {
     throw new Error("[Sixb] SQLite object storage does not support start.includeSubtypes")
@@ -146,7 +176,7 @@ function compileStart(
   const order = compileOrder(identityOrderFields())
   const sql = `
     SELECT *, properties AS _cursor_properties
-    FROM objects
+    FROM ${ctx.source.objectsTable}
     WHERE project_id = ? AND object_type_id = ?
     ORDER BY ${order.sql}
   `
@@ -155,7 +185,7 @@ function compileStart(
   return {
     sql,
     args,
-    totalSql: "SELECT COUNT(*) as total FROM objects WHERE project_id = ? AND object_type_id = ?",
+    totalSql: `SELECT COUNT(*) as total FROM ${ctx.source.objectsTable} WHERE project_id = ? AND object_type_id = ?`,
     totalArgs: [projectId, query.objectTypeId],
     order,
     hasMore: () => false,
@@ -166,7 +196,8 @@ function compileStart(
 
 function compileRefs(
   projectId: string,
-  query: Extract<ObjectQuery, { kind: "refs" }>
+  query: Extract<ObjectQuery, { kind: "refs" }>,
+  ctx: CompileContext
 ): CompiledObjectQuery {
   if (query.refs.length === 0) {
     throw new Error("[Sixb] SQLite object storage requires at least one ref")
@@ -182,10 +213,9 @@ function compileRefs(
     FROM json_each(?) AS ref
   `
   const sql = `
-    WITH requested AS (${requested})
     SELECT selected.*, selected.properties AS _cursor_properties
-    FROM requested
-    JOIN objects AS selected
+    FROM (${requested}) AS requested
+    JOIN ${ctx.source.objectsTable} AS selected
       ON selected.project_id = ?
      AND selected.object_type_id = requested.object_type_id
      AND selected.primary_id = requested.primary_id
@@ -196,10 +226,9 @@ function compileRefs(
     sql,
     args: [refsJson, projectId, ...selectedOrder.args],
     totalSql: `
-      WITH requested AS (${requested})
       SELECT COUNT(*) AS total
-      FROM requested
-      JOIN objects AS selected
+      FROM (${requested}) AS requested
+      JOIN ${ctx.source.objectsTable} AS selected
         ON selected.project_id = ?
        AND selected.object_type_id = requested.object_type_id
        AND selected.primary_id = requested.primary_id
@@ -215,18 +244,20 @@ function compileRefs(
 function compileFilter(
   projectId: string,
   inputQuery: ObjectQuery,
-  predicateNode: ObjectQueryPredicate
+  predicateNode: ObjectQueryPredicate,
+  ctx: CompileContext
 ): CompiledObjectQuery {
   const predicate = compilePredicate(predicateNode)
-  return compileWhere(projectId, inputQuery, predicate)
+  return compileWhere(projectId, inputQuery, predicate, ctx)
 }
 
 function compileWhere(
   projectId: string,
   inputQuery: ObjectQuery,
-  predicate: CompiledPredicate
+  predicate: CompiledPredicate,
+  ctx: CompileContext
 ): CompiledObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const sql = `
     SELECT *
     FROM (${input.sql}) AS input
@@ -255,7 +286,8 @@ function compileText(
   inputQuery: ObjectQuery,
   query: string,
   fields: readonly string[] | undefined,
-  fieldsByObjectType: Readonly<Record<string, readonly string[]>> | undefined
+  fieldsByObjectType: Readonly<Record<string, readonly string[]>> | undefined,
+  ctx: CompileContext
 ): CompiledObjectQuery {
   const predicate =
     fields && fields.length > 0
@@ -265,7 +297,7 @@ function compileText(
   if (!predicate) {
     throw new Error("[Sixb] SQLite object text search requires fields or resolved text defaults")
   }
-  return compileWhere(projectId, inputQuery, predicate)
+  return compileWhere(projectId, inputQuery, predicate, ctx)
 }
 
 function compileSort(
@@ -274,7 +306,7 @@ function compileSort(
   fields: readonly ObjectQuerySortField[],
   ctx: CompileContext
 ): CompiledObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const probeInput =
     ctx.probeLimit && needsLimitProbe(inputQuery)
       ? compileObjectQueryInternal(projectId, inputQuery, ctx)
@@ -313,7 +345,7 @@ function compileLimit(
   rawLimit: number,
   ctx: CompileContext
 ): CompiledObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const limit = Math.max(0, rawLimit)
   const rowLimit = ctx.probeLimit ? limit + 1 : limit
 
@@ -342,9 +374,10 @@ function compilePage(
   projectId: string,
   inputQuery: ObjectQuery,
   rawPageSize: number,
-  pageToken: string | undefined
+  pageToken: string | undefined,
+  ctx: CompileContext
 ): CompiledObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const pageSize = Math.max(0, rawPageSize)
   const cursor = pageToken ? decodePageToken(pageToken, input.order.fields) : undefined
   const cursorPredicate = cursor
@@ -381,30 +414,31 @@ function compileTraversal(
   inputQuery: ObjectQuery,
   linkId: string,
   direction: "outgoing" | "incoming",
-  sourceObjectTypeId?: string
+  sourceObjectTypeId: string | undefined,
+  ctx: CompileContext
 ): CompiledObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const outputAlias = direction === "outgoing" ? "target_object" : "source_object"
   const joinSql =
     direction === "outgoing"
       ? `
-        JOIN links AS edge
+        JOIN ${ctx.source.linksTable} AS edge
           ON edge.project_id = input.project_id
          AND edge.source_type_id = input.object_type_id
          AND edge.source_id = input.primary_id
          AND edge.link_id = ?
-        JOIN objects AS target_object
+        JOIN ${ctx.source.objectsTable} AS target_object
           ON target_object.project_id = edge.project_id
          AND target_object.object_type_id = edge.target_type_id
          AND target_object.primary_id = edge.target_id
       `
       : `
-        JOIN links AS edge
+        JOIN ${ctx.source.linksTable} AS edge
           ON edge.project_id = input.project_id
          AND edge.target_type_id = input.object_type_id
          AND edge.target_id = input.primary_id
          AND edge.link_id = ?${sourceObjectTypeId === undefined ? "" : "\n         AND edge.source_type_id = ?"}
-        JOIN objects AS source_object
+        JOIN ${ctx.source.objectsTable} AS source_object
           ON source_object.project_id = edge.project_id
          AND source_object.object_type_id = edge.source_type_id
          AND source_object.primary_id = edge.source_id
@@ -451,13 +485,15 @@ interface ExpansionParent {
 function compileExpand(
   projectId: string,
   inputQuery: ObjectQuery,
-  expansions: readonly ObjectExpansion[]
+  expansions: readonly ObjectExpansion[],
+  ctx: CompileContext
 ): CompiledObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const expand = compileExpansionsObject(
     expansions,
     { project: "input.project_id", type: "input.object_type_id", id: "input.primary_id" },
-    ""
+    "",
+    ctx
   )
   const inputOrder = compileOrder(input.order.fields, "input", "input._cursor_properties")
   const sql = `
@@ -487,13 +523,14 @@ function compileExpand(
 function compileExpansionsObject(
   expansions: readonly ObjectExpansion[],
   parent: ExpansionParent,
-  pathPrefix: string
+  pathPrefix: string,
+  ctx: CompileContext
 ): CompiledPredicate {
   const parts: string[] = []
   const args: SqliteValue[] = []
   expansions.forEach((expansion, index) => {
     const path = pathPrefix === "" ? `${index}` : `${pathPrefix}_${index}`
-    const value = compileExpansionValue(expansion, parent, path)
+    const value = compileExpansionValue(expansion, parent, path, ctx)
     parts.push("?", `json(${value.sql})`)
     args.push(expansion.linkId, ...value.args)
   })
@@ -509,7 +546,8 @@ function compileExpansionsObject(
 function compileExpansionValue(
   expansion: ObjectExpansion,
   parent: ExpansionParent,
-  path: string
+  path: string,
+  ctx: CompileContext
 ): CompiledPredicate {
   const edge = `edge_${path}`
   const target = `tgt_${path}`
@@ -522,7 +560,7 @@ function compileExpansionValue(
   const parentType = incoming ? `${edge}.target_type_id` : `${edge}.source_type_id`
   const parentId = incoming ? `${edge}.target_id` : `${edge}.source_id`
 
-  const child = compileExpansionChildJson(expansion, edge, target, path)
+  const child = compileExpansionChildJson(expansion, edge, target, path, ctx)
   const order = compileExpansionOrder(expansion, target, neighborType, neighborId)
 
   const whereParts = [
@@ -539,8 +577,8 @@ function compileExpansionValue(
 
   const inner = `
     SELECT ${child.sql} AS elem, row_number() OVER (ORDER BY ${order.sql}) AS _ord
-    FROM links AS ${edge}
-    JOIN objects AS ${target}
+    FROM ${ctx.source.linksTable} AS ${edge}
+    JOIN ${ctx.source.objectsTable} AS ${target}
       ON ${target}.project_id = ${edge}.project_id
      AND ${target}.object_type_id = ${neighborType}
      AND ${target}.primary_id = ${neighborId}
@@ -574,7 +612,8 @@ function compileExpansionChildJson(
   expansion: ObjectExpansion,
   edge: string,
   target: string,
-  path: string
+  path: string,
+  ctx: CompileContext
 ): CompiledPredicate {
   const fields = [
     `'projectId', ${target}.project_id`,
@@ -597,7 +636,8 @@ function compileExpansionChildJson(
         type: `${target}.object_type_id`,
         id: `${target}.primary_id`,
       },
-      path
+      path,
+      ctx
     )
     fields.push(`'links', ${nested.sql}`)
     args.push(...nested.args)
@@ -645,14 +685,15 @@ function compileExpansionOrder(
 function compileSet(
   projectId: string,
   op: ObjectQuerySetOperation,
-  inputs: readonly ObjectQuery[]
+  inputs: readonly ObjectQuery[],
+  ctx: CompileContext
 ): CompiledObjectQuery {
   if (inputs.length === 0) {
     const order = compileOrder(identityOrderFields())
     return {
       sql: `
         SELECT *
-        FROM objects
+        FROM ${ctx.source.objectsTable}
         WHERE 1 = 0
         ORDER BY ${order.sql}
       `,
@@ -667,7 +708,7 @@ function compileSet(
   }
 
   const compiledInputs = inputs.map((input) =>
-    compileObjectQueryInternal(projectId, input, exactContext)
+    compileObjectQueryInternal(projectId, input, exactContext(ctx))
   )
   const identities = compileSetIdentities(op, compiledInputs)
   const order = compileOrder(identityOrderFields())
@@ -675,7 +716,7 @@ function compileSet(
   const sql = `
     SELECT selected.*, selected.properties AS _cursor_properties
     FROM (${identities.sql}) AS ids
-    JOIN objects AS selected
+    JOIN ${ctx.source.objectsTable} AS selected
       ON selected.project_id = ?
      AND selected.object_type_id = ids.object_type_id
      AND selected.primary_id = ids.primary_id
@@ -778,7 +819,7 @@ function compileProjectionExpression(properties: readonly string[]): CompiledPre
     sql: `
       COALESCE(
         (
-          SELECT json_group_object(projected.key, projected.value)
+          SELECT json_group_object(projected.key, ${sqliteJsonEachValue("projected")})
           FROM json_each(input.properties) AS projected
           WHERE projected.key IN (${properties.map(() => "?").join(", ")})
         ),
@@ -787,6 +828,15 @@ function compileProjectionExpression(properties: readonly string[]): CompiledPre
     `,
     args: [...properties],
   }
+}
+
+/** json_each exposes JSON booleans as integer SQL values; restore their JSON representation. */
+export function sqliteJsonEachValue(alias: string): string {
+  return `CASE ${alias}.type
+    WHEN 'true' THEN json('true')
+    WHEN 'false' THEN json('false')
+    ELSE ${alias}.value
+  END`
 }
 
 function compilePredicate(predicate: ObjectQueryPredicate): CompiledPredicate {

--- a/storage/sqlite/src/object-read-scope.ts
+++ b/storage/sqlite/src/object-read-scope.ts
@@ -1,0 +1,316 @@
+import type { CompiledSelectedObjectReadScope } from "@sixb/core/storage"
+import {
+  type CompiledObjectQuery,
+  type SqliteObjectQuerySource,
+  type SqliteValue,
+  sqliteJsonEachValue,
+} from "./object-query-compiler"
+
+export interface SqliteSelectedObjectReadSource extends SqliteObjectQuerySource {
+  readonly objectPropertyPermissionsTable: string
+  readonly traversalProbe: {
+    readonly sql: string
+    readonly args: readonly SqliteValue[]
+  }
+}
+
+/**
+ * Prepare one immutable selected scope as live, path-sensitive SQLite relations.
+ *
+ * The complete compiled scope is serialized once. Every statement receives that one JSON document
+ * and the bound project id, keeping the host-parameter count constant as selections grow.
+ */
+export function compileSqliteSelectedObjectReadSource(
+  projectId: string,
+  scope: CompiledSelectedObjectReadScope,
+  maxTraversalFacts: number
+): SqliteSelectedObjectReadSource {
+  const scopeJson = JSON.stringify({
+    roots: scope.roots,
+    objects: scope.objects,
+    steps: scope.steps,
+  })
+  const compiled = compileSelectedReadScopeCte(scopeJson, projectId)
+  const wrapStatement = (sql: string, args: readonly SqliteValue[] = []) => ({
+    sql: `${compiled.sql}\n${sql}`,
+    args: [...compiled.args, ...args],
+  })
+
+  return Object.freeze({
+    objectsTable: "_sixb_scope_objects",
+    linksTable: "_sixb_scope_links",
+    objectPropertyPermissionsTable: "_sixb_scope_object_permissions",
+    wrapStatement,
+    wrapQuery: (query: CompiledObjectQuery): CompiledObjectQuery => ({
+      ...query,
+      ...wrapStatement(query.sql, query.args),
+      totalSql: `${compiled.sql}\n${query.totalSql}`,
+      totalArgs: [...compiled.args, ...query.totalArgs],
+      ...(query.hasMoreProbe
+        ? {
+            hasMoreProbe: {
+              ...query.hasMoreProbe,
+              ...wrapStatement(query.hasMoreProbe.sql, query.hasMoreProbe.args),
+            },
+          }
+        : {}),
+    }),
+    traversalProbe: wrapStatement(
+      `
+        SELECT COUNT(*) AS total
+        FROM (
+          SELECT 1 AS traversal_fact
+          FROM _sixb_scope_root_facts
+
+          UNION ALL
+
+          SELECT 1 AS traversal_fact
+          FROM _sixb_scope_reached_links
+
+          LIMIT ?
+        ) AS bounded_traversal_facts
+      `,
+      [BigInt(maxTraversalFacts) + 1n]
+    ),
+  })
+}
+
+interface CompiledReadScopeCte {
+  readonly sql: string
+  readonly args: readonly SqliteValue[]
+}
+
+function compileSelectedReadScopeCte(scopeJson: string, projectId: string): CompiledReadScopeCte {
+  return {
+    sql: `
+      WITH RECURSIVE
+      _sixb_scope_document(scope) AS (
+        SELECT json(?)
+      ),
+      _sixb_scope_roots(root_id, node_id, object_type_id, primary_id) AS (
+        SELECT
+          CAST(root.key AS INTEGER),
+          CAST(json_extract(root.value, '$.nodeId') AS INTEGER),
+          CAST(json_extract(root.value, '$.objectTypeId') AS TEXT),
+          CAST(json_extract(root.value, '$.primaryId') AS TEXT)
+        FROM _sixb_scope_document AS document,
+             json_each(json_extract(document.scope, '$.roots')) AS root
+      ),
+      _sixb_scope_root_facts(project_id, root_id, node_id, object_type_id, primary_id) AS (
+        SELECT anchor.project_id, root.root_id, root.node_id, root.object_type_id, root.primary_id
+        FROM _sixb_scope_roots AS root
+        JOIN objects AS anchor
+          ON anchor.project_id = ?
+         AND anchor.object_type_id = root.object_type_id
+         AND anchor.primary_id = root.primary_id
+      ),
+      _sixb_scope_object_selections(node_id, object_type_id, property_ids) AS (
+        SELECT
+          CAST(json_extract(selection.value, '$.nodeId') AS INTEGER),
+          CAST(json_extract(selection.value, '$.objectTypeId') AS TEXT),
+          json_extract(selection.value, '$.propertyIds')
+        FROM _sixb_scope_document AS document,
+             json_each(json_extract(document.scope, '$.objects')) AS selection
+      ),
+      _sixb_scope_link_selections(
+        step_id,
+        node_id,
+        parent_node_id,
+        source_object_type_id,
+        link_id,
+        target_object_type_id,
+        property_ids
+      ) AS (
+        SELECT
+          CAST(step.key AS INTEGER),
+          CAST(json_extract(step.value, '$.nodeId') AS INTEGER),
+          CAST(json_extract(step.value, '$.parentNodeId') AS INTEGER),
+          CAST(json_extract(step.value, '$.sourceObjectTypeId') AS TEXT),
+          CAST(json_extract(step.value, '$.linkId') AS TEXT),
+          CAST(json_extract(step.value, '$.targetObjectTypeId') AS TEXT),
+          json_extract(step.value, '$.propertyIds')
+        FROM _sixb_scope_document AS document,
+             json_each(json_extract(document.scope, '$.steps')) AS step
+      ),
+      _sixb_scope_reachable(project_id, node_id, object_type_id, primary_id) AS (
+        SELECT root.project_id, root.node_id, root.object_type_id, root.primary_id
+        FROM _sixb_scope_root_facts AS root
+
+        UNION
+
+        SELECT edge.project_id, selection.node_id, edge.target_type_id, edge.target_id
+        FROM _sixb_scope_reachable AS parent
+        JOIN _sixb_scope_link_selections AS selection
+          ON selection.parent_node_id = parent.node_id
+         AND selection.source_object_type_id = parent.object_type_id
+        JOIN links AS edge
+          ON edge.project_id = parent.project_id
+         AND edge.source_type_id = parent.object_type_id
+         AND edge.source_id = parent.primary_id
+         AND edge.link_id = selection.link_id
+         AND edge.target_type_id = selection.target_object_type_id
+        JOIN objects AS target
+          ON target.project_id = edge.project_id
+         AND target.object_type_id = edge.target_type_id
+         AND target.primary_id = edge.target_id
+      ),
+      _sixb_scope_object_permissions(project_id, object_type_id, primary_id, property_id) AS (
+        SELECT DISTINCT
+          reachable.project_id,
+          reachable.object_type_id,
+          reachable.primary_id,
+          CAST(selected_property.value AS TEXT)
+        FROM _sixb_scope_reachable AS reachable
+        JOIN _sixb_scope_object_selections AS selection
+          ON selection.node_id = reachable.node_id
+         AND selection.object_type_id = reachable.object_type_id
+        JOIN json_each(selection.property_ids) AS selected_property
+      ),
+      _sixb_scope_object_ids(project_id, object_type_id, primary_id) AS (
+        SELECT DISTINCT project_id, object_type_id, primary_id
+        FROM _sixb_scope_reachable
+      ),
+      _sixb_scope_objects AS (
+        SELECT
+          stored.project_id,
+          stored.object_type_id,
+          stored.primary_id,
+          COALESCE(
+            (
+              SELECT json_group_object(property.key, ${sqliteJsonEachValue("property")})
+              FROM json_each(stored.properties) AS property
+              JOIN _sixb_scope_object_permissions AS permission
+                ON permission.project_id = stored.project_id
+               AND permission.object_type_id = stored.object_type_id
+               AND permission.primary_id = stored.primary_id
+               AND permission.property_id = property.key
+            ),
+            json('{}')
+          ) AS properties,
+          stored.created_at,
+          stored.updated_at,
+          stored.version,
+          stored.last_commit_id
+        FROM objects AS stored
+        JOIN _sixb_scope_object_ids AS visible
+          ON visible.project_id = stored.project_id
+         AND visible.object_type_id = stored.object_type_id
+         AND visible.primary_id = stored.primary_id
+      ),
+      _sixb_scope_reached_links(
+        project_id,
+        step_id,
+        node_id,
+        parent_node_id,
+        source_type_id,
+        source_id,
+        link_id,
+        target_type_id,
+        target_id,
+        property_ids
+      ) AS (
+        SELECT
+          edge.project_id,
+          selection.step_id,
+          selection.node_id,
+          selection.parent_node_id,
+          edge.source_type_id,
+          edge.source_id,
+          edge.link_id,
+          edge.target_type_id,
+          edge.target_id,
+          selection.property_ids
+        FROM _sixb_scope_reachable AS parent
+        JOIN _sixb_scope_link_selections AS selection
+          ON selection.parent_node_id = parent.node_id
+         AND selection.source_object_type_id = parent.object_type_id
+        JOIN links AS edge
+          ON edge.project_id = parent.project_id
+         AND edge.source_type_id = parent.object_type_id
+         AND edge.source_id = parent.primary_id
+         AND edge.link_id = selection.link_id
+         AND edge.target_type_id = selection.target_object_type_id
+        JOIN objects AS target
+          ON target.project_id = edge.project_id
+         AND target.object_type_id = edge.target_type_id
+         AND target.primary_id = edge.target_id
+      ),
+      _sixb_scope_link_permissions(
+        project_id,
+        source_type_id,
+        source_id,
+        link_id,
+        target_type_id,
+        target_id,
+        property_id
+      ) AS (
+        SELECT DISTINCT
+          reached.project_id,
+          reached.source_type_id,
+          reached.source_id,
+          reached.link_id,
+          reached.target_type_id,
+          reached.target_id,
+          CAST(selected_property.value AS TEXT)
+        FROM _sixb_scope_reached_links AS reached
+        JOIN json_each(reached.property_ids) AS selected_property
+      ),
+      _sixb_scope_link_ids(
+        project_id,
+        source_type_id,
+        source_id,
+        link_id,
+        target_type_id,
+        target_id
+      ) AS (
+        SELECT DISTINCT
+          project_id,
+          source_type_id,
+          source_id,
+          link_id,
+          target_type_id,
+          target_id
+        FROM _sixb_scope_reached_links
+      ),
+      _sixb_scope_links AS (
+        SELECT
+          stored.project_id,
+          stored.source_type_id,
+          stored.source_id,
+          stored.link_id,
+          stored.target_type_id,
+          stored.target_id,
+          CASE
+            WHEN stored.properties IS NULL THEN NULL
+            ELSE NULLIF(
+              (
+                SELECT json_group_object(property.key, ${sqliteJsonEachValue("property")})
+                FROM json_each(stored.properties) AS property
+                JOIN _sixb_scope_link_permissions AS permission
+                  ON permission.project_id = stored.project_id
+                 AND permission.source_type_id = stored.source_type_id
+                 AND permission.source_id = stored.source_id
+                 AND permission.link_id = stored.link_id
+                 AND permission.target_type_id = stored.target_type_id
+                 AND permission.target_id = stored.target_id
+                 AND permission.property_id = property.key
+              ),
+              json('{}')
+            )
+          END AS properties,
+          stored.created_at,
+          stored.updated_at,
+          stored.last_commit_id
+        FROM links AS stored
+        JOIN _sixb_scope_link_ids AS visible
+          ON visible.project_id = stored.project_id
+         AND visible.source_type_id = stored.source_type_id
+         AND visible.source_id = stored.source_id
+         AND visible.link_id = stored.link_id
+         AND visible.target_type_id = stored.target_type_id
+         AND visible.target_id = stored.target_id
+      )
+    `,
+    args: [scopeJson, projectId],
+  }
+}

--- a/storage/sqlite/src/object-storage.ts
+++ b/storage/sqlite/src/object-storage.ts
@@ -17,7 +17,6 @@ import type {
   ObjectLinkRow,
   ObjectQueryCapabilities,
   ObjectReadExecutionLimits,
-  ObjectReadScopeFactory,
   ObjectReadStorage,
   ObjectRow,
   ObjectRowLinks,
@@ -133,7 +132,7 @@ const SQLITE_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
  * Stores object projections and links. V1 object-query IR pushdown covers the
  * scalar JSON-property and link-traversal subset declared by queryCapabilities().
  */
-export class SqliteObjectStorage implements ObjectStorage, ObjectReadScopeFactory {
+export class SqliteObjectStorage implements ObjectStorage {
   private readonly connection: SqliteStoreConnection
   private readonly db: Database
 

--- a/storage/sqlite/src/object-storage.ts
+++ b/storage/sqlite/src/object-storage.ts
@@ -1,6 +1,7 @@
 import type { Database } from "bun:sqlite"
 import type { ObjectQuery } from "@sixb/core"
 import type {
+  CompiledSelectedObjectReadScope,
   CountObjectsInput,
   CountObjectsResult,
   ExistsObjectsInput,
@@ -15,6 +16,8 @@ import type {
   ObjectFacetRequest,
   ObjectLinkRow,
   ObjectQueryCapabilities,
+  ObjectReadExecutionLimits,
+  ObjectReadScopeFactory,
   ObjectReadStorage,
   ObjectRow,
   ObjectRowLinks,
@@ -24,12 +27,30 @@ import type {
   QueryObjectsInput,
   QueryObjectsResult,
 } from "@sixb/core/storage"
-import { linkBatchKey, objectBatchKey } from "@sixb/core/storage"
+import {
+  assertObjectReaderProject,
+  assertObjectReadFacetCount,
+  assertObjectReadOutputWithinLimit,
+  linkBatchKey,
+  ObjectReadLimitExceededError,
+  objectBatchKey,
+  snapshotObjectReadExecutionLimits,
+} from "@sixb/core/storage"
 import { installFreshSqliteSchema } from "./migrations"
-import { type CompiledObjectQuery, compileObjectQuery } from "./object-query-compiler"
+import {
+  type CompiledObjectQuery,
+  compileObjectQuery,
+  type SqliteObjectQuerySource,
+  type SqliteValue,
+} from "./object-query-compiler"
+import {
+  compileSqliteSelectedObjectReadSource,
+  type SqliteSelectedObjectReadSource,
+} from "./object-read-scope"
 import {
   closeSqliteStoreConnection,
   openSqliteStoreConnection,
+  runDeferredReadTransaction,
   type SqliteStoreConnection,
 } from "./transactions"
 
@@ -112,7 +133,7 @@ const SQLITE_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
  * Stores object projections and links. V1 object-query IR pushdown covers the
  * scalar JSON-property and link-traversal subset declared by queryCapabilities().
  */
-export class SqliteObjectStorage implements ObjectStorage {
+export class SqliteObjectStorage implements ObjectStorage, ObjectReadScopeFactory {
   private readonly connection: SqliteStoreConnection
   private readonly db: Database
 
@@ -129,9 +150,97 @@ export class SqliteObjectStorage implements ObjectStorage {
     return SQLITE_OBJECT_QUERY_CAPABILITIES
   }
 
+  createSelectedReadScope(params: {
+    projectId: string
+    scope: CompiledSelectedObjectReadScope
+    limits: ObjectReadExecutionLimits
+  }): ObjectReadStorage {
+    const projectId = params.projectId
+    const limits = snapshotObjectReadExecutionLimits(params.limits)
+    const source = compileSqliteSelectedObjectReadSource(
+      projectId,
+      params.scope,
+      limits.maxTraversalFacts
+    )
+    const assertProject = (actualProjectId: string): void =>
+      assertObjectReaderProject(projectId, actualProjectId)
+    const read = <T>(run: () => T): T =>
+      runDeferredReadTransaction(this.db, () => {
+        assertTraversalBudget(this.db, source, limits.maxTraversalFacts)
+        const value = run()
+        assertObjectReadOutputWithinLimit(value, limits)
+        return value
+      })
+    const readMap = <TKey, TValue>(run: () => Map<TKey, TValue>): Map<TKey, TValue> =>
+      runDeferredReadTransaction(this.db, () => {
+        assertTraversalBudget(this.db, source, limits.maxTraversalFacts)
+        const value = run()
+        assertObjectReadOutputWithinLimit([...value.entries()], limits)
+        return value
+      })
+
+    return Object.freeze({
+      queryCapabilities: () => this.queryCapabilities(),
+      queryObjects: async (input) => {
+        assertProject(input.projectId)
+        return read(() => this.queryObjectsFromSource(input, source))
+      },
+      countObjects: async (input) => {
+        assertProject(input.projectId)
+        return read(() => this.countObjectsFromSource(input, source))
+      },
+      existsObjects: async (input) => {
+        assertProject(input.projectId)
+        return read(() => this.existsObjectsFromSource(input, source))
+      },
+      facetObjects: async (input) => {
+        assertProject(input.projectId)
+        assertObjectReadFacetCount(input.facets.length)
+        return read(() => this.facetObjectsFromSource(input, source))
+      },
+      getByPrimaryId: async (input) => {
+        assertProject(input.projectId)
+        return read(() => this.getByPrimaryIdFromSource(input, source))
+      },
+      selectsObjectProperties: async (input) => {
+        assertProject(input.projectId)
+        return read(() => this.selectsObjectPropertiesFromSource(input, source))
+      },
+      listLinks: async (input) => {
+        assertProject(input.projectId)
+        return read(() => this.listLinksFromSource(input, source))
+      },
+      getByPrimaryIdBatch: async (input) => {
+        assertProject(input.projectId)
+        return readMap(() => this.getByPrimaryIdBatchFromSource(input, source))
+      },
+      listLinksBatch: async (input) => {
+        assertProject(input.projectId)
+        return readMap(() => this.listLinksBatchFromSource(input, source))
+      },
+      queryLinks: async (input) => {
+        assertProject(input.projectId)
+        assertLinkQueryLimit(input.limit)
+        return read(() => this.queryLinksFromSource(input, source))
+      },
+      list: async (input) => {
+        assertProject(input.projectId)
+        return read(() => this.listFromSource(input, source))
+      },
+    } satisfies ObjectReadStorage)
+  }
+
   async queryObjects(params: QueryObjectsInput): Promise<QueryObjectsResult> {
+    return this.queryObjectsFromSource(params)
+  }
+
+  private queryObjectsFromSource(
+    params: QueryObjectsInput,
+    source?: SqliteObjectQuerySource
+  ): QueryObjectsResult {
     const compiled = compileObjectQuery(params.projectId, params.query, {
       includeTotal: params.includeTotal,
+      ...(source ? { source } : {}),
     })
     const total = params.includeTotal === false ? undefined : readTotal(this.db, compiled)
     const rawRows = this.db.query(compiled.sql).all(...compiled.args) as ObjectQueryDatabaseRow[]
@@ -152,21 +261,48 @@ export class SqliteObjectStorage implements ObjectStorage {
   }
 
   async countObjects(params: CountObjectsInput): Promise<CountObjectsResult> {
+    return this.countObjectsFromSource(params)
+  }
+
+  private countObjectsFromSource(
+    params: CountObjectsInput,
+    source?: SqliteObjectQuerySource
+  ): CountObjectsResult {
     return {
       count: readTotal(
         this.db,
-        compileObjectQuery(params.projectId, stripOuterRowShape(params.query))
+        compileObjectQuery(params.projectId, stripOuterRowShape(params.query), {
+          ...(source ? { source } : {}),
+        })
       ),
     }
   }
 
   async existsObjects(params: ExistsObjectsInput): Promise<ExistsObjectsResult> {
-    const compiled = compileObjectQuery(params.projectId, existsProbeQuery(params.query))
+    return this.existsObjectsFromSource(params)
+  }
+
+  private existsObjectsFromSource(
+    params: ExistsObjectsInput,
+    source?: SqliteObjectQuerySource
+  ): ExistsObjectsResult {
+    const compiled = compileObjectQuery(params.projectId, existsProbeQuery(params.query), {
+      ...(source ? { source } : {}),
+    })
     return { exists: this.db.query(compiled.sql).get(...compiled.args) !== null }
   }
 
   async facetObjects(params: FacetObjectsInput): Promise<FacetObjectsResult> {
-    const compiled = compileObjectQuery(params.projectId, stripOuterRowShape(params.query))
+    return this.facetObjectsFromSource(params)
+  }
+
+  private facetObjectsFromSource(
+    params: FacetObjectsInput,
+    source?: SqliteObjectQuerySource
+  ): FacetObjectsResult {
+    const compiled = compileObjectQuery(params.projectId, stripOuterRowShape(params.query), {
+      ...(source ? { source } : {}),
+    })
     return {
       facets: params.facets.map((facet) => ({
         propertyId: facet.propertyId,
@@ -180,9 +316,24 @@ export class SqliteObjectStorage implements ObjectStorage {
     objectTypeId: string
     primaryId: string
   }): Promise<ObjectRow | null> {
-    const row = this.db
-      .query("SELECT * FROM objects WHERE project_id = ? AND object_type_id = ? AND primary_id = ?")
-      .get(params.projectId, params.objectTypeId, params.primaryId) as DatabaseRow | null
+    return this.getByPrimaryIdFromSource(params)
+  }
+
+  private getByPrimaryIdFromSource(
+    params: {
+      projectId: string
+      objectTypeId: string
+      primaryId: string
+    },
+    source?: SqliteObjectQuerySource
+  ): ObjectRow | null {
+    const objectsTable = source?.objectsTable ?? "objects"
+    const statement = wrapSourceStatement(
+      source,
+      `SELECT * FROM ${objectsTable} WHERE project_id = ? AND object_type_id = ? AND primary_id = ?`,
+      [params.projectId, params.objectTypeId, params.primaryId]
+    )
+    const row = this.db.query(statement.sql).get(...statement.args) as DatabaseRow | null
 
     return row ? this.rowToObject(row) : null
   }
@@ -190,13 +341,39 @@ export class SqliteObjectStorage implements ObjectStorage {
   async selectsObjectProperties(
     params: Parameters<ObjectReadStorage["selectsObjectProperties"]>[0]
   ): Promise<readonly boolean[]> {
-    const objects = await this.getByPrimaryIdBatch({
-      projectId: params.projectId,
-      items: params.items,
-    })
-    return params.items.map((item) =>
-      objects.has(objectBatchKey(item.objectTypeId, item.primaryId))
+    return this.selectsObjectPropertiesFromSource(params)
+  }
+
+  private selectsObjectPropertiesFromSource(
+    params: Parameters<ObjectReadStorage["selectsObjectProperties"]>[0],
+    source?: SqliteSelectedObjectReadSource
+  ): readonly boolean[] {
+    const result = params.items.map(() => false)
+    if (params.items.length === 0) return result
+
+    const items = params.items.map((item, batchIndex) => ({ ...item, batchIndex }))
+    const requestedType = "CAST(json_extract(requested.value, '$.objectTypeId') AS TEXT)"
+    const requestedId = "CAST(json_extract(requested.value, '$.primaryId') AS TEXT)"
+    const requestedProperty = "CAST(json_extract(requested.value, '$.propertyId') AS TEXT)"
+    const storedTable = source?.objectPropertyPermissionsTable ?? "objects"
+    const propertyJoin = source ? `AND stored.property_id = ${requestedProperty}` : ""
+    const statement = wrapSourceStatement(
+      source,
+      `SELECT DISTINCT
+         CAST(json_extract(requested.value, '$.batchIndex') AS INTEGER) AS _batch_index
+       FROM ${storedTable} AS stored
+       JOIN json_each(?) AS requested
+         ON stored.object_type_id = ${requestedType}
+        AND stored.primary_id = ${requestedId}
+        ${propertyJoin}
+       WHERE stored.project_id = ?`,
+      [JSON.stringify(items), params.projectId]
     )
+    const rows = this.db
+      .query(statement.sql)
+      .all(...statement.args) as PropertyPermissionBatchDatabaseRow[]
+    for (const row of rows) result[row._batch_index] = true
+    return result
   }
 
   async listLinks(params: {
@@ -206,6 +383,19 @@ export class SqliteObjectStorage implements ObjectStorage {
     linkId?: string
     direction?: LinkDirection
   }): Promise<readonly ObjectLinkRow[]> {
+    return this.listLinksFromSource(params)
+  }
+
+  private listLinksFromSource(
+    params: {
+      projectId: string
+      objectTypeId: string
+      objectId: string
+      linkId?: string
+      direction?: LinkDirection
+    },
+    source?: SqliteObjectQuerySource
+  ): readonly ObjectLinkRow[] {
     const direction = params.direction ?? "outgoing"
     const directionWhere =
       direction === "incoming"
@@ -213,7 +403,7 @@ export class SqliteObjectStorage implements ObjectStorage {
         : direction === "both"
           ? "((source_type_id = ? AND source_id = ?) OR (target_type_id = ? AND target_id = ?))"
           : "source_type_id = ? AND source_id = ?"
-    let query = `SELECT * FROM links WHERE project_id = ? AND ${directionWhere}`
+    let query = `SELECT * FROM ${source?.linksTable ?? "links"} WHERE project_id = ? AND ${directionWhere}`
     const args: (string | number)[] =
       direction === "both"
         ? [
@@ -230,7 +420,8 @@ export class SqliteObjectStorage implements ObjectStorage {
       args.push(params.linkId)
     }
 
-    const rows = this.db.query(query).all(...args) as LinkDatabaseRow[]
+    const statement = wrapSourceStatement(source, query, args)
+    const rows = this.db.query(statement.sql).all(...statement.args) as LinkDatabaseRow[]
 
     return rows.map((row) => this.rowToLink(row))
   }
@@ -239,23 +430,39 @@ export class SqliteObjectStorage implements ObjectStorage {
     projectId: string
     items: readonly { objectTypeId: string; primaryId: string }[]
   }): Promise<Map<ObjectBatchKey, ObjectRow>> {
+    return this.getByPrimaryIdBatchFromSource(params)
+  }
+
+  private getByPrimaryIdBatchFromSource(
+    params: {
+      projectId: string
+      items: readonly { objectTypeId: string; primaryId: string }[]
+    },
+    source?: SqliteObjectQuerySource
+  ): Map<ObjectBatchKey, ObjectRow> {
     const result = new Map<ObjectBatchKey, ObjectRow>()
     if (params.items.length === 0) return result
 
-    const rows = this.db
-      .query(
-        `
-          SELECT object.*
-          FROM json_each(?) AS requested
-          JOIN objects AS object
-            ON object.project_id = ?
-           AND object.object_type_id = json_extract(requested.value, '$.objectTypeId')
-           AND object.primary_id = json_extract(requested.value, '$.primaryId')
-        `
-      )
-      .all(JSON.stringify(params.items), params.projectId) as DatabaseRow[]
-    for (const row of rows) {
-      result.set(objectBatchKey(row.object_type_id, row.primary_id), this.rowToObject(row))
+    const items = params.items.map((item, batchIndex) => ({ ...item, batchIndex }))
+    const statement = wrapSourceStatement(
+      source,
+      `
+        SELECT
+          object.*,
+          CAST(json_extract(requested.value, '$.batchIndex') AS INTEGER) AS _batch_index
+        FROM json_each(?) AS requested
+        JOIN ${source?.objectsTable ?? "objects"} AS object
+          ON object.project_id = ?
+         AND object.object_type_id = json_extract(requested.value, '$.objectTypeId')
+         AND object.primary_id = json_extract(requested.value, '$.primaryId')
+      `,
+      [JSON.stringify(items), params.projectId]
+    )
+    const rows = this.db.query(statement.sql).all(...statement.args) as ObjectBatchDatabaseRow[]
+    const rowsByIndex = new Map(rows.map((row) => [row._batch_index, row]))
+    for (const [index, item] of params.items.entries()) {
+      const row = rowsByIndex.get(index)
+      if (row) result.set(objectBatchKey(item.objectTypeId, item.primaryId), this.rowToObject(row))
     }
     return result
   }
@@ -265,19 +472,58 @@ export class SqliteObjectStorage implements ObjectStorage {
     direction?: LinkDirection
     items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
   }): Promise<Map<LinkBatchKey, ObjectLinkRow[]>> {
+    return this.listLinksBatchFromSource(params)
+  }
+
+  private listLinksBatchFromSource(
+    params: {
+      projectId: string
+      direction?: LinkDirection
+      items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
+    },
+    source?: SqliteObjectQuerySource
+  ): Map<LinkBatchKey, ObjectLinkRow[]> {
     const result = new Map<LinkBatchKey, ObjectLinkRow[]>()
     if (params.items.length === 0) return result
 
-    for (const item of params.items) {
-      const rows = await this.listLinks({
-        projectId: params.projectId,
-        objectTypeId: item.objectTypeId,
-        objectId: item.objectId,
-        linkId: item.linkId,
-        ...(params.direction === undefined ? {} : { direction: params.direction }),
-      })
-      if (rows.length > 0) {
-        result.set(linkBatchKey(item.objectTypeId, item.objectId, item.linkId), [...rows])
+    const direction = params.direction ?? "outgoing"
+    const requestedType = "CAST(json_extract(requested.value, '$.objectTypeId') AS TEXT)"
+    const requestedId = "CAST(json_extract(requested.value, '$.objectId') AS TEXT)"
+    const requestedLink = "CAST(json_extract(requested.value, '$.linkId') AS TEXT)"
+    const outgoing = `stored.source_type_id = ${requestedType} AND stored.source_id = ${requestedId}`
+    const incoming = `stored.target_type_id = ${requestedType} AND stored.target_id = ${requestedId}`
+    const directionJoin =
+      direction === "both"
+        ? `((${outgoing}) OR (${incoming}))`
+        : direction === "incoming"
+          ? incoming
+          : outgoing
+    const items = params.items.map((item, batchIndex) => ({ ...item, batchIndex }))
+    const statement = wrapSourceStatement(
+      source,
+      `
+        SELECT
+          stored.*,
+          CAST(json_extract(requested.value, '$.batchIndex') AS INTEGER) AS _batch_index
+        FROM ${source?.linksTable ?? "links"} AS stored
+        JOIN json_each(?) AS requested
+          ON ${directionJoin}
+         AND stored.link_id = ${requestedLink}
+        WHERE stored.project_id = ?
+        ORDER BY _batch_index, source_type_id, source_id, link_id, target_type_id, target_id
+      `,
+      [JSON.stringify(items), params.projectId]
+    )
+    const rows = this.db.query(statement.sql).all(...statement.args) as LinkBatchDatabaseRow[]
+    const rowsByIndex = params.items.map(() => new Map<string, ObjectLinkRow>())
+    for (const row of rows) {
+      const link = this.rowToLink(row)
+      rowsByIndex[row._batch_index]?.set(fullLinkIdentity(link), link)
+    }
+    for (const [index, item] of params.items.entries()) {
+      const links = [...(rowsByIndex[index]?.values() ?? [])]
+      if (links.length > 0) {
+        result.set(linkBatchKey(item.objectTypeId, item.objectId, item.linkId), links)
       }
     }
     return result
@@ -285,22 +531,36 @@ export class SqliteObjectStorage implements ObjectStorage {
 
   async queryLinks(params: QueryObjectLinksInput): Promise<QueryObjectLinksResult> {
     assertLinkQueryLimit(params.limit)
+    return this.queryLinksFromSource(params)
+  }
+
+  private queryLinksFromSource(
+    params: QueryObjectLinksInput,
+    source?: SqliteObjectQuerySource
+  ): QueryObjectLinksResult {
     if (params.objectRefs.length === 0 || params.endpointObjectTypeIds?.length === 0) {
       return { links: [], hasMore: false }
     }
 
+    const requested = `
+      SELECT DISTINCT
+        json_extract(value, '$.objectTypeId') AS object_type_id,
+        json_extract(value, '$.primaryId') AS object_id
+      FROM json_each(?)
+    `
+    const linksTable = source?.linksTable ?? "links"
     const sourceJoin = `
       SELECT link.*
-      FROM links AS link
-      JOIN requested
+      FROM ${linksTable} AS link
+      JOIN (${requested}) AS requested
         ON requested.object_type_id = link.source_type_id
        AND requested.object_id = link.source_id
       WHERE link.project_id = ?
     `
     const targetJoin = `
       SELECT link.*
-      FROM links AS link
-      JOIN requested
+      FROM ${linksTable} AS link
+      JOIN (${requested}) AS requested
         ON requested.object_type_id = link.target_type_id
        AND requested.object_id = link.target_id
       WHERE link.project_id = ?
@@ -311,8 +571,11 @@ export class SqliteObjectStorage implements ObjectStorage {
         : params.direction === "incoming"
           ? targetJoin
           : `${sourceJoin} UNION ${targetJoin}`
-    const args: (string | number)[] = [JSON.stringify(params.objectRefs), params.projectId]
-    if (params.direction === "both") args.push(params.projectId)
+    const requestedJson = JSON.stringify(params.objectRefs)
+    const args: (string | number)[] =
+      params.direction === "both"
+        ? [requestedJson, params.projectId, requestedJson, params.projectId]
+        : [requestedJson, params.projectId]
 
     const predicates: string[] = []
     if (params.linkId !== undefined) {
@@ -336,23 +599,18 @@ export class SqliteObjectStorage implements ObjectStorage {
     args.push(params.limit + 1)
 
     const whereSql = predicates.length > 0 ? `WHERE ${predicates.join(" AND ")}` : ""
-    const rows = this.db
-      .query(
-        `
-          WITH requested AS (
-            SELECT DISTINCT
-              json_extract(value, '$.objectTypeId') AS object_type_id,
-              json_extract(value, '$.primaryId') AS object_id
-            FROM json_each(?)
-          ), incident AS (${incidentSql})
-          SELECT *
-          FROM incident
-          ${whereSql}
-          ORDER BY source_type_id, source_id, link_id, target_type_id, target_id
-          LIMIT ?
-        `
-      )
-      .all(...args) as LinkDatabaseRow[]
+    const statement = wrapSourceStatement(
+      source,
+      `
+        SELECT *
+        FROM (${incidentSql}) AS incident
+        ${whereSql}
+        ORDER BY source_type_id, source_id, link_id, target_type_id, target_id
+        LIMIT ?
+      `,
+      args
+    )
+    const rows = this.db.query(statement.sql).all(...statement.args) as LinkDatabaseRow[]
 
     return {
       links: rows.slice(0, params.limit).map((row) => this.rowToLink(row)),
@@ -442,7 +700,14 @@ export class SqliteObjectStorage implements ObjectStorage {
     orderBy?: "createdAt" | "updatedAt" | "primaryId"
     order?: "asc" | "desc"
   }): Promise<{ objects: readonly ObjectRow[]; hasMore: boolean; total: number }> {
-    let query = "SELECT * FROM objects WHERE project_id = ?"
+    return this.listFromSource(params)
+  }
+
+  private listFromSource(
+    params: Parameters<ObjectReadStorage["list"]>[0],
+    source?: SqliteObjectQuerySource
+  ): { objects: readonly ObjectRow[]; hasMore: boolean; total: number } {
+    let query = `SELECT * FROM ${source?.objectsTable ?? "objects"} WHERE project_id = ?`
     const args: (string | number | null)[] = [params.projectId]
 
     if (params.objectTypeId) {
@@ -486,7 +751,12 @@ export class SqliteObjectStorage implements ObjectStorage {
     }
 
     // Get total count
-    const countResult = this.db.query(`SELECT COUNT(*) as total FROM (${query})`).get(...args) as {
+    const countStatement = wrapSourceStatement(
+      source,
+      `SELECT COUNT(*) as total FROM (${query}) AS filtered_objects`,
+      args
+    )
+    const countResult = this.db.query(countStatement.sql).get(...countStatement.args) as {
       total: number
     }
     const total = countResult.total
@@ -506,7 +776,8 @@ export class SqliteObjectStorage implements ObjectStorage {
     query += " LIMIT ? OFFSET ?"
     args.push(limit + 1, offset) // +1 to check for hasMore
 
-    const rows = this.db.query(query).all(...args) as DatabaseRow[]
+    const rowsStatement = wrapSourceStatement(source, query, args)
+    const rows = this.db.query(rowsStatement.sql).all(...rowsStatement.args) as DatabaseRow[]
     const hasMore = rows.length > limit
     const objects = rows.slice(0, limit).map((row) => this.rowToObject(row))
 
@@ -543,7 +814,7 @@ export class SqliteObjectStorage implements ObjectStorage {
       linkId: row.link_id,
       targetTypeId: row.target_type_id,
       targetId: row.target_id,
-      properties: row.properties ? JSON.parse(row.properties) : undefined,
+      ...(row.properties === null ? {} : { properties: JSON.parse(row.properties) }),
       createdAt: new Date(row.created_at),
       updatedAt: new Date(row.updated_at),
       lastCommitId: row.last_commit_id,
@@ -556,6 +827,37 @@ export class SqliteObjectStorage implements ObjectStorage {
   close(): void {
     closeSqliteStoreConnection(this.connection)
   }
+}
+
+function wrapSourceStatement(
+  source: SqliteObjectQuerySource | undefined,
+  sql: string,
+  args: readonly SqliteValue[] = []
+): { readonly sql: string; readonly args: readonly SqliteValue[] } {
+  return source?.wrapStatement(sql, args) ?? { sql, args }
+}
+
+function assertTraversalBudget(
+  db: Database,
+  source: SqliteSelectedObjectReadSource,
+  maxTraversalFacts: number
+): void {
+  const row = db.query(source.traversalProbe.sql).get(...source.traversalProbe.args) as {
+    total: number | bigint
+  }
+  if (BigInt(row.total) > BigInt(maxTraversalFacts)) {
+    throw new ObjectReadLimitExceededError("traversalFacts", maxTraversalFacts)
+  }
+}
+
+function fullLinkIdentity(link: ObjectLinkRow): string {
+  return JSON.stringify([
+    link.sourceTypeId,
+    link.sourceId,
+    link.linkId,
+    link.targetTypeId,
+    link.targetId,
+  ])
 }
 
 function assertReconciliationPageLimit(limit: number): void {
@@ -698,6 +1000,14 @@ interface ObjectQueryDatabaseRow extends DatabaseRow {
   _expand?: string | null
 }
 
+interface ObjectBatchDatabaseRow extends DatabaseRow {
+  _batch_index: number
+}
+
+interface PropertyPermissionBatchDatabaseRow {
+  _batch_index: number
+}
+
 interface FacetDatabaseRow {
   value_type: string | null
   value: unknown
@@ -715,4 +1025,8 @@ interface LinkDatabaseRow {
   created_at: string
   updated_at: string
   last_commit_id: string
+}
+
+interface LinkBatchDatabaseRow extends LinkDatabaseRow {
+  _batch_index: number
 }

--- a/storage/sqlite/src/transactions.ts
+++ b/storage/sqlite/src/transactions.ts
@@ -45,6 +45,7 @@ export function closeSqliteStoreConnection(connection: SqliteStoreConnection): v
 }
 
 const activeImmediateTransactions = new WeakSet<Database>()
+const activeDeferredReadTransactions = new WeakSet<Database>()
 
 export function runImmediateTransaction<T>(db: Database, run: () => T): T {
   if (activeImmediateTransactions.has(db)) {
@@ -91,6 +92,37 @@ export async function runImmediateTransactionAsync<T>(
     throw error
   } finally {
     activeImmediateTransactions.delete(db)
+  }
+}
+
+/**
+ * Run a multi-statement read against one proven SQLite snapshot.
+ *
+ * A provider-owned immediate transaction already has a stable snapshot and may be reused. Any
+ * other pre-existing transaction is rejected because this provider cannot prove who owns it or
+ * which lifecycle will close it.
+ */
+export function runDeferredReadTransaction<T>(db: Database, run: () => T): T {
+  if (activeImmediateTransactions.has(db) || activeDeferredReadTransactions.has(db)) {
+    return run()
+  }
+  if (db.inTransaction) {
+    throw new Error(
+      "[SixbSqlite] Selected object reads cannot join an unverified SQLite transaction."
+    )
+  }
+
+  db.run("BEGIN DEFERRED")
+  activeDeferredReadTransactions.add(db)
+  try {
+    const result = run()
+    db.run("COMMIT")
+    return result
+  } catch (error) {
+    rollbackQuietly(db)
+    throw error
+  } finally {
+    activeDeferredReadTransactions.delete(db)
   }
 }
 

--- a/storage/sqlite/tests/sqlite-object-read-scope-provider.test.ts
+++ b/storage/sqlite/tests/sqlite-object-read-scope-provider.test.ts
@@ -1,0 +1,505 @@
+import { Database, type SQLQueryBindings } from "bun:sqlite"
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { migrateStorage } from "@sixb/core"
+import {
+  compileSelectedObjectReadScope,
+  linkBatchKey,
+  type ObjectReadExecutionLimits,
+  type ObjectReadScopeFactory,
+  type ObjectReadStorage,
+  type ObjectStorage,
+  objectBatchKey,
+  type SelectedObjectReadScope,
+} from "@sixb/core/storage"
+import { SqliteStorage } from "../src"
+import { installFreshSqliteSchema, sqliteStoragePath } from "../src/migrations"
+import { compileSqliteSelectedObjectReadSource } from "../src/object-read-scope"
+import { SqliteObjectStorage } from "../src/object-storage"
+import { runImmediateTransactionAsync } from "../src/transactions"
+
+const projectId = "sqlite-selected-reader"
+const RootType = "SqliteScopeRoot"
+const TargetType = "SqliteScopeTarget"
+const timestamp = "2026-08-31T00:00:00.000Z"
+const generousLimits: ObjectReadExecutionLimits = {
+  maxTraversalFacts: 100,
+  maxOutputJsonBytes: 1_000_000,
+}
+
+describe("SqliteObjectStorage selected reader invariants", () => {
+  test("counts live path facts exactly and preserves redacted JSON values", async () => {
+    const storage = new SqliteObjectStorage()
+    try {
+      const db = databaseOf(storage)
+      insertObject(db, RootType, "root-1", {
+        id: "root-1",
+        nested: { key: "value" },
+        values: [1, true, null],
+        enabled: true,
+        disabled: false,
+        nullable: null,
+        amount: 2.5,
+        hidden: "root-secret",
+      })
+      insertObject(db, TargetType, "target-1", {
+        id: "target-1",
+        label: "visible",
+        hidden: "target-secret",
+      })
+      insertLink(db, "root-1", "items", "target-1", {
+        nested: { edge: true },
+        values: [false, null, 3],
+        enabled: true,
+        disabled: false,
+        nullable: null,
+        amount: 7.5,
+        hidden: "edge-secret",
+      })
+      // A stored edge whose target is absent is not a live traversal fact.
+      insertLink(db, "root-1", "items", "target-missing", { enabled: true })
+      const otherProjectId = `${projectId}-other`
+      insertObject(db, RootType, "root-1", { id: "other-root" }, otherProjectId)
+      insertObject(db, TargetType, "target-1", { id: "other-target" }, otherProjectId)
+      insertLink(db, "root-1", "items", "target-1", { enabled: false }, otherProjectId)
+
+      const scope = repeatedPathScope()
+      const exact = createReader(storage, scope, { ...generousLimits, maxTraversalFacts: 3 })
+      expect((await exact.list({ projectId })).objects.map((row) => row.primaryId).sort()).toEqual([
+        "root-1",
+        "target-1",
+      ])
+      expect(
+        (await exact.list({ projectId })).objects.every((row) => row.projectId === projectId)
+      ).toBe(true)
+      expect(
+        await exact.getByPrimaryId({
+          projectId,
+          objectTypeId: RootType,
+          primaryId: "root-1",
+        })
+      ).toMatchObject({
+        properties: {
+          id: "root-1",
+          nested: { key: "value" },
+          values: [1, true, null],
+          enabled: true,
+          disabled: false,
+          nullable: null,
+          amount: 2.5,
+        },
+      })
+      const links = await exact.listLinks({
+        projectId,
+        objectTypeId: RootType,
+        objectId: "root-1",
+        linkId: "items",
+      })
+      expect(links).toHaveLength(1)
+      expect(links[0]?.properties).toEqual({
+        nested: { edge: true },
+        values: [false, null, 3],
+        enabled: true,
+        disabled: false,
+        nullable: null,
+        amount: 7.5,
+      })
+
+      const batch = await exact.getByPrimaryIdBatch({
+        projectId,
+        items: [
+          { objectTypeId: TargetType, primaryId: "target-1" },
+          { objectTypeId: RootType, primaryId: "root-1" },
+          { objectTypeId: TargetType, primaryId: "target-1" },
+        ],
+      })
+      expect([...batch.keys()]).toEqual([
+        objectBatchKey(TargetType, "target-1"),
+        objectBatchKey(RootType, "root-1"),
+      ])
+      const linkBatch = await exact.listLinksBatch({
+        projectId,
+        items: [
+          { objectTypeId: TargetType, objectId: "target-1", linkId: "items" },
+          { objectTypeId: RootType, objectId: "root-1", linkId: "items" },
+        ],
+        direction: "both",
+      })
+      expect([...linkBatch.keys()]).toEqual([
+        linkBatchKey(TargetType, "target-1", "items"),
+        linkBatchKey(RootType, "root-1", "items"),
+      ])
+
+      const overBudget = createReader(storage, scope, {
+        ...generousLimits,
+        maxTraversalFacts: 2,
+      })
+      await expect(overBudget.list({ projectId })).rejects.toMatchObject({
+        code: "object_read_limit_exceeded",
+        metric: "traversalFacts",
+        limit: 2,
+      })
+      await expect(
+        overBudget.queryLinks({
+          projectId,
+          objectRefs: [{ objectTypeId: RootType, primaryId: "root-1" }],
+          direction: "outgoing",
+          limit: 0,
+        })
+      ).rejects.toThrow("positive safe integer")
+    } finally {
+      storage.close()
+    }
+  })
+
+  test("wraps main, total, and has-more statements in the selected source", async () => {
+    const storage = new SqliteObjectStorage()
+    try {
+      const db = databaseOf(storage)
+      insertObject(db, RootType, "root-1", { id: "root-1" })
+      insertObject(db, TargetType, "target-a", { id: "target-a", enabled: true, hidden: "a" })
+      insertObject(db, TargetType, "target-b", { id: "target-b", enabled: false, hidden: "b" })
+      insertObject(db, TargetType, "target-hidden", { id: "target-hidden" })
+      insertLink(db, "root-1", "items", "target-a")
+      insertLink(db, "root-1", "items", "target-b")
+      const reader = createReader(storage, singlePathScope())
+
+      const withTotal = await reader.queryObjects?.({
+        projectId,
+        query: { kind: "start", objectTypeId: TargetType },
+      })
+      expect(withTotal).toMatchObject({
+        total: 2,
+        hasMore: false,
+        objects: [{ primaryId: "target-a" }, { primaryId: "target-b" }],
+      })
+      expect(withTotal?.objects[0]?.properties).toEqual({ id: "target-a", enabled: true })
+
+      const withoutTotal = await reader.queryObjects?.({
+        projectId,
+        includeTotal: false,
+        query: {
+          kind: "sort",
+          fields: [{ kind: "property", propertyId: "id", direction: "asc" }],
+          input: {
+            kind: "limit",
+            limit: 1,
+            input: { kind: "start", objectTypeId: TargetType },
+          },
+        },
+      })
+      expect(withoutTotal).toMatchObject({
+        hasMore: true,
+        objects: [{ primaryId: "target-a" }],
+      })
+      expect(withoutTotal).not.toHaveProperty("total")
+
+      const projected = await reader.queryObjects?.({
+        projectId,
+        query: {
+          kind: "project",
+          properties: ["id", "enabled"],
+          input: { kind: "start", objectTypeId: TargetType },
+        },
+      })
+      expect(projected?.objects.map((object) => object.properties)).toEqual([
+        { id: "target-a", enabled: true },
+        { id: "target-b", enabled: false },
+      ])
+
+      const propertylessLinks = await reader.listLinks({
+        projectId,
+        objectTypeId: RootType,
+        objectId: "root-1",
+        linkId: "items",
+      })
+      expect(propertylessLinks).toHaveLength(2)
+      expect(propertylessLinks.every((link) => !Object.hasOwn(link, "properties"))).toBe(true)
+    } finally {
+      storage.close()
+    }
+  })
+
+  test("serializes a large compiled scope into one bounded statement parameter", () => {
+    const scope = compileSelectedObjectReadScope({
+      kind: "selected",
+      roots: Array.from({ length: 400 }, (_, index) => ({
+        anchor: { objectTypeId: RootType, primaryId: `root-${index}` },
+        node: {
+          objects: [{ objectTypeId: RootType, propertyIds: ["id"] }],
+          links: [],
+        },
+      })),
+    })
+    const source = compileSqliteSelectedObjectReadSource(projectId, scope, 1_000)
+    const statement = source.wrapStatement("SELECT ? AS terminal", ["value"])
+
+    expect(statement.args).toHaveLength(3)
+    expect(statement.args[0]).toBeString()
+    expect(statement.args[1]).toBe(projectId)
+    expect(statement.args[2]).toBe("value")
+    expect(statement.sql.match(/json\(\?\)/g)).toHaveLength(1)
+  })
+
+  test("reuses provider-owned transactions and rejects unverified ones", async () => {
+    const storage = new SqliteObjectStorage()
+    try {
+      const db = databaseOf(storage)
+      insertObject(db, RootType, "root-1", { id: "root-1" })
+      const reader = createReader(storage, rootOnlyScope())
+
+      const row = await runImmediateTransactionAsync(db, () =>
+        reader.getByPrimaryId({
+          projectId,
+          objectTypeId: RootType,
+          primaryId: "root-1",
+        })
+      )
+      expect(row?.primaryId).toBe("root-1")
+
+      db.run("BEGIN DEFERRED")
+      try {
+        await expect(reader.list({ projectId })).rejects.toThrow("unverified SQLite transaction")
+      } finally {
+        db.run("ROLLBACK")
+      }
+    } finally {
+      storage.close()
+    }
+  })
+
+  test("runs selected reads through the file-backed readonly production connection", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "sixb-sqlite-selected-readonly-"))
+    const storage = new SqliteStorage({ path: directory })
+    let writer: Database | undefined
+    try {
+      await migrateStorage(storage)
+      writer = new Database(sqliteStoragePath(directory))
+      insertObject(writer, RootType, "root-1", { id: "root-1", hidden: "secret" })
+
+      const factory = storage.objects as ObjectStorage & ObjectReadScopeFactory
+      const reader = factory.createSelectedReadScope({
+        projectId,
+        scope: compileSelectedObjectReadScope(rootOnlyScope()),
+        limits: generousLimits,
+      })
+      expect(
+        await reader.getByPrimaryId({
+          projectId,
+          objectTypeId: RootType,
+          primaryId: "root-1",
+        })
+      ).toMatchObject({ properties: { id: "root-1" } })
+    } finally {
+      writer?.close()
+      storage.close()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  test("keeps the traversal probe and every terminal statement on one WAL snapshot", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "sixb-sqlite-selected-snapshot-"))
+    const databasePath = join(directory, "scope.sqlite")
+    const setup = new Database(databasePath)
+    installFreshSqliteSchema(setup)
+    setup.run("PRAGMA journal_mode = WAL")
+    setup.close()
+
+    const storage = new SqliteObjectStorage({ path: databasePath })
+    const writer = new Database(databasePath)
+    writer.run("PRAGMA journal_mode = WAL")
+    writer.run("PRAGMA busy_timeout = 5000")
+    const holder = storage as unknown as { db: Database }
+    const originalDb = holder.db
+
+    try {
+      insertObject(originalDb, RootType, "root-1", { id: "root-1" })
+      insertObject(originalDb, TargetType, "target-1", { id: "target-1" })
+      const reader = createReader(storage, singlePathScope(), {
+        ...generousLimits,
+        maxTraversalFacts: 1,
+      })
+      let writerCommitted = false
+
+      holder.db = {
+        get inTransaction() {
+          return originalDb.inTransaction
+        },
+        run: originalDb.run.bind(originalDb),
+        query: (sql: string) => {
+          const statement = originalDb.query(sql)
+          return {
+            all: (...args: SQLQueryBindings[]) => statement.all(...args),
+            get: (...args: SQLQueryBindings[]) => {
+              const result = statement.get(...args)
+              if (!writerCommitted && sql.includes("bounded_traversal_facts")) {
+                writerCommitted = true
+                insertLink(writer, "root-1", "items", "target-1")
+              }
+              return result
+            },
+          }
+        },
+      } as unknown as Database
+
+      expect(await reader.list({ projectId })).toEqual({
+        objects: [expect.objectContaining({ primaryId: "root-1" })],
+        hasMore: false,
+        total: 1,
+      })
+      expect(writerCommitted).toBe(true)
+
+      holder.db = originalDb
+      await expect(reader.list({ projectId })).rejects.toMatchObject({
+        code: "object_read_limit_exceeded",
+        metric: "traversalFacts",
+        limit: 1,
+      })
+    } finally {
+      holder.db = originalDb
+      writer.close()
+      storage.close()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})
+
+function createReader(
+  storage: SqliteObjectStorage,
+  scope: SelectedObjectReadScope,
+  limits: ObjectReadExecutionLimits = generousLimits
+): ObjectReadStorage {
+  return storage.createSelectedReadScope({
+    projectId,
+    scope: compileSelectedObjectReadScope(scope),
+    limits,
+  })
+}
+
+function rootOnlyScope(): SelectedObjectReadScope {
+  return {
+    kind: "selected",
+    roots: [rootSelection("root-1")],
+  }
+}
+
+function singlePathScope(): SelectedObjectReadScope {
+  return {
+    kind: "selected",
+    roots: [
+      {
+        ...rootSelection("root-1"),
+        node: {
+          objects: [{ objectTypeId: RootType, propertyIds: ["id"] }],
+          links: [targetPath()],
+        },
+      },
+    ],
+  }
+}
+
+function repeatedPathScope(): SelectedObjectReadScope {
+  return {
+    kind: "selected",
+    roots: [
+      {
+        ...rootSelection("root-1"),
+        node: {
+          objects: [
+            {
+              objectTypeId: RootType,
+              propertyIds: ["id", "nested", "values", "enabled", "disabled", "nullable", "amount"],
+            },
+          ],
+          links: [targetPath(true), targetPath(true)],
+        },
+      },
+      rootSelection("root-missing"),
+    ],
+  }
+}
+
+function rootSelection(primaryId: string) {
+  return {
+    anchor: { objectTypeId: RootType, primaryId },
+    node: {
+      objects: [{ objectTypeId: RootType, propertyIds: ["id"] }],
+      links: [],
+    },
+  }
+}
+
+function targetPath(selectLinkValues = false) {
+  return {
+    definitions: [
+      {
+        sourceObjectTypeId: RootType,
+        linkId: "items",
+        targetObjectTypeIds: [TargetType],
+        propertyIds: selectLinkValues
+          ? ["nested", "values", "enabled", "disabled", "nullable", "amount"]
+          : [],
+      },
+    ],
+    target: {
+      objects: [{ objectTypeId: TargetType, propertyIds: ["id", "label", "enabled"] }],
+      links: [],
+    },
+  }
+}
+
+function databaseOf(storage: SqliteObjectStorage): Database {
+  return (storage as unknown as { db: Database }).db
+}
+
+function insertObject(
+  db: Database,
+  objectTypeId: string,
+  primaryId: string,
+  properties: Readonly<Record<string, unknown>>,
+  rowProjectId = projectId
+): void {
+  db.query(`
+    INSERT INTO objects (
+      project_id, object_type_id, primary_id, properties,
+      created_at, updated_at, version, last_commit_id
+    ) VALUES (?, ?, ?, json(?), ?, ?, 1, ?)
+  `).run(
+    rowProjectId,
+    objectTypeId,
+    primaryId,
+    JSON.stringify(properties),
+    timestamp,
+    timestamp,
+    "scope-test"
+  )
+}
+
+function insertLink(
+  db: Database,
+  sourceId: string,
+  linkId: string,
+  targetId: string,
+  properties?: Readonly<Record<string, unknown>>,
+  rowProjectId = projectId
+): void {
+  db.query(`
+    INSERT INTO links (
+      project_id, source_type_id, source_id, link_id, target_type_id, target_id,
+      properties, created_at, updated_at, last_commit_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    rowProjectId,
+    RootType,
+    sourceId,
+    linkId,
+    TargetType,
+    targetId,
+    properties === undefined ? null : JSON.stringify(properties),
+    timestamp,
+    timestamp,
+    "scope-test"
+  )
+}

--- a/storage/sqlite/tests/sqlite-object-read-scope-provider.test.ts
+++ b/storage/sqlite/tests/sqlite-object-read-scope-provider.test.ts
@@ -8,9 +8,7 @@ import {
   compileSelectedObjectReadScope,
   linkBatchKey,
   type ObjectReadExecutionLimits,
-  type ObjectReadScopeFactory,
   type ObjectReadStorage,
-  type ObjectStorage,
   objectBatchKey,
   type SelectedObjectReadScope,
 } from "@sixb/core/storage"
@@ -279,8 +277,7 @@ describe("SqliteObjectStorage selected reader invariants", () => {
       writer = new Database(sqliteStoragePath(directory))
       insertObject(writer, RootType, "root-1", { id: "root-1", hidden: "secret" })
 
-      const factory = storage.objects as ObjectStorage & ObjectReadScopeFactory
-      const reader = factory.createSelectedReadScope({
+      const reader = storage.objects.createSelectedReadScope({
         projectId,
         scope: compileSelectedObjectReadScope(rootOnlyScope()),
         limits: generousLimits,
@@ -296,6 +293,38 @@ describe("SqliteObjectStorage selected reader invariants", () => {
       writer?.close()
       storage.close()
       await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  test("preserves selected readers through a storage transaction and expires escaped readers", async () => {
+    const storage = new SqliteStorage()
+    let escapedReader: ObjectReadStorage | undefined
+    let escapedList: ObjectReadStorage["list"] | undefined
+    try {
+      await storage.transaction(async (tx) => {
+        const reader = tx.objects.createSelectedReadScope({
+          projectId,
+          scope: compileSelectedObjectReadScope(rootOnlyScope()),
+          limits: generousLimits,
+        })
+        await expect(reader.list({ projectId })).resolves.toEqual({
+          objects: [],
+          hasMore: false,
+          total: 0,
+        })
+        escapedReader = reader
+        escapedList = reader.list
+      })
+
+      if (!escapedReader || !escapedList) throw new Error("expected escaped selected reader")
+      const reader = escapedReader
+      const list = escapedList
+      expect(() => reader.queryCapabilities()).toThrow("after transaction completion")
+      await expect(Promise.resolve().then(() => list({ projectId }))).rejects.toMatchObject({
+        code: "transaction_inactive",
+      })
+    } finally {
+      storage.close()
     }
   })
 

--- a/storage/sqlite/tests/sqlite-object-read-scope.test.ts
+++ b/storage/sqlite/tests/sqlite-object-read-scope.test.ts
@@ -1,0 +1,16 @@
+import type { ObjectReadScopeFactory, ObjectStorage } from "@sixb/core/storage"
+import { runObjectReadScopeContractSuite } from "@sixb/core/testing"
+import { SqliteStorage } from "../src"
+
+runObjectReadScopeContractSuite("SqliteStorage selected object-read scope contract", {
+  createHarness: () => {
+    const storage = new SqliteStorage()
+    return {
+      storage,
+      // Storage activation is a later slice. The provider facade already preserves the concrete
+      // factory method, so this contract can validate SQLite independently in the meantime.
+      objectReadScopeFactory: storage.objects as ObjectStorage & ObjectReadScopeFactory,
+    }
+  },
+  teardown: ({ storage }) => storage.close(),
+})

--- a/storage/sqlite/tests/sqlite-object-read-scope.test.ts
+++ b/storage/sqlite/tests/sqlite-object-read-scope.test.ts
@@ -1,4 +1,3 @@
-import type { ObjectReadScopeFactory, ObjectStorage } from "@sixb/core/storage"
 import { runObjectReadScopeContractSuite } from "@sixb/core/testing"
 import { SqliteStorage } from "../src"
 
@@ -7,9 +6,7 @@ runObjectReadScopeContractSuite("SqliteStorage selected object-read scope contra
     const storage = new SqliteStorage()
     return {
       storage,
-      // Storage activation is a later slice. The provider facade already preserves the concrete
-      // factory method, so this contract can validate SQLite independently in the meantime.
-      objectReadScopeFactory: storage.objects as ObjectStorage & ObjectReadScopeFactory,
+      objectReadScopeFactory: storage.objects,
     }
   },
   teardown: ({ storage }) => storage.close(),


### PR DESCRIPTION
## Depends on

- #493

## Why

Selected readers are now implemented by every first-party provider. Storage façades must preserve
their provider scope and transaction lifetime without a broad-read fallback.

## What

- Make `ObjectReadScopeFactory` part of the required `ObjectStorage` contract.
- Preserve selected-reader creation through InMemory, SQLite, and PostgreSQL façades.
- Guard frozen provider readers explicitly across capabilities and all 11 terminals.
- Expire readers, captured methods, and factories created through a completed transaction.
- Keep PostgreSQL default transactions fail-closed with actionable `SERIALIZABLE` guidance.

```txt
Storage.objects
  └─ createSelectedReadScope()
       └─ provider scope / transaction lifetime
            └─ selected read terminal
```

## Guarantees

- A provider without selected-read support is rejected immediately.
- Root selected reads use the same operation scope as ordinary object reads.
- Transaction handles cannot escape their callback.
- Frozen readers are never wrapped with an invariant-breaking generic Proxy.

## Validation

- 4,618 unit tests passed; 7 skipped; 0 failed
- targeted Core, SQLite, and PostgreSQL tests
- root typecheck, package builds, publish checks, and Biome
- PostgreSQL transaction E2E coverage added

## Scope

- Storage activation only.
- No authorization policy, Share, session, telemetry, or HTTP concepts.

## Next

- #495
