### PR TITLE
core: centralize ordinary and delegated object reads

### DIFF
--- a/packages/core/src/agents/context-resolution.ts
+++ b/packages/core/src/agents/context-resolution.ts
@@ -1,4 +1,3 @@
-import { assertAuthorized } from "../authorization"
 import type { SixbRuntimeContext } from "../runtime/types"
 import {
   type AgentContextEntryInput,
@@ -24,9 +23,7 @@ export async function resolveAgentContextParts(
       invalidContext(`context references an unknown object type '${objectTypeId}'`)
     }
 
-    assertAuthorized(runtime, { kind: "object.view", objectTypeId })
-    const object = await runtime.storage.objects.getByPrimaryId({
-      projectId: runtime.projectId,
+    const object = await runtime.objectReader.getByPrimaryId({
       objectTypeId,
       primaryId,
     })

--- a/packages/core/src/authorization/decision.ts
+++ b/packages/core/src/authorization/decision.ts
@@ -135,6 +135,12 @@ export function isAllowed(
 
 export function assertAuthorized(runtime: AuthorizedRuntime, request: AuthzRequest): void {
   const resolved = assertRuntimeAuthorizationBound(runtime)
+  if (resolved.type === "delegated") {
+    throw new AuthorizationError(
+      `delegated:${request.kind}`,
+      `[Sixb] Operation '${request.kind}' is not covered by delegated authorization.`
+    )
+  }
   const authorization = resolved.type === "principal" ? resolved.context : undefined
   const decision = evaluate(authorization, request)
   if (decision.allowed) {

--- a/packages/core/src/execution/authorization.ts
+++ b/packages/core/src/execution/authorization.ts
@@ -226,30 +226,44 @@ export function assertExecutionScopeProject(projectId: string, scope: ExecutionS
   }
 }
 
+/**
+ * Capture the two opaque capabilities carried by a scope exactly once.
+ *
+ * Security-sensitive boundaries must not resolve a caller-owned wrapper and then read it again:
+ * accessor-backed inputs could otherwise substitute a different execution or authority between
+ * those operations.
+ */
+export function captureExecutionScope(scope: ExecutionScope): ExecutionScope {
+  const execution = scope.execution
+  const authorization = scope.authorization
+  return Object.freeze({ execution, authorization })
+}
+
 /** Validate that one registered authority belongs to the exact execution it accompanies. */
 export function resolveExecutionScopeAuthorization(
   projectId: string,
   scope: ExecutionScope
 ): RegisteredRuntimeAuthorization {
-  assertExecutionScopeProject(projectId, scope)
-  const resolved = resolveRuntimeAuthorization(scope.authorization)
+  const capturedScope = captureExecutionScope(scope)
+  assertExecutionScopeProject(projectId, capturedScope)
+  const resolved = resolveRuntimeAuthorization(capturedScope.authorization)
   if (resolved.type === "denied") {
     throw createSixbError(
       "internal.unexpected",
       "[Sixb] Execution scope carries unregistered runtime authorization.",
-      { details: { executionId: scope.execution.id, projectId } }
+      { details: { executionId: capturedScope.execution.id, projectId } }
     )
   }
 
-  const registration = registeredAuthorizations.get(scope.authorization)
-  if (!registration || !executionMatchesBinding(registration.execution, scope.execution)) {
+  const registration = registeredAuthorizations.get(capturedScope.authorization)
+  if (!registration || !executionMatchesBinding(registration.execution, capturedScope.execution)) {
     throw invalidExecutionAuthority(
-      scope.execution.id,
+      capturedScope.execution.id,
       "authority is bound to different execution provenance"
     )
   }
 
-  assertResolvedAuthorizationMatchesExecution(resolved, scope.execution)
+  assertResolvedAuthorizationMatchesExecution(resolved, capturedScope.execution)
   return resolved
 }
 

--- a/packages/core/src/execution/authorization.ts
+++ b/packages/core/src/execution/authorization.ts
@@ -5,6 +5,15 @@ import { TARGETED_GRANT_KIND_KEYS, type TargetedGrantKind } from "../authorizati
 import type { AuthorizationContext, GrantIndex } from "../authorization/types"
 import { createSixbError } from "../errors/internal"
 import {
+  type ObjectReadExecutionLimits,
+  snapshotObjectReadExecutionLimits,
+} from "../storage/objects/execution-limits"
+import { compileSelectedObjectReadScope } from "../storage/objects/read-scope"
+import type {
+  CompiledSelectedObjectReadScope,
+  SelectedObjectReadScope,
+} from "../storage/objects/types"
+import {
   type AuthorizablePrincipal,
   type AuthorizationRef,
   createRuntimeAuthorizationCapability,
@@ -29,7 +38,18 @@ export type ResolvedRuntimeAuthorization =
       readonly projectId: string
       readonly ref: Exclude<AuthorizationRef, { readonly type: "principal" }>
     }
+  | {
+      readonly type: "delegated"
+      readonly projectId: string
+      readonly objectRead: DelegatedObjectReadAuthorization
+    }
   | { readonly type: "denied" }
+
+/** Immutable process-local object-read authority. It has no durable representation. */
+export interface DelegatedObjectReadAuthorization {
+  readonly scope: CompiledSelectedObjectReadScope
+  readonly limits: ObjectReadExecutionLimits
+}
 
 type RegisteredRuntimeAuthorization = Exclude<
   ResolvedRuntimeAuthorization,
@@ -127,6 +147,33 @@ export function createDisabledRuntimeAuthorization(
   })
 }
 
+/** Register exact object-read authority without fabricating a principal identity. */
+export function createDelegatedRuntimeAuthorization(input: {
+  readonly execution: ExecutionContext
+  readonly objectRead: {
+    readonly selection: SelectedObjectReadScope
+    readonly limits: ObjectReadExecutionLimits
+  }
+}): RuntimeAuthorization {
+  const execution = input.execution
+  const objectReadInput = input.objectRead
+  if (execution.executor.type !== "request" || execution.requestedBy !== undefined) {
+    throw new Error(
+      "[Sixb] Delegated runtime authorization requires a request execution without a principal."
+    )
+  }
+
+  const objectRead = Object.freeze({
+    scope: compileSelectedObjectReadScope(objectReadInput.selection),
+    limits: snapshotObjectReadExecutionLimits(objectReadInput.limits),
+  })
+  return register(execution, {
+    type: "delegated",
+    projectId: execution.projectId,
+    objectRead,
+  })
+}
+
 export function createTrustedPrimitiveRuntimeAuthorization(input: {
   readonly execution: ExecutionContext
   readonly primitive: TrustedPrimitiveRef
@@ -183,6 +230,11 @@ export function getAuthorizationRef(authorization: RuntimeAuthorization): Author
   const resolved = resolveRuntimeAuthorization(authorization)
   if (resolved.type === "denied") {
     throw new Error("[Sixb] Runtime authorization is not a registered Core capability.")
+  }
+  if (resolved.type === "delegated") {
+    throw new Error(
+      "[Sixb] Delegated runtime authorization cannot cross a durable execution boundary."
+    )
   }
   return cloneAuthorizationRef(resolved.ref)
 }
@@ -279,11 +331,8 @@ function assertResolvedAuthorizationMatchesExecution(
       ) {
         throw invalidExecutionAuthority(execution.id, "request source does not match its executor")
       }
-      if (resolved.ref.type === "principal") {
-        if (
-          resolved.type !== "principal" ||
-          !principalsEqual(execution.requestedBy, resolved.ref.principal)
-        ) {
+      if (resolved.type === "principal") {
+        if (!principalsEqual(execution.requestedBy, resolved.ref.principal)) {
           throw invalidExecutionAuthority(
             execution.id,
             "request authority does not match its requested-by principal"
@@ -291,14 +340,22 @@ function assertResolvedAuthorizationMatchesExecution(
         }
         return
       }
-      if (resolved.ref.type === "disabled" && execution.requestedBy === undefined) return
+      if (
+        resolved.type === "unrestricted" &&
+        resolved.ref.type === "disabled" &&
+        execution.requestedBy === undefined
+      ) {
+        return
+      }
+      if (resolved.type === "delegated" && execution.requestedBy === undefined) return
       throw invalidExecutionAuthority(
         execution.id,
-        "request execution requires principal or explicitly disabled authority"
+        "request execution requires principal, delegated, or explicitly disabled authority"
       )
 
     case "primitive":
       if (
+        resolved.type !== "unrestricted" ||
         resolved.ref.type !== "trustedPrimitive" ||
         resolved.ref.primitive.kind !== execution.executor.kind ||
         resolved.ref.primitive.id !== execution.executor.id ||
@@ -347,6 +404,7 @@ function assertResolvedAuthorizationMatchesExecution(
 
     case "kernel":
       if (
+        resolved.type !== "unrestricted" ||
         resolved.ref.type !== "kernel" ||
         execution.requestedBy !== undefined ||
         resolved.ref.operation.type !== execution.executor.operation.type ||

--- a/packages/core/src/execution/authorized-object-reader.ts
+++ b/packages/core/src/execution/authorized-object-reader.ts
@@ -472,8 +472,9 @@ function objectStorageForAuthority(
         scope: authority.objectRead.scope,
         limits: authority.objectRead.limits,
       })
+    default:
+      return assertNever(authority)
   }
-  return assertNever(authority)
 }
 
 function assertNever(value: never): never {

--- a/packages/core/src/execution/authorized-object-reader.ts
+++ b/packages/core/src/execution/authorized-object-reader.ts
@@ -1,0 +1,455 @@
+import { assertAuthorized, isAllowed } from "../authorization"
+import type { AuthorizationContext } from "../authorization/types"
+import {
+  countObjects,
+  type ExecuteObjectCountInput,
+  type ExecuteObjectCountResult,
+  type ExecuteObjectExistsInput,
+  type ExecuteObjectExistsResult,
+  type ExecuteObjectFacetsInput,
+  type ExecuteObjectFacetsResult,
+  type ExecuteObjectQueryInput,
+  type ExecuteObjectQueryLinksInput,
+  type ExecuteObjectQueryLinksResult,
+  type ExecuteObjectQueryResult,
+  executeObjectQuery,
+  executeObjectQueryLinks,
+  existsObjects,
+  facetObjects,
+} from "../objects/query"
+import { ObjectQueryValidationError } from "../objects/query/errors"
+import type { ObjectQuery } from "../objects/query/ir"
+import type { OntologyRegistry } from "../ontology"
+import type { LinkBatchKey, ObjectLinkRow, ObjectReadStorage, ObjectStorage } from "../storage"
+import { captureExecutionScope, resolveExecutionScopeAuthorization } from "./authorization"
+import type { ExecutionScope, RuntimeAuthorization } from "./types"
+
+type RuntimeReadAuthorization = {
+  readonly projectId: string
+  readonly runtimeAuthorization: RuntimeAuthorization
+  readonly authorization?: AuthorizationContext
+}
+
+type ResolvedExecutionAuthority = ReturnType<typeof resolveExecutionScopeAuthorization>
+type GetObjectInput = Omit<Parameters<ObjectReadStorage["getByPrimaryId"]>[0], "projectId">
+type GetObjectsInput = Omit<Parameters<ObjectReadStorage["getByPrimaryIdBatch"]>[0], "projectId">
+type SelectObjectPropertiesInput = Parameters<ObjectReadStorage["selectsObjectProperties"]>[0]
+type CanReadObjectPropertyInput = SelectObjectPropertiesInput["items"][number]
+type CanReadObjectPropertiesBatchInput = Omit<SelectObjectPropertiesInput, "projectId">
+type ListObjectsInput = Omit<Parameters<ObjectReadStorage["list"]>[0], "projectId">
+type ListLinksInput = Omit<Parameters<ObjectReadStorage["listLinks"]>[0], "projectId">
+type ListLinksBatchInput = Omit<Parameters<ObjectReadStorage["listLinksBatch"]>[0], "projectId">
+
+const readerConstructionKey = Object.freeze({})
+
+/**
+ * Core-owned object read boundary for one exact execution authority.
+ *
+ * The implementation class is intentionally private to this module. Its private fields make the
+ * exported instance type nominal, while the construction key prevents code that discovers the
+ * JavaScript constructor through an instance from manufacturing another reader.
+ */
+class AuthorizedObjectReaderImpl {
+  readonly #authorization: RuntimeAuthorization
+  readonly #authority: ResolvedExecutionAuthority
+  readonly #runtime: RuntimeReadAuthorization
+  readonly #ontology: OntologyRegistry
+  readonly #storage: ObjectReadStorage
+
+  constructor(
+    key: typeof readerConstructionKey,
+    input: {
+      readonly scope: ExecutionScope
+      readonly ontology: OntologyRegistry
+      readonly storage: ObjectReadStorage
+      readonly authority: ResolvedExecutionAuthority
+    }
+  ) {
+    if (key !== readerConstructionKey) {
+      throw new Error("[Sixb] AuthorizedObjectReader can only be created by Core.")
+    }
+
+    this.#authorization = input.scope.authorization
+    this.#authority = input.authority
+    this.#ontology = input.ontology
+    this.#storage = input.storage
+    this.#runtime = Object.freeze({
+      projectId: input.scope.execution.projectId,
+      runtimeAuthorization: input.scope.authorization,
+      ...(input.authority.type === "principal" ? { authorization: input.authority.context } : {}),
+    })
+  }
+
+  static assertBound(reader: AuthorizedObjectReaderImpl, scope: ExecutionScope): void {
+    const capturedScope = captureExecutionScope(scope)
+    resolveExecutionScopeAuthorization(reader.#runtime.projectId, capturedScope)
+    if (capturedScope.authorization !== reader.#authorization) {
+      throw new Error(
+        "[Sixb] AuthorizedObjectReader is not bound to this exact execution authority."
+      )
+    }
+  }
+
+  /** Project identity carried by this nominal reader capability. */
+  get projectId(): string {
+    return this.#runtime.projectId
+  }
+
+  async getByPrimaryId(input: GetObjectInput): ReturnType<ObjectReadStorage["getByPrimaryId"]> {
+    const request = snapshotReadValue({
+      objectTypeId: input.objectTypeId,
+      primaryId: input.primaryId,
+    })
+    this.#assertObjectTypesViewable([request.objectTypeId])
+    return detachReadResult(
+      await this.#storage.getByPrimaryId({
+        ...request,
+        projectId: this.#runtime.projectId,
+      })
+    )
+  }
+
+  async getByPrimaryIdBatch(
+    input: GetObjectsInput
+  ): ReturnType<ObjectReadStorage["getByPrimaryIdBatch"]> {
+    const request = snapshotReadValue({
+      items: input.items.map((item) => ({
+        objectTypeId: item.objectTypeId,
+        primaryId: item.primaryId,
+      })),
+    })
+    this.#assertObjectTypesViewable(request.items.map((item) => item.objectTypeId))
+    return detachReadResult(
+      await this.#storage.getByPrimaryIdBatch({
+        ...request,
+        projectId: this.#runtime.projectId,
+      })
+    )
+  }
+
+  async canReadObjectProperty(input: CanReadObjectPropertyInput): Promise<boolean> {
+    const request = snapshotReadValue({
+      objectTypeId: input.objectTypeId,
+      primaryId: input.primaryId,
+      propertyId: input.propertyId,
+    })
+    this.#assertObjectTypesViewable([request.objectTypeId])
+    const [readable] = await this.#storage.selectsObjectProperties({
+      projectId: this.#runtime.projectId,
+      items: [request],
+    })
+    return readable ?? false
+  }
+
+  async canReadObjectPropertiesBatch(
+    input: CanReadObjectPropertiesBatchInput
+  ): Promise<readonly boolean[]> {
+    const request = snapshotReadValue({
+      items: input.items.map((item) => ({
+        objectTypeId: item.objectTypeId,
+        primaryId: item.primaryId,
+        propertyId: item.propertyId,
+      })),
+    })
+    this.#assertObjectTypesViewable(request.items.map((item) => item.objectTypeId))
+    return detachReadResult(
+      await this.#storage.selectsObjectProperties({
+        ...request,
+        projectId: this.#runtime.projectId,
+      })
+    )
+  }
+
+  async list(input: ListObjectsInput): ReturnType<ObjectReadStorage["list"]> {
+    const request = snapshotReadValue({
+      objectTypeId:
+        typeof input.objectTypeId === "string"
+          ? input.objectTypeId
+          : input.objectTypeId === undefined
+            ? undefined
+            : [...input.objectTypeId],
+      primaryIdPrefix: input.primaryIdPrefix,
+      primaryIdSuffix: input.primaryIdSuffix,
+      updatedAfter: input.updatedAfter,
+      updatedBefore: input.updatedBefore,
+      createdAfter: input.createdAfter,
+      createdBefore: input.createdBefore,
+      limit: input.limit,
+      offset: input.offset,
+      orderBy: input.orderBy,
+      order: input.order,
+    })
+    const objectTypeId = this.#resolveListObjectTypes(request.objectTypeId)
+
+    // An empty type selection means "none", never "all". Short-circuiting here prevents a
+    // provider with different empty-array semantics from turning a principal read into a broad one.
+    if (Array.isArray(objectTypeId) && objectTypeId.length === 0) {
+      return { objects: [], hasMore: false, total: 0 }
+    }
+
+    return detachReadResult(
+      await this.#storage.list({
+        ...request,
+        ...(objectTypeId === undefined ? {} : { objectTypeId }),
+        projectId: this.#runtime.projectId,
+      })
+    )
+  }
+
+  async listLinks(input: ListLinksInput): ReturnType<ObjectReadStorage["listLinks"]> {
+    const request = snapshotReadValue({
+      objectTypeId: input.objectTypeId,
+      objectId: input.objectId,
+      linkId: input.linkId,
+      direction: input.direction,
+    })
+    this.#assertObjectTypesViewable([request.objectTypeId])
+    const links = detachReadResult(
+      await this.#storage.listLinks({
+        ...request,
+        projectId: this.#runtime.projectId,
+      })
+    )
+    return links.filter((link) => this.#isLinkViewable(link))
+  }
+
+  async listLinksBatch(
+    input: ListLinksBatchInput
+  ): ReturnType<ObjectReadStorage["listLinksBatch"]> {
+    const request = snapshotReadValue({
+      direction: input.direction,
+      items: input.items.map((item) => ({
+        objectTypeId: item.objectTypeId,
+        objectId: item.objectId,
+        linkId: item.linkId,
+      })),
+    })
+    this.#assertObjectTypesViewable(request.items.map((item) => item.objectTypeId))
+    const pages = detachReadResult(
+      await this.#storage.listLinksBatch({
+        ...request,
+        projectId: this.#runtime.projectId,
+      })
+    )
+    const filtered = new Map<LinkBatchKey, ObjectLinkRow[]>()
+    for (const [key, links] of pages) {
+      filtered.set(
+        key,
+        links.filter((link) => this.#isLinkViewable(link))
+      )
+    }
+    return filtered
+  }
+
+  async executeQuery(
+    input: Omit<ExecuteObjectQueryInput, "projectId">
+  ): Promise<ExecuteObjectQueryResult> {
+    const query = snapshotAuthoredQuery(input.query)
+    const includeTotal = snapshotReadValue(input.includeTotal)
+    return detachReadResult(
+      await executeObjectQuery(
+        {
+          query,
+          ...(includeTotal === undefined ? {} : { includeTotal }),
+          projectId: this.#runtime.projectId,
+        },
+        this.#queryExecutorOptions()
+      )
+    )
+  }
+
+  async queryLinks(
+    input: Omit<ExecuteObjectQueryLinksInput, "projectId">
+  ): Promise<ExecuteObjectQueryLinksResult> {
+    const query = snapshotAuthoredQuery(input.query)
+    const request = snapshotReadValue({
+      direction: input.direction,
+      linkId: input.linkId,
+      includeObjects: input.includeObjects,
+      pageSize: input.pageSize,
+      pageToken: input.pageToken,
+    })
+    const result = detachReadResult(
+      await executeObjectQueryLinks(
+        { query, ...request, projectId: this.#runtime.projectId },
+        this.#queryExecutorOptions()
+      )
+    )
+
+    // Link pagination is computed by the provider-facing executor. Filtering afterward would make
+    // its cursor and hasMore metadata describe hidden rows, so a provider contract violation must
+    // fail closed instead of returning a partially filtered page.
+    if (
+      result.objects.some((row) => !this.#isObjectTypeViewable(row.objectTypeId)) ||
+      result.links.some((link) => !this.#isLinkViewable(link))
+    ) {
+      throw new Error("[Sixb] Object storage returned a link page outside its authorized scope.")
+    }
+    return result
+  }
+
+  async count(
+    input: Omit<ExecuteObjectCountInput, "projectId">
+  ): Promise<ExecuteObjectCountResult> {
+    const query = snapshotAuthoredQuery(input.query)
+    return detachReadResult(
+      await countObjects(
+        { query, projectId: this.#runtime.projectId },
+        this.#queryExecutorOptions()
+      )
+    )
+  }
+
+  async exists(
+    input: Omit<ExecuteObjectExistsInput, "projectId">
+  ): Promise<ExecuteObjectExistsResult> {
+    const query = snapshotAuthoredQuery(input.query)
+    return detachReadResult(
+      await existsObjects(
+        { query, projectId: this.#runtime.projectId },
+        this.#queryExecutorOptions()
+      )
+    )
+  }
+
+  async facet(
+    input: Omit<ExecuteObjectFacetsInput, "projectId">
+  ): Promise<ExecuteObjectFacetsResult> {
+    const query = snapshotAuthoredQuery(input.query)
+    const facets = snapshotReadValue(
+      input.facets.map((facet) => ({ propertyId: facet.propertyId, limit: facet.limit }))
+    )
+    return detachReadResult(
+      await facetObjects(
+        { query, facets, projectId: this.#runtime.projectId },
+        this.#queryExecutorOptions()
+      )
+    )
+  }
+
+  #queryExecutorOptions() {
+    return {
+      ontology: this.#ontology,
+      storage: this.#storage,
+      runtimeAuthorization: this.#runtime.runtimeAuthorization,
+      ...(this.#runtime.authorization === undefined
+        ? {}
+        : { authorization: this.#runtime.authorization }),
+    }
+  }
+
+  #assertObjectTypesViewable(objectTypeIds: readonly string[]): void {
+    for (const objectTypeId of new Set(objectTypeIds)) {
+      assertAuthorized(this.#runtime, { kind: "object.view", objectTypeId })
+    }
+  }
+
+  #resolveListObjectTypes(
+    requested: ListObjectsInput["objectTypeId"]
+  ): ListObjectsInput["objectTypeId"] {
+    if (requested !== undefined) {
+      const objectTypeIds = typeof requested === "string" ? [requested] : [...new Set(requested)]
+      for (const objectTypeId of objectTypeIds) {
+        this.#ontology.resolveObjectType(objectTypeId)
+      }
+      this.#assertObjectTypesViewable(objectTypeIds)
+      return typeof requested === "string" ? requested : objectTypeIds
+    }
+
+    if (this.#authority.type === "unrestricted") return undefined
+    return this.#ontology
+      .listObjectTypes()
+      .map((objectType) => objectType.id)
+      .filter((objectTypeId) => this.#isObjectTypeViewable(objectTypeId))
+  }
+
+  #isObjectTypeViewable(objectTypeId: string): boolean {
+    return isAllowed(this.#runtime.authorization, { kind: "object.view", objectTypeId })
+  }
+
+  #isLinkViewable(link: ObjectLinkRow): boolean {
+    return (
+      this.#isObjectTypeViewable(link.sourceTypeId) && this.#isObjectTypeViewable(link.targetTypeId)
+    )
+  }
+}
+
+Object.freeze(AuthorizedObjectReaderImpl.prototype)
+Object.freeze(AuthorizedObjectReaderImpl)
+
+export type AuthorizedObjectReader = AuthorizedObjectReaderImpl
+
+/** Build the sole application-facing object reader for one registered execution scope. */
+export function createAuthorizedObjectReader(input: {
+  readonly scope: ExecutionScope
+  readonly ontology: OntologyRegistry
+  readonly objectStorage: ObjectStorage
+}): AuthorizedObjectReader {
+  const scope = captureExecutionScope(input.scope)
+  const projectId = scope.execution.projectId
+  const authority = resolveExecutionScopeAuthorization(projectId, scope)
+  const storage = objectStorageForAuthority(authority, input.objectStorage)
+  const reader = new AuthorizedObjectReaderImpl(readerConstructionKey, {
+    scope,
+    ontology: input.ontology,
+    storage,
+    authority,
+  })
+  Object.freeze(reader)
+  return reader
+}
+
+/** Reject recombining an authorized reader with any other execution authority. */
+export function assertAuthorizedObjectReaderBinding(input: {
+  readonly reader: AuthorizedObjectReader
+  readonly scope: ExecutionScope
+}): void {
+  AuthorizedObjectReaderImpl.assertBound(input.reader, input.scope)
+}
+
+function objectStorageForAuthority(
+  authority: ResolvedExecutionAuthority,
+  objectStorage: ObjectStorage
+): ObjectReadStorage {
+  switch (authority.type) {
+    case "principal":
+    case "unrestricted":
+      return objectStorage
+  }
+  return assertNever(authority)
+}
+
+function assertNever(value: never): never {
+  throw new Error(
+    `[Sixb] Unsupported object reader authority '${String((value as { type?: unknown }).type)}'.`
+  )
+}
+
+/**
+ * Storage providers may optimize trusted reads with live references. Values crossing the
+ * application-facing authorization boundary must not retain them.
+ */
+function detachReadResult<T>(value: T): T {
+  return structuredClone(value)
+}
+
+/** Capture caller-owned values before authorization and execution. */
+function snapshotReadValue<T>(value: T): T {
+  return structuredClone(value)
+}
+
+/** Capture one serializable query before either authorization or execution sees it. */
+function snapshotAuthoredQuery(query: ObjectQuery): ObjectQuery {
+  try {
+    return structuredClone(query)
+  } catch (error) {
+    if (error instanceof ObjectQueryValidationError) throw error
+    throw new ObjectQueryValidationError([
+      {
+        path: "$",
+        code: "query_not_cloneable",
+        message: "Object query must contain only structured-cloneable data",
+      },
+    ])
+  }
+}

--- a/packages/core/src/execution/authorized-object-reader.ts
+++ b/packages/core/src/execution/authorized-object-reader.ts
@@ -1,4 +1,5 @@
 import { assertAuthorized, isAllowed } from "../authorization"
+import { AuthorizationError } from "../authorization/errors"
 import type { AuthorizationContext } from "../authorization/types"
 import {
   countObjects,
@@ -20,7 +21,13 @@ import {
 import { ObjectQueryValidationError } from "../objects/query/errors"
 import type { ObjectQuery } from "../objects/query/ir"
 import type { OntologyRegistry } from "../ontology"
-import type { LinkBatchKey, ObjectLinkRow, ObjectReadStorage, ObjectStorage } from "../storage"
+import type {
+  CompiledObjectReadStep,
+  LinkBatchKey,
+  ObjectLinkRow,
+  ObjectReadStorage,
+  ObjectStorage,
+} from "../storage"
 import { captureExecutionScope, resolveExecutionScopeAuthorization } from "./authorization"
 import type { ExecutionScope, RuntimeAuthorization } from "./types"
 
@@ -55,6 +62,8 @@ class AuthorizedObjectReaderImpl {
   readonly #runtime: RuntimeReadAuthorization
   readonly #ontology: OntologyRegistry
   readonly #storage: ObjectReadStorage
+  readonly #delegatedObjectTypeIds?: ReadonlySet<string>
+  readonly #delegatedLinkDefinitions?: ReadonlySet<string>
 
   constructor(
     key: typeof readerConstructionKey,
@@ -73,6 +82,14 @@ class AuthorizedObjectReaderImpl {
     this.#authority = input.authority
     this.#ontology = input.ontology
     this.#storage = input.storage
+    this.#delegatedObjectTypeIds =
+      input.authority.type === "delegated"
+        ? new Set(input.authority.objectRead.scope.objects.map((object) => object.objectTypeId))
+        : undefined
+    this.#delegatedLinkDefinitions =
+      input.authority.type === "delegated"
+        ? new Set(input.authority.objectRead.scope.steps.map(delegatedLinkDefinitionKey))
+        : undefined
     this.#runtime = Object.freeze({
       projectId: input.scope.execution.projectId,
       runtimeAuthorization: input.scope.authorization,
@@ -244,6 +261,7 @@ class AuthorizedObjectReaderImpl {
   async executeQuery(
     input: Omit<ExecuteObjectQueryInput, "projectId">
   ): Promise<ExecuteObjectQueryResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     const includeTotal = snapshotReadValue(input.includeTotal)
     return detachReadResult(
@@ -261,6 +279,7 @@ class AuthorizedObjectReaderImpl {
   async queryLinks(
     input: Omit<ExecuteObjectQueryLinksInput, "projectId">
   ): Promise<ExecuteObjectQueryLinksResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     const request = snapshotReadValue({
       direction: input.direction,
@@ -291,6 +310,7 @@ class AuthorizedObjectReaderImpl {
   async count(
     input: Omit<ExecuteObjectCountInput, "projectId">
   ): Promise<ExecuteObjectCountResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     return detachReadResult(
       await countObjects(
@@ -303,6 +323,7 @@ class AuthorizedObjectReaderImpl {
   async exists(
     input: Omit<ExecuteObjectExistsInput, "projectId">
   ): Promise<ExecuteObjectExistsResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     return detachReadResult(
       await existsObjects(
@@ -315,6 +336,7 @@ class AuthorizedObjectReaderImpl {
   async facet(
     input: Omit<ExecuteObjectFacetsInput, "projectId">
   ): Promise<ExecuteObjectFacetsResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     const facets = snapshotReadValue(
       input.facets.map((facet) => ({ propertyId: facet.propertyId, limit: facet.limit }))
@@ -339,6 +361,17 @@ class AuthorizedObjectReaderImpl {
   }
 
   #assertObjectTypesViewable(objectTypeIds: readonly string[]): void {
+    if (this.#authority.type === "delegated") {
+      for (const objectTypeId of new Set(objectTypeIds)) {
+        if (this.#delegatedObjectTypeIds?.has(objectTypeId)) continue
+        throw new AuthorizationError(
+          `delegated:object.view:${objectTypeId}`,
+          `[Sixb] Delegated authorization does not select object type '${objectTypeId}'.`
+        )
+      }
+      return
+    }
+
     for (const objectTypeId of new Set(objectTypeIds)) {
       assertAuthorized(this.#runtime, { kind: "object.view", objectTypeId })
     }
@@ -364,12 +397,30 @@ class AuthorizedObjectReaderImpl {
   }
 
   #isObjectTypeViewable(objectTypeId: string): boolean {
+    if (this.#authority.type === "delegated") {
+      return this.#delegatedObjectTypeIds?.has(objectTypeId) ?? false
+    }
     return isAllowed(this.#runtime.authorization, { kind: "object.view", objectTypeId })
   }
 
+  #assertDelegatedQueriesAdmitted(): void {
+    if (this.#authority.type !== "delegated") return
+    throw new AuthorizationError(
+      "delegated:object.query",
+      "[Sixb] Object Query terminals require explicit selected-path admission under delegated authorization."
+    )
+  }
+
   #isLinkViewable(link: ObjectLinkRow): boolean {
+    if (
+      !this.#isObjectTypeViewable(link.sourceTypeId) ||
+      !this.#isObjectTypeViewable(link.targetTypeId)
+    ) {
+      return false
+    }
     return (
-      this.#isObjectTypeViewable(link.sourceTypeId) && this.#isObjectTypeViewable(link.targetTypeId)
+      this.#delegatedLinkDefinitions?.has(delegatedLinkDefinitionKey(link)) ??
+      this.#authority.type !== "delegated"
     )
   }
 }
@@ -415,6 +466,12 @@ function objectStorageForAuthority(
     case "principal":
     case "unrestricted":
       return objectStorage
+    case "delegated":
+      return objectStorage.createSelectedReadScope({
+        projectId: authority.projectId,
+        scope: authority.objectRead.scope,
+        limits: authority.objectRead.limits,
+      })
   }
   return assertNever(authority)
 }
@@ -423,6 +480,16 @@ function assertNever(value: never): never {
   throw new Error(
     `[Sixb] Unsupported object reader authority '${String((value as { type?: unknown }).type)}'.`
   )
+}
+
+function delegatedLinkDefinitionKey(
+  input:
+    | Pick<CompiledObjectReadStep, "sourceObjectTypeId" | "linkId" | "targetObjectTypeId">
+    | Pick<ObjectLinkRow, "sourceTypeId" | "linkId" | "targetTypeId">
+): string {
+  return "sourceObjectTypeId" in input
+    ? JSON.stringify([input.sourceObjectTypeId, input.linkId, input.targetObjectTypeId])
+    : JSON.stringify([input.sourceTypeId, input.linkId, input.targetTypeId])
 }
 
 /**

--- a/packages/core/src/execution/scopes.ts
+++ b/packages/core/src/execution/scopes.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto"
 import type { AuthorizationContext } from "../authorization"
+import type { ObjectReadExecutionLimits, SelectedObjectReadScope } from "../storage"
 import {
+  createDelegatedRuntimeAuthorization,
   createDisabledRuntimeAuthorization,
   createKernelRuntimeAuthorization,
   createPrincipalRuntimeAuthorization,
@@ -47,6 +49,26 @@ export function createDisabledRequestScope(input: {
   return Object.freeze({
     execution,
     authorization: createDisabledRuntimeAuthorization(execution),
+  })
+}
+
+/** Internal request scope carrying only a finite object-read selection. */
+export function createDelegatedRequestScope(input: {
+  readonly projectId: string
+  readonly requestId: string
+  readonly correlationId: string
+  readonly objectRead: {
+    readonly selection: SelectedObjectReadScope
+    readonly limits: ObjectReadExecutionLimits
+  }
+}): ExecutionScope {
+  const execution = createRequestExecution(input)
+  return Object.freeze({
+    execution,
+    authorization: createDelegatedRuntimeAuthorization({
+      execution,
+      objectRead: input.objectRead,
+    }),
   })
 }
 

--- a/packages/core/src/objects/execution.ts
+++ b/packages/core/src/objects/execution.ts
@@ -1,5 +1,6 @@
 import { assertAuthorized, isAllowed } from "../authorization"
 import type { ExecutionContext } from "../execution"
+import { assertAuthorizedObjectReaderBinding } from "../execution/authorized-object-reader"
 import type { ValueType } from "../ontology"
 import { assertObjectTypeRegistered } from "../ontology"
 import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
@@ -20,22 +21,17 @@ import type {
   TimeseriesHistoryBatchResult,
   TimeseriesPoint,
 } from "../storage"
-import {
-  countObjects,
-  type ExecuteObjectCountInput,
-  type ExecuteObjectCountResult,
-  type ExecuteObjectExistsInput,
-  type ExecuteObjectExistsResult,
-  type ExecuteObjectFacetsInput,
-  type ExecuteObjectFacetsResult,
-  type ExecuteObjectQueryInput,
-  type ExecuteObjectQueryLinksInput,
-  type ExecuteObjectQueryLinksResult,
-  type ExecuteObjectQueryResult,
-  executeObjectQuery,
-  executeObjectQueryLinks,
-  existsObjects,
-  facetObjects,
+import type {
+  ExecuteObjectCountInput,
+  ExecuteObjectCountResult,
+  ExecuteObjectExistsInput,
+  ExecuteObjectExistsResult,
+  ExecuteObjectFacetsInput,
+  ExecuteObjectFacetsResult,
+  ExecuteObjectQueryInput,
+  ExecuteObjectQueryLinksInput,
+  ExecuteObjectQueryLinksResult,
+  ExecuteObjectQueryResult,
 } from "./query"
 import { createObjectSet } from "./sdk"
 import type { ListObjectsParams } from "./service"
@@ -173,6 +169,10 @@ export function createObjectsRuntime<TOntologySources extends readonly OntologyS
   runtime: SixbRuntimeContext,
   execution: ExecutionContext
 ): ObjectsRuntime<TOntologySources> {
+  assertAuthorizedObjectReaderBinding({
+    reader: runtime.objectReader,
+    scope: { execution, authorization: runtime.runtimeAuthorization },
+  })
   const objects = Object.assign(
     <TObjectType extends RegisteredObjectType<TOntologySources>>(objectType: TObjectType) => {
       assertObjectTypeRegistered(runtime.ontology.getObjectTypesById(), objectType)
@@ -209,77 +209,21 @@ export function createObjectsRuntime<TOntologySources extends readonly OntologyS
       isValidLinkTarget: (expected: string | string[], actual: string) =>
         runtime.ontology.isValidLinkTarget(expected, actual),
       executeQuery: (input: Omit<ExecuteObjectQueryInput, "projectId">) =>
-        executeObjectQuery(
-          { projectId: runtime.projectId, ...input },
-          {
-            ontology: runtime.ontology,
-            storage: runtime.storage.objects,
-            runtimeAuthorization: runtime.runtimeAuthorization,
-            authorization: runtime.authorization,
-          }
-        ),
-      queryLinks: (input: ObjectQueryLinksInput) =>
-        executeObjectQueryLinks(
-          { projectId: runtime.projectId, ...input },
-          {
-            ontology: runtime.ontology,
-            storage: runtime.storage.objects,
-            runtimeAuthorization: runtime.runtimeAuthorization,
-            authorization: runtime.authorization,
-          }
-        ),
+        runtime.objectReader.executeQuery(input),
+      queryLinks: (input: ObjectQueryLinksInput) => runtime.objectReader.queryLinks(input),
       count: (input: Omit<ExecuteObjectCountInput, "projectId">) =>
-        countObjects(
-          { projectId: runtime.projectId, ...input },
-          {
-            ontology: runtime.ontology,
-            storage: runtime.storage.objects,
-            runtimeAuthorization: runtime.runtimeAuthorization,
-            authorization: runtime.authorization,
-          }
-        ),
+        runtime.objectReader.count(input),
       exists: (input: Omit<ExecuteObjectExistsInput, "projectId">) =>
-        existsObjects(
-          { projectId: runtime.projectId, ...input },
-          {
-            ontology: runtime.ontology,
-            storage: runtime.storage.objects,
-            runtimeAuthorization: runtime.runtimeAuthorization,
-            authorization: runtime.authorization,
-          }
-        ),
+        runtime.objectReader.exists(input),
       facet: (input: Omit<ExecuteObjectFacetsInput, "projectId">) =>
-        facetObjects(
-          { projectId: runtime.projectId, ...input },
-          {
-            ontology: runtime.ontology,
-            storage: runtime.storage.objects,
-            runtimeAuthorization: runtime.runtimeAuthorization,
-            authorization: runtime.authorization,
-          }
-        ),
+        runtime.objectReader.facet(input),
       listLinks: async (input: {
         objectTypeId: string
         objectId: string
         linkId?: string
         direction?: LinkDirection
       }) => {
-        assertAuthorized(runtime, { kind: "object.view", objectTypeId: input.objectTypeId })
-        const links = await runtime.storage.objects.listLinks({
-          projectId: runtime.projectId,
-          ...input,
-        })
-        return links.filter(
-          (link) =>
-            isAllowed(runtime.authorization, {
-              kind: "object.view",
-              objectTypeId: link.sourceTypeId,
-            }) &&
-            isAllowed(runtime.authorization, {
-              kind: "object.view",
-              objectTypeId: link.targetTypeId,
-            })
-        )
+        return runtime.objectReader.listLinks(input)
       },
       getTelemetryHistoryBatch: (input: Omit<TimeseriesHistoryBatchInput, "projectId">) =>
         getTelemetryHistoryBatch(
@@ -317,14 +261,8 @@ export function createObjectsRuntime<TOntologySources extends readonly OntologyS
         })
       },
       list: (params: ListObjectsParams) => objectService.listObjects(runtime, params),
-      get: async (objectTypeId: string, primaryId: string) => {
-        assertAuthorized(runtime, { kind: "object.view", objectTypeId })
-        return runtime.storage.objects.getByPrimaryId({
-          projectId: runtime.projectId,
-          objectTypeId,
-          primaryId,
-        })
-      },
+      get: (objectTypeId: string, primaryId: string) =>
+        runtime.objectReader.getByPrimaryId({ objectTypeId, primaryId }),
       getPrimaryPropertyId: (objectTypeId: string) => {
         assertAuthorized(runtime, { kind: "object.view", objectTypeId })
         return runtime.ontology.getPrimaryPropertyId(objectTypeId)

--- a/packages/core/src/objects/sdk/object-handle.ts
+++ b/packages/core/src/objects/sdk/object-handle.ts
@@ -4,7 +4,6 @@
  * per-property telemetry appenders with compile-time unit and value type safety.
  */
 import type { ActionDefinition } from "../../actions"
-import { assertAuthorized, assertPrivileged } from "../../authorization"
 import type { ObjectLink, ObjectRef, ValueType } from "../../ontology"
 import { OntologyValidationError } from "../../ontology/errors"
 import type { LinkToken, ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
@@ -28,9 +27,7 @@ export function createObjectByIdHandle<
 >(ctx: ExecutionObjectContext, primaryId: string): ObjectByIdHandle<TObjectType, TValueTypes> {
   const objectHandle = {
     get: async () => {
-      assertAuthorized(ctx, { kind: "object.view", objectTypeId: ctx.objectType.id })
-      const row = await ctx.storage.objects.getByPrimaryId({
-        projectId: ctx.projectId,
+      const row = await ctx.objectReader.getByPrimaryId({
         objectTypeId: ctx.objectType.id,
         primaryId,
       })
@@ -38,13 +35,10 @@ export function createObjectByIdHandle<
     },
 
     listLinks: async (linkToken?: AnyLinkToken) => {
-      // Link rows reveal target types; no link grant semantics exist yet.
-      assertPrivileged(ctx, "listLinks")
       if (linkToken) {
         assertLinkTokenBelongsToObjectType(ctx.objectType, linkToken)
       }
-      return ctx.storage.objects.listLinks({
-        projectId: ctx.projectId,
+      return ctx.objectReader.listLinks({
         objectTypeId: ctx.objectType.id,
         objectId: primaryId,
         linkId: linkToken?.id,

--- a/packages/core/src/objects/sdk/object-set.ts
+++ b/packages/core/src/objects/sdk/object-set.ts
@@ -6,9 +6,9 @@
 
 import type { ActionDefinition } from "../../actions"
 import type { AuthorizationContext } from "../../authorization"
-import { assertAuthorized } from "../../authorization"
 import { shareSixbErrorReporter } from "../../error-reporting/capability"
 import type { ExecutionContext } from "../../execution"
+import { assertAuthorizedObjectReaderBinding } from "../../execution/authorized-object-reader"
 import type { ValueType } from "../../ontology"
 import { OntologyValidationError } from "../../ontology/errors"
 import type { ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
@@ -43,6 +43,10 @@ export function createObjectSet<
     readonly authorization?: AuthorizationContext
   }
 ): ObjectSet<TObjectType, TValueTypes, TRegisteredObjectTypes> {
+  assertAuthorizedObjectReaderBinding({
+    reader: params.objectReader,
+    scope: { execution: params.execution, authorization: params.runtimeAuthorization },
+  })
   const { objectType } = params
   const primaryProp = objectType.properties.find((p) => p.primary)
   if (!primaryProp) {
@@ -58,16 +62,14 @@ export function createObjectSet<
     events,
     storage,
     queues,
+    objectReader,
     runtimeAuthorization,
     authorization,
     execution,
   } = params
   const queryExecutor = createRuntimeQueryExecutor({
-    projectId,
     ontology,
-    storage,
-    runtimeAuthorization,
-    authorization,
+    objectReader,
   })
 
   const resolvedCtx: ExecutionObjectContext = {
@@ -78,6 +80,7 @@ export function createObjectSet<
     events,
     storage,
     queues,
+    objectReader,
     runtimeAuthorization,
     authorization,
     execution,
@@ -89,9 +92,7 @@ export function createObjectSet<
 
   const objectSet = {
     get: async (id: string) => {
-      assertAuthorized(resolvedCtx, { kind: "object.view", objectTypeId: objectType.id })
-      const row = await storage.objects.getByPrimaryId({
-        projectId,
+      const row = await objectReader.getByPrimaryId({
         objectTypeId: objectType.id,
         primaryId: id,
       })
@@ -112,9 +113,7 @@ export function createObjectSet<
     byId: (id: string) => createObjectByIdHandle<TObjectType, TValueTypes>(resolvedCtx, id),
 
     list: async (input?: ObjectSetListInput) => {
-      assertAuthorized(resolvedCtx, { kind: "object.view", objectTypeId: objectType.id })
-      const result = await storage.objects.list({
-        projectId,
+      const result = await objectReader.list({
         objectTypeId: objectType.id,
         primaryIdPrefix: input?.idPrefix,
         primaryIdSuffix: input?.idSuffix,

--- a/packages/core/src/objects/sdk/runtime-query-executor.ts
+++ b/packages/core/src/objects/sdk/runtime-query-executor.ts
@@ -4,44 +4,24 @@
  * HTTP executor in `@sixb/client` is the remote counterpart.
  */
 
-import type { AuthorizationContext } from "../../authorization"
-import type { RuntimeAuthorization } from "../../execution/types"
+import type { AuthorizedObjectReader } from "../../execution/authorized-object-reader"
 import type { OntologyRegistry } from "../../ontology"
-import type { Storage } from "../../storage"
-import {
-  countObjects,
-  executeObjectQuery,
-  existsObjects,
-  facetObjects,
-  ObjectQueryPlanningError,
-} from "../query"
+import { ObjectQueryPlanningError } from "../query"
 import { explainObjectQuery } from "../query/explain"
 import type { ObjectQuery } from "../query/ir"
 import { validateObjectQuery } from "../query/validate"
 import type { ObjectQueryExecutor, ObjectQueryExecutorFacetRequest } from "./query-executor"
 
 export function createRuntimeQueryExecutor(params: {
-  projectId: string
   ontology: OntologyRegistry
-  storage: Storage
-  runtimeAuthorization?: RuntimeAuthorization
-  authorization?: AuthorizationContext
+  objectReader: AuthorizedObjectReader
 }): ObjectQueryExecutor {
-  const { projectId, ontology, storage, runtimeAuthorization, authorization } = params
-  const executorOptions = {
-    ontology,
-    storage: storage.objects,
-    runtimeAuthorization,
-    authorization,
-  }
+  const { ontology, objectReader } = params
 
   return {
     async list(query: ObjectQuery, options?: { includeTotal?: boolean }) {
       try {
-        return await executeObjectQuery(
-          { projectId, query, includeTotal: options?.includeTotal },
-          executorOptions
-        )
+        return await objectReader.executeQuery({ query, includeTotal: options?.includeTotal })
       } catch (error) {
         if (error instanceof ObjectQueryPlanningError) {
           throw addSdkPlanningHints(error)
@@ -51,17 +31,17 @@ export function createRuntimeQueryExecutor(params: {
     },
 
     async count(query: ObjectQuery) {
-      const result = await countObjects({ projectId, query }, executorOptions)
+      const result = await objectReader.count({ query })
       return result.count
     },
 
     async exists(query: ObjectQuery) {
-      const result = await existsObjects({ projectId, query }, executorOptions)
+      const result = await objectReader.exists({ query })
       return result.exists
     },
 
     async facets(query: ObjectQuery, facets: readonly ObjectQueryExecutorFacetRequest[]) {
-      const result = await facetObjects({ projectId, query, facets }, executorOptions)
+      const result = await objectReader.facet({ query, facets })
       return result.facets.map((facet) => ({
         propertyId: facet.propertyId,
         buckets: [...facet.buckets],

--- a/packages/core/src/objects/service/list-service.ts
+++ b/packages/core/src/objects/service/list-service.ts
@@ -1,12 +1,10 @@
 /**
  * Cross-type object listing for dashboards and search.
  *
- * On principal-bound runtimes the type filter is authorized before the storage call:
- * explicitly requested types must all be viewable, and unfiltered listings
- * narrow to the principal's viewable types instead of post-filtering rows.
+ * Type hierarchies are expanded before the request reaches the canonical object
+ * reader, which owns authorization and provider-scope enforcement.
  */
 
-import { assertAuthorized } from "../../authorization"
 import type { ListResult, SixbRuntimeContext } from "../../runtime/types"
 import type { ObjectRow } from "../../storage"
 
@@ -28,14 +26,13 @@ export async function listObjects(
   runtime: SixbRuntimeContext,
   params: ListObjectsParams
 ): Promise<ListResult<ObjectRow>> {
-  const objectTypeIds = resolveAuthorizedTypeFilter(runtime, params.objectTypeIds)
+  const objectTypeIds = resolveTypeFilter(runtime, params.objectTypeIds)
 
-  if (runtime.authorization && objectTypeIds !== undefined && objectTypeIds.length === 0) {
+  if (objectTypeIds !== undefined && objectTypeIds.length === 0) {
     return { objects: [], hasMore: false, total: 0 }
   }
 
-  const result = await runtime.storage.objects.list({
-    projectId: runtime.projectId,
+  const result = await runtime.objectReader.list({
     objectTypeId: objectTypeIds?.length === 1 ? objectTypeIds[0] : objectTypeIds,
     primaryIdPrefix: params.idPrefix,
     primaryIdSuffix: params.idSuffix,
@@ -56,7 +53,7 @@ export async function listObjects(
   }
 }
 
-function resolveAuthorizedTypeFilter(
+function resolveTypeFilter(
   runtime: SixbRuntimeContext,
   requested: readonly string[] | undefined
 ): readonly string[] | undefined {
@@ -66,24 +63,7 @@ function resolveAuthorizedTypeFilter(
     }
   }
 
-  const expanded = requested
+  return requested
     ? [...new Set(requested.flatMap((id) => [id, ...runtime.ontology.listSubTypes(id)]))]
     : undefined
-
-  if (!runtime.authorization) {
-    return expanded
-  }
-
-  if (!expanded) {
-    // Broad listings narrow to the visible universe rather than failing. The
-    // set already contains every registered type when "all" was granted.
-    return [...runtime.authorization.grants["view:object"]]
-  }
-
-  // Explicitly requested types must all be viewable.
-  for (const objectTypeId of expanded) {
-    assertAuthorized(runtime, { kind: "object.view", objectTypeId })
-  }
-
-  return expanded
 }

--- a/packages/core/src/runtime/host.ts
+++ b/packages/core/src/runtime/host.ts
@@ -36,7 +36,11 @@ import {
   type DomainEventService,
   OntologyOutboxDispatcher,
 } from "../events"
-import { resolveExecutionScopeAuthorization } from "../execution/authorization"
+import {
+  captureExecutionScope,
+  resolveExecutionScopeAuthorization,
+} from "../execution/authorization"
+import { createAuthorizedObjectReader } from "../execution/authorized-object-reader"
 import type { ExecutionScope } from "../execution/types"
 import type { LakeStorage } from "../lake-storage"
 import { type LoggerProvider, LoggingService, type ObservabilityOptions } from "../logging"
@@ -239,24 +243,36 @@ export class SixbHost<
 
   /** Bind an existing opaque scope. This method never creates or escalates authority. */
   withScope(scope: ExecutionScope): Sixb<TOntologySources> {
-    const authorization = resolveExecutionScopeAuthorization(this.projectId, scope)
+    const capturedScope = captureExecutionScope(scope)
+    const authorization = resolveExecutionScopeAuthorization(this.projectId, capturedScope)
     if (authorization.ref.type === "kernel") {
       throw new Error("[Sixb] Kernel authority cannot be bound to the domain SDK.")
     }
 
+    const objectReader = createAuthorizedObjectReader({
+      scope: capturedScope,
+      ontology: this.hostContext.ontology,
+      objectStorage: this.storage.objects,
+    })
+
     const runtime: SixbRuntimeContext = {
       ...this.hostContext,
-      runtimeAuthorization: scope.authorization,
+      runtimeAuthorization: capturedScope.authorization,
+      objectReader,
       ...(authorization.type === "principal" ? { authorization: authorization.context } : {}),
     }
     registerOntologyMutationRuntime(
       runtime,
       createOntologyMutationRuntime({
-        materializer: this.materializer.withScope(scope),
+        materializer: this.materializer.withScope(capturedScope),
         notifyCommittedFacts: () => this.committedFacts.notify(),
       })
     )
-    return createBoundSixb<TOntologySources>(runtime, this.sixbDependencies(), scope.execution)
+    return createBoundSixb<TOntologySources>(
+      runtime,
+      this.sixbDependencies(),
+      capturedScope.execution
+    )
   }
 
   get id(): string {

--- a/packages/core/src/runtime/host.ts
+++ b/packages/core/src/runtime/host.ts
@@ -245,7 +245,12 @@ export class SixbHost<
   withScope(scope: ExecutionScope): Sixb<TOntologySources> {
     const capturedScope = captureExecutionScope(scope)
     const authorization = resolveExecutionScopeAuthorization(this.projectId, capturedScope)
-    if (authorization.ref.type === "kernel") {
+    if (authorization.type === "delegated") {
+      throw new Error(
+        "[Sixb] Delegated runtime authorization cannot be bound to the domain SDK until every delegated surface is activated."
+      )
+    }
+    if (authorization.type === "unrestricted" && authorization.ref.type === "kernel") {
       throw new Error("[Sixb] Kernel authority cannot be bound to the domain SDK.")
     }
 

--- a/packages/core/src/runtime/internal.ts
+++ b/packages/core/src/runtime/internal.ts
@@ -9,6 +9,7 @@ export type {
   StartConnectorAuthorizationResult,
 } from "../connectors/connections/contracts"
 export type { ConnectorConnectionsRuntime } from "../connectors/connections/execution"
+export type { AuthorizedObjectReader } from "../execution/authorized-object-reader"
 export type { OntologyMutationRuntime } from "./ontology-mutations"
 export {
   createOntologyMutationRuntime,

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -12,6 +12,7 @@ import { createDatasetsRuntime, type DatasetsRuntime } from "../datasets/executi
 import { createEventsRuntime, type EventsRuntime } from "../events/execution"
 import type { ExecutionContext } from "../execution"
 import { resolveExecutionScopeAuthorization } from "../execution/authorization"
+import { assertAuthorizedObjectReaderBinding } from "../execution/authorized-object-reader"
 import type { LakeStorage } from "../lake-storage/types"
 import { createLogsRuntime, type LogsRuntime } from "../logging/execution"
 import type { LoggingService } from "../logging/service"
@@ -67,6 +68,10 @@ export function createBoundSixb<TOntologySources extends readonly OntologySource
   resolveExecutionScopeAuthorization(runtime.projectId, {
     execution,
     authorization: runtime.runtimeAuthorization,
+  })
+  assertAuthorizedObjectReaderBinding({
+    reader: runtime.objectReader,
+    scope: { execution, authorization: runtime.runtimeAuthorization },
   })
   const sixb: Sixb<TOntologySources> = {
     execution,

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -15,6 +15,7 @@ import type { AuthorizationContext } from "../authorization"
 import type { Broker } from "../broker"
 import type { DomainEventLog } from "../events"
 import type { RuntimeAuthorization } from "../execution"
+import type { AuthorizedObjectReader } from "../execution/authorized-object-reader"
 import type {
   ObjectQuery,
   ObjectQueryExplanation,
@@ -60,6 +61,8 @@ export interface SixbHostContext {
 /** Host dependencies paired with the process-local authority of one bound execution. */
 export interface SixbRuntimeContext extends SixbHostContext {
   readonly runtimeAuthorization: RuntimeAuthorization
+  /** Core-owned read boundary carrying this exact execution authority. */
+  readonly objectReader: AuthorizedObjectReader
   /**
    * Resolved principal grants. Absent for trusted primitive and explicitly disabled executions.
    * The opaque `runtimeAuthorization` remains the source of authority.

--- a/packages/core/src/storage/in-memory/index.ts
+++ b/packages/core/src/storage/in-memory/index.ts
@@ -21,6 +21,7 @@ import { ProviderMaterializationTransactionLifecycle } from "../ontology/provide
 import {
   createAgentOperationScope,
   createAuthOperationScope,
+  createObjectOperationScope,
   createOntologyOperationScope,
   createOperationScopedFacade,
   createStorageOperationScope,
@@ -134,7 +135,7 @@ export class InMemoryStorage implements Storage {
       (run) => this.withStorageOperation(run),
       () => this.assertRootOperationAvailable()
     )
-    this.objects = createOperationScopedFacade(this.objectStorage, scope)
+    this.objects = createObjectOperationScope(this.objectStorage, scope)
     this.timeseries = createOperationScopedFacade(this.timeseriesStorage, scope)
     this.auth = createAuthOperationScope(this.authStorage, scope)
     this.executions = createOperationScopedFacade(this.executionStorage, scope)

--- a/packages/core/src/storage/objects/guard.ts
+++ b/packages/core/src/storage/objects/guard.ts
@@ -1,0 +1,55 @@
+import type { ObjectReadScopeFactory, ObjectReadStorage, ObjectStorage } from "./types"
+
+export interface ObjectReadStorageCallGuard {
+  assertAvailable(): void
+  run<TResult>(operation: () => Promise<TResult>): Promise<TResult>
+}
+
+/** Validate the required runtime capability before any facade can expose broad object reads. */
+export function requireObjectReadScopeFactory(storage: ObjectStorage): ObjectReadScopeFactory {
+  if (typeof storage.createSelectedReadScope !== "function") {
+    throw new Error(
+      "[Sixb] Object storage provider must implement ObjectReadScopeFactory to create selected object readers."
+    )
+  }
+  return storage
+}
+
+/**
+ * Guard every selected-reader terminal without proxying the provider reader.
+ *
+ * First-party providers freeze their readers. A Proxy cannot substitute a frozen own method
+ * without violating JavaScript's invariants, so operation and lifetime guards use this explicit
+ * facade instead.
+ */
+export function createGuardedObjectReadStorage(
+  reader: ObjectReadStorage,
+  guard: ObjectReadStorageCallGuard
+): ObjectReadStorage {
+  const guarded: ObjectReadStorage = {
+    queryCapabilities: () => {
+      guard.assertAvailable()
+      return reader.queryCapabilities()
+    },
+    getByPrimaryId: (input) => guard.run(() => reader.getByPrimaryId(input)),
+    selectsObjectProperties: (input) => guard.run(() => reader.selectsObjectProperties(input)),
+    listLinks: (input) => guard.run(() => reader.listLinks(input)),
+    getByPrimaryIdBatch: (input) => guard.run(() => reader.getByPrimaryIdBatch(input)),
+    listLinksBatch: (input) => guard.run(() => reader.listLinksBatch(input)),
+    queryLinks: (input) => guard.run(() => reader.queryLinks(input)),
+    list: (input) => guard.run(() => reader.list(input)),
+  }
+  if (reader.queryObjects) {
+    guarded.queryObjects = (input) => guard.run(() => reader.queryObjects!(input))
+  }
+  if (reader.countObjects) {
+    guarded.countObjects = (input) => guard.run(() => reader.countObjects!(input))
+  }
+  if (reader.existsObjects) {
+    guarded.existsObjects = (input) => guard.run(() => reader.existsObjects!(input))
+  }
+  if (reader.facetObjects) {
+    guarded.facetObjects = (input) => guard.run(() => reader.facetObjects!(input))
+  }
+  return Object.freeze(guarded)
+}

--- a/packages/core/src/storage/objects/in-memory/storage.ts
+++ b/packages/core/src/storage/objects/in-memory/storage.ts
@@ -12,7 +12,6 @@ import type {
   LinkDirection,
   ObjectLinkRow,
   ObjectQueryCapabilities,
-  ObjectReadScopeFactory,
   ObjectReadStorage,
   ObjectRow,
   ObjectStorage,
@@ -89,7 +88,7 @@ export function getInMemoryObjectMaterializerAdapter(
   return adapter
 }
 
-export class InMemoryObjectStorage implements ObjectStorage, ObjectReadScopeFactory {
+export class InMemoryObjectStorage implements ObjectStorage {
   private readonly rows = new Map<string, Map<string, ObjectRow>>()
   private readonly links = new Map<string, Map<string, ObjectLinkRow>>()
 

--- a/packages/core/src/storage/objects/types.ts
+++ b/packages/core/src/storage/objects/types.ts
@@ -344,7 +344,7 @@ export interface ObjectReadStorage {
   }): Promise<{ objects: readonly ObjectRow[]; hasMore: boolean; total: number }>
 }
 
-/** Optional provider capability for enforcing a finite, precompiled object-read selection. */
+/** Provider capability for enforcing a finite, precompiled object-read selection. */
 export interface ObjectReadScopeFactory {
   createSelectedReadScope(params: {
     projectId: string
@@ -353,8 +353,8 @@ export interface ObjectReadScopeFactory {
   }): ObjectReadStorage
 }
 
-/** Latest-state projection storage, including trusted internal read primitives. */
-export interface ObjectStorage extends ObjectReadStorage {
+/** Latest-state projection storage, including selected reads and trusted internal primitives. */
+export interface ObjectStorage extends ObjectReadStorage, ObjectReadScopeFactory {
   /**
    * Batch fetch every link incident to any of the given objects, in BOTH directions (the object as
    * link source or target). Returns a flat, de-duplicated list: a physical link incident to two

--- a/packages/core/src/storage/operation-scope.ts
+++ b/packages/core/src/storage/operation-scope.ts
@@ -1,6 +1,8 @@
 import { AsyncLocalStorage } from "node:async_hooks"
 import type { AgentStorage } from "./agents"
 import type { AuthStorage } from "./auth"
+import type { ObjectStorage } from "./objects"
+import { createGuardedObjectReadStorage, requireObjectReadScopeFactory } from "./objects/guard"
 import type { OntologyStorage } from "./ontology"
 import type { WorkflowRunStorage } from "./workflow-runs"
 
@@ -228,6 +230,20 @@ export function createOntologyOperationScope<T extends OntologyStorage>(
     sources: createOperationScopedFacade(target.sources, scope),
     materializations: createOperationScopedFacade(target.materializations, scope),
     outbox: createOperationScopedFacade(target.outbox, scope),
+  }) as T
+}
+
+/** Keep synchronously created selected readers inside the provider's root operation scope. */
+export function createObjectOperationScope<T extends ObjectStorage>(
+  target: T,
+  scope: StorageOperationScope
+): T {
+  const factory = requireObjectReadScopeFactory(target)
+  return createOperationScopedFacade<ObjectStorage>(target, scope, {
+    createSelectedReadScope: (params) => {
+      scope.assertAvailable()
+      return createGuardedObjectReadStorage(factory.createSelectedReadScope(params), scope)
+    },
   }) as T
 }
 

--- a/packages/core/src/storage/transaction.ts
+++ b/packages/core/src/storage/transaction.ts
@@ -1,12 +1,21 @@
 import { StorageTransactionError } from "./errors"
+import { createObjectOperationScope } from "./operation-scope"
+import type { Storage } from "./types"
 
 type ObjectLike = Record<PropertyKey, unknown>
 
-export function createTransactionStorageProxy<T extends object>(
+export function createTransactionStorageProxy<T extends Storage>(
   target: T,
   isActive: () => boolean
 ): T {
   const proxies = new WeakMap<object, object>()
+  const objectStorage = createObjectOperationScope(target.objects, {
+    assertAvailable: () => assertTransactionActive(isActive),
+    run: async <TResult>(operation: () => Promise<TResult> | TResult): Promise<TResult> => {
+      assertTransactionActive(isActive)
+      return operation()
+    },
+  })
 
   const wrap = <TValue extends object>(value: TValue): TValue => {
     const existing = proxies.get(value)
@@ -19,7 +28,10 @@ export function createTransactionStorageProxy<T extends object>(
       // from `tx` are wrapped (a handful), not the row/link data graph, and never per-record.
       get(current, property, receiver) {
         assertTransactionActive(isActive)
-        const result = Reflect.get(current, property, receiver)
+        const result =
+          current === target && property === "objects"
+            ? objectStorage
+            : Reflect.get(current, property, receiver)
         if (typeof result === "function") {
           return (...args: unknown[]) => {
             assertTransactionActive(isActive)

--- a/packages/core/tests/authorization-decision.test.ts
+++ b/packages/core/tests/authorization-decision.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { type AuthorizationContext, emptyGrantIndex, isAllowed } from "../src"
 import {
+  assertAuthorized,
   assertCanAppendTelemetry,
   assertCanEdit,
   canViewEvent,
@@ -18,7 +19,7 @@ import type {
   StoredTelemetryAppendedEvent,
   StoredWorkflowRunStartedEvent,
 } from "../src/events"
-import { createTestingScope } from "../src/execution/scopes"
+import { createDelegatedRequestScope, createTestingScope } from "../src/execution/scopes"
 
 function context(grants: {
   applications?: readonly string[]
@@ -69,6 +70,30 @@ const unrestrictedScope = createTestingScope({ projectId: "decision-test" })
 const unrestrictedRuntime = {
   projectId: "decision-test",
   runtimeAuthorization: unrestrictedScope.authorization,
+}
+const delegatedScope = createDelegatedRequestScope({
+  projectId: "decision-test",
+  requestId: "delegated-request",
+  correlationId: "delegated-correlation",
+  objectRead: {
+    selection: {
+      kind: "selected",
+      roots: [
+        {
+          anchor: { objectTypeId: "quote", primaryId: "quote-1" },
+          node: {
+            objects: [{ objectTypeId: "quote", propertyIds: ["id"] }],
+            links: [],
+          },
+        },
+      ],
+    },
+    limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+  },
+})
+const delegatedRuntime = {
+  projectId: "decision-test",
+  runtimeAuthorization: delegatedScope.authorization,
 }
 
 describe("evaluate", () => {
@@ -229,6 +254,22 @@ describe("evaluate", () => {
 })
 
 describe("write asserts", () => {
+  test("generic authorization denies delegated operations instead of treating them as unrestricted", () => {
+    for (const operation of [
+      () => assertAuthorized(delegatedRuntime, { kind: "object.view", objectTypeId: "quote" }),
+      () =>
+        assertAuthorized(delegatedRuntime, {
+          kind: "object.query",
+          touchedObjectTypeIds: ["quote"],
+        }),
+      () => assertAuthorized(delegatedRuntime, { kind: "action.apply", actionId: "approve" }),
+      () => assertCanEdit(delegatedRuntime, "quote"),
+      () => assertCanAppendTelemetry(delegatedRuntime, "sensor"),
+    ]) {
+      expect(operation).toThrow("not covered by delegated authorization")
+    }
+  })
+
   test("assertCanEdit demands view as well as edit, and names the missing one", () => {
     const both = principalRuntime({ view: ["quote"], edit: ["quote"] })
     expect(() => assertCanEdit(both, "quote")).not.toThrow()

--- a/packages/core/tests/authorized-object-reader-runtime.test.ts
+++ b/packages/core/tests/authorized-object-reader-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createAuthorizedObjectReader } from "../src/execution/authorized-object-reader"
-import { createTestingScope } from "../src/execution/scopes"
+import { createDelegatedRequestScope, createTestingScope } from "../src/execution/scopes"
 import { OntologyRegistry } from "../src/ontology"
 import { SixbHost } from "../src/runtime/host"
 import { createBoundSixb, type SixbDependencies } from "../src/runtime/sixb"
@@ -46,6 +46,23 @@ describe("AuthorizedObjectReader runtime binding", () => {
     expect(host.withScope(accessorScope).execution).toBe(source.execution)
     expect(executionReads).toBe(1)
     expect(authorizationReads).toBe(1)
+  })
+
+  test("SixbHost keeps delegated authority off the domain SDK until every surface is active", () => {
+    const host = new SixbHost({ id: projectId, ontology: [], ...createTestRuntimeDeps() })
+    const scope = createDelegatedRequestScope({
+      projectId,
+      requestId: "delegated-request",
+      correlationId: "delegated-correlation",
+      objectRead: {
+        selection: { kind: "selected", roots: [] },
+        limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+      },
+    })
+
+    expect(() => host.withScope(scope)).toThrow(
+      "Delegated runtime authorization cannot be bound to the domain SDK"
+    )
   })
 
   test("createBoundSixb rejects a reader from another exact authority", () => {

--- a/packages/core/tests/authorized-object-reader-runtime.test.ts
+++ b/packages/core/tests/authorized-object-reader-runtime.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+import { createAuthorizedObjectReader } from "../src/execution/authorized-object-reader"
+import { createTestingScope } from "../src/execution/scopes"
+import { OntologyRegistry } from "../src/ontology"
+import { SixbHost } from "../src/runtime/host"
+import { createBoundSixb, type SixbDependencies } from "../src/runtime/sixb"
+import type { SixbRuntimeContext } from "../src/runtime/types"
+import { InMemoryStorage } from "../src/storage"
+import { createTestRuntimeDeps } from "./test-runtime-deps"
+
+const projectId = "authorized-object-reader-runtime"
+
+describe("AuthorizedObjectReader runtime binding", () => {
+  test("SixbHost creates the bound reader before composing the SDK", () => {
+    const host = new SixbHost({ id: projectId, ontology: [], ...createTestRuntimeDeps() })
+    const scope = createTestingScope({ projectId, executionId: "execution-1" })
+
+    expect(host.withScope(scope).execution).toBe(scope.execution)
+  })
+
+  test("SixbHost captures an accessor-backed scope once before composition", () => {
+    const host = new SixbHost({ id: projectId, ontology: [], ...createTestRuntimeDeps() })
+    const source = createTestingScope({ projectId, executionId: "execution-accessor" })
+    let executionReads = 0
+    let authorizationReads = 0
+    const accessorScope = Object.defineProperties(
+      {},
+      {
+        execution: {
+          enumerable: true,
+          get: () => {
+            executionReads += 1
+            return source.execution
+          },
+        },
+        authorization: {
+          enumerable: true,
+          get: () => {
+            authorizationReads += 1
+            return source.authorization
+          },
+        },
+      }
+    ) as typeof source
+
+    expect(host.withScope(accessorScope).execution).toBe(source.execution)
+    expect(executionReads).toBe(1)
+    expect(authorizationReads).toBe(1)
+  })
+
+  test("createBoundSixb rejects a reader from another exact authority", () => {
+    const ontology = new OntologyRegistry({ sources: [] })
+    const storage = new InMemoryStorage()
+    const boundScope = createTestingScope({ projectId, executionId: "execution-bound" })
+    const foreignScope = createTestingScope({ projectId, executionId: "execution-foreign" })
+    const foreignReader = createAuthorizedObjectReader({
+      scope: foreignScope,
+      ontology,
+      objectStorage: storage.objects,
+    })
+    const runtime = {
+      projectId,
+      runtimeAuthorization: boundScope.authorization,
+      objectReader: foreignReader,
+    } as SixbRuntimeContext
+
+    expect(() =>
+      createBoundSixb<readonly []>(runtime, {} as SixbDependencies, boundScope.execution)
+    ).toThrow("AuthorizedObjectReader is not bound to this exact execution authority")
+  })
+})

--- a/packages/core/tests/execution-authorization.test.ts
+++ b/packages/core/tests/execution-authorization.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   assertExecutionScopeProject,
   createAgentRuntimeAuthorization,
+  createDelegatedRuntimeAuthorization,
   createPrincipalRuntimeAuthorization,
   createTrustedPrimitiveRuntimeAuthorization,
   getAuthorizationRef,
@@ -22,6 +23,7 @@ import {
   restoreTrustedPrimitiveExecutionScope,
 } from "../src/execution/durable"
 import {
+  createDelegatedRequestScope,
   createDisabledRequestScope,
   createKernelScope,
   createPrincipalRequestScope,
@@ -33,6 +35,7 @@ import {
   type ExecutionScope,
   type RuntimeAuthorization,
 } from "../src/execution/types"
+import type { SelectedObjectReadScope } from "../src/storage"
 
 describe("runtime authorization capabilities", () => {
   test("snapshots principal authority and exposes only a defensive durable reference", () => {
@@ -220,6 +223,99 @@ describe("execution scopes", () => {
         resolveExecutionScopeAuthorization("project-1", { execution: changed, authorization })
       ).toThrow("authority is bound to different execution provenance")
     }
+  })
+
+  test("compiles and freezes process-local delegated object-read authority once", () => {
+    const propertyIds = ["id"]
+    const roots: SelectedObjectReadScope["roots"][number][] = [
+      {
+        anchor: { objectTypeId: "Proposal", primaryId: "proposal-1" },
+        node: {
+          objects: [{ objectTypeId: "Proposal", propertyIds }],
+          links: [],
+        },
+      },
+    ]
+    const scope = createDelegatedRequestScope({
+      projectId: "project-1",
+      requestId: "delegated-request-1",
+      correlationId: "delegated-correlation-1",
+      objectRead: {
+        selection: { kind: "selected", roots },
+        limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 1_024 },
+      },
+    })
+
+    propertyIds.push("secret")
+    roots.push({
+      anchor: { objectTypeId: "Proposal", primaryId: "proposal-2" },
+      node: {
+        objects: [{ objectTypeId: "Proposal", propertyIds: ["id"] }],
+        links: [],
+      },
+    })
+
+    const resolved = resolveRuntimeAuthorization(scope.authorization)
+    expect(resolved.type).toBe("delegated")
+    if (resolved.type !== "delegated") throw new Error("expected delegated authorization")
+    expect(resolved.objectRead.scope.roots).toHaveLength(1)
+    expect(resolved.objectRead.scope.objects).toEqual([
+      { nodeId: 0, objectTypeId: "Proposal", propertyIds: ["id"] },
+    ])
+    expect(resolved.objectRead.limits).toEqual({
+      maxTraversalFacts: 100,
+      maxOutputJsonBytes: 1_024,
+    })
+    expect(Object.isFrozen(resolved)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead.scope)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead.scope.roots)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead.scope.objects[0]?.propertyIds)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead.limits)).toBe(true)
+
+    expect(() => getAuthorizationRef(scope.authorization)).toThrow(
+      "cannot cross a durable execution boundary"
+    )
+    expect(() =>
+      executionRecordInputFromRuntime({
+        execution: scope.execution,
+        runtimeAuthorization: scope.authorization,
+      })
+    ).toThrow("cannot cross a durable execution boundary")
+  })
+
+  test("binds delegated authority only to its exact principal-free request", () => {
+    const scope = createDelegatedRequestScope({
+      projectId: "project-1",
+      requestId: "delegated-request-bound",
+      correlationId: "delegated-correlation-bound",
+      objectRead: {
+        selection: delegatedSelection(),
+        limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+      },
+    })
+    const other = createDisabledRequestScope({
+      projectId: "project-1",
+      requestId: "delegated-request-other",
+      correlationId: "delegated-correlation-other",
+    })
+
+    expect(() => resolveExecutionScopeAuthorization("project-1", scope)).not.toThrow()
+    expect(() =>
+      resolveExecutionScopeAuthorization("project-1", {
+        execution: other.execution,
+        authorization: scope.authorization,
+      })
+    ).toThrow("authority is bound to different execution provenance")
+    expect(() =>
+      createDelegatedRuntimeAuthorization({
+        execution: requestExecution("delegated-principal", { type: "user", id: "user-1" }),
+        objectRead: {
+          selection: delegatedSelection(),
+          limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+        },
+      })
+    ).toThrow("requires a request execution without a principal")
   })
 
   test("durable serialization rejects a mismatched execution and authority pair", () => {
@@ -624,5 +720,20 @@ function requestExecution(
     executor: { type: "request", requestId: `request-${id}` },
     source: { type: "http", requestId: `request-${id}` },
     correlationId: `correlation-${id}`,
+  }
+}
+
+function delegatedSelection(): SelectedObjectReadScope {
+  return {
+    kind: "selected",
+    roots: [
+      {
+        anchor: { objectTypeId: "Proposal", primaryId: "proposal-1" },
+        node: {
+          objects: [{ objectTypeId: "Proposal", propertyIds: ["id"] }],
+          links: [],
+        },
+      },
+    ],
   }
 }

--- a/packages/core/tests/in-memory-object-read-scope.test.ts
+++ b/packages/core/tests/in-memory-object-read-scope.test.ts
@@ -6,7 +6,6 @@ import {
   getInMemoryObjectMaterializerAdapter,
   InMemoryObjectStorage,
 } from "../src/storage/objects/in-memory"
-import type { ObjectReadScopeFactory, ObjectStorage } from "../src/storage/objects/types"
 import {
   createMaterializerTestFixture,
   objectReadScopeContractOntology,
@@ -16,7 +15,7 @@ import {
 runObjectReadScopeContractSuite("InMemoryStorage selected object-read scope contract", {
   createHarness: () => {
     const storage = new InMemoryStorage()
-    return { storage, objectReadScopeFactory: requireScopeFactory(storage.objects) }
+    return { storage, objectReadScopeFactory: storage.objects }
   },
 })
 
@@ -82,7 +81,7 @@ describe("InMemoryObjectStorage selected read behavior", () => {
       ],
     })
 
-    const reader = requireScopeFactory(storage.objects).createSelectedReadScope({
+    const reader = storage.objects.createSelectedReadScope({
       projectId: "in-memory-vector-scope",
       scope: compileSelectedObjectReadScope({
         kind: "selected",
@@ -188,14 +187,3 @@ describe("InMemoryObjectStorage selected read behavior", () => {
     ).toMatchObject({ properties: { id: "prototype-1" } })
   })
 })
-
-function requireScopeFactory(storage: ObjectStorage): ObjectReadScopeFactory {
-  if (!("createSelectedReadScope" in storage)) {
-    throw new Error("[Sixb] Expected the in-memory object-read scope factory.")
-  }
-  const factory = storage as ObjectStorage & Partial<ObjectReadScopeFactory>
-  if (typeof factory.createSelectedReadScope !== "function") {
-    throw new Error("[Sixb] Expected the in-memory object-read scope factory.")
-  }
-  return factory as ObjectReadScopeFactory
-}

--- a/packages/core/tests/object-read-storage-guard.test.ts
+++ b/packages/core/tests/object-read-storage-guard.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test"
+import type { ObjectReadStorage } from "../src/storage"
+import { createGuardedObjectReadStorage } from "../src/storage/objects/guard"
+
+describe("selected object reader guards", () => {
+  test("forwards every terminal from a frozen provider reader through one guard", async () => {
+    const provider = fullReader()
+    let availabilityChecks = 0
+    let guardedRuns = 0
+    const reader = createGuardedObjectReadStorage(provider, {
+      assertAvailable: () => {
+        availabilityChecks += 1
+      },
+      run: async (operation) => {
+        guardedRuns += 1
+        return operation()
+      },
+    })
+
+    expect(reader.queryCapabilities()).toEqual({ queryObjects: true })
+    const query = { kind: "start", objectTypeId: "GuardedObject" } as const
+    await reader.queryObjects?.({ projectId: "guard-project", query })
+    await reader.countObjects?.({ projectId: "guard-project", query })
+    await reader.existsObjects?.({ projectId: "guard-project", query })
+    await reader.facetObjects?.({
+      projectId: "guard-project",
+      query,
+      facets: [{ propertyId: "id", limit: 10 }],
+    })
+    await reader.getByPrimaryId({
+      projectId: "guard-project",
+      objectTypeId: "GuardedObject",
+      primaryId: "root",
+    })
+    await reader.selectsObjectProperties({ projectId: "guard-project", items: [] })
+    await reader.listLinks({
+      projectId: "guard-project",
+      objectTypeId: "GuardedObject",
+      objectId: "root",
+    })
+    await reader.getByPrimaryIdBatch({ projectId: "guard-project", items: [] })
+    await reader.listLinksBatch({ projectId: "guard-project", items: [] })
+    await reader.queryLinks({
+      projectId: "guard-project",
+      objectRefs: [],
+      direction: "outgoing",
+      limit: 1,
+    })
+    await reader.list({ projectId: "guard-project" })
+
+    expect(Object.isFrozen(provider)).toBe(true)
+    expect(Object.isFrozen(reader)).toBe(true)
+    expect(availabilityChecks).toBe(1)
+    expect(guardedRuns).toBe(11)
+  })
+
+  test("does not invent optional query terminals", () => {
+    const provider = requiredReader()
+    const reader = createGuardedObjectReadStorage(provider, {
+      assertAvailable: () => undefined,
+      run: (operation) => operation(),
+    })
+
+    expect(reader.queryObjects).toBeUndefined()
+    expect(reader.countObjects).toBeUndefined()
+    expect(reader.existsObjects).toBeUndefined()
+    expect(reader.facetObjects).toBeUndefined()
+  })
+})
+
+function fullReader(): ObjectReadStorage {
+  return Object.freeze({
+    ...requiredReader(),
+    queryCapabilities: () => ({ queryObjects: true }),
+    queryObjects: async () => ({ objects: [], hasMore: false, total: 0 }),
+    countObjects: async () => ({ count: 0 }),
+    existsObjects: async () => ({ exists: false }),
+    facetObjects: async () => ({ facets: [] }),
+  })
+}
+
+function requiredReader(): ObjectReadStorage {
+  return Object.freeze({
+    queryCapabilities: () => ({ queryObjects: false }),
+    getByPrimaryId: async () => null,
+    selectsObjectProperties: async () => [],
+    listLinks: async () => [],
+    getByPrimaryIdBatch: async () => new Map(),
+    listLinksBatch: async () => new Map(),
+    queryLinks: async () => ({ links: [], hasMore: false }),
+    list: async () => ({ objects: [], hasMore: false, total: 0 }),
+  })
+}

--- a/packages/core/tests/object-reader-binding.test.ts
+++ b/packages/core/tests/object-reader-binding.test.ts
@@ -1,0 +1,657 @@
+import { describe, expect, test } from "bun:test"
+import { emptyGrantIndex } from "../src/authorization"
+import { AuthorizationError } from "../src/authorization/errors"
+import {
+  type AuthorizedObjectReader,
+  assertAuthorizedObjectReaderBinding,
+  createAuthorizedObjectReader,
+} from "../src/execution/authorized-object-reader"
+import { createDisabledRequestScope, createPrincipalRequestScope } from "../src/execution/scopes"
+import type { ExecutionScope } from "../src/execution/types"
+import type { ObjectQuery } from "../src/objects/query"
+import { defineObjectType, link, OntologyRegistry, prop } from "../src/ontology"
+import {
+  linkBatchKey,
+  type ObjectLinkRow,
+  type ObjectQueryCapabilities,
+  type ObjectRow,
+  type ObjectStorage,
+  objectBatchKey,
+} from "../src/storage"
+
+const projectId = "authorized-object-reader"
+const at = new Date("2026-01-01T00:00:00.000Z")
+
+const LineItem = defineObjectType({
+  id: "LineItem",
+  name: "Line item",
+  properties: [prop("id", "string", { required: true, primary: true }), prop("name", "string")],
+})
+
+const Secret = defineObjectType({
+  id: "Secret",
+  name: "Secret",
+  properties: [prop("id", "string", { required: true, primary: true }), prop("value", "string")],
+})
+
+const Proposal = defineObjectType({
+  id: "Proposal",
+  name: "Proposal",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("title", "string", { query: { searchable: true, facet: true } }),
+  ],
+  links: [link("items", LineItem), link("secret", Secret)],
+})
+
+const ontology = new OntologyRegistry({ sources: [Proposal, LineItem, Secret] })
+
+type PublicReaderMethod =
+  | "getByPrimaryId"
+  | "getByPrimaryIdBatch"
+  | "canReadObjectProperty"
+  | "canReadObjectPropertiesBatch"
+  | "list"
+  | "listLinks"
+  | "listLinksBatch"
+  | "executeQuery"
+  | "queryLinks"
+  | "count"
+  | "exists"
+  | "facet"
+
+type InputsWithoutProjectId = {
+  [Method in PublicReaderMethod]: "projectId" extends keyof Parameters<
+    AuthorizedObjectReader[Method]
+  >[0]
+    ? never
+    : true
+}
+
+const inputsWithoutProjectId: InputsWithoutProjectId = {
+  getByPrimaryId: true,
+  getByPrimaryIdBatch: true,
+  canReadObjectProperty: true,
+  canReadObjectPropertiesBatch: true,
+  list: true,
+  listLinks: true,
+  listLinksBatch: true,
+  executeQuery: true,
+  queryLinks: true,
+  count: true,
+  exists: true,
+  facet: true,
+}
+
+type FacadeIsNominal =
+  Pick<AuthorizedObjectReader, keyof AuthorizedObjectReader> extends AuthorizedObjectReader
+    ? never
+    : true
+
+const facadeIsNominal: FacadeIsNominal = true
+
+describe("AuthorizedObjectReader", () => {
+  test("is a frozen nominal facade that injects project identity", () => {
+    const backend = createReadStorage()
+    const reader = createAuthorizedObjectReader({
+      scope: principalScope("shape", [Proposal.id]),
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    expect(facadeIsNominal).toBe(true)
+    expect(Object.values(inputsWithoutProjectId).every(Boolean)).toBe(true)
+    expect(reader.projectId).toBe(projectId)
+    expect(Object.isFrozen(reader)).toBe(true)
+    expect(Object.isFrozen(Object.getPrototypeOf(reader))).toBe(true)
+    expect(backend.selectedScopeCalls).toBe(0)
+
+    const ReaderConstructor = Object.getPrototypeOf(reader).constructor as new (
+      ...args: unknown[]
+    ) => unknown
+    expect(() => Reflect.construct(ReaderConstructor, [])).toThrow(
+      "AuthorizedObjectReader can only be created by Core"
+    )
+  })
+
+  test("is bound to one exact registered execution authority", () => {
+    const backend = createReadStorage()
+    const first = principalScope("first", [Proposal.id])
+    const second = principalScope("second", [Proposal.id])
+    const reader = createAuthorizedObjectReader({
+      scope: first,
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    expect(() => assertAuthorizedObjectReaderBinding({ reader, scope: first })).not.toThrow()
+    expect(() => assertAuthorizedObjectReaderBinding({ reader, scope: second })).toThrow(
+      "AuthorizedObjectReader is not bound to this exact execution authority"
+    )
+
+    const mismatchedExecution: ExecutionScope = {
+      execution: second.execution,
+      authorization: first.authorization,
+    }
+    expect(() =>
+      assertAuthorizedObjectReaderBinding({ reader, scope: mismatchedExecution })
+    ).toThrow("authority is bound to different execution provenance")
+  })
+
+  test("captures authority instead of retaining a mutable scope wrapper", () => {
+    const backend = createReadStorage()
+    const first = principalScope("captured", [Proposal.id])
+    const second = principalScope("replacement", [Proposal.id])
+    const mutableScope = {
+      execution: first.execution,
+      authorization: first.authorization,
+    }
+    const reader = createAuthorizedObjectReader({
+      scope: mutableScope,
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    mutableScope.authorization = second.authorization
+
+    expect(() => assertAuthorizedObjectReaderBinding({ reader, scope: first })).not.toThrow()
+    expect(() => assertAuthorizedObjectReaderBinding({ reader, scope: second })).toThrow(
+      "AuthorizedObjectReader is not bound to this exact execution authority"
+    )
+  })
+
+  test("captures an accessor-backed scope atomically", () => {
+    const backend = createReadStorage()
+    const source = principalScope("accessor", [Proposal.id])
+    let executionReads = 0
+    let authorizationReads = 0
+    const accessorScope = Object.defineProperties(
+      {},
+      {
+        execution: {
+          enumerable: true,
+          get: () => {
+            executionReads += 1
+            return source.execution
+          },
+        },
+        authorization: {
+          enumerable: true,
+          get: () => {
+            authorizationReads += 1
+            return source.authorization
+          },
+        },
+      }
+    ) as ExecutionScope
+
+    const reader = createAuthorizedObjectReader({
+      scope: accessorScope,
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    expect(reader.projectId).toBe(projectId)
+    expect(executionReads).toBe(1)
+    expect(authorizationReads).toBe(1)
+  })
+
+  test("denies principal reads before storage and bounds an unfiltered empty listing", async () => {
+    const backend = createReadStorage()
+    const reader = createAuthorizedObjectReader({
+      scope: principalScope("denied"),
+      ontology,
+      objectStorage: backend.storage,
+    })
+    const query = { kind: "start" as const, objectTypeId: Proposal.id }
+
+    for (const operation of [
+      () => reader.getByPrimaryId({ objectTypeId: Proposal.id, primaryId: "proposal-1" }),
+      () =>
+        reader.getByPrimaryIdBatch({
+          items: [{ objectTypeId: Proposal.id, primaryId: "proposal-1" }],
+        }),
+      () =>
+        reader.canReadObjectProperty({
+          objectTypeId: Proposal.id,
+          primaryId: "proposal-1",
+          propertyId: "title",
+        }),
+      () =>
+        reader.canReadObjectPropertiesBatch({
+          items: [{ objectTypeId: Proposal.id, primaryId: "proposal-1", propertyId: "title" }],
+        }),
+      () => reader.list({ objectTypeId: Proposal.id }),
+      () => reader.listLinks({ objectTypeId: Proposal.id, objectId: "proposal-1" }),
+      () =>
+        reader.listLinksBatch({
+          items: [{ objectTypeId: Proposal.id, objectId: "proposal-1", linkId: "items" }],
+        }),
+      () => reader.executeQuery({ query }),
+      () => reader.queryLinks({ query }),
+      () => reader.count({ query }),
+      () => reader.exists({ query }),
+      () => reader.facet({ query, facets: [{ propertyId: "title", limit: 10 }] }),
+    ]) {
+      await expect(operation()).rejects.toBeInstanceOf(AuthorizationError)
+    }
+
+    expect(await reader.list({})).toEqual({ objects: [], hasMore: false, total: 0 })
+    expect(backend.calls).toEqual([])
+  })
+
+  test("covers every read terminal, scopes principal lists, and filters hidden link endpoints", async () => {
+    const backend = createReadStorage()
+    const reader = createAuthorizedObjectReader({
+      scope: principalScope("allowed", [Proposal.id, LineItem.id]),
+      ontology,
+      objectStorage: backend.storage,
+    })
+    const query = { kind: "start" as const, objectTypeId: Proposal.id }
+
+    expect(
+      await reader.getByPrimaryId({ objectTypeId: Proposal.id, primaryId: "proposal-1" })
+    ).toMatchObject({ objectTypeId: Proposal.id, primaryId: "proposal-1" })
+    expect(
+      await reader.getByPrimaryIdBatch({
+        items: [
+          { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+          { objectTypeId: LineItem.id, primaryId: "line-1" },
+        ],
+      })
+    ).toHaveLength(2)
+    expect(
+      await reader.canReadObjectPropertiesBatch({
+        items: [{ objectTypeId: Proposal.id, primaryId: "proposal-1", propertyId: "title" }],
+      })
+    ).toEqual([true])
+    expect(
+      await reader.canReadObjectProperty({
+        objectTypeId: Proposal.id,
+        primaryId: "proposal-1",
+        propertyId: "title",
+      })
+    ).toBe(true)
+
+    const listed = await reader.list({})
+    expect(listed.objects.map((row) => row.objectTypeId)).toEqual([Proposal.id, LineItem.id])
+    expect(backend.calls.find((call) => call.operation === "list")?.input).toMatchObject({
+      projectId,
+      objectTypeId: [Proposal.id, LineItem.id],
+    })
+
+    const links = await reader.listLinks({
+      objectTypeId: Proposal.id,
+      objectId: "proposal-1",
+    })
+    expect(links.map((row) => row.targetTypeId)).toEqual([LineItem.id])
+
+    const linkPages = await reader.listLinksBatch({
+      items: [{ objectTypeId: Proposal.id, objectId: "proposal-1", linkId: "items" }],
+    })
+    expect(
+      linkPages
+        .get(linkBatchKey(Proposal.id, "proposal-1", "items"))
+        ?.map((row) => row.targetTypeId)
+    ).toEqual([LineItem.id])
+
+    expect((await reader.executeQuery({ query, includeTotal: true })).objects).toHaveLength(1)
+    expect((await reader.count({ query })).count).toBe(1)
+    expect((await reader.exists({ query })).exists).toBe(true)
+    expect(
+      (await reader.facet({ query, facets: [{ propertyId: "title", limit: 10 }] })).facets
+    ).toEqual([{ propertyId: "title", buckets: [{ value: "Proposal", count: 1 }] }])
+
+    const queriedLinks = await reader.queryLinks({ query, includeObjects: true })
+    expect(queriedLinks.links.map((row) => row.targetTypeId)).toEqual([LineItem.id])
+    expect(queriedLinks.objects.map((row) => row.objectTypeId)).toEqual([Proposal.id, LineItem.id])
+    expect(backend.calls.find((call) => call.operation === "queryLinks")?.input).toMatchObject({
+      projectId,
+      endpointObjectTypeIds: [Proposal.id, LineItem.id],
+    })
+
+    expect(backend.selectedScopeCalls).toBe(0)
+    for (const call of backend.calls) {
+      if (call.operation === "queryCapabilities") continue
+      expect(call.input).toMatchObject({ projectId })
+    }
+  })
+
+  test("preserves unrestricted broad reads", async () => {
+    const backend = createReadStorage()
+    const reader = createAuthorizedObjectReader({
+      scope: createDisabledRequestScope({
+        projectId,
+        requestId: "request-unrestricted",
+        correlationId: "correlation-unrestricted",
+      }),
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    const listed = await reader.list({})
+    expect(listed.objects.map((row) => row.objectTypeId)).toEqual([
+      Proposal.id,
+      LineItem.id,
+      Secret.id,
+    ])
+    expect(backend.calls.find((call) => call.operation === "list")?.input).toEqual({
+      objectTypeId: undefined,
+      primaryIdPrefix: undefined,
+      primaryIdSuffix: undefined,
+      updatedAfter: undefined,
+      updatedBefore: undefined,
+      createdAfter: undefined,
+      createdBefore: undefined,
+      limit: undefined,
+      offset: undefined,
+      orderBy: undefined,
+      order: undefined,
+      projectId,
+    })
+
+    const links = await reader.listLinks({
+      objectTypeId: Proposal.id,
+      objectId: "proposal-1",
+    })
+    expect(links.map((row) => row.targetTypeId)).toEqual([LineItem.id, Secret.id])
+  })
+
+  test("ignores caller project extras and executes the exact query snapshot it authorized", async () => {
+    let objectTypeReads = 0
+    const authoredQuery = Object.defineProperties(
+      {},
+      {
+        kind: { enumerable: true, value: "start" },
+        objectTypeId: {
+          enumerable: true,
+          get: () => (objectTypeReads++ === 0 ? Proposal.id : Secret.id),
+        },
+      }
+    ) as ObjectQuery
+    const backend = createReadStorage()
+    const reader = createAuthorizedObjectReader({
+      scope: principalScope("snapshot", [Proposal.id]),
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    await reader.getByPrimaryId({
+      objectTypeId: Proposal.id,
+      primaryId: "proposal-1",
+      projectId: "other-project",
+    } as Parameters<AuthorizedObjectReader["getByPrimaryId"]>[0])
+    await reader.executeQuery({
+      query: authoredQuery,
+      projectId: "other-project",
+    } as Parameters<AuthorizedObjectReader["executeQuery"]>[0])
+
+    expect(objectTypeReads).toBe(1)
+    expect(backend.calls.find((call) => call.operation === "getByPrimaryId")?.input).toEqual({
+      objectTypeId: Proposal.id,
+      primaryId: "proposal-1",
+      projectId,
+    })
+    expect(backend.calls.find((call) => call.operation === "queryObjects")?.input).toMatchObject({
+      projectId,
+      query: { kind: "start", objectTypeId: Proposal.id },
+    })
+  })
+
+  test("detaches provider-owned rows, maps, and links", async () => {
+    const backend = createReadStorage()
+    const reader = createAuthorizedObjectReader({
+      scope: principalScope("detach", [Proposal.id, LineItem.id]),
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    const object = await reader.getByPrimaryId({
+      objectTypeId: Proposal.id,
+      primaryId: "proposal-1",
+    })
+    object!.properties.title = "mutated"
+    expect(backend.rows.proposal.properties.title).toBe("Proposal")
+
+    const batch = await reader.getByPrimaryIdBatch({
+      items: [{ objectTypeId: LineItem.id, primaryId: "line-1" }],
+    })
+    batch.get(objectBatchKey(LineItem.id, "line-1"))!.properties.name = "mutated"
+    expect(backend.rows.line.properties.name).toBe("Line")
+
+    const links = await reader.listLinks({
+      objectTypeId: Proposal.id,
+      objectId: "proposal-1",
+    })
+    links[0].properties!.position = 99
+    expect(backend.links[0].properties?.position).toBe(1)
+  })
+
+  test("fails closed when a provider returns a hidden endpoint in a paginated link page", async () => {
+    const backend = createReadStorage({ ignoreEndpointTypeFilter: true, queryLinksHasMore: true })
+    const reader = createAuthorizedObjectReader({
+      scope: principalScope("invalid-link-page", [Proposal.id, LineItem.id]),
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    await expect(
+      reader.queryLinks({
+        query: { kind: "start", objectTypeId: Proposal.id },
+        includeObjects: true,
+      })
+    ).rejects.toThrow("Object storage returned a link page outside its authorized scope")
+  })
+})
+
+function principalScope(id: string, view: readonly string[] = []): ExecutionScope {
+  return createPrincipalRequestScope({
+    projectId,
+    requestId: `request-${id}`,
+    correlationId: `correlation-${id}`,
+    context: {
+      principal: { type: "user", id: `user-${id}` },
+      groupIds: [],
+      roleIds: [],
+      grants: { ...emptyGrantIndex(), "view:object": new Set(view) },
+    },
+  })
+}
+
+type ReadCall = {
+  readonly operation: string
+  readonly input?: unknown
+}
+
+function createReadStorage(options?: {
+  readonly ignoreEndpointTypeFilter?: boolean
+  readonly queryLinksHasMore?: boolean
+}): {
+  readonly storage: ObjectStorage
+  readonly calls: ReadCall[]
+  readonly selectedScopeCalls: number
+  readonly rows: {
+    readonly proposal: ObjectRow
+    readonly line: ObjectRow
+    readonly secret: ObjectRow
+  }
+  readonly links: readonly ObjectLinkRow[]
+} {
+  const calls: ReadCall[] = []
+  const rows = {
+    proposal: row(Proposal.id, "proposal-1", { id: "proposal-1", title: "Proposal" }),
+    line: row(LineItem.id, "line-1", { id: "line-1", name: "Line" }),
+    secret: row(Secret.id, "secret-1", { id: "secret-1", value: "hidden" }),
+  }
+  const allRows = [rows.proposal, rows.line, rows.secret]
+  const links: ObjectLinkRow[] = [
+    objectLink("items", LineItem.id, "line-1", { position: 1 }),
+    objectLink("secret", Secret.id, "secret-1"),
+  ]
+  let selectedScopeCalls = 0
+  const record = (operation: string, input?: unknown): void => {
+    calls.push({ operation, ...(input === undefined ? {} : { input }) })
+  }
+  const capabilities: ObjectQueryCapabilities = {
+    queryObjects: true,
+    countObjects: true,
+    existsObjects: true,
+    facetObjects: true,
+    nodes: { start: true, limit: true },
+  }
+
+  const storage: ObjectStorage = {
+    queryCapabilities() {
+      record("queryCapabilities")
+      return capabilities
+    },
+    async queryObjects(input) {
+      record("queryObjects", input)
+      return { objects: [rows.proposal], hasMore: false, total: 1 }
+    },
+    async countObjects(input) {
+      record("countObjects", input)
+      return { count: 1 }
+    },
+    async existsObjects(input) {
+      record("existsObjects", input)
+      return { exists: true }
+    },
+    async facetObjects(input) {
+      record("facetObjects", input)
+      return {
+        facets: input.facets.map((facet) => ({
+          propertyId: facet.propertyId,
+          buckets: [{ value: "Proposal", count: 1 }],
+        })),
+      }
+    },
+    async getByPrimaryId(input) {
+      record("getByPrimaryId", input)
+      return findRow(allRows, input.objectTypeId, input.primaryId)
+    },
+    async getByPrimaryIdBatch(input) {
+      record("getByPrimaryIdBatch", input)
+      const result = new Map()
+      for (const item of input.items) {
+        const found = findRow(allRows, item.objectTypeId, item.primaryId)
+        if (found) result.set(objectBatchKey(item.objectTypeId, item.primaryId), found)
+      }
+      return result
+    },
+    async selectsObjectProperties(input) {
+      record("selectsObjectProperties", input)
+      return input.items.map((item) => Boolean(findRow(allRows, item.objectTypeId, item.primaryId)))
+    },
+    async listLinks(input) {
+      record("listLinks", input)
+      return links
+    },
+    async listLinksBatch(input) {
+      record("listLinksBatch", input)
+      return new Map(
+        input.items.map((item) => [
+          linkBatchKey(item.objectTypeId, item.objectId, item.linkId),
+          links,
+        ])
+      )
+    },
+    async queryLinks(input) {
+      record("queryLinks", input)
+      const endpointObjectTypeIds =
+        options?.ignoreEndpointTypeFilter || input.endpointObjectTypeIds === undefined
+          ? undefined
+          : new Set(input.endpointObjectTypeIds)
+      const visibleLinks = endpointObjectTypeIds
+        ? links.filter(
+            (link) =>
+              endpointObjectTypeIds.has(link.sourceTypeId) &&
+              endpointObjectTypeIds.has(link.targetTypeId)
+          )
+        : links
+      return { links: visibleLinks, hasMore: options?.queryLinksHasMore ?? false }
+    },
+    async list(input) {
+      record("list", input)
+      const requested =
+        input.objectTypeId === undefined
+          ? undefined
+          : new Set(
+              typeof input.objectTypeId === "string" ? [input.objectTypeId] : input.objectTypeId
+            )
+      const objects = requested
+        ? allRows.filter((candidate) => requested.has(candidate.objectTypeId))
+        : allRows
+      return { objects, hasMore: false, total: objects.length }
+    },
+    createSelectedReadScope() {
+      selectedScopeCalls += 1
+      throw new Error("createSelectedReadScope must not be called for existing authorities")
+    },
+    async listIncidentLinksBatch() {
+      return []
+    },
+    async listByPrimaryIdPage() {
+      return { objects: [] }
+    },
+  }
+
+  return {
+    storage,
+    calls,
+    get selectedScopeCalls() {
+      return selectedScopeCalls
+    },
+    rows,
+    links,
+  }
+}
+
+function row(
+  objectTypeId: string,
+  primaryId: string,
+  properties: Record<string, unknown>
+): ObjectRow {
+  return {
+    projectId,
+    objectTypeId,
+    primaryId,
+    properties,
+    createdAt: at,
+    updatedAt: at,
+    version: 1,
+    lastCommitId: `commit-${primaryId}`,
+  }
+}
+
+function objectLink(
+  linkId: string,
+  targetTypeId: string,
+  targetId: string,
+  properties?: Record<string, unknown>
+): ObjectLinkRow {
+  return {
+    projectId,
+    sourceTypeId: Proposal.id,
+    sourceId: "proposal-1",
+    linkId,
+    targetTypeId,
+    targetId,
+    ...(properties === undefined ? {} : { properties }),
+    createdAt: at,
+    updatedAt: at,
+    lastCommitId: `commit-${linkId}`,
+  }
+}
+
+function findRow(
+  rows: readonly ObjectRow[],
+  objectTypeId: string,
+  primaryId: string
+): ObjectRow | null {
+  return (
+    rows.find(
+      (candidate) => candidate.objectTypeId === objectTypeId && candidate.primaryId === primaryId
+    ) ?? null
+  )
+}

--- a/packages/core/tests/object-reader-binding.test.ts
+++ b/packages/core/tests/object-reader-binding.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, test } from "bun:test"
 import { emptyGrantIndex } from "../src/authorization"
 import { AuthorizationError } from "../src/authorization/errors"
+import { resolveRuntimeAuthorization } from "../src/execution/authorization"
 import {
   type AuthorizedObjectReader,
   assertAuthorizedObjectReaderBinding,
   createAuthorizedObjectReader,
 } from "../src/execution/authorized-object-reader"
-import { createDisabledRequestScope, createPrincipalRequestScope } from "../src/execution/scopes"
+import {
+  createDelegatedRequestScope,
+  createDisabledRequestScope,
+  createPrincipalRequestScope,
+} from "../src/execution/scopes"
 import type { ExecutionScope } from "../src/execution/types"
 import type { ObjectQuery } from "../src/objects/query"
 import { defineObjectType, link, OntologyRegistry, prop } from "../src/ontology"
@@ -14,6 +19,8 @@ import {
   linkBatchKey,
   type ObjectLinkRow,
   type ObjectQueryCapabilities,
+  type ObjectReadExecutionLimits,
+  type ObjectReadStorage,
   type ObjectRow,
   type ObjectStorage,
   objectBatchKey,
@@ -357,6 +364,146 @@ describe("AuthorizedObjectReader", () => {
     expect(links.map((row) => row.targetTypeId)).toEqual([LineItem.id, Secret.id])
   })
 
+  test("creates one selected provider reader for delegated non-query terminals", async () => {
+    const selectedCalls: ReadCall[] = []
+    const selectedRows = [
+      row(Proposal.id, "proposal-1", { id: "proposal-1", title: "Proposal" }),
+      row(LineItem.id, "line-1", { id: "line-1", name: "Line" }),
+    ]
+    const selectedLinks = [
+      objectLink("items", LineItem.id, "line-1", { position: 1 }),
+      objectLink("unselected", LineItem.id, "line-1"),
+    ]
+    const backend = createReadStorage({
+      selectedReader: createSelectedReader(selectedRows, selectedLinks, selectedCalls),
+    })
+    const scope = createDelegatedRequestScope({
+      projectId,
+      requestId: "request-delegated",
+      correlationId: "correlation-delegated",
+      objectRead: {
+        selection: {
+          kind: "selected",
+          roots: [
+            {
+              anchor: { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+              node: {
+                objects: [{ objectTypeId: Proposal.id, propertyIds: ["id", "title"] }],
+                links: [
+                  {
+                    definitions: [
+                      {
+                        sourceObjectTypeId: Proposal.id,
+                        linkId: "items",
+                        targetObjectTypeIds: [LineItem.id],
+                        propertyIds: ["position"],
+                      },
+                    ],
+                    target: {
+                      objects: [{ objectTypeId: LineItem.id, propertyIds: ["id", "name"] }],
+                      links: [],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 4_096 },
+      },
+    })
+    const reader = createAuthorizedObjectReader({
+      scope,
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    expect(backend.selectedScopeCalls).toBe(1)
+    expect(backend.selectedScopeInputs).toHaveLength(1)
+    expect(backend.selectedScopeInputs[0]).toMatchObject({
+      projectId,
+      limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 4_096 },
+    })
+    const resolved = resolveRuntimeAuthorization(scope.authorization)
+    expect(resolved.type).toBe("delegated")
+    if (resolved.type !== "delegated") throw new Error("expected delegated authorization")
+    expect(backend.selectedScopeInputs[0]?.scope).toBe(resolved.objectRead.scope)
+    expect(backend.selectedScopeInputs[0]?.limits).toBe(resolved.objectRead.limits)
+
+    await expect(
+      reader.getByPrimaryId({ objectTypeId: Proposal.id, primaryId: "proposal-1" })
+    ).resolves.toMatchObject({ primaryId: "proposal-1" })
+    await expect(
+      reader.getByPrimaryId({ objectTypeId: Proposal.id, primaryId: "proposal-2" })
+    ).resolves.toBeNull()
+    const batch = await reader.getByPrimaryIdBatch({
+      items: [
+        { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+        { objectTypeId: Proposal.id, primaryId: "proposal-2" },
+      ],
+    })
+    expect(batch.size).toBe(1)
+    await expect(
+      reader.canReadObjectProperty({
+        objectTypeId: Proposal.id,
+        primaryId: "proposal-1",
+        propertyId: "title",
+      })
+    ).resolves.toBe(true)
+    await expect(
+      reader.canReadObjectPropertiesBatch({
+        items: [
+          {
+            objectTypeId: Proposal.id,
+            primaryId: "proposal-1",
+            propertyId: "title",
+          },
+          {
+            objectTypeId: Proposal.id,
+            primaryId: "proposal-1",
+            propertyId: "secret",
+          },
+        ],
+      })
+    ).resolves.toEqual([true, false])
+    await expect(reader.list({})).resolves.toMatchObject({ total: 2 })
+    await expect(
+      reader.listLinks({ objectTypeId: Proposal.id, objectId: "proposal-1" })
+    ).resolves.toHaveLength(1)
+    const linkBatch = await reader.listLinksBatch({
+      items: [{ objectTypeId: Proposal.id, objectId: "proposal-1", linkId: "items" }],
+    })
+    expect(linkBatch.size).toBe(1)
+    expect(linkBatch.get(linkBatchKey(Proposal.id, "proposal-1", "items"))).toHaveLength(1)
+    await expect(
+      reader.getByPrimaryId({ objectTypeId: Secret.id, primaryId: "secret-1" })
+    ).rejects.toThrow("does not select object type 'Secret'")
+
+    const query = { kind: "start" as const, objectTypeId: Proposal.id }
+    for (const operation of [
+      () => reader.executeQuery({ query }),
+      () => reader.queryLinks({ query }),
+      () => reader.count({ query }),
+      () => reader.exists({ query }),
+      () => reader.facet({ query, facets: [{ propertyId: "title", limit: 10 }] }),
+    ]) {
+      await expect(operation()).rejects.toThrow("require explicit selected-path admission")
+    }
+
+    expect(backend.selectedScopeCalls).toBe(1)
+    expect(backend.calls).toEqual([])
+    expect(selectedCalls.map((call) => call.operation)).toEqual([
+      "getByPrimaryId",
+      "getByPrimaryId",
+      "getByPrimaryIdBatch",
+      "selectsObjectProperties",
+      "selectsObjectProperties",
+      "list",
+      "listLinks",
+      "listLinksBatch",
+    ])
+  })
+
   test("ignores caller project extras and executes the exact query snapshot it authorized", async () => {
     let objectTypeReads = 0
     const authoredQuery = Object.defineProperties(
@@ -466,10 +613,16 @@ type ReadCall = {
 function createReadStorage(options?: {
   readonly ignoreEndpointTypeFilter?: boolean
   readonly queryLinksHasMore?: boolean
+  readonly selectedReader?: ObjectReadStorage
 }): {
   readonly storage: ObjectStorage
   readonly calls: ReadCall[]
   readonly selectedScopeCalls: number
+  readonly selectedScopeInputs: readonly {
+    readonly projectId: string
+    readonly scope: Parameters<ObjectStorage["createSelectedReadScope"]>[0]["scope"]
+    readonly limits: ObjectReadExecutionLimits
+  }[]
   readonly rows: {
     readonly proposal: ObjectRow
     readonly line: ObjectRow
@@ -489,6 +642,11 @@ function createReadStorage(options?: {
     objectLink("secret", Secret.id, "secret-1"),
   ]
   let selectedScopeCalls = 0
+  const selectedScopeInputs: {
+    projectId: string
+    scope: Parameters<ObjectStorage["createSelectedReadScope"]>[0]["scope"]
+    limits: ObjectReadExecutionLimits
+  }[] = []
   const record = (operation: string, input?: unknown): void => {
     calls.push({ operation, ...(input === undefined ? {} : { input }) })
   }
@@ -584,8 +742,10 @@ function createReadStorage(options?: {
         : allRows
       return { objects, hasMore: false, total: objects.length }
     },
-    createSelectedReadScope() {
+    createSelectedReadScope(input) {
       selectedScopeCalls += 1
+      selectedScopeInputs.push(input)
+      if (options?.selectedReader) return options.selectedReader
       throw new Error("createSelectedReadScope must not be called for existing authorities")
     },
     async listIncidentLinksBatch() {
@@ -602,8 +762,75 @@ function createReadStorage(options?: {
     get selectedScopeCalls() {
       return selectedScopeCalls
     },
+    selectedScopeInputs,
     rows,
     links,
+  }
+}
+
+function createSelectedReader(
+  rows: readonly ObjectRow[],
+  links: readonly ObjectLinkRow[],
+  calls: ReadCall[]
+): ObjectReadStorage {
+  const record = (operation: string, input?: unknown): void => {
+    calls.push({ operation, ...(input === undefined ? {} : { input }) })
+  }
+  return {
+    queryCapabilities() {
+      record("queryCapabilities")
+      return { queryObjects: false }
+    },
+    async getByPrimaryId(input) {
+      record("getByPrimaryId", input)
+      return findRow(rows, input.objectTypeId, input.primaryId)
+    },
+    async getByPrimaryIdBatch(input) {
+      record("getByPrimaryIdBatch", input)
+      const result = new Map()
+      for (const item of input.items) {
+        const found = findRow(rows, item.objectTypeId, item.primaryId)
+        if (found) result.set(objectBatchKey(item.objectTypeId, item.primaryId), found)
+      }
+      return result
+    },
+    async selectsObjectProperties(input) {
+      record("selectsObjectProperties", input)
+      return input.items.map(
+        (item) =>
+          item.objectTypeId === Proposal.id &&
+          item.primaryId === "proposal-1" &&
+          item.propertyId === "title"
+      )
+    },
+    async listLinks(input) {
+      record("listLinks", input)
+      return links
+    },
+    async listLinksBatch(input) {
+      record("listLinksBatch", input)
+      return new Map(
+        input.items.map((item) => [
+          linkBatchKey(item.objectTypeId, item.objectId, item.linkId),
+          [...links],
+        ])
+      )
+    },
+    async queryLinks(input) {
+      record("queryLinks", input)
+      return { links, hasMore: false }
+    },
+    async list(input) {
+      record("list", input)
+      const requested =
+        input.objectTypeId === undefined
+          ? undefined
+          : new Set(
+              typeof input.objectTypeId === "string" ? [input.objectTypeId] : input.objectTypeId
+            )
+      const objects = requested ? rows.filter((row) => requested.has(row.objectTypeId)) : [...rows]
+      return { objects, hasMore: false, total: objects.length }
+    },
   }
 }
 

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -351,6 +351,25 @@ describe("bound Sixb object reads", () => {
 
     expect(query.list()).rejects.toThrow(AuthorizationError)
   })
+
+  test("typed and dynamic listLinks share endpoint filtering", async () => {
+    const host = createRuntime()
+    const sixb = createTestSixb(host)
+    await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
+    await sixb.objects(Invoice).upsert({ properties: { id: "i1" } })
+    await sixb.objects(Invoice).upsertLink({
+      sourceId: "i1",
+      linkId: "contract",
+      targetTypeId: "contract",
+      targetId: "c1",
+    })
+    const principalSixb = bindPrincipal(host, contextFor(host, ["finance"]))
+
+    expect(await principalSixb.objects(Invoice).byId("i1").listLinks()).toEqual([])
+    expect(
+      await principalSixb.objects.listLinks({ objectTypeId: "invoice", objectId: "i1" })
+    ).toEqual([])
+  })
 })
 
 describe("bound Sixb cross-type list", () => {
@@ -1077,20 +1096,6 @@ describe("direct writes are attributable", () => {
 })
 
 describe("bound Sixb fails closed on ungranted surfaces", () => {
-  test("listLinks denies even when reached at runtime", async () => {
-    const host = createRuntime()
-    const sixb = createTestSixb(host)
-    await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
-    const principalSixb = bindPrincipal(host, contextFor(host, ["editors"]))
-
-    // Trusted executions need this method on the shared Sixb surface. A principal can reach it too,
-    // but link rows name target types no read grant covers, so the protected leaf fails closed even
-    // when the principal may edit the source type.
-    expect(principalSixb.objects(Contract).byId("c1").listLinks()).rejects.toThrow(
-      AuthorizationError
-    )
-  })
-
   test("an explicit auth-disabled execution remains unrestricted", async () => {
     const host = createRuntime()
     const sixb = createTestSixb(host)

--- a/packages/core/tests/storage-operation-scope.test.ts
+++ b/packages/core/tests/storage-operation-scope.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import {
+  compileSelectedObjectReadScope,
+  type ObjectReadStorage,
+  type ObjectStorage,
+  StorageTransactionError,
+} from "../src/storage"
+import { InMemoryStorage } from "../src/storage/in-memory"
+import {
+  createObjectOperationScope,
   createOperationScopedFacade,
   createStorageOperationScope,
 } from "../src/storage/operation-scope"
@@ -11,6 +19,17 @@ class TestStorage {
 }
 
 describe("storage operation scope", () => {
+  test("fails closed when object storage omits the selected-read factory", () => {
+    const malformed = { createSelectedReadScope: undefined } as unknown as ObjectStorage
+
+    expect(() =>
+      createObjectOperationScope(
+        malformed,
+        createStorageOperationScope(async (run) => run())
+      )
+    ).toThrow("must implement ObjectReadScopeFactory")
+  })
+
   test("keeps decorated provider methods inside their operation scope", async () => {
     const target = new TestStorage()
     let scopeRuns = 0
@@ -82,4 +101,93 @@ describe("storage operation scope", () => {
 
     await expect(facade.read()).rejects.toThrow("scope became unavailable")
   })
+
+  test("runs selected-reader terminals through the same root operation lock", async () => {
+    const storage = new InMemoryStorage()
+    const input = selectedReaderInput()
+    const reader = storage.objects.createSelectedReadScope(input)
+    let transactionEntered!: () => void
+    const entered = new Promise<void>((resolve) => {
+      transactionEntered = resolve
+    })
+    let releaseTransaction!: () => void
+    const blocked = new Promise<void>((resolve) => {
+      releaseTransaction = resolve
+    })
+    const transaction = storage.transaction(async () => {
+      transactionEntered()
+      await blocked
+    })
+    await entered
+
+    let readFinished = false
+    const read = reader.list({ projectId: input.projectId }).then((result) => {
+      readFinished = true
+      return result
+    })
+    try {
+      await Bun.sleep(0)
+      expect(readFinished).toBe(false)
+    } finally {
+      releaseTransaction()
+      await transaction
+    }
+    await expect(read).resolves.toEqual({ objects: [], hasMore: false, total: 0 })
+  })
+
+  test("guards transaction-created readers and captured factory methods after completion", async () => {
+    const storage = new InMemoryStorage()
+    const input = selectedReaderInput()
+    let escapedReader: ObjectReadStorage | undefined
+    let escapedRead: ObjectReadStorage["list"] | undefined
+    let escapedFactory: ObjectStorage["createSelectedReadScope"] | undefined
+
+    await storage.transaction(async (tx) => {
+      expect(() => storage.objects.createSelectedReadScope(input)).toThrow(
+        "use the provided tx storage"
+      )
+
+      const reader = tx.objects.createSelectedReadScope(input)
+      await expect(reader.list({ projectId: input.projectId })).resolves.toEqual({
+        objects: [],
+        hasMore: false,
+        total: 0,
+      })
+      escapedReader = reader
+      escapedRead = reader.list
+      escapedFactory = tx.objects.createSelectedReadScope
+    })
+
+    if (!escapedReader || !escapedRead || !escapedFactory) {
+      throw new Error("Expected transaction reader handles to be captured.")
+    }
+    const reader = escapedReader
+    const read = escapedRead
+    const createReader = escapedFactory
+    expect(() => reader.queryCapabilities()).toThrow(StorageTransactionError)
+    expect(() => createReader(input)).toThrow(StorageTransactionError)
+    await expect(
+      Promise.resolve().then(() => read({ projectId: input.projectId }))
+    ).rejects.toMatchObject({ code: "transaction_inactive" })
+  })
 })
+
+function selectedReaderInput() {
+  const projectId = "operation-scope-project"
+  return {
+    projectId,
+    scope: compileSelectedObjectReadScope({
+      kind: "selected",
+      roots: [
+        {
+          anchor: { objectTypeId: "OperationScopeObject", primaryId: "root" },
+          node: {
+            objects: [{ objectTypeId: "OperationScopeObject", propertyIds: ["id"] }],
+            links: [],
+          },
+        },
+      ],
+    }),
+    limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 10_000 },
+  }
+}

--- a/storage/pg/src/index.ts
+++ b/storage/pg/src/index.ts
@@ -13,6 +13,7 @@ import { ProviderMaterializationTransactionLifecycle } from "@sixb/core/internal
 import {
   createAgentOperationScope,
   createAuthOperationScope,
+  createObjectOperationScope,
   createOntologyOperationScope,
   createOperationScopedFacade,
   createStorageOperationScope,
@@ -208,7 +209,7 @@ export class PostgresStorage implements MigrationCapableStorage {
       },
       () => this.assertRootOperationAvailable()
     )
-    this.objects = createOperationScopedFacade(stores.objects, scope)
+    this.objects = createObjectOperationScope(stores.objects, scope)
     this.ontology = createOntologyOperationScope(stores.ontology, scope)
     this.auth = createAuthOperationScope(stores.auth, scope)
     this.executions = createOperationScopedFacade(stores.executions, scope)

--- a/storage/pg/src/objects/storage.ts
+++ b/storage/pg/src/objects/storage.ts
@@ -12,7 +12,6 @@ import type {
   ObjectLinkRow,
   ObjectQueryCapabilities,
   ObjectReadExecutionLimits,
-  ObjectReadScopeFactory,
   ObjectReadStorage,
   ObjectRow,
   ObjectStorage,
@@ -101,7 +100,7 @@ const PG_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
 }
 
 /** PostgreSQL object provider; interactive reads share one source-aware reader. */
-export class PgObjectStorage implements ObjectStorage, ObjectReadScopeFactory {
+export class PgObjectStorage implements ObjectStorage {
   private readonly reader: PgObjectReader
 
   constructor(private readonly sql: PgStoreClient) {

--- a/storage/pg/src/transactions.ts
+++ b/storage/pg/src/transactions.ts
@@ -67,7 +67,7 @@ export async function runPgRepeatableReadTransaction<T>(
   }
 
   throw new Error(
-    "[SixbPg] Selected object reads cannot join an unverified PostgreSQL transaction."
+    '[SixbPg] Selected object reads cannot join an unverified PostgreSQL transaction. Use storage.transaction(..., { isolation: "serializable" }) when reading through tx.objects.'
   )
 }
 

--- a/storage/pg/tests/pg-object-read-scope-provider.e2e.ts
+++ b/storage/pg/tests/pg-object-read-scope-provider.e2e.ts
@@ -3,9 +3,7 @@ import {
   compileSelectedObjectReadScope,
   linkBatchKey,
   type ObjectReadExecutionLimits,
-  type ObjectReadScopeFactory,
   type ObjectReadStorage,
-  type ObjectStorage,
   objectBatchKey,
   type SelectedObjectReadScope,
 } from "@sixb/core/storage"
@@ -292,17 +290,20 @@ describe("PgObjectStorage selected reader invariants", () => {
 
   test("reuses a serializable PostgresStorage transaction end to end", async () => {
     const { storage } = await createTestStorage()
+    let escapedReader: ObjectReadStorage | undefined
+    let escapedList: ObjectReadStorage["list"] | undefined
     try {
       await insertObject(sqlOf(storage), RootType, "root-1", { id: "root-1", hidden: "secret" })
 
       const row = await storage.transaction(
         async (tx) => {
-          const factory = tx.objects as ObjectStorage & ObjectReadScopeFactory
-          const reader = factory.createSelectedReadScope({
+          const reader = tx.objects.createSelectedReadScope({
             projectId,
             scope: compileSelectedObjectReadScope(rootOnlyScope()),
             limits: generousLimits,
           })
+          escapedReader = reader
+          escapedList = reader.list
           return reader.getByPrimaryId({
             projectId,
             objectTypeId: RootType,
@@ -312,18 +313,24 @@ describe("PgObjectStorage selected reader invariants", () => {
         { isolation: "serializable" }
       )
       expect(row).toMatchObject({ primaryId: "root-1", properties: { id: "root-1" } })
+      if (!escapedReader || !escapedList) throw new Error("expected escaped selected reader")
+      const reader = escapedReader
+      const list = escapedList
+      expect(() => reader.queryCapabilities()).toThrow("after transaction completion")
+      await expect(Promise.resolve().then(() => list({ projectId }))).rejects.toMatchObject({
+        code: "transaction_inactive",
+      })
 
       await expect(
         storage.transaction(async (tx) => {
-          const factory = tx.objects as ObjectStorage & ObjectReadScopeFactory
-          const reader = factory.createSelectedReadScope({
+          const reader = tx.objects.createSelectedReadScope({
             projectId,
             scope: compileSelectedObjectReadScope(rootOnlyScope()),
             limits: generousLimits,
           })
           return reader.list({ projectId })
         })
-      ).rejects.toThrow("cannot join an unverified PostgreSQL transaction")
+      ).rejects.toThrow('{ isolation: "serializable" }')
     } finally {
       await storage.dropSchema()
       await storage.close()
@@ -336,10 +343,7 @@ function createReader(
   scope: SelectedObjectReadScope,
   limits: ObjectReadExecutionLimits = generousLimits
 ): ObjectReadStorage {
-  const factory =
-    storage instanceof PgObjectStorage
-      ? storage
-      : (storage.objects as ObjectStorage & ObjectReadScopeFactory)
+  const factory = storage instanceof PgObjectStorage ? storage : storage.objects
   return factory.createSelectedReadScope({
     projectId,
     scope: compileSelectedObjectReadScope(scope),

--- a/storage/pg/tests/pg-object-read-scope.e2e.ts
+++ b/storage/pg/tests/pg-object-read-scope.e2e.ts
@@ -1,4 +1,3 @@
-import type { ObjectReadScopeFactory, ObjectStorage } from "@sixb/core/storage"
 import { runObjectReadScopeContractSuite } from "@sixb/core/testing"
 import { createTestStorage } from "./helpers"
 
@@ -7,7 +6,7 @@ runObjectReadScopeContractSuite("PostgresStorage selected object-read scope cont
     const { storage } = await createTestStorage()
     return {
       storage,
-      objectReadScopeFactory: storage.objects as ObjectStorage & ObjectReadScopeFactory,
+      objectReadScopeFactory: storage.objects,
     }
   },
   teardown: async ({ storage }) => {

--- a/storage/pg/tests/pg-transactions.test.ts
+++ b/storage/pg/tests/pg-transactions.test.ts
@@ -80,7 +80,7 @@ describe("runPgTransaction isolation", () => {
   test("rejects unverified, read-committed, and escaped transaction clients", async () => {
     await expect(
       runPgRepeatableReadTransaction({} as PgStoreClient, async () => "unverified")
-    ).rejects.toThrow("cannot join an unverified PostgreSQL transaction")
+    ).rejects.toThrow('{ isolation: "serializable" }')
 
     const readCommitted = fakeSql()
     await runPgTransaction(readCommitted.sql, async (tx) => {

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -13,6 +13,7 @@ import { ProviderMaterializationTransactionLifecycle } from "@sixb/core/internal
 import {
   createAgentOperationScope,
   createAuthOperationScope,
+  createObjectOperationScope,
   createOntologyOperationScope,
   createOperationScopedFacade,
   createStorageOperationScope,
@@ -143,7 +144,7 @@ export class SqliteStorage implements MigrationCapableStorage {
     const readTimeseries = path
       ? new SqliteTimeseriesStorage({ connection: this.readConnection })
       : stores.timeseries
-    this.objects = createOperationScopedFacade(readObjects, readScope)
+    this.objects = createObjectOperationScope(readObjects, readScope)
     this.ontology = createOntologyOperationScope(stores.ontology, ontologyScope)
     this.auth = createAuthOperationScope(stores.auth, scope)
     this.executions = createOperationScopedFacade(stores.executions, scope)

--- a/storage/sqlite/src/objects/storage.ts
+++ b/storage/sqlite/src/objects/storage.ts
@@ -13,7 +13,6 @@ import type {
   ObjectLinkRow,
   ObjectQueryCapabilities,
   ObjectReadExecutionLimits,
-  ObjectReadScopeFactory,
   ObjectReadStorage,
   ObjectRow,
   ObjectStorage,
@@ -112,7 +111,7 @@ const SQLITE_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
  * Stores object projections and links. V1 object-query IR pushdown covers the
  * scalar JSON-property and link-traversal subset declared by queryCapabilities().
  */
-export class SqliteObjectStorage implements ObjectStorage, ObjectReadScopeFactory {
+export class SqliteObjectStorage implements ObjectStorage {
   private readonly connection: SqliteStoreConnection
   private readonly db: Database
   private readonly reader: SqliteObjectReader

--- a/storage/sqlite/tests/sqlite-object-read-scope-provider.test.ts
+++ b/storage/sqlite/tests/sqlite-object-read-scope-provider.test.ts
@@ -8,9 +8,7 @@ import {
   compileSelectedObjectReadScope,
   linkBatchKey,
   type ObjectReadExecutionLimits,
-  type ObjectReadScopeFactory,
   type ObjectReadStorage,
-  type ObjectStorage,
   objectBatchKey,
   type SelectedObjectReadScope,
 } from "@sixb/core/storage"
@@ -279,8 +277,7 @@ describe("SqliteObjectStorage selected reader invariants", () => {
       writer = new Database(sqliteStoragePath(directory))
       insertObject(writer, RootType, "root-1", { id: "root-1", hidden: "secret" })
 
-      const factory = storage.objects as ObjectStorage & ObjectReadScopeFactory
-      const reader = factory.createSelectedReadScope({
+      const reader = storage.objects.createSelectedReadScope({
         projectId,
         scope: compileSelectedObjectReadScope(rootOnlyScope()),
         limits: generousLimits,
@@ -296,6 +293,38 @@ describe("SqliteObjectStorage selected reader invariants", () => {
       writer?.close()
       storage.close()
       await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  test("preserves selected readers through a storage transaction and expires escaped readers", async () => {
+    const storage = new SqliteStorage()
+    let escapedReader: ObjectReadStorage | undefined
+    let escapedList: ObjectReadStorage["list"] | undefined
+    try {
+      await storage.transaction(async (tx) => {
+        const reader = tx.objects.createSelectedReadScope({
+          projectId,
+          scope: compileSelectedObjectReadScope(rootOnlyScope()),
+          limits: generousLimits,
+        })
+        await expect(reader.list({ projectId })).resolves.toEqual({
+          objects: [],
+          hasMore: false,
+          total: 0,
+        })
+        escapedReader = reader
+        escapedList = reader.list
+      })
+
+      if (!escapedReader || !escapedList) throw new Error("expected escaped selected reader")
+      const reader = escapedReader
+      const list = escapedList
+      expect(() => reader.queryCapabilities()).toThrow("after transaction completion")
+      await expect(Promise.resolve().then(() => list({ projectId }))).rejects.toMatchObject({
+        code: "transaction_inactive",
+      })
+    } finally {
+      storage.close()
     }
   })
 

--- a/storage/sqlite/tests/sqlite-object-read-scope.test.ts
+++ b/storage/sqlite/tests/sqlite-object-read-scope.test.ts
@@ -1,4 +1,3 @@
-import type { ObjectReadScopeFactory, ObjectStorage } from "@sixb/core/storage"
 import { runObjectReadScopeContractSuite } from "@sixb/core/testing"
 import { SqliteStorage } from "../src"
 
@@ -7,9 +6,7 @@ runObjectReadScopeContractSuite("SqliteStorage selected object-read scope contra
     const storage = new SqliteStorage()
     return {
       storage,
-      // Storage activation is a later slice. The provider facade already preserves the concrete
-      // factory method, so this contract can validate SQLite independently in the meantime.
-      objectReadScopeFactory: storage.objects as ObjectStorage & ObjectReadScopeFactory,
+      objectReadScopeFactory: storage.objects,
     }
   },
   teardown: ({ storage }) => storage.close(),


### PR DESCRIPTION
Part of #269 · Stack #547 · Parent: #493 · Next: #498

## Why

The previous PRs taught storage providers to read within a selected scope. This PR connects that capability to Core: **one `AuthorizedObjectReader` chooses the right storage reader for the execution's authority**, and existing read APIs use it.

For example, a delegated reader for proposal `P-123` must keep that selection even when used from another API entry point. It must never fall back to the ordinary provider or borrow another execution's authority.

## Reader creation and request flows

`createAuthorizedObjectReader(...)` validates the `ExecutionScope`, chooses the storage reader and binds the resulting instance to that exact authority. Callers receive the `AuthorizedObjectReader` type; the implementation class and its construction key stay private to the module.

```text
Ordinary authority
  createAuthorizedObjectReader(scope, ontology, objectStorage)
    → keep the provider's ordinary ObjectStorage

  Object / Link read API
    → AuthorizedObjectReader: apply ordinary authorization
    → provider read method
    → copied result returned to the caller

Delegated authority
  createAuthorizedObjectReader(scope, ontology, objectStorage)
    → objectStorage.createSelectedReadScope(projectId, scope, limits)
    → restricted ObjectReadStorage

  Object / Link read API
    → AuthorizedObjectReader: check the delegated selection
    → restricted provider read: scope applies before calculations
    → copied result returned to the caller
```

`ObjectStorage` and `ObjectReadStorage` are interfaces. The provider implements the reads; `AuthorizedObjectReader` binds them to request authority. Ordinary reads keep their existing behavior and do not acquire selected-reader budgets.

## Responsibilities

| Component | What it adds |
| --- | --- |
| `AuthorizedObjectReader` | Captures inputs, checks access, delegates reads and copies results so callers cannot mutate stored values through returned references. |
| Execution binding | Rejects pairing a reader with another authority, including a sibling execution with equivalent permissions. |
| Storage contract | Requires `createSelectedReadScope` on object providers and exposes it through storage façades. |
| Operation / transaction guards | Prevent selected readers and captured methods from being used after their transaction ends. |

Existing typed, dynamic, Agent-context, Object and Link read paths are routed through the shared reader. This provides the extension point planned by #185.

## What is enabled here

Delegated object lookups, lists, links and property-selection checks can use the restricted reader. **Delegated Object Query terminals remain rejected until #498; delegated domain SDK access remains closed until #542.** This PR does not expose Shared Links to end users.

## Validation

- After rebasing onto #493: 84 targeted unit tests and 18 PostgreSQL integration tests pass.
- Core/PostgreSQL typecheck and the touched file's Biome check pass.

Incorporates #494 and #497.
