### PR TITLE
core: bind delegated object readers

### DIFF
--- a/packages/core/src/authorization/decision.ts
+++ b/packages/core/src/authorization/decision.ts
@@ -134,6 +134,12 @@ export function isAllowed(
 
 export function assertAuthorized(runtime: AuthorizedRuntime, request: AuthzRequest): void {
   const resolved = assertRuntimeAuthorizationBound(runtime)
+  if (resolved.type === "delegated") {
+    throw new AuthorizationError(
+      `delegated:${request.kind}`,
+      `[Sixb] Operation '${request.kind}' is not covered by delegated authorization.`
+    )
+  }
   const authorization = resolved.type === "principal" ? resolved.context : undefined
   const decision = evaluate(authorization, request)
   if (decision.allowed) {

--- a/packages/core/src/execution/authorization.ts
+++ b/packages/core/src/execution/authorization.ts
@@ -5,6 +5,15 @@ import { GRANT_KIND_KEYS, type GrantKind } from "../authorization/grant-kinds"
 import type { AuthorizationContext, GrantIndex } from "../authorization/types"
 import { createSixbError } from "../errors/internal"
 import {
+  type ObjectReadExecutionLimits,
+  snapshotObjectReadExecutionLimits,
+} from "../storage/objects/execution-limits"
+import { compileSelectedObjectReadScope } from "../storage/objects/read-scope"
+import type {
+  CompiledSelectedObjectReadScope,
+  SelectedObjectReadScope,
+} from "../storage/objects/types"
+import {
   type AuthorizablePrincipal,
   type AuthorizationRef,
   createRuntimeAuthorizationCapability,
@@ -29,7 +38,18 @@ export type ResolvedRuntimeAuthorization =
       readonly projectId: string
       readonly ref: Exclude<AuthorizationRef, { readonly type: "principal" }>
     }
+  | {
+      readonly type: "delegated"
+      readonly projectId: string
+      readonly objectRead: DelegatedObjectReadAuthorization
+    }
   | { readonly type: "denied" }
+
+/** Immutable process-local object-read authority. It has no durable representation. */
+export interface DelegatedObjectReadAuthorization {
+  readonly scope: CompiledSelectedObjectReadScope
+  readonly limits: ObjectReadExecutionLimits
+}
 
 type RegisteredRuntimeAuthorization = Exclude<
   ResolvedRuntimeAuthorization,
@@ -112,6 +132,33 @@ export function createDisabledRuntimeAuthorization(
   })
 }
 
+/** Register exact object-read authority without fabricating a principal identity. */
+export function createDelegatedRuntimeAuthorization(input: {
+  readonly execution: ExecutionContext
+  readonly objectRead: {
+    readonly selection: SelectedObjectReadScope
+    readonly limits: ObjectReadExecutionLimits
+  }
+}): RuntimeAuthorization {
+  const execution = input.execution
+  const objectReadInput = input.objectRead
+  if (execution.executor.type !== "request" || execution.requestedBy !== undefined) {
+    throw new Error(
+      "[Sixb] Delegated runtime authorization requires a request execution without a principal."
+    )
+  }
+
+  const objectRead = Object.freeze({
+    scope: compileSelectedObjectReadScope(objectReadInput.selection),
+    limits: snapshotObjectReadExecutionLimits(objectReadInput.limits),
+  })
+  return register(execution, {
+    type: "delegated",
+    projectId: execution.projectId,
+    objectRead,
+  })
+}
+
 export function createTrustedPrimitiveRuntimeAuthorization(input: {
   readonly execution: ExecutionContext
   readonly primitive: TrustedPrimitiveRef
@@ -168,6 +215,11 @@ export function getAuthorizationRef(authorization: RuntimeAuthorization): Author
   const resolved = resolveRuntimeAuthorization(authorization)
   if (resolved.type === "denied") {
     throw new Error("[Sixb] Runtime authorization is not a registered Core capability.")
+  }
+  if (resolved.type === "delegated") {
+    throw new Error(
+      "[Sixb] Delegated runtime authorization cannot cross a durable execution boundary."
+    )
   }
   return cloneAuthorizationRef(resolved.ref)
 }
@@ -264,11 +316,8 @@ function assertResolvedAuthorizationMatchesExecution(
       ) {
         throw invalidExecutionAuthority(execution.id, "request source does not match its executor")
       }
-      if (resolved.ref.type === "principal") {
-        if (
-          resolved.type !== "principal" ||
-          !principalsEqual(execution.requestedBy, resolved.ref.principal)
-        ) {
+      if (resolved.type === "principal") {
+        if (!principalsEqual(execution.requestedBy, resolved.ref.principal)) {
           throw invalidExecutionAuthority(
             execution.id,
             "request authority does not match its requested-by principal"
@@ -276,14 +325,22 @@ function assertResolvedAuthorizationMatchesExecution(
         }
         return
       }
-      if (resolved.ref.type === "disabled" && execution.requestedBy === undefined) return
+      if (
+        resolved.type === "unrestricted" &&
+        resolved.ref.type === "disabled" &&
+        execution.requestedBy === undefined
+      ) {
+        return
+      }
+      if (resolved.type === "delegated" && execution.requestedBy === undefined) return
       throw invalidExecutionAuthority(
         execution.id,
-        "request execution requires principal or explicitly disabled authority"
+        "request execution requires principal, delegated, or explicitly disabled authority"
       )
 
     case "primitive":
       if (
+        resolved.type !== "unrestricted" ||
         resolved.ref.type !== "trustedPrimitive" ||
         resolved.ref.primitive.kind !== execution.executor.kind ||
         resolved.ref.primitive.id !== execution.executor.id ||
@@ -313,6 +370,7 @@ function assertResolvedAuthorizationMatchesExecution(
 
     case "kernel":
       if (
+        resolved.type !== "unrestricted" ||
         resolved.ref.type !== "kernel" ||
         execution.requestedBy !== undefined ||
         resolved.ref.operation.type !== execution.executor.operation.type ||

--- a/packages/core/src/execution/authorized-object-reader.ts
+++ b/packages/core/src/execution/authorized-object-reader.ts
@@ -1,4 +1,5 @@
 import { assertAuthorized, isAllowed } from "../authorization"
+import { AuthorizationError } from "../authorization/errors"
 import type { AuthorizationContext } from "../authorization/types"
 import {
   countObjects,
@@ -21,7 +22,13 @@ import { assertObjectQueryComplexity } from "../objects/query/complexity"
 import { ObjectQueryValidationError } from "../objects/query/errors"
 import type { ObjectQuery } from "../objects/query/ir"
 import type { OntologyRegistry } from "../ontology"
-import type { LinkBatchKey, ObjectLinkRow, ObjectReadStorage, ObjectStorage } from "../storage"
+import type {
+  CompiledObjectReadStep,
+  LinkBatchKey,
+  ObjectLinkRow,
+  ObjectReadStorage,
+  ObjectStorage,
+} from "../storage"
 import { captureExecutionScope, resolveExecutionScopeAuthorization } from "./authorization"
 import type { ExecutionScope, RuntimeAuthorization } from "./types"
 
@@ -56,6 +63,8 @@ class AuthorizedObjectReaderImpl {
   readonly #runtime: RuntimeReadAuthorization
   readonly #ontology: OntologyRegistry
   readonly #storage: ObjectReadStorage
+  readonly #delegatedObjectTypeIds?: ReadonlySet<string>
+  readonly #delegatedLinkDefinitions?: ReadonlySet<string>
 
   constructor(
     key: typeof readerConstructionKey,
@@ -74,6 +83,14 @@ class AuthorizedObjectReaderImpl {
     this.#authority = input.authority
     this.#ontology = input.ontology
     this.#storage = input.storage
+    this.#delegatedObjectTypeIds =
+      input.authority.type === "delegated"
+        ? new Set(input.authority.objectRead.scope.objects.map((object) => object.objectTypeId))
+        : undefined
+    this.#delegatedLinkDefinitions =
+      input.authority.type === "delegated"
+        ? new Set(input.authority.objectRead.scope.steps.map(delegatedLinkDefinitionKey))
+        : undefined
     this.#runtime = Object.freeze({
       projectId: input.scope.execution.projectId,
       runtimeAuthorization: input.scope.authorization,
@@ -245,6 +262,7 @@ class AuthorizedObjectReaderImpl {
   async executeQuery(
     input: Omit<ExecuteObjectQueryInput, "projectId">
   ): Promise<ExecuteObjectQueryResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     const includeTotal = snapshotReadValue(input.includeTotal)
     return detachReadResult(
@@ -262,6 +280,7 @@ class AuthorizedObjectReaderImpl {
   async queryLinks(
     input: Omit<ExecuteObjectQueryLinksInput, "projectId">
   ): Promise<ExecuteObjectQueryLinksResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     const request = snapshotReadValue({
       direction: input.direction,
@@ -292,6 +311,7 @@ class AuthorizedObjectReaderImpl {
   async count(
     input: Omit<ExecuteObjectCountInput, "projectId">
   ): Promise<ExecuteObjectCountResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     return detachReadResult(
       await countObjects(
@@ -304,6 +324,7 @@ class AuthorizedObjectReaderImpl {
   async exists(
     input: Omit<ExecuteObjectExistsInput, "projectId">
   ): Promise<ExecuteObjectExistsResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     return detachReadResult(
       await existsObjects(
@@ -316,6 +337,7 @@ class AuthorizedObjectReaderImpl {
   async facet(
     input: Omit<ExecuteObjectFacetsInput, "projectId">
   ): Promise<ExecuteObjectFacetsResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     const facets = snapshotReadValue(
       input.facets.map((facet) => ({ propertyId: facet.propertyId, limit: facet.limit }))
@@ -340,6 +362,17 @@ class AuthorizedObjectReaderImpl {
   }
 
   #assertObjectTypesViewable(objectTypeIds: readonly string[]): void {
+    if (this.#authority.type === "delegated") {
+      for (const objectTypeId of new Set(objectTypeIds)) {
+        if (this.#delegatedObjectTypeIds?.has(objectTypeId)) continue
+        throw new AuthorizationError(
+          `delegated:object.view:${objectTypeId}`,
+          `[Sixb] Delegated authorization does not select object type '${objectTypeId}'.`
+        )
+      }
+      return
+    }
+
     for (const objectTypeId of new Set(objectTypeIds)) {
       assertAuthorized(this.#runtime, { kind: "object.view", objectTypeId })
     }
@@ -365,12 +398,30 @@ class AuthorizedObjectReaderImpl {
   }
 
   #isObjectTypeViewable(objectTypeId: string): boolean {
+    if (this.#authority.type === "delegated") {
+      return this.#delegatedObjectTypeIds?.has(objectTypeId) ?? false
+    }
     return isAllowed(this.#runtime.authorization, { kind: "object.view", objectTypeId })
   }
 
+  #assertDelegatedQueriesAdmitted(): void {
+    if (this.#authority.type !== "delegated") return
+    throw new AuthorizationError(
+      "delegated:object.query",
+      "[Sixb] Object Query terminals require explicit selected-path admission under delegated authorization."
+    )
+  }
+
   #isLinkViewable(link: ObjectLinkRow): boolean {
+    if (
+      !this.#isObjectTypeViewable(link.sourceTypeId) ||
+      !this.#isObjectTypeViewable(link.targetTypeId)
+    ) {
+      return false
+    }
     return (
-      this.#isObjectTypeViewable(link.sourceTypeId) && this.#isObjectTypeViewable(link.targetTypeId)
+      this.#delegatedLinkDefinitions?.has(delegatedLinkDefinitionKey(link)) ??
+      this.#authority.type !== "delegated"
     )
   }
 }
@@ -416,6 +467,12 @@ function objectStorageForAuthority(
     case "principal":
     case "unrestricted":
       return objectStorage
+    case "delegated":
+      return objectStorage.createSelectedReadScope({
+        projectId: authority.projectId,
+        scope: authority.objectRead.scope,
+        limits: authority.objectRead.limits,
+      })
   }
   return assertNever(authority)
 }
@@ -424,6 +481,16 @@ function assertNever(value: never): never {
   throw new Error(
     `[Sixb] Unsupported object reader authority '${String((value as { type?: unknown }).type)}'.`
   )
+}
+
+function delegatedLinkDefinitionKey(
+  input:
+    | Pick<CompiledObjectReadStep, "sourceObjectTypeId" | "linkId" | "targetObjectTypeId">
+    | Pick<ObjectLinkRow, "sourceTypeId" | "linkId" | "targetTypeId">
+): string {
+  return "sourceObjectTypeId" in input
+    ? JSON.stringify([input.sourceObjectTypeId, input.linkId, input.targetObjectTypeId])
+    : JSON.stringify([input.sourceTypeId, input.linkId, input.targetTypeId])
 }
 
 /**

--- a/packages/core/src/execution/scopes.ts
+++ b/packages/core/src/execution/scopes.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto"
 import type { AuthorizationContext } from "../authorization"
+import type { ObjectReadExecutionLimits, SelectedObjectReadScope } from "../storage"
 import {
+  createDelegatedRuntimeAuthorization,
   createDisabledRuntimeAuthorization,
   createKernelRuntimeAuthorization,
   createPrincipalRuntimeAuthorization,
@@ -47,6 +49,26 @@ export function createDisabledRequestScope(input: {
   return Object.freeze({
     execution,
     authorization: createDisabledRuntimeAuthorization(execution),
+  })
+}
+
+/** Internal request scope carrying only a finite object-read selection. */
+export function createDelegatedRequestScope(input: {
+  readonly projectId: string
+  readonly requestId: string
+  readonly correlationId: string
+  readonly objectRead: {
+    readonly selection: SelectedObjectReadScope
+    readonly limits: ObjectReadExecutionLimits
+  }
+}): ExecutionScope {
+  const execution = createRequestExecution(input)
+  return Object.freeze({
+    execution,
+    authorization: createDelegatedRuntimeAuthorization({
+      execution,
+      objectRead: input.objectRead,
+    }),
   })
 }
 

--- a/packages/core/src/runtime/host.ts
+++ b/packages/core/src/runtime/host.ts
@@ -244,7 +244,12 @@ export class SixbHost<
   withScope(scope: ExecutionScope): Sixb<TOntologySources> {
     const capturedScope = captureExecutionScope(scope)
     const authorization = resolveExecutionScopeAuthorization(this.projectId, capturedScope)
-    if (authorization.ref.type === "kernel") {
+    if (authorization.type === "delegated") {
+      throw new Error(
+        "[Sixb] Delegated runtime authorization cannot be bound to the domain SDK until every delegated surface is activated."
+      )
+    }
+    if (authorization.type === "unrestricted" && authorization.ref.type === "kernel") {
       throw new Error("[Sixb] Kernel authority cannot be bound to the domain SDK.")
     }
 

--- a/packages/core/tests/authorization-decision.test.ts
+++ b/packages/core/tests/authorization-decision.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { type AuthorizationContext, emptyGrantIndex, isAllowed } from "../src"
 import {
+  assertAuthorized,
   assertCanAppendTelemetry,
   assertCanEdit,
   canViewEvent,
@@ -18,7 +19,7 @@ import type {
   StoredTelemetryAppendedEvent,
   StoredWorkflowRunStartedEvent,
 } from "../src/events"
-import { createTestingScope } from "../src/execution/scopes"
+import { createDelegatedRequestScope, createTestingScope } from "../src/execution/scopes"
 
 function context(grants: {
   applications?: readonly string[]
@@ -69,6 +70,30 @@ const unrestrictedScope = createTestingScope({ projectId: "decision-test" })
 const unrestrictedRuntime = {
   projectId: "decision-test",
   runtimeAuthorization: unrestrictedScope.authorization,
+}
+const delegatedScope = createDelegatedRequestScope({
+  projectId: "decision-test",
+  requestId: "delegated-request",
+  correlationId: "delegated-correlation",
+  objectRead: {
+    selection: {
+      kind: "selected",
+      roots: [
+        {
+          anchor: { objectTypeId: "quote", primaryId: "quote-1" },
+          node: {
+            objects: [{ objectTypeId: "quote", propertyIds: ["id"] }],
+            links: [],
+          },
+        },
+      ],
+    },
+    limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+  },
+})
+const delegatedRuntime = {
+  projectId: "decision-test",
+  runtimeAuthorization: delegatedScope.authorization,
 }
 
 describe("evaluate", () => {
@@ -230,6 +255,22 @@ describe("evaluate", () => {
 })
 
 describe("write asserts", () => {
+  test("generic authorization denies delegated operations instead of treating them as unrestricted", () => {
+    for (const operation of [
+      () => assertAuthorized(delegatedRuntime, { kind: "object.view", objectTypeId: "quote" }),
+      () =>
+        assertAuthorized(delegatedRuntime, {
+          kind: "object.query",
+          touchedObjectTypeIds: ["quote"],
+        }),
+      () => assertAuthorized(delegatedRuntime, { kind: "action.apply", actionId: "approve" }),
+      () => assertCanEdit(delegatedRuntime, "quote"),
+      () => assertCanAppendTelemetry(delegatedRuntime, "sensor"),
+    ]) {
+      expect(operation).toThrow("not covered by delegated authorization")
+    }
+  })
+
   test("assertCanEdit demands view as well as edit, and names the missing one", () => {
     const both = principalRuntime({ view: ["quote"], edit: ["quote"] })
     expect(() => assertCanEdit(both, "quote")).not.toThrow()

--- a/packages/core/tests/authorized-object-reader-runtime.test.ts
+++ b/packages/core/tests/authorized-object-reader-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createAuthorizedObjectReader } from "../src/execution/authorized-object-reader"
-import { createTestingScope } from "../src/execution/scopes"
+import { createDelegatedRequestScope, createTestingScope } from "../src/execution/scopes"
 import { OntologyRegistry } from "../src/ontology"
 import { SixbHost } from "../src/runtime/host"
 import { createBoundSixb, type SixbDependencies } from "../src/runtime/sixb"
@@ -46,6 +46,23 @@ describe("AuthorizedObjectReader runtime binding", () => {
     expect(host.withScope(accessorScope).execution).toBe(source.execution)
     expect(executionReads).toBe(1)
     expect(authorizationReads).toBe(1)
+  })
+
+  test("SixbHost keeps delegated authority off the domain SDK until every surface is active", () => {
+    const host = new SixbHost({ id: projectId, ontology: [], ...createTestRuntimeDeps() })
+    const scope = createDelegatedRequestScope({
+      projectId,
+      requestId: "delegated-request",
+      correlationId: "delegated-correlation",
+      objectRead: {
+        selection: { kind: "selected", roots: [] },
+        limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+      },
+    })
+
+    expect(() => host.withScope(scope)).toThrow(
+      "Delegated runtime authorization cannot be bound to the domain SDK"
+    )
   })
 
   test("createBoundSixb rejects a reader from another exact authority", () => {

--- a/packages/core/tests/execution-authorization.test.ts
+++ b/packages/core/tests/execution-authorization.test.ts
@@ -7,6 +7,7 @@ import { restoreAgentExecutionScope } from "../src/execution/agent"
 import {
   assertExecutionScopeProject,
   createAgentRuntimeAuthorization,
+  createDelegatedRuntimeAuthorization,
   createPrincipalRuntimeAuthorization,
   createTrustedPrimitiveRuntimeAuthorization,
   getAuthorizationRef,
@@ -19,6 +20,7 @@ import {
   restoreTrustedPrimitiveExecutionScope,
 } from "../src/execution/durable"
 import {
+  createDelegatedRequestScope,
   createDisabledRequestScope,
   createKernelScope,
   createPrincipalRequestScope,
@@ -30,6 +32,7 @@ import {
   type ExecutionScope,
   type RuntimeAuthorization,
 } from "../src/execution/types"
+import type { SelectedObjectReadScope } from "../src/storage"
 
 describe("runtime authorization capabilities", () => {
   test("snapshots principal authority and exposes only a defensive durable reference", () => {
@@ -175,6 +178,99 @@ describe("runtime authorization capabilities", () => {
 })
 
 describe("execution scopes", () => {
+  test("compiles and freezes process-local delegated object-read authority once", () => {
+    const propertyIds = ["id"]
+    const roots: SelectedObjectReadScope["roots"][number][] = [
+      {
+        anchor: { objectTypeId: "Proposal", primaryId: "proposal-1" },
+        node: {
+          objects: [{ objectTypeId: "Proposal", propertyIds }],
+          links: [],
+        },
+      },
+    ]
+    const scope = createDelegatedRequestScope({
+      projectId: "project-1",
+      requestId: "delegated-request-1",
+      correlationId: "delegated-correlation-1",
+      objectRead: {
+        selection: { kind: "selected", roots },
+        limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 1_024 },
+      },
+    })
+
+    propertyIds.push("secret")
+    roots.push({
+      anchor: { objectTypeId: "Proposal", primaryId: "proposal-2" },
+      node: {
+        objects: [{ objectTypeId: "Proposal", propertyIds: ["id"] }],
+        links: [],
+      },
+    })
+
+    const resolved = resolveRuntimeAuthorization(scope.authorization)
+    expect(resolved.type).toBe("delegated")
+    if (resolved.type !== "delegated") throw new Error("expected delegated authorization")
+    expect(resolved.objectRead.scope.roots).toHaveLength(1)
+    expect(resolved.objectRead.scope.objects).toEqual([
+      { nodeId: 0, objectTypeId: "Proposal", propertyIds: ["id"] },
+    ])
+    expect(resolved.objectRead.limits).toEqual({
+      maxTraversalFacts: 100,
+      maxOutputJsonBytes: 1_024,
+    })
+    expect(Object.isFrozen(resolved)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead.scope)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead.scope.roots)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead.scope.objects[0]?.propertyIds)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead.limits)).toBe(true)
+
+    expect(() => getAuthorizationRef(scope.authorization)).toThrow(
+      "cannot cross a durable execution boundary"
+    )
+    expect(() =>
+      executionRecordInputFromRuntime({
+        execution: scope.execution,
+        runtimeAuthorization: scope.authorization,
+      })
+    ).toThrow("cannot cross a durable execution boundary")
+  })
+
+  test("binds delegated authority only to its exact principal-free request", () => {
+    const scope = createDelegatedRequestScope({
+      projectId: "project-1",
+      requestId: "delegated-request-bound",
+      correlationId: "delegated-correlation-bound",
+      objectRead: {
+        selection: delegatedSelection(),
+        limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+      },
+    })
+    const other = createDisabledRequestScope({
+      projectId: "project-1",
+      requestId: "delegated-request-other",
+      correlationId: "delegated-correlation-other",
+    })
+
+    expect(() => resolveExecutionScopeAuthorization("project-1", scope)).not.toThrow()
+    expect(() =>
+      resolveExecutionScopeAuthorization("project-1", {
+        execution: other.execution,
+        authorization: scope.authorization,
+      })
+    ).toThrow("authority is bound to different execution provenance")
+    expect(() =>
+      createDelegatedRuntimeAuthorization({
+        execution: requestExecution("delegated-principal", { type: "user", id: "user-1" }),
+        objectRead: {
+          selection: delegatedSelection(),
+          limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+        },
+      })
+    ).toThrow("requires a request execution without a principal")
+  })
+
   test("durable serialization rejects a mismatched execution and authority pair", () => {
     const projectOne = createTestingScope({ projectId: "project-1" })
     const projectTwo = createTestingScope({ projectId: "project-2" })
@@ -532,5 +628,20 @@ function requestExecution(
     executor: { type: "request", requestId: `request-${id}` },
     source: { type: "http", requestId: `request-${id}` },
     correlationId: `correlation-${id}`,
+  }
+}
+
+function delegatedSelection(): SelectedObjectReadScope {
+  return {
+    kind: "selected",
+    roots: [
+      {
+        anchor: { objectTypeId: "Proposal", primaryId: "proposal-1" },
+        node: {
+          objects: [{ objectTypeId: "Proposal", propertyIds: ["id"] }],
+          links: [],
+        },
+      },
+    ],
   }
 }

--- a/packages/core/tests/object-reader-binding.test.ts
+++ b/packages/core/tests/object-reader-binding.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, test } from "bun:test"
 import { emptyGrantIndex } from "../src/authorization"
 import { AuthorizationError } from "../src/authorization/errors"
+import { resolveRuntimeAuthorization } from "../src/execution/authorization"
 import {
   type AuthorizedObjectReader,
   assertAuthorizedObjectReaderBinding,
   createAuthorizedObjectReader,
 } from "../src/execution/authorized-object-reader"
-import { createDisabledRequestScope, createPrincipalRequestScope } from "../src/execution/scopes"
+import {
+  createDelegatedRequestScope,
+  createDisabledRequestScope,
+  createPrincipalRequestScope,
+} from "../src/execution/scopes"
 import type { ExecutionScope } from "../src/execution/types"
 import type { ObjectQuery } from "../src/objects/query"
 import { defineObjectType, link, OntologyRegistry, prop } from "../src/ontology"
@@ -14,6 +19,8 @@ import {
   linkBatchKey,
   type ObjectLinkRow,
   type ObjectQueryCapabilities,
+  type ObjectReadExecutionLimits,
+  type ObjectReadStorage,
   type ObjectRow,
   type ObjectStorage,
   objectBatchKey,
@@ -357,6 +364,146 @@ describe("AuthorizedObjectReader", () => {
     expect(links.map((row) => row.targetTypeId)).toEqual([LineItem.id, Secret.id])
   })
 
+  test("creates one selected provider reader for delegated non-query terminals", async () => {
+    const selectedCalls: ReadCall[] = []
+    const selectedRows = [
+      row(Proposal.id, "proposal-1", { id: "proposal-1", title: "Proposal" }),
+      row(LineItem.id, "line-1", { id: "line-1", name: "Line" }),
+    ]
+    const selectedLinks = [
+      objectLink("items", LineItem.id, "line-1", { position: 1 }),
+      objectLink("unselected", LineItem.id, "line-1"),
+    ]
+    const backend = createReadStorage({
+      selectedReader: createSelectedReader(selectedRows, selectedLinks, selectedCalls),
+    })
+    const scope = createDelegatedRequestScope({
+      projectId,
+      requestId: "request-delegated",
+      correlationId: "correlation-delegated",
+      objectRead: {
+        selection: {
+          kind: "selected",
+          roots: [
+            {
+              anchor: { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+              node: {
+                objects: [{ objectTypeId: Proposal.id, propertyIds: ["id", "title"] }],
+                links: [
+                  {
+                    definitions: [
+                      {
+                        sourceObjectTypeId: Proposal.id,
+                        linkId: "items",
+                        targetObjectTypeIds: [LineItem.id],
+                        propertyIds: ["position"],
+                      },
+                    ],
+                    target: {
+                      objects: [{ objectTypeId: LineItem.id, propertyIds: ["id", "name"] }],
+                      links: [],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 4_096 },
+      },
+    })
+    const reader = createAuthorizedObjectReader({
+      scope,
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    expect(backend.selectedScopeCalls).toBe(1)
+    expect(backend.selectedScopeInputs).toHaveLength(1)
+    expect(backend.selectedScopeInputs[0]).toMatchObject({
+      projectId,
+      limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 4_096 },
+    })
+    const resolved = resolveRuntimeAuthorization(scope.authorization)
+    expect(resolved.type).toBe("delegated")
+    if (resolved.type !== "delegated") throw new Error("expected delegated authorization")
+    expect(backend.selectedScopeInputs[0]?.scope).toBe(resolved.objectRead.scope)
+    expect(backend.selectedScopeInputs[0]?.limits).toBe(resolved.objectRead.limits)
+
+    await expect(
+      reader.getByPrimaryId({ objectTypeId: Proposal.id, primaryId: "proposal-1" })
+    ).resolves.toMatchObject({ primaryId: "proposal-1" })
+    await expect(
+      reader.getByPrimaryId({ objectTypeId: Proposal.id, primaryId: "proposal-2" })
+    ).resolves.toBeNull()
+    const batch = await reader.getByPrimaryIdBatch({
+      items: [
+        { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+        { objectTypeId: Proposal.id, primaryId: "proposal-2" },
+      ],
+    })
+    expect(batch.size).toBe(1)
+    await expect(
+      reader.canReadObjectProperty({
+        objectTypeId: Proposal.id,
+        primaryId: "proposal-1",
+        propertyId: "title",
+      })
+    ).resolves.toBe(true)
+    await expect(
+      reader.canReadObjectPropertiesBatch({
+        items: [
+          {
+            objectTypeId: Proposal.id,
+            primaryId: "proposal-1",
+            propertyId: "title",
+          },
+          {
+            objectTypeId: Proposal.id,
+            primaryId: "proposal-1",
+            propertyId: "secret",
+          },
+        ],
+      })
+    ).resolves.toEqual([true, false])
+    await expect(reader.list({})).resolves.toMatchObject({ total: 2 })
+    await expect(
+      reader.listLinks({ objectTypeId: Proposal.id, objectId: "proposal-1" })
+    ).resolves.toHaveLength(1)
+    const linkBatch = await reader.listLinksBatch({
+      items: [{ objectTypeId: Proposal.id, objectId: "proposal-1", linkId: "items" }],
+    })
+    expect(linkBatch.size).toBe(1)
+    expect(linkBatch.get(linkBatchKey(Proposal.id, "proposal-1", "items"))).toHaveLength(1)
+    await expect(
+      reader.getByPrimaryId({ objectTypeId: Secret.id, primaryId: "secret-1" })
+    ).rejects.toThrow("does not select object type 'Secret'")
+
+    const query = { kind: "start" as const, objectTypeId: Proposal.id }
+    for (const operation of [
+      () => reader.executeQuery({ query }),
+      () => reader.queryLinks({ query }),
+      () => reader.count({ query }),
+      () => reader.exists({ query }),
+      () => reader.facet({ query, facets: [{ propertyId: "title", limit: 10 }] }),
+    ]) {
+      await expect(operation()).rejects.toThrow("require explicit selected-path admission")
+    }
+
+    expect(backend.selectedScopeCalls).toBe(1)
+    expect(backend.calls).toEqual([])
+    expect(selectedCalls.map((call) => call.operation)).toEqual([
+      "getByPrimaryId",
+      "getByPrimaryId",
+      "getByPrimaryIdBatch",
+      "selectsObjectProperties",
+      "selectsObjectProperties",
+      "list",
+      "listLinks",
+      "listLinksBatch",
+    ])
+  })
+
   test("ignores caller project extras and executes the exact query snapshot it authorized", async () => {
     let objectTypeReads = 0
     const authoredQuery = Object.defineProperties(
@@ -466,10 +613,16 @@ type ReadCall = {
 function createReadStorage(options?: {
   readonly ignoreEndpointTypeFilter?: boolean
   readonly queryLinksHasMore?: boolean
+  readonly selectedReader?: ObjectReadStorage
 }): {
   readonly storage: ObjectStorage
   readonly calls: ReadCall[]
   readonly selectedScopeCalls: number
+  readonly selectedScopeInputs: readonly {
+    readonly projectId: string
+    readonly scope: Parameters<ObjectStorage["createSelectedReadScope"]>[0]["scope"]
+    readonly limits: ObjectReadExecutionLimits
+  }[]
   readonly rows: {
     readonly proposal: ObjectRow
     readonly line: ObjectRow
@@ -489,6 +642,11 @@ function createReadStorage(options?: {
     objectLink("secret", Secret.id, "secret-1"),
   ]
   let selectedScopeCalls = 0
+  const selectedScopeInputs: {
+    projectId: string
+    scope: Parameters<ObjectStorage["createSelectedReadScope"]>[0]["scope"]
+    limits: ObjectReadExecutionLimits
+  }[] = []
   const record = (operation: string, input?: unknown): void => {
     calls.push({ operation, ...(input === undefined ? {} : { input }) })
   }
@@ -584,8 +742,10 @@ function createReadStorage(options?: {
         : allRows
       return { objects, hasMore: false, total: objects.length }
     },
-    createSelectedReadScope() {
+    createSelectedReadScope(input) {
       selectedScopeCalls += 1
+      selectedScopeInputs.push(input)
+      if (options?.selectedReader) return options.selectedReader
       throw new Error("createSelectedReadScope must not be called for existing authorities")
     },
     async listIncidentLinksBatch() {
@@ -602,8 +762,75 @@ function createReadStorage(options?: {
     get selectedScopeCalls() {
       return selectedScopeCalls
     },
+    selectedScopeInputs,
     rows,
     links,
+  }
+}
+
+function createSelectedReader(
+  rows: readonly ObjectRow[],
+  links: readonly ObjectLinkRow[],
+  calls: ReadCall[]
+): ObjectReadStorage {
+  const record = (operation: string, input?: unknown): void => {
+    calls.push({ operation, ...(input === undefined ? {} : { input }) })
+  }
+  return {
+    queryCapabilities() {
+      record("queryCapabilities")
+      return { queryObjects: false }
+    },
+    async getByPrimaryId(input) {
+      record("getByPrimaryId", input)
+      return findRow(rows, input.objectTypeId, input.primaryId)
+    },
+    async getByPrimaryIdBatch(input) {
+      record("getByPrimaryIdBatch", input)
+      const result = new Map()
+      for (const item of input.items) {
+        const found = findRow(rows, item.objectTypeId, item.primaryId)
+        if (found) result.set(objectBatchKey(item.objectTypeId, item.primaryId), found)
+      }
+      return result
+    },
+    async selectsObjectProperties(input) {
+      record("selectsObjectProperties", input)
+      return input.items.map(
+        (item) =>
+          item.objectTypeId === Proposal.id &&
+          item.primaryId === "proposal-1" &&
+          item.propertyId === "title"
+      )
+    },
+    async listLinks(input) {
+      record("listLinks", input)
+      return links
+    },
+    async listLinksBatch(input) {
+      record("listLinksBatch", input)
+      return new Map(
+        input.items.map((item) => [
+          linkBatchKey(item.objectTypeId, item.objectId, item.linkId),
+          [...links],
+        ])
+      )
+    },
+    async queryLinks(input) {
+      record("queryLinks", input)
+      return { links, hasMore: false }
+    },
+    async list(input) {
+      record("list", input)
+      const requested =
+        input.objectTypeId === undefined
+          ? undefined
+          : new Set(
+              typeof input.objectTypeId === "string" ? [input.objectTypeId] : input.objectTypeId
+            )
+      const objects = requested ? rows.filter((row) => requested.has(row.objectTypeId)) : [...rows]
+      return { objects, hasMore: false, total: objects.length }
+    },
   }
 }
 


### PR DESCRIPTION
## What

```text
principal-free request
  -> process-local delegated authority
  -> one selected ObjectReadStorage
  -> canonical object reader
```

- compiles and snapshots one finite object selection at authority registration
- binds it to the exact request provenance and project
- routes get, list, batch, property, and link reads through one selected provider reader
- keeps generic operations and Query terminals denied by default
- rejects durable serialization until delegated attribution exists

## Why

- guessed sibling ids reach the selected relation and remain indistinguishable from missing objects
- no principal identity or unrestricted fallback is fabricated
- the next PR can admit Query semantics without changing the Object API

## Safety boundary

- `SixbHost.withScope()` still rejects delegated authority
- no server, Share/session, Action, telemetry, or metadata activation
- principal and trusted execution behavior is unchanged

## Validation

- 63 focused tests; 242 assertions
- clean Core typecheck and targeted Biome check

## Stack

- Base: #496
- Next: #498
