### PR TITLE
core: authorize and execute selected object queries

### DIFF
--- a/packages/core/src/execution/authorized-object-reader.ts
+++ b/packages/core/src/execution/authorized-object-reader.ts
@@ -19,15 +19,28 @@ import {
   facetObjects,
 } from "../objects/query"
 import { ObjectQueryValidationError } from "../objects/query/errors"
+import { validateObjectFacetRequests } from "../objects/query/executor"
 import type { ObjectQuery } from "../objects/query/ir"
+import { preflightObjectQueryLinks } from "../objects/query/links"
+import {
+  createSelectedObjectQueryAdmission,
+  type SelectedObjectQueryAdmission,
+} from "../objects/query/selected-read-admission"
+import {
+  type AdmittedObjectQuery,
+  validateObjectQuery,
+  validateObjectQueryWithAdmission,
+} from "../objects/query/validate"
 import type { OntologyRegistry } from "../ontology"
 import type {
   CompiledObjectReadStep,
   LinkBatchKey,
+  ObjectFacetRequest,
   ObjectLinkRow,
   ObjectReadStorage,
   ObjectStorage,
 } from "../storage"
+import { MAX_OBJECT_READ_FACETS } from "../storage"
 import { captureExecutionScope, resolveExecutionScopeAuthorization } from "./authorization"
 import type { ExecutionScope, RuntimeAuthorization } from "./types"
 
@@ -64,6 +77,7 @@ class AuthorizedObjectReaderImpl {
   readonly #storage: ObjectReadStorage
   readonly #delegatedObjectTypeIds?: ReadonlySet<string>
   readonly #delegatedLinkDefinitions?: ReadonlySet<string>
+  readonly #delegatedQueryAdmission?: SelectedObjectQueryAdmission
 
   constructor(
     key: typeof readerConstructionKey,
@@ -89,6 +103,10 @@ class AuthorizedObjectReaderImpl {
     this.#delegatedLinkDefinitions =
       input.authority.type === "delegated"
         ? new Set(input.authority.objectRead.scope.steps.map(delegatedLinkDefinitionKey))
+        : undefined
+    this.#delegatedQueryAdmission =
+      input.authority.type === "delegated"
+        ? createSelectedObjectQueryAdmission(input.authority.objectRead.scope)
         : undefined
     this.#runtime = Object.freeze({
       projectId: input.scope.execution.projectId,
@@ -261,13 +279,13 @@ class AuthorizedObjectReaderImpl {
   async executeQuery(
     input: Omit<ExecuteObjectQueryInput, "projectId">
   ): Promise<ExecuteObjectQueryResult> {
-    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     const includeTotal = snapshotReadValue(input.includeTotal)
+    const executionQuery = this.#admitDelegatedQuery(query)?.query ?? query
     return detachReadResult(
       await executeObjectQuery(
         {
-          query,
+          query: executionQuery,
           ...(includeTotal === undefined ? {} : { includeTotal }),
           projectId: this.#runtime.projectId,
         },
@@ -279,7 +297,6 @@ class AuthorizedObjectReaderImpl {
   async queryLinks(
     input: Omit<ExecuteObjectQueryLinksInput, "projectId">
   ): Promise<ExecuteObjectQueryLinksResult> {
-    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     const request = snapshotReadValue({
       direction: input.direction,
@@ -288,9 +305,29 @@ class AuthorizedObjectReaderImpl {
       pageSize: input.pageSize,
       pageToken: input.pageToken,
     })
+    let executionQuery = query
+    const admission = this.#delegatedQueryAdmission
+    if (admission) {
+      const preflight = preflightObjectQueryLinks(
+        { query, ...request, projectId: this.#runtime.projectId },
+        { ontology: this.#ontology }
+      )
+      const admitted = validateObjectQueryWithAdmission(
+        preflight.validated.query,
+        { ontology: this.#ontology, normalize: false },
+        admission
+      )
+      admission.assertIncidentEdgeSelected({
+        state: admitted.admissionState,
+        ...(preflight.linkId === undefined ? {} : { linkId: preflight.linkId }),
+        direction: preflight.direction,
+        path: "$.linkId",
+      })
+      executionQuery = admitted.query
+    }
     const result = detachReadResult(
       await executeObjectQueryLinks(
-        { query, ...request, projectId: this.#runtime.projectId },
+        { query: executionQuery, ...request, projectId: this.#runtime.projectId },
         this.#queryExecutorOptions()
       )
     )
@@ -310,11 +347,11 @@ class AuthorizedObjectReaderImpl {
   async count(
     input: Omit<ExecuteObjectCountInput, "projectId">
   ): Promise<ExecuteObjectCountResult> {
-    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
+    const executionQuery = this.#admitDelegatedQuery(query)?.query ?? query
     return detachReadResult(
       await countObjects(
-        { query, projectId: this.#runtime.projectId },
+        { query: executionQuery, projectId: this.#runtime.projectId },
         this.#queryExecutorOptions()
       )
     )
@@ -323,11 +360,11 @@ class AuthorizedObjectReaderImpl {
   async exists(
     input: Omit<ExecuteObjectExistsInput, "projectId">
   ): Promise<ExecuteObjectExistsResult> {
-    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
+    const executionQuery = this.#admitDelegatedQuery(query)?.query ?? query
     return detachReadResult(
       await existsObjects(
-        { query, projectId: this.#runtime.projectId },
+        { query: executionQuery, projectId: this.#runtime.projectId },
         this.#queryExecutorOptions()
       )
     )
@@ -336,20 +373,53 @@ class AuthorizedObjectReaderImpl {
   async facet(
     input: Omit<ExecuteObjectFacetsInput, "projectId">
   ): Promise<ExecuteObjectFacetsResult> {
-    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
-    const facets = snapshotReadValue(
-      input.facets.map((facet) => ({ propertyId: facet.propertyId, limit: facet.limit }))
-    )
+    const facets = snapshotFacetRequests(input.facets)
+    let executionQuery = query
+    let executionFacets = facets
+    const admission = this.#delegatedQueryAdmission
+    if (admission) {
+      // Terminal arguments are ordinary validation errors, not an authorization oracle. Validate
+      // them against the canonical result shape before raising any delegated-scope denial.
+      const validated = validateObjectQuery(query, { ontology: this.#ontology })
+      const normalizedFacets = validateObjectFacetRequests(facets, validated.result.objectTypeIds, {
+        ontology: this.#ontology,
+      })
+      const admitted = validateObjectQueryWithAdmission(
+        validated.query,
+        { ontology: this.#ontology, normalize: false },
+        admission
+      )
+      normalizedFacets.forEach((facet, index) => {
+        admission.assertPropertySelected({
+          state: admitted.admissionState,
+          propertyId: facet.propertyId,
+          use: "facet",
+          path: `$.facets[${index}].propertyId`,
+        })
+      })
+      executionQuery = admitted.query
+      executionFacets = normalizedFacets
+    }
     return detachReadResult(
       await facetObjects(
-        { query, facets, projectId: this.#runtime.projectId },
+        {
+          query: executionQuery,
+          facets: executionFacets,
+          projectId: this.#runtime.projectId,
+        },
         this.#queryExecutorOptions()
       )
     )
   }
 
   #queryExecutorOptions() {
+    if (this.#authority.type === "delegated") {
+      // The selected storage instance is the private execution capability. Passing the delegated
+      // runtime token into the generic executor would either reject this admitted query or tempt a
+      // forgeable bypass flag; neither is needed at this nominal boundary.
+      return { ontology: this.#ontology, storage: this.#storage }
+    }
     return {
       ontology: this.#ontology,
       storage: this.#storage,
@@ -358,6 +428,15 @@ class AuthorizedObjectReaderImpl {
         ? {}
         : { authorization: this.#runtime.authorization }),
     }
+  }
+
+  #admitDelegatedQuery(query: ObjectQuery): AdmittedObjectQuery | undefined {
+    if (!this.#delegatedQueryAdmission) return undefined
+    return validateObjectQueryWithAdmission(
+      query,
+      { ontology: this.#ontology },
+      this.#delegatedQueryAdmission
+    )
   }
 
   #assertObjectTypesViewable(objectTypeIds: readonly string[]): void {
@@ -401,14 +480,6 @@ class AuthorizedObjectReaderImpl {
       return this.#delegatedObjectTypeIds?.has(objectTypeId) ?? false
     }
     return isAllowed(this.#runtime.authorization, { kind: "object.view", objectTypeId })
-  }
-
-  #assertDelegatedQueriesAdmitted(): void {
-    if (this.#authority.type !== "delegated") return
-    throw new AuthorizationError(
-      "delegated:object.query",
-      "[Sixb] Object Query terminals require explicit selected-path admission under delegated authorization."
-    )
   }
 
   #isLinkViewable(link: ObjectLinkRow): boolean {
@@ -504,6 +575,36 @@ function detachReadResult<T>(value: T): T {
 /** Capture caller-owned values before authorization and execution. */
 function snapshotReadValue<T>(value: T): T {
   return structuredClone(value)
+}
+
+/** Bound and capture facet arguments before reading any caller-owned element. */
+function snapshotFacetRequests(facets: readonly ObjectFacetRequest[]): ObjectFacetRequest[] {
+  if (!Array.isArray(facets)) {
+    throw new ObjectQueryValidationError([
+      {
+        path: "$.facets",
+        code: "invalid_facets",
+        message: "facets must be an array",
+      },
+    ])
+  }
+  const length = facets.length
+  if (!Number.isSafeInteger(length) || length > MAX_OBJECT_READ_FACETS) {
+    throw new ObjectQueryValidationError([
+      {
+        path: "$.facets",
+        code: "too_many_facets",
+        message: `facets must include at most ${MAX_OBJECT_READ_FACETS} facet requests`,
+      },
+    ])
+  }
+
+  const snapshot: ObjectFacetRequest[] = []
+  for (let index = 0; index < length; index += 1) {
+    const facet = facets[index]
+    snapshot.push({ propertyId: facet.propertyId, limit: facet.limit })
+  }
+  return snapshot
 }
 
 /** Capture one serializable query before either authorization or execution sees it. */

--- a/packages/core/src/objects/query/executor.ts
+++ b/packages/core/src/objects/query/executor.ts
@@ -16,7 +16,7 @@ import type {
   ObjectRowLinks,
   QueryObjectsResult,
 } from "../../storage"
-import { linkBatchKey, objectBatchKey } from "../../storage"
+import { linkBatchKey, MAX_OBJECT_READ_FACETS, objectBatchKey } from "../../storage"
 import {
   ObjectQueryExecutionError,
   ObjectQueryPlanningError,
@@ -328,7 +328,7 @@ export async function facetObjects(
     normalize: false,
   })
   assertQueryViewable(input.projectId, validated, options)
-  const facets = validateFacetRequests(input.facets, validated.result.objectTypeIds, options)
+  const facets = validateObjectFacetRequests(input.facets, validated.result.objectTypeIds, options)
   const aggregateQuery = stripOuterRowShape(validated.query)
   const capabilities = options.storage.queryCapabilities()
   const hasQueryObjects = typeof options.storage.queryObjects === "function"
@@ -1177,16 +1177,27 @@ function stripOuterRowShape(query: ObjectQuery): ObjectQuery {
   }
 }
 
-function validateFacetRequests(
+/** @internal Shared pre-storage validation; intentionally absent from query barrels. */
+export function validateObjectFacetRequests(
   facets: readonly ObjectFacetRequest[],
   objectTypeIds: readonly string[],
-  options: QueryExecutorOptions
+  options: Pick<QueryExecutorOptions, "ontology" | "maxFacetLimit">
 ): ObjectFacetRequest[] {
   const issues: ObjectQueryValidationIssue[] = []
   const maxLimit = options.maxFacetLimit ?? DEFAULT_MAX_FACET_LIMIT
 
   if (facets.length === 0) {
     addFacetIssue(issues, "$.facets", "empty_facets", "At least one facet is required")
+  }
+
+  if (facets.length > MAX_OBJECT_READ_FACETS) {
+    throw new ObjectQueryValidationError([
+      {
+        path: "$.facets",
+        code: "too_many_facets",
+        message: `facets must include at most ${MAX_OBJECT_READ_FACETS} facet requests`,
+      },
+    ])
   }
 
   if (!Number.isInteger(maxLimit) || maxLimit <= 0) {

--- a/packages/core/src/objects/query/links.ts
+++ b/packages/core/src/objects/query/links.ts
@@ -15,7 +15,7 @@ import { ObjectQueryExecutionError } from "./errors"
 import { executeObjectQuery, type QueryExecutorOptions } from "./executor"
 import type { ObjectQuery } from "./ir"
 import { normalizeObjectQuery } from "./normalize"
-import { validateObjectQuery } from "./validate"
+import { type ValidatedObjectQuery, validateObjectQuery } from "./validate"
 
 export interface ExecuteObjectQueryLinksInput {
   projectId: string
@@ -34,10 +34,98 @@ export interface ExecuteObjectQueryLinksResult {
   nextPageToken?: string
 }
 
+export interface PreflightObjectQueryLinksResult {
+  projectId: string
+  validated: ValidatedObjectQuery
+  direction: LinkDirection
+  linkId?: string
+  includeObjects: boolean
+  pageSize: number
+  cursor?: ObjectLinkCursor
+  pageScope: string
+}
+
 const MAX_LINK_QUERY_OBJECTS = 1_000
 const MAX_LINK_PAGE_SIZE = 1_000
 const DEFAULT_LINK_PAGE_SIZE = 100
 const LINK_PAGE_TOKEN_PREFIX = "link:v1:"
+
+/**
+ * Canonicalize and validate a physical-link query without reading storage.
+ *
+ * This direct-file-only boundary lets higher-level readers complete ordinary request validation
+ * before applying terminal-specific authorization, while the executor consumes the exact same
+ * preflight contract.
+ *
+ * @internal Intentionally absent from query barrels.
+ */
+export function preflightObjectQueryLinks(
+  input: ExecuteObjectQueryLinksInput,
+  options: Pick<QueryExecutorOptions, "ontology" | "maxLimit" | "maxPageSize" | "maxRefs">
+): PreflightObjectQueryLinksResult {
+  // Capture caller-owned scalar fields once so validation, token scoping, and execution agree on
+  // one request even when this internal API is reached without an AuthorizedObjectReader snapshot.
+  const projectId = input.projectId
+  const query = input.query
+  const requestedDirection = input.direction
+  const linkId = input.linkId
+  const requestedIncludeObjects = input.includeObjects
+  const requestedPageSize = input.pageSize
+  const pageToken = input.pageToken
+
+  const direction = requestedDirection ?? "both"
+  if (direction !== "outgoing" && direction !== "incoming" && direction !== "both") {
+    throw new ObjectQueryExecutionError(
+      "invalid_link_direction",
+      "direction must be 'outgoing', 'incoming', or 'both'",
+      "$.direction"
+    )
+  }
+  if (linkId !== undefined && typeof linkId !== "string") {
+    throw new ObjectQueryExecutionError("invalid_link_id", "linkId must be a string", "$.linkId")
+  }
+  if (linkId !== undefined && linkId.length === 0) {
+    throw new ObjectQueryExecutionError("invalid_link_id", "linkId must not be empty", "$.linkId")
+  }
+  if (requestedIncludeObjects !== undefined && typeof requestedIncludeObjects !== "boolean") {
+    throw new ObjectQueryExecutionError(
+      "invalid_link_include_objects",
+      "includeObjects must be a boolean",
+      "$.includeObjects"
+    )
+  }
+
+  const pageSize = requestedPageSize ?? DEFAULT_LINK_PAGE_SIZE
+  if (!Number.isInteger(pageSize) || pageSize <= 0 || pageSize > MAX_LINK_PAGE_SIZE) {
+    throw new ObjectQueryExecutionError(
+      "invalid_link_page_size",
+      `pageSize must be an integer between 1 and ${MAX_LINK_PAGE_SIZE}`,
+      "$.pageSize"
+    )
+  }
+
+  const validated = validateObjectQuery(normalizeObjectQuery(query), {
+    ontology: options.ontology,
+    maxLimit: options.maxLimit,
+    maxPageSize: options.maxPageSize,
+    maxRefs: options.maxRefs,
+    normalize: false,
+  })
+  assertLinkSelectorShape(validated.query)
+  const pageScope = linkPageScope(projectId, validated.query, direction, linkId)
+  const cursor = decodeLinkPageToken(pageToken, pageScope)
+
+  return {
+    projectId,
+    validated,
+    direction,
+    ...(linkId === undefined ? {} : { linkId }),
+    includeObjects: requestedIncludeObjects ?? false,
+    pageSize,
+    ...(cursor === undefined ? {} : { cursor }),
+    pageScope,
+  }
+}
 
 /**
  * Select a bounded object set with the query IR, then return physical links
@@ -48,37 +136,8 @@ export async function executeObjectQueryLinks(
   input: ExecuteObjectQueryLinksInput,
   options: QueryExecutorOptions
 ): Promise<ExecuteObjectQueryLinksResult> {
-  const direction = input.direction ?? "both"
-  if (direction !== "outgoing" && direction !== "incoming" && direction !== "both") {
-    throw new ObjectQueryExecutionError(
-      "invalid_link_direction",
-      "direction must be 'outgoing', 'incoming', or 'both'",
-      "$.direction"
-    )
-  }
-  if (input.linkId !== undefined && input.linkId.length === 0) {
-    throw new ObjectQueryExecutionError("invalid_link_id", "linkId must not be empty", "$.linkId")
-  }
-
-  const pageSize = input.pageSize ?? DEFAULT_LINK_PAGE_SIZE
-  if (!Number.isInteger(pageSize) || pageSize <= 0 || pageSize > MAX_LINK_PAGE_SIZE) {
-    throw new ObjectQueryExecutionError(
-      "invalid_link_page_size",
-      `pageSize must be an integer between 1 and ${MAX_LINK_PAGE_SIZE}`,
-      "$.pageSize"
-    )
-  }
-  const validated = validateObjectQuery(normalizeObjectQuery(input.query), {
-    ontology: options.ontology,
-    maxLimit: options.maxLimit,
-    maxPageSize: options.maxPageSize,
-    maxRefs: options.maxRefs,
-    normalize: false,
-  })
-  assertLinkSelectorShape(validated.query)
-  const selectorQuery = validated.query
-  const pageScope = linkPageScope(input.projectId, selectorQuery, direction, input.linkId)
-  const cursor = decodeLinkPageToken(input.pageToken, pageScope)
+  const preflight = preflightObjectQueryLinks(input, options)
+  const selectorQuery = preflight.validated.query
 
   // A root page already has an explicit result bound and must execute directly: nesting it under a
   // probe limit would expose the provider's internal pageSize+1 row. All other selector shapes are
@@ -89,7 +148,7 @@ export async function executeObjectQueryLinks(
       : { kind: "limit" as const, limit: MAX_LINK_QUERY_OBJECTS + 1, input: selectorQuery }
   const selection = await executeObjectQuery(
     {
-      projectId: input.projectId,
+      projectId: preflight.projectId,
       query: boundedSelector,
       includeTotal: false,
     },
@@ -113,16 +172,16 @@ export async function executeObjectQueryLinks(
 
   const endpointObjectTypeIds = visibleEndpointTypeIds(options)
   const page = await options.storage.queryLinks({
-    projectId: input.projectId,
+    projectId: preflight.projectId,
     objectRefs: selected.map((row) => ({
       objectTypeId: row.objectTypeId,
       primaryId: row.primaryId,
     })),
-    direction,
-    ...(input.linkId === undefined ? {} : { linkId: input.linkId }),
+    direction: preflight.direction,
+    ...(preflight.linkId === undefined ? {} : { linkId: preflight.linkId }),
     ...(endpointObjectTypeIds === undefined ? {} : { endpointObjectTypeIds }),
-    ...(cursor === undefined ? {} : { after: cursor }),
-    limit: pageSize,
+    ...(preflight.cursor === undefined ? {} : { after: preflight.cursor }),
+    limit: preflight.pageSize,
   })
   const lastLink = page.links.at(-1)
   let nextPageToken: string | undefined
@@ -130,10 +189,10 @@ export async function executeObjectQueryLinks(
     if (!lastLink) {
       throw new Error("[Sixb] Object storage returned hasMore for an empty link page.")
     }
-    nextPageToken = encodeLinkPageToken(objectLinkCursor(lastLink), pageScope)
+    nextPageToken = encodeLinkPageToken(objectLinkCursor(lastLink), preflight.pageScope)
   }
-  const objects = input.includeObjects
-    ? await hydrateLinkQueryObjects(input.projectId, selected, page.links, options.storage)
+  const objects = preflight.includeObjects
+    ? await hydrateLinkQueryObjects(preflight.projectId, selected, page.links, options.storage)
     : []
 
   return {

--- a/packages/core/src/objects/query/selected-read-admission.ts
+++ b/packages/core/src/objects/query/selected-read-admission.ts
@@ -1,0 +1,310 @@
+import { AuthorizationError } from "../../authorization/errors"
+import type {
+  CompiledObjectReadObjectSelection,
+  CompiledObjectReadStep,
+  CompiledSelectedObjectReadScope,
+} from "../../storage/objects/types"
+import type {
+  ObjectQueryAdmissionState,
+  ObjectQueryAdmissionTransition,
+  ObjectQueryEdgeUse,
+  ObjectQueryPropertyUse,
+  ObjectQuerySemanticAdmission,
+} from "./validate"
+
+const selectedStateBrand = Symbol("sixb.selected-object-query-admission-state")
+
+interface SelectedObjectQueryState extends ObjectQueryAdmissionState {
+  readonly [selectedStateBrand]: true
+  readonly selections: readonly CompiledObjectReadObjectSelection[]
+}
+
+export interface SelectedObjectQueryAdmission extends ObjectQuerySemanticAdmission {
+  /** Terminal hook for property-bearing operations outside the query IR, such as facets. */
+  assertPropertySelected(input: {
+    readonly state: ObjectQueryAdmissionState
+    readonly propertyId: string
+    readonly objectTypeId?: string
+    readonly use: ObjectQueryPropertyUse
+    readonly path: string
+  }): void
+  /** Terminal hook for the physical-link selector that sits outside `queryLinks.query`. */
+  assertIncidentEdgeSelected(input: {
+    readonly state: ObjectQueryAdmissionState
+    readonly linkId?: string
+    readonly direction: "outgoing" | "incoming" | "both"
+    readonly path: string
+  }): void
+}
+
+/**
+ * Build an immutable semantic admission over one already-compiled selected reader scope.
+ *
+ * Object identities remain provider-owned: query admission follows exact path occurrences while
+ * the selected storage relation decides which live roots and linked instances exist.
+ */
+export function createSelectedObjectQueryAdmission(
+  scope: CompiledSelectedObjectReadScope
+): SelectedObjectQueryAdmission {
+  const selectionByKey = new Map<string, CompiledObjectReadObjectSelection>()
+  const selectionsByType = new Map<string, CompiledObjectReadObjectSelection[]>()
+  const propertiesBySelection = new Map<string, ReadonlySet<string>>()
+
+  for (const selection of scope.objects) {
+    const key = selectionKey(selection.nodeId, selection.objectTypeId)
+    selectionByKey.set(key, selection)
+    propertiesBySelection.set(key, new Set(selection.propertyIds))
+    const byType = selectionsByType.get(selection.objectTypeId) ?? []
+    byType.push(selection)
+    selectionsByType.set(selection.objectTypeId, byType)
+  }
+
+  const outgoing = indexSteps(scope.steps, "outgoing", selectionByKey)
+  const incoming = indexSteps(scope.steps, "incoming", selectionByKey)
+  const emptyState = selectedState([])
+
+  const admission: SelectedObjectQueryAdmission = {
+    empty: () => emptyState,
+    source: (input) => {
+      const selections = input.result.objectTypeIds.flatMap(
+        (objectTypeId) => selectionsByType.get(objectTypeId) ?? []
+      )
+      const state = selectedState(selections)
+
+      if (input.kind === "refs") {
+        const missingType = [...new Set(input.refs?.map((ref) => ref.objectTypeId) ?? [])]
+          .sort()
+          .find((objectTypeId) => !selectionsByType.has(objectTypeId))
+        if (missingType) {
+          return denied(
+            state,
+            new AuthorizationError(
+              `view:object:${missingType}`,
+              `[Sixb] Delegated query cannot reference object type '${missingType}' at '${input.path}': the selected object scope does not contain that type.`
+            )
+          )
+        }
+      }
+
+      if (state.selections.length > 0) return { state }
+      const objectTypeId = input.objectTypeId ?? input.result.objectTypeIds[0] ?? "unknown"
+      return denied(
+        state,
+        new AuthorizationError(
+          `view:object:${objectTypeId}`,
+          `[Sixb] Delegated query cannot start from object type '${objectTypeId}' at '${input.path}': the selected object scope does not contain that type.`
+        )
+      )
+    },
+    property: (input) =>
+      propertyDenial(
+        asSelectedState(input.state),
+        input.propertyId,
+        input.objectTypeId,
+        input.use,
+        input.path,
+        propertiesBySelection
+      ),
+    edge: (input) => {
+      const state = asSelectedState(input.state)
+      const next = followEdge(
+        state,
+        input.linkId,
+        input.direction,
+        input.sourceObjectTypeId,
+        outgoing,
+        incoming,
+        input.result.objectTypeIds
+      )
+      if (next.selections.length > 0 || state.selections.length === 0) return { state: next }
+      return denied(
+        next,
+        edgeDenial(
+          state,
+          input.linkId,
+          input.direction,
+          input.sourceObjectTypeId,
+          input.use,
+          input.path
+        )
+      )
+    },
+    set: ({ op, states }) => {
+      if (op === "subtract") return asSelectedState(states[0] ?? emptyState)
+      return selectedState(states.flatMap((state) => asSelectedState(state).selections))
+    },
+    assertPropertySelected: (input) => {
+      const denial = propertyDenial(
+        asSelectedState(input.state),
+        input.propertyId,
+        input.objectTypeId,
+        input.use,
+        input.path,
+        propertiesBySelection
+      )
+      if (denial) throw denial
+    },
+    assertIncidentEdgeSelected: (input) => {
+      if (input.linkId === undefined) return
+      const state = asSelectedState(input.state)
+      const directions: readonly ("outgoing" | "incoming")[] =
+        input.direction === "both" ? ["outgoing", "incoming"] : [input.direction]
+      const next = selectedState(
+        directions.flatMap(
+          (direction) =>
+            followEdge(state, input.linkId!, direction, undefined, outgoing, incoming).selections
+        )
+      )
+      if (next.selections.length > 0 || state.selections.length === 0) return
+      throw edgeDenial(state, input.linkId, input.direction, undefined, "queryLinks", input.path)
+    },
+  }
+
+  return Object.freeze(admission)
+}
+
+function indexSteps(
+  steps: readonly CompiledObjectReadStep[],
+  direction: "outgoing" | "incoming",
+  selectionByKey: ReadonlyMap<string, CompiledObjectReadObjectSelection>
+): ReadonlyMap<string, readonly CompiledObjectReadObjectSelection[]> {
+  const index = new Map<string, CompiledObjectReadObjectSelection[]>()
+  for (const step of steps) {
+    const fromKey =
+      direction === "outgoing"
+        ? selectionKey(step.parentNodeId, step.sourceObjectTypeId)
+        : selectionKey(step.nodeId, step.targetObjectTypeId)
+    const toKey =
+      direction === "outgoing"
+        ? selectionKey(step.nodeId, step.targetObjectTypeId)
+        : selectionKey(step.parentNodeId, step.sourceObjectTypeId)
+    const target = selectionByKey.get(toKey)
+    if (!selectionByKey.has(fromKey) || !target) {
+      throw new Error("[Sixb] Compiled selected object scope contains an invalid query path step.")
+    }
+    const key = edgeKey(
+      direction === "outgoing" ? step.parentNodeId : step.nodeId,
+      direction === "outgoing" ? step.sourceObjectTypeId : step.targetObjectTypeId,
+      step.linkId
+    )
+    const targets = index.get(key) ?? []
+    targets.push(target)
+    index.set(key, targets)
+  }
+  return index
+}
+
+function followEdge(
+  state: SelectedObjectQueryState,
+  linkId: string,
+  direction: "outgoing" | "incoming",
+  sourceObjectTypeId: string | undefined,
+  outgoing: ReadonlyMap<string, readonly CompiledObjectReadObjectSelection[]>,
+  incoming: ReadonlyMap<string, readonly CompiledObjectReadObjectSelection[]>,
+  resultObjectTypeIds?: readonly string[]
+): SelectedObjectQueryState {
+  const index = direction === "outgoing" ? outgoing : incoming
+  const resultTypes = resultObjectTypeIds ? new Set(resultObjectTypeIds) : undefined
+  const selections = state.selections.flatMap((selection) => {
+    const candidates = index.get(edgeKey(selection.nodeId, selection.objectTypeId, linkId)) ?? []
+    return candidates.filter(
+      (candidate) =>
+        (resultTypes === undefined || resultTypes.has(candidate.objectTypeId)) &&
+        (direction === "outgoing" ||
+          sourceObjectTypeId === undefined ||
+          candidate.objectTypeId === sourceObjectTypeId)
+    )
+  })
+  return selectedState(selections)
+}
+
+function propertyDenial(
+  state: SelectedObjectQueryState,
+  propertyId: string,
+  objectTypeId: string | undefined,
+  use: ObjectQueryPropertyUse,
+  path: string,
+  propertiesBySelection: ReadonlyMap<string, ReadonlySet<string>>
+): AuthorizationError | undefined {
+  const candidates = objectTypeId
+    ? state.selections.filter((selection) => selection.objectTypeId === objectTypeId)
+    : state.selections
+  // A selected reader has no rows for result types absent from this provenance. Those empty
+  // branches cannot observe a property and must not make includeSubtypes queries fail closed.
+  if (candidates.length === 0) return undefined
+
+  const missing = candidates.find(
+    (selection) =>
+      !propertiesBySelection
+        .get(selectionKey(selection.nodeId, selection.objectTypeId))
+        ?.has(propertyId)
+  )
+  if (!missing) return undefined
+
+  const objectTypeIds = [...new Set(candidates.map((selection) => selection.objectTypeId))].sort()
+  return new AuthorizationError(
+    `view:object:${objectTypeIds.join(",")}:property:${propertyId}`,
+    `[Sixb] Delegated query cannot use property '${propertyId}' for ${use} at '${path}': it is not selected on every matching read-scope path (missing on ${formatSelection(missing)}).`
+  )
+}
+
+function edgeDenial(
+  state: SelectedObjectQueryState,
+  linkId: string,
+  direction: "outgoing" | "incoming" | "both",
+  sourceObjectTypeId: string | undefined,
+  use: ObjectQueryEdgeUse,
+  path: string
+): AuthorizationError {
+  const source = sourceObjectTypeId ? `:${sourceObjectTypeId}` : ""
+  return new AuthorizationError(
+    `view:link:${direction}${source}:${linkId}`,
+    `[Sixb] Delegated query cannot use ${direction} link '${linkId}' for ${use} from ${formatState(state)} at '${path}': that exact read-scope path is not selected.`
+  )
+}
+
+function formatState(state: SelectedObjectQueryState): string {
+  if (state.selections.length === 0) return "an empty read-scope provenance"
+  return `read-scope provenance ${state.selections.map(formatSelection).join(", ")}`
+}
+
+function formatSelection(selection: CompiledObjectReadObjectSelection): string {
+  return `'${selection.objectTypeId}'@node ${selection.nodeId}`
+}
+
+function selectedState(
+  selections: readonly CompiledObjectReadObjectSelection[]
+): SelectedObjectQueryState {
+  const unique = new Map<string, CompiledObjectReadObjectSelection>()
+  for (const selection of selections) {
+    unique.set(selectionKey(selection.nodeId, selection.objectTypeId), selection)
+  }
+  return Object.freeze({
+    [selectedStateBrand]: true as const,
+    selections: Object.freeze(
+      [...unique.values()].sort(
+        (left, right) =>
+          left.nodeId - right.nodeId || left.objectTypeId.localeCompare(right.objectTypeId)
+      )
+    ),
+  })
+}
+
+function asSelectedState(state: ObjectQueryAdmissionState): SelectedObjectQueryState {
+  if ((state as Partial<SelectedObjectQueryState>)[selectedStateBrand] !== true) {
+    throw new Error("[Sixb] Object query admission state belongs to another semantic admission.")
+  }
+  return state as SelectedObjectQueryState
+}
+
+function denied(state: SelectedObjectQueryState, denial: Error): ObjectQueryAdmissionTransition {
+  return { state, denial }
+}
+
+function selectionKey(nodeId: number, objectTypeId: string): string {
+  return JSON.stringify([nodeId, objectTypeId])
+}
+
+function edgeKey(nodeId: number, objectTypeId: string, linkId: string): string {
+  return JSON.stringify([nodeId, objectTypeId, linkId])
+}

--- a/packages/core/src/objects/query/validate.ts
+++ b/packages/core/src/objects/query/validate.ts
@@ -13,8 +13,10 @@ import { ObjectQueryValidationError } from "./errors"
 import type {
   ObjectExpansion,
   ObjectQuery,
+  ObjectQueryDirection,
   ObjectQueryPredicate,
   ObjectQueryResultShape,
+  ObjectQuerySetOperation,
   ObjectQuerySortField,
   QueryScalarKind,
 } from "./ir"
@@ -41,6 +43,71 @@ export interface ObjectQueryValidationOptions {
   normalize?: boolean
 }
 
+/** Opaque semantic state carried by the canonical query validator for an internal admission. */
+export type ObjectQueryAdmissionState = object
+
+export type ObjectQueryPropertyUse =
+  | "filter"
+  | "text"
+  | "vector"
+  | "sort"
+  | "project"
+  | "expand.orderBy"
+  | "facet"
+
+export type ObjectQueryEdgeUse = "traverse" | "expand" | "queryLinks"
+
+export interface ObjectQueryAdmissionTransition {
+  readonly state: ObjectQueryAdmissionState
+  /** Recorded during the walk and raised only after ordinary validation succeeds. */
+  readonly denial?: Error
+}
+
+/**
+ * Internal semantic admission reducer driven by the canonical query validator.
+ *
+ * It deliberately has no AST visitor: validation owns recursion through query nodes, predicates,
+ * and expansions, while an admission only reduces the semantic sources, properties, edges, and
+ * set operations it observes.
+ */
+export interface ObjectQuerySemanticAdmission {
+  empty(): ObjectQueryAdmissionState
+  source(input: {
+    readonly kind: "start" | "refs"
+    readonly result: ObjectQueryResultShape
+    readonly objectTypeId?: string
+    readonly refs?: readonly ObjectRef[]
+    readonly path: string
+  }): ObjectQueryAdmissionTransition
+  property(input: {
+    readonly state: ObjectQueryAdmissionState
+    readonly propertyId: string
+    readonly objectTypeId?: string
+    readonly use: ObjectQueryPropertyUse
+    readonly path: string
+  }): Error | undefined
+  edge(input: {
+    readonly state: ObjectQueryAdmissionState
+    /** Ontology-resolved shape after following this edge. */
+    readonly result: ObjectQueryResultShape
+    readonly linkId: string
+    readonly direction: ObjectQueryDirection
+    readonly sourceObjectTypeId?: string
+    readonly use: ObjectQueryEdgeUse
+    readonly path: string
+  }): ObjectQueryAdmissionTransition
+  set(input: {
+    readonly op: ObjectQuerySetOperation
+    readonly states: readonly ObjectQueryAdmissionState[]
+    readonly path: string
+  }): ObjectQueryAdmissionState
+}
+
+export interface AdmittedObjectQuery extends ValidatedObjectQuery {
+  /** Root provenance for terminal-specific checks such as facets and physical link queries. */
+  admissionState: ObjectQueryAdmissionState
+}
+
 type QueryValidationContext = Required<
   Pick<ObjectQueryValidationOptions, "maxLimit" | "maxPageSize" | "maxRefs">
 > & {
@@ -48,11 +115,17 @@ type QueryValidationContext = Required<
   valueTypesById: ReadonlyMap<string, ValueType>
   issues: ObjectQueryValidationIssue[]
   touchedObjectTypeIds: Set<string>
+  admission: ObjectQuerySemanticAdmission
+  admissionDenials: Error[]
 }
 
-interface QueryValidationResult {
+interface QueryNodeValidation {
   result: ObjectQueryResultShape
   query: ObjectQuery
+}
+
+interface QueryValidationResult extends QueryNodeValidation {
+  admissionState: ObjectQueryAdmissionState
 }
 
 interface TextFieldResolution {
@@ -63,22 +136,55 @@ const DEFAULT_MAX_LIMIT = 1_000
 const DEFAULT_MAX_PAGE_SIZE = 1_000
 const DEFAULT_MAX_REFS = 1_000
 
+const NOOP_ADMISSION_STATE = Object.freeze({})
+const NOOP_QUERY_ADMISSION: ObjectQuerySemanticAdmission = Object.freeze({
+  empty: () => NOOP_ADMISSION_STATE,
+  source: () => ({ state: NOOP_ADMISSION_STATE }),
+  property: () => undefined,
+  edge: (input: Parameters<ObjectQuerySemanticAdmission["edge"]>[0]) => ({
+    state: input.state,
+  }),
+  set: (input: Parameters<ObjectQuerySemanticAdmission["set"]>[0]) =>
+    input.states[0] ?? NOOP_ADMISSION_STATE,
+})
+
 export function validateObjectQuery(
   query: ObjectQuery,
   options: ObjectQueryValidationOptions
 ): ValidatedObjectQuery {
+  const admitted = validateObjectQueryWithAdmission(query, options, NOOP_QUERY_ADMISSION)
+  return {
+    query: admitted.query,
+    result: admitted.result,
+    touchedObjectTypeIds: admitted.touchedObjectTypeIds,
+  }
+}
+
+/**
+ * Validate and semantically admit one query in the same canonical walk.
+ *
+ * This is an internal direct-file API. It is intentionally absent from public query barrels.
+ */
+export function validateObjectQueryWithAdmission(
+  query: ObjectQuery,
+  options: ObjectQueryValidationOptions,
+  admission: ObjectQuerySemanticAdmission
+): AdmittedObjectQuery {
   const normalized = options.normalize === false ? query : normalizeObjectQuery(query)
-  const ctx = createValidationContext(options)
+  const ctx = createValidationContext(options, admission)
   const validation = validateQueryNode(normalized, "$", ctx)
 
   if (ctx.issues.length > 0) {
     throw new ObjectQueryValidationError(ctx.issues)
   }
+  const denial = ctx.admissionDenials[0]
+  if (denial) throw denial
 
   return {
     query: validation.query,
     result: validation.result,
     touchedObjectTypeIds: [...ctx.touchedObjectTypeIds],
+    admissionState: validation.admissionState,
   }
 }
 
@@ -87,7 +193,7 @@ export function collectObjectQueryValidationIssues(
   options: ObjectQueryValidationOptions
 ): readonly ObjectQueryValidationIssue[] {
   const normalized = options.normalize === false ? query : normalizeObjectQuery(query)
-  const ctx = createValidationContext(options)
+  const ctx = createValidationContext(options, NOOP_QUERY_ADMISSION)
   validateQueryNode(normalized, "$", ctx)
   return ctx.issues
 }
@@ -99,7 +205,10 @@ export function resolveObjectQueryResultShape(
   return validateObjectQuery(query, options).result
 }
 
-function createValidationContext(options: ObjectQueryValidationOptions): QueryValidationContext {
+function createValidationContext(
+  options: ObjectQueryValidationOptions,
+  admission: ObjectQuerySemanticAdmission
+): QueryValidationContext {
   return {
     ontology: options.ontology,
     valueTypesById: options.ontology.getValueTypesById(),
@@ -108,6 +217,8 @@ function createValidationContext(options: ObjectQueryValidationOptions): QueryVa
     maxRefs: options.maxRefs ?? DEFAULT_MAX_REFS,
     issues: [],
     touchedObjectTypeIds: new Set<string>(),
+    admission,
+    admissionDenials: [],
   }
 }
 
@@ -133,18 +244,61 @@ function dispatchQueryNode(
   ctx: QueryValidationContext
 ): QueryValidationResult {
   switch (query.kind) {
-    case "start":
-      return validateStart(query.objectTypeId, query.includeSubtypes, path, ctx)
-    case "refs":
-      return validateRefs(query.refs, path, ctx)
+    case "start": {
+      const validation = validateStart(query.objectTypeId, query.includeSubtypes, path, ctx)
+      return {
+        ...validation,
+        admissionState: admitTransition(
+          ctx,
+          ctx.admission.source({
+            kind: "start",
+            result: validation.result,
+            objectTypeId: query.objectTypeId,
+            path,
+          })
+        ),
+      }
+    }
+    case "refs": {
+      const validation = validateRefs(query.refs, path, ctx)
+      return {
+        ...validation,
+        admissionState: admitTransition(
+          ctx,
+          ctx.admission.source({
+            kind: "refs",
+            result: validation.result,
+            refs: validation.query.kind === "refs" ? validation.query.refs : query.refs,
+            path,
+          })
+        ),
+      }
+    }
     case "filter": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
-      const predicate = validatePredicate(query.predicate, input.result, `${path}.predicate`, ctx)
-      return { result: input.result, query: { ...query, input: input.query, predicate } }
+      const predicate = validatePredicate(
+        query.predicate,
+        input.result,
+        input.admissionState,
+        `${path}.predicate`,
+        ctx
+      )
+      return {
+        result: input.result,
+        query: { ...query, input: input.query, predicate },
+        admissionState: input.admissionState,
+      }
     }
     case "text": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
-      const textFields = validateTextQuery(query.query, query.fields, input.result, path, ctx)
+      const textFields = validateTextQuery(
+        query.query,
+        query.fields,
+        input.result,
+        input.admissionState,
+        path,
+        ctx
+      )
       return {
         result: input.result,
         query: {
@@ -153,48 +307,97 @@ function dispatchQueryNode(
           fields: query.fields,
           fieldsByObjectType: query.fields ? undefined : textFields.fieldsByObjectType,
         },
+        admissionState: input.admissionState,
       }
     }
     case "vector": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
-      validateVectorQuery(query.vector, query.propertyId, query.k, input.result, path, ctx)
-      return { result: input.result, query: { ...query, input: input.query } }
+      validateVectorQuery(
+        query.vector,
+        query.propertyId,
+        query.k,
+        input.result,
+        input.admissionState,
+        path,
+        ctx
+      )
+      return {
+        result: input.result,
+        query: { ...query, input: input.query },
+        admissionState: input.admissionState,
+      }
     }
     case "traverse": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
+      const result = validateTraverse(
+        query.linkId,
+        query.direction,
+        query.sourceObjectTypeId,
+        input.result,
+        path,
+        ctx
+      )
       return {
-        result: validateTraverse(
-          query.linkId,
-          query.direction,
-          query.sourceObjectTypeId,
-          input.result,
-          path,
-          ctx
-        ),
+        result,
         query: { ...query, input: input.query },
+        admissionState: admitTransition(
+          ctx,
+          ctx.admission.edge({
+            state: input.admissionState,
+            result,
+            linkId: query.linkId,
+            direction: query.direction,
+            sourceObjectTypeId: query.sourceObjectTypeId,
+            use: "traverse",
+            path,
+          })
+        ),
       }
     }
     case "set":
       return validateSet(query.inputs, query.op, path, ctx)
     case "sort": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
-      const fields = validateSortFields(query.fields, input.result, path, ctx)
-      return { result: input.result, query: { ...query, input: input.query, fields } }
+      const fields = validateSortFields(
+        query.fields,
+        input.result,
+        input.admissionState,
+        "sort",
+        path,
+        ctx
+      )
+      return {
+        result: input.result,
+        query: { ...query, input: input.query, fields },
+        admissionState: input.admissionState,
+      }
     }
     case "limit": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
       validateLimit(query.limit, path, ctx)
-      return { result: input.result, query: { ...query, input: input.query } }
+      return {
+        result: input.result,
+        query: { ...query, input: input.query },
+        admissionState: input.admissionState,
+      }
     }
     case "page": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
       validatePage(query.pageSize, query.pageToken, path, ctx)
-      return { result: input.result, query: { ...query, input: input.query } }
+      return {
+        result: input.result,
+        query: { ...query, input: input.query },
+        admissionState: input.admissionState,
+      }
     }
     case "project": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
-      validateProjection(query.properties, input.result, path, ctx)
-      return { result: input.result, query: { ...query, input: input.query } }
+      validateProjection(query.properties, input.result, input.admissionState, path, ctx)
+      return {
+        result: input.result,
+        query: { ...query, input: input.query },
+        admissionState: input.admissionState,
+      }
     }
     case "expand": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
@@ -203,10 +406,15 @@ function dispatchQueryNode(
       const expansions = validateExpansions(
         query.expansions,
         input.result,
+        input.admissionState,
         `${path}.expansions`,
         ctx
       )
-      return { result: input.result, query: { ...query, input: input.query, expansions } }
+      return {
+        result: input.result,
+        query: { ...query, input: input.query, expansions },
+        admissionState: input.admissionState,
+      }
     }
   }
 }
@@ -215,7 +423,7 @@ function validateRefs(
   refs: readonly ObjectRef[],
   path: string,
   ctx: QueryValidationContext
-): QueryValidationResult {
+): QueryNodeValidation {
   if (refs.length === 0) {
     addIssue(ctx, `${path}.refs`, "empty_refs", "refs must include at least one object reference")
   }
@@ -260,7 +468,7 @@ function validateStart(
   includeSubtypes: boolean | undefined,
   path: string,
   ctx: QueryValidationContext
-): QueryValidationResult {
+): QueryNodeValidation {
   if (!objectTypeId) {
     addIssue(ctx, path, "missing_object_type", "start.objectTypeId is required")
     return { result: { objectTypeIds: [] }, query: { kind: "start", objectTypeId } }
@@ -281,6 +489,7 @@ function validateStart(
 function validatePredicate(
   predicate: ObjectQueryPredicate,
   shape: ObjectQueryResultShape,
+  admissionState: ObjectQueryAdmissionState,
   path: string,
   ctx: QueryValidationContext
 ): ObjectQueryPredicate {
@@ -298,13 +507,13 @@ function validatePredicate(
       return {
         ...predicate,
         items: predicate.items.map((item, index) =>
-          validatePredicate(item, shape, `${path}.items[${index}]`, ctx)
+          validatePredicate(item, shape, admissionState, `${path}.items[${index}]`, ctx)
         ),
       }
     case "not":
       return {
         ...predicate,
-        item: validatePredicate(predicate.item, shape, `${path}.item`, ctx),
+        item: validatePredicate(predicate.item, shape, admissionState, `${path}.item`, ctx),
       }
     case "eq":
     case "neq":
@@ -321,6 +530,12 @@ function validatePredicate(
         ctx
       )
       validatePredicateValue(predicate.propertyId, predicate.value, shape, path, ctx)
+      admitProperty(ctx, {
+        state: admissionState,
+        propertyId: predicate.propertyId,
+        use: "filter",
+        path,
+      })
       return {
         ...authoredPredicate,
         value: normalizeObjectQueryValue(predicate.value, scalarKind),
@@ -342,6 +557,12 @@ function validatePredicate(
       predicate.values.forEach((value, index) => {
         validatePredicateValue(predicate.propertyId, value, shape, `${path}.values[${index}]`, ctx)
       })
+      admitProperty(ctx, {
+        state: admissionState,
+        propertyId: predicate.propertyId,
+        use: "filter",
+        path,
+      })
       return {
         ...authoredPredicate,
         values: predicate.values.map((value) => normalizeObjectQueryValue(value, scalarKind)),
@@ -350,6 +571,12 @@ function validatePredicate(
     }
     case "exists":
       resolveAndValidatePredicateProperty(predicate.propertyId, predicate.op, shape, path, ctx)
+      admitProperty(ctx, {
+        state: admissionState,
+        propertyId: predicate.propertyId,
+        use: "filter",
+        path,
+      })
       if (typeof predicate.value !== "boolean") {
         addIssue(ctx, path, "invalid_exists_value", "Predicate 'exists' value must be boolean")
       }
@@ -357,6 +584,12 @@ function validatePredicate(
     case "contains":
       resolveAndValidatePredicateProperty(predicate.propertyId, predicate.op, shape, path, ctx)
       validateContainsValue(predicate.propertyId, predicate.value, shape, path, ctx)
+      admitProperty(ctx, {
+        state: admissionState,
+        propertyId: predicate.propertyId,
+        use: "filter",
+        path,
+      })
       return predicate
   }
 }
@@ -552,6 +785,7 @@ function validateTextQuery(
   query: string,
   fields: readonly string[] | undefined,
   shape: ObjectQueryResultShape,
+  admissionState: ObjectQueryAdmissionState,
   path: string,
   ctx: QueryValidationContext
 ): TextFieldResolution {
@@ -576,6 +810,13 @@ function validateTextQuery(
     if (fieldsByObjectType) fieldsByObjectType[objectType.id] = uniqueStrings(fieldIds)
 
     for (const fieldId of fieldIds) {
+      admitProperty(ctx, {
+        state: admissionState,
+        propertyId: fieldId,
+        objectTypeId: objectType.id,
+        use: "text",
+        path: `${path}.fields`,
+      })
       const property = getProperty(objectType, fieldId)
       if (!property) {
         addIssue(
@@ -609,6 +850,7 @@ function validateVectorQuery(
   propertyId: string,
   k: number,
   shape: ObjectQueryResultShape,
+  admissionState: ObjectQueryAdmissionState,
   path: string,
   ctx: QueryValidationContext
 ): void {
@@ -625,6 +867,13 @@ function validateVectorQuery(
   }
 
   for (const objectType of getObjectTypesForResult(shape, ctx)) {
+    admitProperty(ctx, {
+      state: admissionState,
+      propertyId,
+      objectTypeId: objectType.id,
+      use: "vector",
+      path,
+    })
     const property = getProperty(objectType, propertyId)
     if (!property) {
       addIssue(
@@ -795,17 +1044,19 @@ function validateIncomingTraverse(
 function validateExpansions(
   expansions: readonly ObjectExpansion[],
   shape: ObjectQueryResultShape,
+  admissionState: ObjectQueryAdmissionState,
   path: string,
   ctx: QueryValidationContext
 ): ObjectExpansion[] {
   return expansions.map((expansion, index) =>
-    validateExpansion(expansion, shape, `${path}[${index}]`, ctx)
+    validateExpansion(expansion, shape, admissionState, `${path}[${index}]`, ctx)
   )
 }
 
 function validateExpansion(
   expansion: ObjectExpansion,
   shape: ObjectQueryResultShape,
+  admissionState: ObjectQueryAdmissionState,
   path: string,
   ctx: QueryValidationContext
 ): ObjectExpansion {
@@ -830,6 +1081,18 @@ function validateExpansion(
           path,
           ctx
         )
+  const targetAdmissionState = admitTransition(
+    ctx,
+    ctx.admission.edge({
+      state: admissionState,
+      result: targetShape,
+      linkId: expansion.linkId,
+      direction: expansion.direction,
+      sourceObjectTypeId: expansion.sourceObjectTypeId,
+      use: "expand",
+      path,
+    })
+  )
 
   // Expansion targets are touched types: the principal must be able to `view`
   // every type a query hydrates, exactly like `start`/`traverse`. `dispatch`'s
@@ -841,10 +1104,17 @@ function validateExpansion(
 
   validateExpansionLimit(expansion.limit, path, ctx)
   const orderBy = expansion.orderBy
-    ? validateSortFields(expansion.orderBy, targetShape, `${path}.orderBy`, ctx)
+    ? validateSortFields(
+        expansion.orderBy,
+        targetShape,
+        targetAdmissionState,
+        "expand.orderBy",
+        `${path}.orderBy`,
+        ctx
+      )
     : undefined
   const expand = expansion.expand
-    ? validateExpansions(expansion.expand, targetShape, `${path}.expand`, ctx)
+    ? validateExpansions(expansion.expand, targetShape, targetAdmissionState, `${path}.expand`, ctx)
     : undefined
 
   return { ...expansion, orderBy, expand }
@@ -996,7 +1266,11 @@ function validateSet(
 ): QueryValidationResult {
   if (inputs.length === 0) {
     addIssue(ctx, path, "empty_set", `Set operation '${op}' must include at least one input`)
-    return { result: { objectTypeIds: [] }, query: { kind: "set", op, inputs } }
+    return {
+      result: { objectTypeIds: [] },
+      query: { kind: "set", op, inputs },
+      admissionState: ctx.admission.empty(),
+    }
   }
 
   const results = inputs.map((input, index) =>
@@ -1019,12 +1293,19 @@ function validateSet(
   return {
     result: first,
     query: { kind: "set", op, inputs: results.map((result) => result.query) },
+    admissionState: ctx.admission.set({
+      op,
+      states: results.map((result) => result.admissionState),
+      path,
+    }),
   }
 }
 
 function validateSortFields(
   fields: readonly ObjectQuerySortField[],
   shape: ObjectQueryResultShape,
+  admissionState: ObjectQueryAdmissionState,
+  use: Extract<ObjectQueryPropertyUse, "sort" | "expand.orderBy">,
   path: string,
   ctx: QueryValidationContext
 ): ObjectQuerySortField[] {
@@ -1056,6 +1337,13 @@ function validateSortFields(
     seen.add(key)
 
     if (field.kind === "relevance") return field
+
+    admitProperty(ctx, {
+      state: admissionState,
+      propertyId: field.propertyId,
+      use,
+      path: `${path}.fields[${index}]`,
+    })
 
     const { scalarKind: _authoredScalarKind, ...authoredField } = field
 
@@ -1132,6 +1420,7 @@ function validatePage(
 function validateProjection(
   properties: readonly string[] | undefined,
   shape: ObjectQueryResultShape,
+  admissionState: ObjectQueryAdmissionState,
   path: string,
   ctx: QueryValidationContext
 ): void {
@@ -1142,6 +1431,12 @@ function validateProjection(
 
   const seen = new Set<string>()
   properties.forEach((propertyId, index) => {
+    admitProperty(ctx, {
+      state: admissionState,
+      propertyId,
+      use: "project",
+      path: `${path}.properties[${index}]`,
+    })
     if (seen.has(propertyId)) {
       addIssue(
         ctx,
@@ -1325,6 +1620,28 @@ function keyForTypeIds(typeIds: readonly string[]): string {
 
 function uniqueStrings(values: readonly string[]): string[] {
   return [...new Set(values)]
+}
+
+function admitTransition(
+  ctx: QueryValidationContext,
+  transition: ObjectQueryAdmissionTransition
+): ObjectQueryAdmissionState {
+  if (transition.denial) recordAdmissionDenial(ctx, transition.denial)
+  return transition.state
+}
+
+function admitProperty(
+  ctx: QueryValidationContext,
+  input: Parameters<ObjectQuerySemanticAdmission["property"]>[0]
+): void {
+  const denial = ctx.admission.property(input)
+  if (denial) recordAdmissionDenial(ctx, denial)
+}
+
+function recordAdmissionDenial(ctx: QueryValidationContext, denial: Error): void {
+  // Only the first deterministic denial is observable. Keep walking so ordinary validation keeps
+  // priority, but do not retain attacker-controlled messages for every rejected field or edge.
+  if (ctx.admissionDenials.length === 0) ctx.admissionDenials.push(denial)
 }
 
 function addIssue(ctx: QueryValidationContext, path: string, code: string, message: string): void {

--- a/packages/core/tests/delegated-object-query-reader.test.ts
+++ b/packages/core/tests/delegated-object-query-reader.test.ts
@@ -1,0 +1,160 @@
+import { expect, test } from "bun:test"
+import { createAuthorizedObjectReader } from "../src/execution/authorized-object-reader"
+import { createDelegatedRequestScope } from "../src/execution/scopes"
+import { InMemoryStorage } from "../src/storage/in-memory"
+import { createMaterializerTestFixture, objectReadScopeContractOntology } from "../src/testing"
+
+const projectId = "delegated-object-query-reader"
+const Proposal = "ScopeProposal"
+const LineItem = "ScopeLineItem"
+
+test("delegated object-query terminals never reveal a guessed sibling outside the selected graph", async () => {
+  const storage = new InMemoryStorage()
+  const fixture = createMaterializerTestFixture({
+    projectId,
+    ontology: objectReadScopeContractOntology,
+    storage,
+  })
+  await fixture.seed({
+    objects: [
+      {
+        ref: { objectTypeId: Proposal, primaryId: "proposal-1" },
+        properties: {
+          id: "proposal-1",
+          title: "Selected proposal",
+          category: "selected",
+        },
+      },
+      {
+        ref: { objectTypeId: Proposal, primaryId: "proposal-2" },
+        properties: {
+          id: "proposal-2",
+          title: "Guessed sibling",
+          category: "hidden",
+        },
+      },
+      {
+        ref: { objectTypeId: LineItem, primaryId: "item-1" },
+        properties: { id: "item-1", name: "Selected item" },
+      },
+      {
+        ref: { objectTypeId: LineItem, primaryId: "item-2" },
+        properties: { id: "item-2", name: "Hidden item" },
+      },
+    ],
+    links: [
+      {
+        ref: {
+          source: { objectTypeId: Proposal, primaryId: "proposal-1" },
+          linkId: "items",
+          target: { objectTypeId: LineItem, primaryId: "item-1" },
+        },
+        properties: { position: 1 },
+      },
+      {
+        ref: {
+          source: { objectTypeId: Proposal, primaryId: "proposal-2" },
+          linkId: "items",
+          target: { objectTypeId: LineItem, primaryId: "item-2" },
+        },
+        properties: { position: 2 },
+      },
+    ],
+  })
+
+  const scope = createDelegatedRequestScope({
+    projectId,
+    requestId: "request-1",
+    correlationId: "correlation-1",
+    objectRead: {
+      selection: {
+        kind: "selected",
+        roots: [
+          {
+            anchor: { objectTypeId: Proposal, primaryId: "proposal-1" },
+            node: {
+              objects: [
+                {
+                  objectTypeId: Proposal,
+                  propertyIds: ["id", "title", "category"],
+                },
+              ],
+              links: [
+                {
+                  definitions: [
+                    {
+                      sourceObjectTypeId: Proposal,
+                      linkId: "items",
+                      targetObjectTypeIds: [LineItem],
+                      propertyIds: ["position"],
+                    },
+                  ],
+                  target: {
+                    objects: [{ objectTypeId: LineItem, propertyIds: ["id", "name"] }],
+                    links: [],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 100_000 },
+    },
+  })
+  const reader = createAuthorizedObjectReader({
+    scope,
+    ontology: objectReadScopeContractOntology,
+    objectStorage: storage.objects,
+  })
+  const selectedQuery = {
+    kind: "refs" as const,
+    refs: [{ objectTypeId: Proposal, primaryId: "proposal-1" }],
+  }
+  const guessedSiblingQuery = {
+    kind: "refs" as const,
+    refs: [{ objectTypeId: Proposal, primaryId: "proposal-2" }],
+  }
+
+  expect(
+    (await reader.executeQuery({ query: selectedQuery })).objects.map((row) => row.primaryId)
+  ).toEqual(["proposal-1"])
+  expect(await reader.count({ query: selectedQuery })).toMatchObject({ count: 1 })
+  expect(await reader.exists({ query: selectedQuery })).toMatchObject({ exists: true })
+  expect(
+    (await reader.facet({ query: selectedQuery, facets: [{ propertyId: "category", limit: 10 }] }))
+      .facets
+  ).toEqual([{ propertyId: "category", buckets: [{ value: "selected", count: 1 }] }])
+  const selectedLinks = await reader.queryLinks({
+    query: selectedQuery,
+    direction: "outgoing",
+    linkId: "items",
+    includeObjects: true,
+  })
+  expect(selectedLinks.links.map((link) => `${link.sourceId}->${link.targetId}`)).toEqual([
+    "proposal-1->item-1",
+  ])
+  expect(selectedLinks.objects.map((row) => `${row.objectTypeId}:${row.primaryId}`).sort()).toEqual(
+    [`${LineItem}:item-1`, `${Proposal}:proposal-1`].sort()
+  )
+
+  expect((await reader.executeQuery({ query: guessedSiblingQuery })).objects).toEqual([])
+  expect(await reader.count({ query: guessedSiblingQuery })).toMatchObject({ count: 0 })
+  expect(await reader.exists({ query: guessedSiblingQuery })).toMatchObject({ exists: false })
+  expect(
+    (
+      await reader.facet({
+        query: guessedSiblingQuery,
+        facets: [{ propertyId: "category", limit: 10 }],
+      })
+    ).facets
+  ).toEqual([{ propertyId: "category", buckets: [] }])
+  expect(
+    await reader.queryLinks({
+      query: guessedSiblingQuery,
+      direction: "outgoing",
+      linkId: "items",
+      includeObjects: true,
+    })
+  ).toEqual({ objects: [], links: [], hasMore: false })
+})

--- a/packages/core/tests/object-query-selected-read-admission.test.ts
+++ b/packages/core/tests/object-query-selected-read-admission.test.ts
@@ -1,0 +1,525 @@
+import { describe, expect, test } from "bun:test"
+import { AuthorizationError } from "../src/authorization/errors"
+import type { ObjectQuery } from "../src/objects/query/ir"
+import { createSelectedObjectQueryAdmission } from "../src/objects/query/selected-read-admission"
+import {
+  type AdmittedObjectQuery,
+  validateObjectQueryWithAdmission,
+} from "../src/objects/query/validate"
+import { defineObjectType, link, OntologyRegistry, prop } from "../src/ontology"
+import { compileSelectedObjectReadScope } from "../src/storage/objects/read-scope"
+
+const Product = defineObjectType({
+  id: "Product",
+  name: "Product",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", {
+      query: { searchable: true, text: true, filterable: true, sortable: true },
+    }),
+    prop("price", "double", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
+  ],
+})
+
+const LineItem = defineObjectType({
+  id: "LineItem",
+  name: "Line item",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", {
+      query: { searchable: true, text: true, filterable: true, sortable: true },
+    }),
+    prop("role", "string", {
+      query: { searchable: true, text: true, filterable: true, sortable: true },
+    }),
+    prop("cost", "double", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
+    prop(
+      "embedding",
+      { type: "array", items: "double" },
+      { query: { searchable: true, vector: true } }
+    ),
+    prop(
+      "privateEmbedding",
+      { type: "array", items: "double" },
+      { query: { searchable: true, vector: true } }
+    ),
+  ],
+  links: [link("product", Product)],
+  search: {
+    defaultText: ["name"],
+    vector: { property: "embedding", source: ["name"] },
+  },
+})
+
+const Proposal = defineObjectType({
+  id: "Proposal",
+  name: "Proposal",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("title", "string", {
+      query: { searchable: true, text: true, filterable: true, sortable: true },
+    }),
+    prop("secret", "string", {
+      query: { searchable: true, text: true, filterable: true, sortable: true },
+    }),
+  ],
+  links: [link("items", LineItem), link("reviewers", LineItem)],
+  search: { defaultText: ["title", "secret"] },
+})
+
+const Asset = defineObjectType({
+  id: "Asset",
+  name: "Asset",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("label", "string", {
+      query: { searchable: true, text: true, filterable: true, sortable: true },
+    }),
+  ],
+})
+
+const SpecialAsset = defineObjectType({
+  id: "SpecialAsset",
+  name: "Special asset",
+  extends: Asset,
+  properties: [],
+})
+
+const Unselected = defineObjectType({
+  id: "Unselected",
+  name: "Unselected",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+const ontology = new OntologyRegistry({
+  sources: [Proposal, LineItem, Product, Asset, SpecialAsset, Unselected],
+})
+
+const admission = createSelectedObjectQueryAdmission(
+  compileSelectedObjectReadScope({
+    kind: "selected",
+    roots: [
+      {
+        anchor: { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+        node: {
+          objects: [{ objectTypeId: Proposal.id, propertyIds: ["id", "title"] }],
+          links: [
+            {
+              definitions: [
+                {
+                  sourceObjectTypeId: Proposal.id,
+                  linkId: "items",
+                  targetObjectTypeIds: [LineItem.id],
+                  propertyIds: ["position"],
+                },
+              ],
+              target: {
+                objects: [
+                  {
+                    objectTypeId: LineItem.id,
+                    propertyIds: ["id", "name", "embedding"],
+                  },
+                ],
+                links: [
+                  {
+                    definitions: [
+                      {
+                        sourceObjectTypeId: LineItem.id,
+                        linkId: "product",
+                        targetObjectTypeIds: [Product.id],
+                        propertyIds: [],
+                      },
+                    ],
+                    target: {
+                      objects: [{ objectTypeId: Product.id, propertyIds: ["id", "name"] }],
+                      links: [],
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              definitions: [
+                {
+                  sourceObjectTypeId: Proposal.id,
+                  linkId: "reviewers",
+                  targetObjectTypeIds: [LineItem.id],
+                  propertyIds: [],
+                },
+              ],
+              target: {
+                objects: [
+                  {
+                    objectTypeId: LineItem.id,
+                    propertyIds: ["id", "role"],
+                  },
+                ],
+                links: [],
+              },
+            },
+          ],
+        },
+      },
+      {
+        anchor: { objectTypeId: SpecialAsset.id, primaryId: "asset-1" },
+        node: {
+          objects: [{ objectTypeId: SpecialAsset.id, propertyIds: ["id", "label"] }],
+          links: [],
+        },
+      },
+    ],
+  })
+)
+
+describe("selected object query admission", () => {
+  test("admits sources by possible selected provenance while leaving exact refs to storage", () => {
+    expectAuthorized({ kind: "start", objectTypeId: Proposal.id })
+    expectAuthorized({
+      kind: "refs",
+      refs: [{ objectTypeId: Proposal.id, primaryId: "guessed-sibling" }],
+    })
+    expectAuthorized({ kind: "start", objectTypeId: Asset.id, includeSubtypes: true })
+
+    expectDenied({ kind: "start", objectTypeId: Asset.id })
+    expectDenied({
+      kind: "refs",
+      refs: [{ objectTypeId: Unselected.id, primaryId: "known-id" }],
+    })
+  })
+
+  test("covers every predicate form in the canonical predicate walk", () => {
+    const allowed = [
+      { op: "eq", propertyId: "title", value: "A" },
+      { op: "neq", propertyId: "title", value: "A" },
+      { op: "lt", propertyId: "title", value: "A" },
+      { op: "lte", propertyId: "title", value: "A" },
+      { op: "gt", propertyId: "title", value: "A" },
+      { op: "gte", propertyId: "title", value: "A" },
+      { op: "in", propertyId: "title", values: ["A"] },
+      { op: "exists", propertyId: "title", value: true },
+      { op: "contains", propertyId: "title", value: "A" },
+    ] as const
+
+    for (const predicate of allowed) {
+      expectAuthorized({ kind: "filter", input: start(Proposal.id), predicate })
+    }
+
+    expectDenied({
+      kind: "filter",
+      input: start(Proposal.id),
+      predicate: {
+        op: "and",
+        items: [
+          { op: "eq", propertyId: "title", value: "A" },
+          {
+            op: "or",
+            items: [
+              {
+                op: "not",
+                item: { op: "contains", propertyId: "secret", value: "hidden" },
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
+  test("authorizes text, vector, sort, and project properties in their existing validators", () => {
+    expectAuthorized({
+      kind: "text",
+      input: start(Proposal.id),
+      query: "visible",
+      fields: ["title"],
+    })
+    expectDenied({ kind: "text", input: start(Proposal.id), query: "hidden" })
+    expectDenied({
+      kind: "text",
+      input: start(Proposal.id),
+      query: "hidden",
+      fields: ["secret"],
+    })
+
+    expectAuthorized({
+      kind: "vector",
+      input: traverse("items", start(Proposal.id)),
+      propertyId: "embedding",
+      vector: [1],
+      k: 1,
+    })
+    expectDenied({
+      kind: "vector",
+      input: start(LineItem.id),
+      propertyId: "embedding",
+      vector: [1],
+      k: 1,
+    })
+
+    expectAuthorized({
+      kind: "sort",
+      input: start(Proposal.id),
+      fields: [{ kind: "property", propertyId: "title" }],
+    })
+    expectAuthorized({
+      kind: "sort",
+      input: start(Proposal.id),
+      fields: [{ kind: "relevance" }],
+    })
+    expectDenied({
+      kind: "sort",
+      input: start(Proposal.id),
+      fields: [{ kind: "property", propertyId: "secret" }],
+    })
+
+    expectAuthorized({ kind: "project", input: start(Proposal.id) })
+    expectAuthorized({ kind: "project", input: start(Proposal.id), properties: ["title"] })
+    expectDenied({ kind: "project", input: start(Proposal.id), properties: ["secret"] })
+  })
+
+  test("requires a property on every possible occurrence instead of borrowing from a sibling path", () => {
+    expectDenied({
+      kind: "filter",
+      input: start(LineItem.id),
+      predicate: { op: "eq", propertyId: "name", value: "visible" },
+    })
+    expectAuthorized({
+      kind: "filter",
+      input: traverse("items", start(Proposal.id)),
+      predicate: { op: "eq", propertyId: "name", value: "visible" },
+    })
+    expectAuthorized({
+      kind: "filter",
+      input: traverse("reviewers", start(Proposal.id)),
+      predicate: { op: "eq", propertyId: "role", value: "approver" },
+    })
+  })
+
+  test("preserves exact outgoing and incoming path provenance", () => {
+    expectAuthorized(traverse("product", traverse("items", start(Proposal.id))))
+    expectDenied(traverse("product", traverse("reviewers", start(Proposal.id))))
+
+    expectAuthorized({
+      kind: "traverse",
+      linkId: "items",
+      direction: "incoming",
+      sourceObjectTypeId: Proposal.id,
+      input: {
+        kind: "traverse",
+        linkId: "product",
+        direction: "incoming",
+        sourceObjectTypeId: LineItem.id,
+        input: start(Product.id),
+      },
+    })
+    expectDenied({
+      kind: "traverse",
+      linkId: "items",
+      direction: "incoming",
+      sourceObjectTypeId: Proposal.id,
+      input: traverse("reviewers", start(Proposal.id)),
+    })
+  })
+
+  test("fails closed when a compiled step disagrees with the ontology-resolved target", () => {
+    const staleAdmission = createSelectedObjectQueryAdmission(
+      compileSelectedObjectReadScope({
+        kind: "selected",
+        roots: [
+          {
+            anchor: { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+            node: {
+              objects: [{ objectTypeId: Proposal.id, propertyIds: ["id"] }],
+              links: [
+                {
+                  definitions: [
+                    {
+                      sourceObjectTypeId: Proposal.id,
+                      linkId: "items",
+                      targetObjectTypeIds: [Product.id],
+                      propertyIds: [],
+                    },
+                  ],
+                  target: {
+                    objects: [{ objectTypeId: Product.id, propertyIds: ["id"] }],
+                    links: [],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      })
+    )
+
+    expect(() =>
+      validateObjectQueryWithAdmission(
+        traverse("items", start(Proposal.id)),
+        { ontology },
+        staleAdmission
+      )
+    ).toThrow(AuthorizationError)
+  })
+
+  test("uses the same edge and property hooks for nested expansions", () => {
+    expectAuthorized({
+      kind: "expand",
+      input: start(Proposal.id),
+      expansions: [
+        {
+          linkId: "items",
+          direction: "outgoing",
+          expand: [
+            {
+              linkId: "product",
+              direction: "outgoing",
+              orderBy: [{ kind: "property", propertyId: "name" }],
+            },
+          ],
+        },
+      ],
+    })
+
+    expectDenied({
+      kind: "expand",
+      input: start(Proposal.id),
+      expansions: [
+        {
+          linkId: "items",
+          direction: "outgoing",
+          expand: [
+            {
+              linkId: "product",
+              direction: "outgoing",
+              orderBy: [{ kind: "property", propertyId: "price" }],
+            },
+          ],
+        },
+      ],
+    })
+    expectDenied({
+      kind: "expand",
+      input: start(Proposal.id),
+      expansions: [
+        {
+          linkId: "reviewers",
+          direction: "outgoing",
+          expand: [{ linkId: "product", direction: "outgoing" }],
+        },
+      ],
+    })
+  })
+
+  test("carries result-producing provenance through every set operation", () => {
+    const items = traverse("items", start(Proposal.id))
+    const reviewers = traverse("reviewers", start(Proposal.id))
+
+    expectAuthorized(traverse("product", { kind: "set", op: "union", inputs: [items, reviewers] }))
+    expectAuthorized(
+      traverse("product", { kind: "set", op: "intersect", inputs: [items, reviewers] })
+    )
+    expectDenied(traverse("product", { kind: "set", op: "subtract", inputs: [reviewers, items] }))
+  })
+
+  test("passes neutral limit/page nodes and exposes root state for terminal checks", () => {
+    const validated = authorize({
+      kind: "page",
+      pageSize: 10,
+      input: { kind: "limit", limit: 10, input: start(Proposal.id) },
+    })
+
+    expect(() =>
+      admission.assertPropertySelected({
+        state: validated.admissionState,
+        propertyId: "title",
+        use: "facet",
+        path: "$.facets[0]",
+      })
+    ).not.toThrow()
+    expect(() =>
+      admission.assertPropertySelected({
+        state: validated.admissionState,
+        propertyId: "secret",
+        use: "facet",
+        path: "$.facets[0]",
+      })
+    ).toThrow(AuthorizationError)
+    expect(() =>
+      admission.assertIncidentEdgeSelected({
+        state: validated.admissionState,
+        linkId: "items",
+        direction: "outgoing",
+        path: "$.linkId",
+      })
+    ).not.toThrow()
+    expect(() =>
+      admission.assertIncidentEdgeSelected({
+        state: validated.admissionState,
+        linkId: "product",
+        direction: "outgoing",
+        path: "$.linkId",
+      })
+    ).toThrow(AuthorizationError)
+    expect(() =>
+      admission.assertIncidentEdgeSelected({
+        state: validated.admissionState,
+        direction: "both",
+        path: "$.linkId",
+      })
+    ).not.toThrow()
+    try {
+      admission.assertIncidentEdgeSelected({
+        state: validated.admissionState,
+        linkId: "product",
+        direction: "both",
+        path: "$.linkId",
+      })
+      throw new Error("Expected both-direction link admission to fail")
+    } catch (error) {
+      expect(error).toBeInstanceOf(AuthorizationError)
+      if (!(error instanceof AuthorizationError)) throw error
+      expect(error.grantKey).toBe("view:link:both:product")
+      expect(error.message).toContain("both link 'product'")
+    }
+  })
+
+  test("raises ordinary validation before a deferred admission denial", () => {
+    expect(() =>
+      authorize({
+        kind: "filter",
+        input: start(Proposal.id),
+        predicate: { op: "eq", propertyId: "unknown", value: "x" },
+      })
+    ).toThrow("Object query validation failed")
+  })
+})
+
+function start(objectTypeId: string): ObjectQuery {
+  return { kind: "start", objectTypeId }
+}
+
+function traverse(linkId: string, input: ObjectQuery): ObjectQuery {
+  return { kind: "traverse", linkId, direction: "outgoing", input }
+}
+
+function authorize(query: ObjectQuery): AdmittedObjectQuery {
+  return validateObjectQueryWithAdmission(query, { ontology }, admission)
+}
+
+function expectAuthorized(query: ObjectQuery): void {
+  expect(() => authorize(query)).not.toThrow()
+}
+
+function expectDenied(query: ObjectQuery): AuthorizationError {
+  try {
+    authorize(query)
+  } catch (error) {
+    expect(error).toBeInstanceOf(AuthorizationError)
+    if (error instanceof AuthorizationError) return error
+    throw error
+  }
+  throw new Error("Expected the selected query admission to deny the query")
+}

--- a/packages/core/tests/object-query.test.ts
+++ b/packages/core/tests/object-query.test.ts
@@ -37,6 +37,7 @@ import type {
   QueryObjectsInput,
   QueryObjectsResult,
 } from "../src/storage"
+import { MAX_OBJECT_READ_FACETS } from "../src/storage"
 import { createMaterializerTestFixture, type MaterializerTestFixture } from "../src/testing"
 
 const Order = defineObjectType({
@@ -1121,6 +1122,33 @@ describe("object query planner and executor", () => {
     })
   })
 
+  test("validates physical-link terminal scalars before storage", async () => {
+    const { objects: storage } = createTestStorage()
+    const query = { kind: "start" as const, objectTypeId: "Customer" }
+
+    await expect(
+      executeObjectQueryLinks(
+        { projectId: "p1", query, linkId: 42 as unknown as string },
+        { ontology, storage }
+      )
+    ).rejects.toMatchObject({ code: "invalid_link_id", path: "$.linkId" })
+    await expect(
+      executeObjectQueryLinks(
+        { projectId: "p1", query, includeObjects: "yes" as unknown as boolean },
+        { ontology, storage }
+      )
+    ).rejects.toMatchObject({
+      code: "invalid_link_include_objects",
+      path: "$.includeObjects",
+    })
+    await expect(
+      executeObjectQueryLinks(
+        { projectId: "p1", query, pageToken: 42 as unknown as string },
+        { ontology, storage }
+      )
+    ).rejects.toMatchObject({ code: "invalid_link_page_token", path: "$.pageToken" })
+  })
+
   test("hydrates delimiter-bearing endpoint identities without collisions", async () => {
     const { objects: storage, fixture } = createTestStorage()
     await fixture.seed({
@@ -1520,6 +1548,31 @@ describe("object query planner and executor", () => {
         expect(error.issues.map((issue) => issue.code)).toContain("property_not_facetable")
       }
     }
+  })
+
+  test("bounds facet fan-out before consulting storage", async () => {
+    const testStorage = createTestStorage()
+    const { storage, calls } = countQueryCalls(testStorage.objects)
+
+    await expect(
+      facetObjects(
+        {
+          projectId: "p1",
+          query: { kind: "start", objectTypeId: "Customer" },
+          facets: Array.from({ length: MAX_OBJECT_READ_FACETS + 1 }, () => ({
+            propertyId: "status",
+            limit: 1,
+          })),
+        },
+        { ontology, storage }
+      )
+    ).rejects.toMatchObject({
+      issues: [expect.objectContaining({ code: "too_many_facets", path: "$.facets" })],
+    })
+    expect(calls.facetObjects).toBe(0)
+    expect(calls.queryObjects).toBe(0)
+    expect(calls.countObjects).toBe(0)
+    expect(calls.existsObjects).toBe(0)
   })
 
   test("falls back when provider capabilities are incomplete but fallback is safe", () => {

--- a/packages/core/tests/object-reader-binding.test.ts
+++ b/packages/core/tests/object-reader-binding.test.ts
@@ -13,10 +13,20 @@ import {
   createPrincipalRequestScope,
 } from "../src/execution/scopes"
 import type { ExecutionScope } from "../src/execution/types"
-import type { ObjectQuery } from "../src/objects/query"
+import {
+  countObjects,
+  executeObjectQuery,
+  executeObjectQueryLinks,
+  existsObjects,
+  facetObjects,
+  type ObjectQuery,
+  ObjectQueryExecutionError,
+  ObjectQueryValidationError,
+} from "../src/objects/query"
 import { defineObjectType, link, OntologyRegistry, prop } from "../src/ontology"
 import {
   linkBatchKey,
+  MAX_OBJECT_READ_FACETS,
   type ObjectLinkRow,
   type ObjectQueryCapabilities,
   type ObjectReadExecutionLimits,
@@ -47,6 +57,9 @@ const Proposal = defineObjectType({
   properties: [
     prop("id", "string", { required: true, primary: true }),
     prop("title", "string", { query: { searchable: true, facet: true } }),
+    prop("internal", "string", {
+      query: { searchable: true, filterable: true, facet: true },
+    }),
   ],
   links: [link("items", LineItem), link("secret", Secret)],
 })
@@ -364,7 +377,7 @@ describe("AuthorizedObjectReader", () => {
     expect(links.map((row) => row.targetTypeId)).toEqual([LineItem.id, Secret.id])
   })
 
-  test("creates one selected provider reader for delegated non-query terminals", async () => {
+  test("binds every delegated read terminal to one selected provider reader", async () => {
     const selectedCalls: ReadCall[] = []
     const selectedRows = [
       row(Proposal.id, "proposal-1", { id: "proposal-1", title: "Proposal" }),
@@ -377,41 +390,7 @@ describe("AuthorizedObjectReader", () => {
     const backend = createReadStorage({
       selectedReader: createSelectedReader(selectedRows, selectedLinks, selectedCalls),
     })
-    const scope = createDelegatedRequestScope({
-      projectId,
-      requestId: "request-delegated",
-      correlationId: "correlation-delegated",
-      objectRead: {
-        selection: {
-          kind: "selected",
-          roots: [
-            {
-              anchor: { objectTypeId: Proposal.id, primaryId: "proposal-1" },
-              node: {
-                objects: [{ objectTypeId: Proposal.id, propertyIds: ["id", "title"] }],
-                links: [
-                  {
-                    definitions: [
-                      {
-                        sourceObjectTypeId: Proposal.id,
-                        linkId: "items",
-                        targetObjectTypeIds: [LineItem.id],
-                        propertyIds: ["position"],
-                      },
-                    ],
-                    target: {
-                      objects: [{ objectTypeId: LineItem.id, propertyIds: ["id", "name"] }],
-                      links: [],
-                    },
-                  },
-                ],
-              },
-            },
-          ],
-        },
-        limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 4_096 },
-      },
-    })
+    const scope = delegatedScope("terminals")
     const reader = createAuthorizedObjectReader({
       scope,
       ontology,
@@ -479,19 +458,6 @@ describe("AuthorizedObjectReader", () => {
       reader.getByPrimaryId({ objectTypeId: Secret.id, primaryId: "secret-1" })
     ).rejects.toThrow("does not select object type 'Secret'")
 
-    const query = { kind: "start" as const, objectTypeId: Proposal.id }
-    for (const operation of [
-      () => reader.executeQuery({ query }),
-      () => reader.queryLinks({ query }),
-      () => reader.count({ query }),
-      () => reader.exists({ query }),
-      () => reader.facet({ query, facets: [{ propertyId: "title", limit: 10 }] }),
-    ]) {
-      await expect(operation()).rejects.toThrow("require explicit selected-path admission")
-    }
-
-    expect(backend.selectedScopeCalls).toBe(1)
-    expect(backend.calls).toEqual([])
     expect(selectedCalls.map((call) => call.operation)).toEqual([
       "getByPrimaryId",
       "getByPrimaryId",
@@ -502,6 +468,233 @@ describe("AuthorizedObjectReader", () => {
       "listLinks",
       "listLinksBatch",
     ])
+
+    selectedCalls.length = 0
+    const query = { kind: "start" as const, objectTypeId: Proposal.id }
+    expect(await reader.executeQuery({ query, includeTotal: true })).toMatchObject({
+      objects: [{ objectTypeId: Proposal.id, primaryId: "proposal-1" }],
+      hasMore: false,
+      total: 1,
+    })
+    expect(await reader.count({ query })).toMatchObject({ count: 1 })
+    expect(await reader.exists({ query })).toMatchObject({ exists: true })
+    expect(
+      await reader.facet({ query, facets: [{ propertyId: "title", limit: 10 }] })
+    ).toMatchObject({
+      facets: [{ propertyId: "title", buckets: [{ value: "Proposal", count: 1 }] }],
+    })
+    expect(
+      await reader.queryLinks({
+        query,
+        direction: "outgoing",
+        linkId: "items",
+        includeObjects: true,
+      })
+    ).toMatchObject({
+      links: [{ linkId: "items", targetId: "line-1" }],
+      objects: [
+        { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+        { objectTypeId: LineItem.id, primaryId: "line-1" },
+      ],
+      hasMore: false,
+    })
+
+    const guessedSibling = await reader.executeQuery({
+      query: {
+        kind: "refs",
+        refs: [{ objectTypeId: Proposal.id, primaryId: "proposal-2" }],
+      },
+    })
+    expect(guessedSibling.objects).toEqual([])
+    expect(selectedCalls.map((call) => call.operation)).toContain("queryObjects")
+    expect(selectedCalls.map((call) => call.operation)).toContain("countObjects")
+    expect(selectedCalls.map((call) => call.operation)).toContain("existsObjects")
+    expect(selectedCalls.map((call) => call.operation)).toContain("facetObjects")
+    expect(selectedCalls.map((call) => call.operation)).toContain("queryLinks")
+    expect(backend.selectedScopeCalls).toBe(1)
+    expect(backend.calls).toEqual([])
+
+    selectedCalls.length = 0
+    const deniedOperations = [
+      () =>
+        reader.executeQuery({
+          query: {
+            kind: "filter" as const,
+            input: query,
+            predicate: { op: "eq" as const, propertyId: "internal", value: "hidden" },
+          },
+        }),
+      () =>
+        reader.count({
+          query: {
+            kind: "traverse" as const,
+            input: query,
+            linkId: "secret",
+            direction: "outgoing" as const,
+          },
+        }),
+      () =>
+        reader.exists({
+          query: {
+            kind: "refs" as const,
+            refs: [{ objectTypeId: Secret.id, primaryId: "secret-1" }],
+          },
+        }),
+      () => reader.facet({ query, facets: [{ propertyId: "internal", limit: 10 }] }),
+      () => reader.queryLinks({ query, direction: "outgoing", linkId: "secret" }),
+    ]
+    for (const operation of deniedOperations) {
+      await expect(operation()).rejects.toBeInstanceOf(AuthorizationError)
+      expect(selectedCalls).toEqual([])
+    }
+  })
+
+  test("validates delegated terminal parameters before terminal-specific admission", async () => {
+    const selectedCalls: ReadCall[] = []
+    const backend = createReadStorage({
+      selectedReader: createSelectedReader(
+        [row(Proposal.id, "proposal-1", { id: "proposal-1", title: "Proposal" })],
+        [objectLink("items", LineItem.id, "line-1")],
+        selectedCalls
+      ),
+    })
+    const reader = createAuthorizedObjectReader({
+      scope: delegatedScope("validation-order"),
+      ontology,
+      objectStorage: backend.storage,
+    })
+    const query = { kind: "start" as const, objectTypeId: Proposal.id }
+
+    const invalidLinks = reader.queryLinks({
+      query,
+      direction: "sideways",
+      linkId: "secret",
+    } as unknown as Parameters<AuthorizedObjectReader["queryLinks"]>[0])
+    await expect(invalidLinks).rejects.toMatchObject({
+      code: "invalid_link_direction",
+      path: "$.direction",
+    })
+    await expect(invalidLinks).rejects.toBeInstanceOf(ObjectQueryExecutionError)
+
+    const invalidFacets = reader.facet({
+      query,
+      facets: [{ propertyId: "internal", limit: 0 }],
+    })
+    await expect(invalidFacets).rejects.toBeInstanceOf(ObjectQueryValidationError)
+    await expect(invalidFacets).rejects.toMatchObject({
+      issues: expect.arrayContaining([expect.objectContaining({ code: "invalid_facet_limit" })]),
+    })
+
+    let oversizedFacetReads = 0
+    const oversizedFacets = Array.from({ length: MAX_OBJECT_READ_FACETS + 1 }, () => ({
+      propertyId: "internal",
+      limit: 1,
+    }))
+    Object.defineProperty(oversizedFacets, 0, {
+      get: () => {
+        oversizedFacetReads += 1
+        throw new Error("oversized facet must not be read")
+      },
+    })
+    await expect(reader.facet({ query, facets: oversizedFacets })).rejects.toBeInstanceOf(
+      ObjectQueryValidationError
+    )
+    expect(oversizedFacetReads).toBe(0)
+
+    expect(selectedCalls).toEqual([])
+    expect(backend.calls).toEqual([])
+  })
+
+  test("keeps delegated runtime authorization unusable at low-level query executors", async () => {
+    const backend = createReadStorage()
+    const scope = delegatedScope("low-level")
+    const query = { kind: "start" as const, objectTypeId: Proposal.id }
+    const options = {
+      ontology,
+      storage: backend.storage,
+      runtimeAuthorization: scope.authorization,
+    }
+
+    for (const operation of [
+      () => executeObjectQuery({ projectId, query }, options),
+      () => countObjects({ projectId, query }, options),
+      () => existsObjects({ projectId, query }, options),
+      () =>
+        facetObjects({ projectId, query, facets: [{ propertyId: "title", limit: 10 }] }, options),
+      () => executeObjectQueryLinks({ projectId, query }, options),
+    ]) {
+      await expect(operation()).rejects.toBeInstanceOf(AuthorizationError)
+    }
+
+    expect(backend.calls).toEqual([])
+    expect(backend.selectedScopeCalls).toBe(0)
+  })
+
+  test("executes the exact delegated query snapshot it admits", async () => {
+    let objectTypeReads = 0
+    const authoredQuery = Object.defineProperties(
+      {},
+      {
+        kind: { enumerable: true, value: "start" },
+        objectTypeId: {
+          enumerable: true,
+          get: () => (objectTypeReads++ === 0 ? Proposal.id : Secret.id),
+        },
+      }
+    ) as ObjectQuery
+    const selectedCalls: ReadCall[] = []
+    const backend = createReadStorage({
+      selectedReader: createSelectedReader(
+        [row(Proposal.id, "proposal-1", { id: "proposal-1", title: "Proposal" })],
+        [],
+        selectedCalls
+      ),
+    })
+    const reader = createAuthorizedObjectReader({
+      scope: delegatedScope("snapshot"),
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    await expect(reader.executeQuery({ query: authoredQuery })).resolves.toMatchObject({
+      objects: [{ objectTypeId: Proposal.id, primaryId: "proposal-1" }],
+    })
+
+    expect(objectTypeReads).toBe(1)
+    expect(selectedCalls.find((call) => call.operation === "queryObjects")?.input).toMatchObject({
+      projectId,
+      query: { kind: "start", objectTypeId: Proposal.id },
+    })
+
+    let queryReads = 0
+    let linkIdReads = 0
+    const linkRequest = Object.defineProperties(
+      {},
+      {
+        query: {
+          enumerable: true,
+          get: () => {
+            queryReads += 1
+            return {
+              kind: "start",
+              objectTypeId: queryReads === 1 ? Proposal.id : Secret.id,
+            }
+          },
+        },
+        linkId: {
+          enumerable: true,
+          get: () => (linkIdReads++ === 0 ? "items" : "secret"),
+        },
+      }
+    ) as Parameters<AuthorizedObjectReader["queryLinks"]>[0]
+    await expect(reader.queryLinks(linkRequest)).resolves.toMatchObject({ links: [] })
+
+    expect(queryReads).toBe(1)
+    expect(linkIdReads).toBe(1)
+    expect(
+      [...selectedCalls].reverse().find((call) => call.operation === "queryLinks")?.input
+    ).toMatchObject({ projectId, linkId: "items" })
+    expect(backend.calls).toEqual([])
   })
 
   test("ignores caller project extras and executes the exact query snapshot it authorized", async () => {
@@ -601,6 +794,44 @@ function principalScope(id: string, view: readonly string[] = []): ExecutionScop
       groupIds: [],
       roleIds: [],
       grants: { ...emptyGrantIndex(), "view:object": new Set(view) },
+    },
+  })
+}
+
+function delegatedScope(id: string): ExecutionScope {
+  return createDelegatedRequestScope({
+    projectId,
+    requestId: `request-${id}`,
+    correlationId: `correlation-${id}`,
+    objectRead: {
+      selection: {
+        kind: "selected",
+        roots: [
+          {
+            anchor: { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+            node: {
+              objects: [{ objectTypeId: Proposal.id, propertyIds: ["id", "title"] }],
+              links: [
+                {
+                  definitions: [
+                    {
+                      sourceObjectTypeId: Proposal.id,
+                      linkId: "items",
+                      targetObjectTypeIds: [LineItem.id],
+                      propertyIds: ["position"],
+                    },
+                  ],
+                  target: {
+                    objects: [{ objectTypeId: LineItem.id, propertyIds: ["id", "name"] }],
+                    links: [],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 4_096 },
     },
   })
 }
@@ -779,7 +1010,40 @@ function createSelectedReader(
   return {
     queryCapabilities() {
       record("queryCapabilities")
-      return { queryObjects: false }
+      return {
+        queryObjects: true,
+        countObjects: true,
+        existsObjects: true,
+        facetObjects: true,
+        nodes: { start: true, refs: true, limit: true },
+      }
+    },
+    async queryObjects(input) {
+      record("queryObjects", input)
+      const objects = selectedQueryRows(rows, input.query)
+      return {
+        objects,
+        hasMore: false,
+        ...(input.includeTotal ? { total: objects.length } : {}),
+      }
+    },
+    async countObjects(input) {
+      record("countObjects", input)
+      return { count: selectedQueryRows(rows, input.query).length }
+    },
+    async existsObjects(input) {
+      record("existsObjects", input)
+      return { exists: selectedQueryRows(rows, input.query).length > 0 }
+    },
+    async facetObjects(input) {
+      record("facetObjects", input)
+      const objects = selectedQueryRows(rows, input.query)
+      return {
+        facets: input.facets.map((facet) => ({
+          propertyId: facet.propertyId,
+          buckets: facetBuckets(objects, facet.propertyId, facet.limit),
+        })),
+      }
     },
     async getByPrimaryId(input) {
       record("getByPrimaryId", input)
@@ -818,7 +1082,20 @@ function createSelectedReader(
     },
     async queryLinks(input) {
       record("queryLinks", input)
-      return { links, hasMore: false }
+      const selectedRefs = new Set(
+        input.objectRefs.map((ref) => objectBatchKey(ref.objectTypeId, ref.primaryId))
+      )
+      const visibleLinks = links
+        .filter((link) => link.linkId === "items")
+        .filter((link) => input.linkId === undefined || link.linkId === input.linkId)
+        .filter((link) => {
+          const sourceSelected = selectedRefs.has(objectBatchKey(link.sourceTypeId, link.sourceId))
+          const targetSelected = selectedRefs.has(objectBatchKey(link.targetTypeId, link.targetId))
+          if (input.direction === "outgoing") return sourceSelected
+          if (input.direction === "incoming") return targetSelected
+          return sourceSelected || targetSelected
+        })
+      return { links: visibleLinks.slice(0, input.limit), hasMore: false }
     },
     async list(input) {
       record("list", input)
@@ -832,6 +1109,34 @@ function createSelectedReader(
       return { objects, hasMore: false, total: objects.length }
     },
   }
+}
+
+function selectedQueryRows(rows: readonly ObjectRow[], query: ObjectQuery): ObjectRow[] {
+  switch (query.kind) {
+    case "start":
+      return rows.filter((row) => row.objectTypeId === query.objectTypeId)
+    case "refs": {
+      const refs = new Set(query.refs.map((ref) => objectBatchKey(ref.objectTypeId, ref.primaryId)))
+      return rows.filter((row) => refs.has(objectBatchKey(row.objectTypeId, row.primaryId)))
+    }
+    case "limit":
+      return selectedQueryRows(rows, query.input).slice(0, query.limit)
+    default:
+      return []
+  }
+}
+
+function facetBuckets(
+  rows: readonly ObjectRow[],
+  propertyId: string,
+  limit: number
+): readonly { value: unknown; count: number }[] {
+  const counts = new Map<unknown, number>()
+  for (const row of rows) {
+    const value = row.properties[propertyId]
+    counts.set(value, (counts.get(value) ?? 0) + 1)
+  }
+  return [...counts].slice(0, limit).map(([value, count]) => ({ value, count }))
 }
 
 function row(


### PR DESCRIPTION
Part of #269 · Stack #547 · Parent: #495 · Next: #500

## Why

Ordinary shared pages need the normal Query API with selected-path authorization, not a separate resource loader.

## Flow

```text
request snapshot → normal validation → selected-path admission
                 → canonical executor → selected storage
```

## What

- Carry selection-node/type provenance through the existing Query visitor.
- Admit filters, text/vector search, ordering, projection, traversal and expansion.
- Preserve provenance across refs, subtypes and set operations.
- Activate query, count, exists, facet and physical-link terminals.
- Execute the exact admitted snapshot; bound facet fan-out before reading authored elements.

## Guarantees

Unselected properties/paths fail before storage. Guessed sibling IDs return empty results. Low-level executors cannot bypass the reader. Principal/trusted behavior stays unchanged.

## Review order

1. Selected admission and canonical validation.
2. Reader binding and terminal preflights.
3. Admission, query and sibling-isolation regressions.

Preserves two focused commits; incorporates #499. No second AST walker or forgeable executor flag.
