### PR TITLE
core: bind delegated object queries

### DIFF
--- a/packages/core/src/agents/context-resolution.ts
+++ b/packages/core/src/agents/context-resolution.ts
@@ -1,4 +1,3 @@
-import { assertAuthorized } from "../authorization"
 import type { SixbRuntimeContext } from "../runtime/types"
 import {
   type AgentContextEntryInput,
@@ -24,9 +23,7 @@ export async function resolveAgentContextParts(
       invalidContext(`context references an unknown object type '${objectTypeId}'`)
     }
 
-    assertAuthorized(runtime, { kind: "object.view", objectTypeId })
-    const object = await runtime.storage.objects.getByPrimaryId({
-      projectId: runtime.projectId,
+    const object = await runtime.objectReader.getByPrimaryId({
       objectTypeId,
       primaryId,
     })

--- a/packages/core/src/authorization/decision.ts
+++ b/packages/core/src/authorization/decision.ts
@@ -134,6 +134,12 @@ export function isAllowed(
 
 export function assertAuthorized(runtime: AuthorizedRuntime, request: AuthzRequest): void {
   const resolved = assertRuntimeAuthorizationBound(runtime)
+  if (resolved.type === "delegated") {
+    throw new AuthorizationError(
+      `delegated:${request.kind}`,
+      `[Sixb] Operation '${request.kind}' is not covered by delegated authorization.`
+    )
+  }
   const authorization = resolved.type === "principal" ? resolved.context : undefined
   const decision = evaluate(authorization, request)
   if (decision.allowed) {

--- a/packages/core/src/execution/authorization.ts
+++ b/packages/core/src/execution/authorization.ts
@@ -211,30 +211,44 @@ export function assertExecutionScopeProject(projectId: string, scope: ExecutionS
   }
 }
 
+/**
+ * Capture the two opaque capabilities carried by a scope exactly once.
+ *
+ * Security-sensitive boundaries must not resolve a caller-owned wrapper and then read it again:
+ * accessor-backed inputs could otherwise substitute a different execution or authority between
+ * those operations.
+ */
+export function captureExecutionScope(scope: ExecutionScope): ExecutionScope {
+  const execution = scope.execution
+  const authorization = scope.authorization
+  return Object.freeze({ execution, authorization })
+}
+
 /** Validate that one registered authority belongs to the exact execution it accompanies. */
 export function resolveExecutionScopeAuthorization(
   projectId: string,
   scope: ExecutionScope
 ): RegisteredRuntimeAuthorization {
-  assertExecutionScopeProject(projectId, scope)
-  const resolved = resolveRuntimeAuthorization(scope.authorization)
+  const capturedScope = captureExecutionScope(scope)
+  assertExecutionScopeProject(projectId, capturedScope)
+  const resolved = resolveRuntimeAuthorization(capturedScope.authorization)
   if (resolved.type === "denied") {
     throw createSixbError(
       "internal.unexpected",
       "[Sixb] Execution scope carries unregistered runtime authorization.",
-      { details: { executionId: scope.execution.id, projectId } }
+      { details: { executionId: capturedScope.execution.id, projectId } }
     )
   }
 
-  const registration = registeredAuthorizations.get(scope.authorization)
-  if (!registration || !executionMatchesBinding(registration.execution, scope.execution)) {
+  const registration = registeredAuthorizations.get(capturedScope.authorization)
+  if (!registration || !executionMatchesBinding(registration.execution, capturedScope.execution)) {
     throw invalidExecutionAuthority(
-      scope.execution.id,
+      capturedScope.execution.id,
       "authority is bound to different execution provenance"
     )
   }
 
-  assertResolvedAuthorizationMatchesExecution(resolved, scope.execution)
+  assertResolvedAuthorizationMatchesExecution(resolved, capturedScope.execution)
   return resolved
 }
 

--- a/packages/core/src/execution/authorization.ts
+++ b/packages/core/src/execution/authorization.ts
@@ -5,6 +5,15 @@ import { GRANT_KIND_KEYS, type GrantKind } from "../authorization/grant-kinds"
 import type { AuthorizationContext, GrantIndex } from "../authorization/types"
 import { createSixbError } from "../errors/internal"
 import {
+  type ObjectReadExecutionLimits,
+  snapshotObjectReadExecutionLimits,
+} from "../storage/objects/execution-limits"
+import { compileSelectedObjectReadScope } from "../storage/objects/read-scope"
+import type {
+  CompiledSelectedObjectReadScope,
+  SelectedObjectReadScope,
+} from "../storage/objects/types"
+import {
   type AuthorizablePrincipal,
   type AuthorizationRef,
   createRuntimeAuthorizationCapability,
@@ -29,7 +38,18 @@ export type ResolvedRuntimeAuthorization =
       readonly projectId: string
       readonly ref: Exclude<AuthorizationRef, { readonly type: "principal" }>
     }
+  | {
+      readonly type: "delegated"
+      readonly projectId: string
+      readonly objectRead: DelegatedObjectReadAuthorization
+    }
   | { readonly type: "denied" }
+
+/** Immutable process-local object-read authority. It has no durable representation. */
+export interface DelegatedObjectReadAuthorization {
+  readonly scope: CompiledSelectedObjectReadScope
+  readonly limits: ObjectReadExecutionLimits
+}
 
 type RegisteredRuntimeAuthorization = Exclude<
   ResolvedRuntimeAuthorization,
@@ -112,6 +132,33 @@ export function createDisabledRuntimeAuthorization(
   })
 }
 
+/** Register exact object-read authority without fabricating a principal identity. */
+export function createDelegatedRuntimeAuthorization(input: {
+  readonly execution: ExecutionContext
+  readonly objectRead: {
+    readonly selection: SelectedObjectReadScope
+    readonly limits: ObjectReadExecutionLimits
+  }
+}): RuntimeAuthorization {
+  const execution = input.execution
+  const objectReadInput = input.objectRead
+  if (execution.executor.type !== "request" || execution.requestedBy !== undefined) {
+    throw new Error(
+      "[Sixb] Delegated runtime authorization requires a request execution without a principal."
+    )
+  }
+
+  const objectRead = Object.freeze({
+    scope: compileSelectedObjectReadScope(objectReadInput.selection),
+    limits: snapshotObjectReadExecutionLimits(objectReadInput.limits),
+  })
+  return register(execution, {
+    type: "delegated",
+    projectId: execution.projectId,
+    objectRead,
+  })
+}
+
 export function createTrustedPrimitiveRuntimeAuthorization(input: {
   readonly execution: ExecutionContext
   readonly primitive: TrustedPrimitiveRef
@@ -168,6 +215,11 @@ export function getAuthorizationRef(authorization: RuntimeAuthorization): Author
   const resolved = resolveRuntimeAuthorization(authorization)
   if (resolved.type === "denied") {
     throw new Error("[Sixb] Runtime authorization is not a registered Core capability.")
+  }
+  if (resolved.type === "delegated") {
+    throw new Error(
+      "[Sixb] Delegated runtime authorization cannot cross a durable execution boundary."
+    )
   }
   return cloneAuthorizationRef(resolved.ref)
 }
@@ -264,11 +316,8 @@ function assertResolvedAuthorizationMatchesExecution(
       ) {
         throw invalidExecutionAuthority(execution.id, "request source does not match its executor")
       }
-      if (resolved.ref.type === "principal") {
-        if (
-          resolved.type !== "principal" ||
-          !principalsEqual(execution.requestedBy, resolved.ref.principal)
-        ) {
+      if (resolved.type === "principal") {
+        if (!principalsEqual(execution.requestedBy, resolved.ref.principal)) {
           throw invalidExecutionAuthority(
             execution.id,
             "request authority does not match its requested-by principal"
@@ -276,14 +325,22 @@ function assertResolvedAuthorizationMatchesExecution(
         }
         return
       }
-      if (resolved.ref.type === "disabled" && execution.requestedBy === undefined) return
+      if (
+        resolved.type === "unrestricted" &&
+        resolved.ref.type === "disabled" &&
+        execution.requestedBy === undefined
+      ) {
+        return
+      }
+      if (resolved.type === "delegated" && execution.requestedBy === undefined) return
       throw invalidExecutionAuthority(
         execution.id,
-        "request execution requires principal or explicitly disabled authority"
+        "request execution requires principal, delegated, or explicitly disabled authority"
       )
 
     case "primitive":
       if (
+        resolved.type !== "unrestricted" ||
         resolved.ref.type !== "trustedPrimitive" ||
         resolved.ref.primitive.kind !== execution.executor.kind ||
         resolved.ref.primitive.id !== execution.executor.id ||
@@ -313,6 +370,7 @@ function assertResolvedAuthorizationMatchesExecution(
 
     case "kernel":
       if (
+        resolved.type !== "unrestricted" ||
         resolved.ref.type !== "kernel" ||
         execution.requestedBy !== undefined ||
         resolved.ref.operation.type !== execution.executor.operation.type ||

--- a/packages/core/src/execution/authorized-object-reader.ts
+++ b/packages/core/src/execution/authorized-object-reader.ts
@@ -20,15 +20,28 @@ import {
 } from "../objects/query"
 import { assertObjectQueryComplexity } from "../objects/query/complexity"
 import { ObjectQueryValidationError } from "../objects/query/errors"
+import { validateObjectFacetRequests } from "../objects/query/executor"
 import type { ObjectQuery } from "../objects/query/ir"
+import { preflightObjectQueryLinks } from "../objects/query/links"
+import {
+  createSelectedObjectQueryAdmission,
+  type SelectedObjectQueryAdmission,
+} from "../objects/query/selected-read-admission"
+import {
+  type AdmittedObjectQuery,
+  validateObjectQuery,
+  validateObjectQueryWithAdmission,
+} from "../objects/query/validate"
 import type { OntologyRegistry } from "../ontology"
 import type {
   CompiledObjectReadStep,
   LinkBatchKey,
+  ObjectFacetRequest,
   ObjectLinkRow,
   ObjectReadStorage,
   ObjectStorage,
 } from "../storage"
+import { MAX_OBJECT_READ_FACETS } from "../storage"
 import { captureExecutionScope, resolveExecutionScopeAuthorization } from "./authorization"
 import type { ExecutionScope, RuntimeAuthorization } from "./types"
 
@@ -65,6 +78,7 @@ class AuthorizedObjectReaderImpl {
   readonly #storage: ObjectReadStorage
   readonly #delegatedObjectTypeIds?: ReadonlySet<string>
   readonly #delegatedLinkDefinitions?: ReadonlySet<string>
+  readonly #delegatedQueryAdmission?: SelectedObjectQueryAdmission
 
   constructor(
     key: typeof readerConstructionKey,
@@ -90,6 +104,10 @@ class AuthorizedObjectReaderImpl {
     this.#delegatedLinkDefinitions =
       input.authority.type === "delegated"
         ? new Set(input.authority.objectRead.scope.steps.map(delegatedLinkDefinitionKey))
+        : undefined
+    this.#delegatedQueryAdmission =
+      input.authority.type === "delegated"
+        ? createSelectedObjectQueryAdmission(input.authority.objectRead.scope)
         : undefined
     this.#runtime = Object.freeze({
       projectId: input.scope.execution.projectId,
@@ -262,13 +280,13 @@ class AuthorizedObjectReaderImpl {
   async executeQuery(
     input: Omit<ExecuteObjectQueryInput, "projectId">
   ): Promise<ExecuteObjectQueryResult> {
-    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     const includeTotal = snapshotReadValue(input.includeTotal)
+    const executionQuery = this.#admitDelegatedQuery(query)?.query ?? query
     return detachReadResult(
       await executeObjectQuery(
         {
-          query,
+          query: executionQuery,
           ...(includeTotal === undefined ? {} : { includeTotal }),
           projectId: this.#runtime.projectId,
         },
@@ -280,7 +298,6 @@ class AuthorizedObjectReaderImpl {
   async queryLinks(
     input: Omit<ExecuteObjectQueryLinksInput, "projectId">
   ): Promise<ExecuteObjectQueryLinksResult> {
-    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     const request = snapshotReadValue({
       direction: input.direction,
@@ -289,9 +306,29 @@ class AuthorizedObjectReaderImpl {
       pageSize: input.pageSize,
       pageToken: input.pageToken,
     })
+    let executionQuery = query
+    const admission = this.#delegatedQueryAdmission
+    if (admission) {
+      const preflight = preflightObjectQueryLinks(
+        { query, ...request, projectId: this.#runtime.projectId },
+        { ontology: this.#ontology }
+      )
+      const admitted = validateObjectQueryWithAdmission(
+        preflight.validated.query,
+        { ontology: this.#ontology, normalize: false },
+        admission
+      )
+      admission.assertIncidentEdgeSelected({
+        state: admitted.admissionState,
+        ...(preflight.linkId === undefined ? {} : { linkId: preflight.linkId }),
+        direction: preflight.direction,
+        path: "$.linkId",
+      })
+      executionQuery = admitted.query
+    }
     const result = detachReadResult(
       await executeObjectQueryLinks(
-        { query, ...request, projectId: this.#runtime.projectId },
+        { query: executionQuery, ...request, projectId: this.#runtime.projectId },
         this.#queryExecutorOptions()
       )
     )
@@ -311,11 +348,11 @@ class AuthorizedObjectReaderImpl {
   async count(
     input: Omit<ExecuteObjectCountInput, "projectId">
   ): Promise<ExecuteObjectCountResult> {
-    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
+    const executionQuery = this.#admitDelegatedQuery(query)?.query ?? query
     return detachReadResult(
       await countObjects(
-        { query, projectId: this.#runtime.projectId },
+        { query: executionQuery, projectId: this.#runtime.projectId },
         this.#queryExecutorOptions()
       )
     )
@@ -324,11 +361,11 @@ class AuthorizedObjectReaderImpl {
   async exists(
     input: Omit<ExecuteObjectExistsInput, "projectId">
   ): Promise<ExecuteObjectExistsResult> {
-    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
+    const executionQuery = this.#admitDelegatedQuery(query)?.query ?? query
     return detachReadResult(
       await existsObjects(
-        { query, projectId: this.#runtime.projectId },
+        { query: executionQuery, projectId: this.#runtime.projectId },
         this.#queryExecutorOptions()
       )
     )
@@ -337,20 +374,53 @@ class AuthorizedObjectReaderImpl {
   async facet(
     input: Omit<ExecuteObjectFacetsInput, "projectId">
   ): Promise<ExecuteObjectFacetsResult> {
-    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
-    const facets = snapshotReadValue(
-      input.facets.map((facet) => ({ propertyId: facet.propertyId, limit: facet.limit }))
-    )
+    const facets = snapshotFacetRequests(input.facets)
+    let executionQuery = query
+    let executionFacets = facets
+    const admission = this.#delegatedQueryAdmission
+    if (admission) {
+      // Terminal arguments are ordinary validation errors, not an authorization oracle. Validate
+      // them against the canonical result shape before raising any delegated-scope denial.
+      const validated = validateObjectQuery(query, { ontology: this.#ontology })
+      const normalizedFacets = validateObjectFacetRequests(facets, validated.result.objectTypeIds, {
+        ontology: this.#ontology,
+      })
+      const admitted = validateObjectQueryWithAdmission(
+        validated.query,
+        { ontology: this.#ontology, normalize: false },
+        admission
+      )
+      normalizedFacets.forEach((facet, index) => {
+        admission.assertPropertySelected({
+          state: admitted.admissionState,
+          propertyId: facet.propertyId,
+          use: "facet",
+          path: `$.facets[${index}].propertyId`,
+        })
+      })
+      executionQuery = admitted.query
+      executionFacets = normalizedFacets
+    }
     return detachReadResult(
       await facetObjects(
-        { query, facets, projectId: this.#runtime.projectId },
+        {
+          query: executionQuery,
+          facets: executionFacets,
+          projectId: this.#runtime.projectId,
+        },
         this.#queryExecutorOptions()
       )
     )
   }
 
   #queryExecutorOptions() {
+    if (this.#authority.type === "delegated") {
+      // The selected storage instance is the private execution capability. Passing the delegated
+      // runtime token into the generic executor would either reject this admitted query or tempt a
+      // forgeable bypass flag; neither is needed at this nominal boundary.
+      return { ontology: this.#ontology, storage: this.#storage }
+    }
     return {
       ontology: this.#ontology,
       storage: this.#storage,
@@ -359,6 +429,15 @@ class AuthorizedObjectReaderImpl {
         ? {}
         : { authorization: this.#runtime.authorization }),
     }
+  }
+
+  #admitDelegatedQuery(query: ObjectQuery): AdmittedObjectQuery | undefined {
+    if (!this.#delegatedQueryAdmission) return undefined
+    return validateObjectQueryWithAdmission(
+      query,
+      { ontology: this.#ontology },
+      this.#delegatedQueryAdmission
+    )
   }
 
   #assertObjectTypesViewable(objectTypeIds: readonly string[]): void {
@@ -402,14 +481,6 @@ class AuthorizedObjectReaderImpl {
       return this.#delegatedObjectTypeIds?.has(objectTypeId) ?? false
     }
     return isAllowed(this.#runtime.authorization, { kind: "object.view", objectTypeId })
-  }
-
-  #assertDelegatedQueriesAdmitted(): void {
-    if (this.#authority.type !== "delegated") return
-    throw new AuthorizationError(
-      "delegated:object.query",
-      "[Sixb] Object Query terminals require explicit selected-path admission under delegated authorization."
-    )
   }
 
   #isLinkViewable(link: ObjectLinkRow): boolean {
@@ -504,6 +575,36 @@ function detachReadResult<T>(value: T): T {
 /** Capture caller-owned values before authorization and execution. */
 function snapshotReadValue<T>(value: T): T {
   return structuredClone(value)
+}
+
+/** Bound and capture facet arguments before reading any caller-owned element. */
+function snapshotFacetRequests(facets: readonly ObjectFacetRequest[]): ObjectFacetRequest[] {
+  if (!Array.isArray(facets)) {
+    throw new ObjectQueryValidationError([
+      {
+        path: "$.facets",
+        code: "invalid_facets",
+        message: "facets must be an array",
+      },
+    ])
+  }
+  const length = facets.length
+  if (!Number.isSafeInteger(length) || length > MAX_OBJECT_READ_FACETS) {
+    throw new ObjectQueryValidationError([
+      {
+        path: "$.facets",
+        code: "too_many_facets",
+        message: `facets must include at most ${MAX_OBJECT_READ_FACETS} facet requests`,
+      },
+    ])
+  }
+
+  const snapshot: ObjectFacetRequest[] = []
+  for (let index = 0; index < length; index += 1) {
+    const facet = facets[index]
+    snapshot.push({ propertyId: facet.propertyId, limit: facet.limit })
+  }
+  return snapshot
 }
 
 /**

--- a/packages/core/src/execution/authorized-object-reader.ts
+++ b/packages/core/src/execution/authorized-object-reader.ts
@@ -1,4 +1,5 @@
 import { assertAuthorized, isAllowed } from "../authorization"
+import { AuthorizationError } from "../authorization/errors"
 import type { AuthorizationContext } from "../authorization/types"
 import {
   countObjects,
@@ -21,7 +22,13 @@ import { assertObjectQueryComplexity } from "../objects/query/complexity"
 import { ObjectQueryValidationError } from "../objects/query/errors"
 import type { ObjectQuery } from "../objects/query/ir"
 import type { OntologyRegistry } from "../ontology"
-import type { LinkBatchKey, ObjectLinkRow, ObjectReadStorage, ObjectStorage } from "../storage"
+import type {
+  CompiledObjectReadStep,
+  LinkBatchKey,
+  ObjectLinkRow,
+  ObjectReadStorage,
+  ObjectStorage,
+} from "../storage"
 import { captureExecutionScope, resolveExecutionScopeAuthorization } from "./authorization"
 import type { ExecutionScope, RuntimeAuthorization } from "./types"
 
@@ -56,6 +63,8 @@ class AuthorizedObjectReaderImpl {
   readonly #runtime: RuntimeReadAuthorization
   readonly #ontology: OntologyRegistry
   readonly #storage: ObjectReadStorage
+  readonly #delegatedObjectTypeIds?: ReadonlySet<string>
+  readonly #delegatedLinkDefinitions?: ReadonlySet<string>
 
   constructor(
     key: typeof readerConstructionKey,
@@ -74,6 +83,14 @@ class AuthorizedObjectReaderImpl {
     this.#authority = input.authority
     this.#ontology = input.ontology
     this.#storage = input.storage
+    this.#delegatedObjectTypeIds =
+      input.authority.type === "delegated"
+        ? new Set(input.authority.objectRead.scope.objects.map((object) => object.objectTypeId))
+        : undefined
+    this.#delegatedLinkDefinitions =
+      input.authority.type === "delegated"
+        ? new Set(input.authority.objectRead.scope.steps.map(delegatedLinkDefinitionKey))
+        : undefined
     this.#runtime = Object.freeze({
       projectId: input.scope.execution.projectId,
       runtimeAuthorization: input.scope.authorization,
@@ -245,6 +262,7 @@ class AuthorizedObjectReaderImpl {
   async executeQuery(
     input: Omit<ExecuteObjectQueryInput, "projectId">
   ): Promise<ExecuteObjectQueryResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     const includeTotal = snapshotReadValue(input.includeTotal)
     return detachReadResult(
@@ -262,6 +280,7 @@ class AuthorizedObjectReaderImpl {
   async queryLinks(
     input: Omit<ExecuteObjectQueryLinksInput, "projectId">
   ): Promise<ExecuteObjectQueryLinksResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     const request = snapshotReadValue({
       direction: input.direction,
@@ -292,6 +311,7 @@ class AuthorizedObjectReaderImpl {
   async count(
     input: Omit<ExecuteObjectCountInput, "projectId">
   ): Promise<ExecuteObjectCountResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     return detachReadResult(
       await countObjects(
@@ -304,6 +324,7 @@ class AuthorizedObjectReaderImpl {
   async exists(
     input: Omit<ExecuteObjectExistsInput, "projectId">
   ): Promise<ExecuteObjectExistsResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     return detachReadResult(
       await existsObjects(
@@ -316,6 +337,7 @@ class AuthorizedObjectReaderImpl {
   async facet(
     input: Omit<ExecuteObjectFacetsInput, "projectId">
   ): Promise<ExecuteObjectFacetsResult> {
+    this.#assertDelegatedQueriesAdmitted()
     const query = snapshotAuthoredQuery(input.query)
     const facets = snapshotReadValue(
       input.facets.map((facet) => ({ propertyId: facet.propertyId, limit: facet.limit }))
@@ -340,6 +362,17 @@ class AuthorizedObjectReaderImpl {
   }
 
   #assertObjectTypesViewable(objectTypeIds: readonly string[]): void {
+    if (this.#authority.type === "delegated") {
+      for (const objectTypeId of new Set(objectTypeIds)) {
+        if (this.#delegatedObjectTypeIds?.has(objectTypeId)) continue
+        throw new AuthorizationError(
+          `delegated:object.view:${objectTypeId}`,
+          `[Sixb] Delegated authorization does not select object type '${objectTypeId}'.`
+        )
+      }
+      return
+    }
+
     for (const objectTypeId of new Set(objectTypeIds)) {
       assertAuthorized(this.#runtime, { kind: "object.view", objectTypeId })
     }
@@ -365,12 +398,30 @@ class AuthorizedObjectReaderImpl {
   }
 
   #isObjectTypeViewable(objectTypeId: string): boolean {
+    if (this.#authority.type === "delegated") {
+      return this.#delegatedObjectTypeIds?.has(objectTypeId) ?? false
+    }
     return isAllowed(this.#runtime.authorization, { kind: "object.view", objectTypeId })
   }
 
+  #assertDelegatedQueriesAdmitted(): void {
+    if (this.#authority.type !== "delegated") return
+    throw new AuthorizationError(
+      "delegated:object.query",
+      "[Sixb] Object Query terminals require explicit selected-path admission under delegated authorization."
+    )
+  }
+
   #isLinkViewable(link: ObjectLinkRow): boolean {
+    if (
+      !this.#isObjectTypeViewable(link.sourceTypeId) ||
+      !this.#isObjectTypeViewable(link.targetTypeId)
+    ) {
+      return false
+    }
     return (
-      this.#isObjectTypeViewable(link.sourceTypeId) && this.#isObjectTypeViewable(link.targetTypeId)
+      this.#delegatedLinkDefinitions?.has(delegatedLinkDefinitionKey(link)) ??
+      this.#authority.type !== "delegated"
     )
   }
 }
@@ -416,6 +467,12 @@ function objectStorageForAuthority(
     case "principal":
     case "unrestricted":
       return objectStorage
+    case "delegated":
+      return objectStorage.createSelectedReadScope({
+        projectId: authority.projectId,
+        scope: authority.objectRead.scope,
+        limits: authority.objectRead.limits,
+      })
   }
   return assertNever(authority)
 }
@@ -424,6 +481,16 @@ function assertNever(value: never): never {
   throw new Error(
     `[Sixb] Unsupported object reader authority '${String((value as { type?: unknown }).type)}'.`
   )
+}
+
+function delegatedLinkDefinitionKey(
+  input:
+    | Pick<CompiledObjectReadStep, "sourceObjectTypeId" | "linkId" | "targetObjectTypeId">
+    | Pick<ObjectLinkRow, "sourceTypeId" | "linkId" | "targetTypeId">
+): string {
+  return "sourceObjectTypeId" in input
+    ? JSON.stringify([input.sourceObjectTypeId, input.linkId, input.targetObjectTypeId])
+    : JSON.stringify([input.sourceTypeId, input.linkId, input.targetTypeId])
 }
 
 /**

--- a/packages/core/src/execution/authorized-object-reader.ts
+++ b/packages/core/src/execution/authorized-object-reader.ts
@@ -1,0 +1,462 @@
+import { assertAuthorized, isAllowed } from "../authorization"
+import type { AuthorizationContext } from "../authorization/types"
+import {
+  countObjects,
+  type ExecuteObjectCountInput,
+  type ExecuteObjectCountResult,
+  type ExecuteObjectExistsInput,
+  type ExecuteObjectExistsResult,
+  type ExecuteObjectFacetsInput,
+  type ExecuteObjectFacetsResult,
+  type ExecuteObjectQueryInput,
+  type ExecuteObjectQueryLinksInput,
+  type ExecuteObjectQueryLinksResult,
+  type ExecuteObjectQueryResult,
+  executeObjectQuery,
+  executeObjectQueryLinks,
+  existsObjects,
+  facetObjects,
+} from "../objects/query"
+import { assertObjectQueryComplexity } from "../objects/query/complexity"
+import { ObjectQueryValidationError } from "../objects/query/errors"
+import type { ObjectQuery } from "../objects/query/ir"
+import type { OntologyRegistry } from "../ontology"
+import type { LinkBatchKey, ObjectLinkRow, ObjectReadStorage, ObjectStorage } from "../storage"
+import { captureExecutionScope, resolveExecutionScopeAuthorization } from "./authorization"
+import type { ExecutionScope, RuntimeAuthorization } from "./types"
+
+type RuntimeReadAuthorization = {
+  readonly projectId: string
+  readonly runtimeAuthorization: RuntimeAuthorization
+  readonly authorization?: AuthorizationContext
+}
+
+type ResolvedExecutionAuthority = ReturnType<typeof resolveExecutionScopeAuthorization>
+type GetObjectInput = Omit<Parameters<ObjectReadStorage["getByPrimaryId"]>[0], "projectId">
+type GetObjectsInput = Omit<Parameters<ObjectReadStorage["getByPrimaryIdBatch"]>[0], "projectId">
+type SelectObjectPropertiesInput = Parameters<ObjectReadStorage["selectsObjectProperties"]>[0]
+type CanReadObjectPropertyInput = SelectObjectPropertiesInput["items"][number]
+type CanReadObjectPropertiesBatchInput = Omit<SelectObjectPropertiesInput, "projectId">
+type ListObjectsInput = Omit<Parameters<ObjectReadStorage["list"]>[0], "projectId">
+type ListLinksInput = Omit<Parameters<ObjectReadStorage["listLinks"]>[0], "projectId">
+type ListLinksBatchInput = Omit<Parameters<ObjectReadStorage["listLinksBatch"]>[0], "projectId">
+
+const readerConstructionKey = Object.freeze({})
+
+/**
+ * Core-owned object read boundary for one exact execution authority.
+ *
+ * The implementation class is intentionally private to this module. Its private fields make the
+ * exported instance type nominal, while the construction key prevents code that discovers the
+ * JavaScript constructor through an instance from manufacturing another reader.
+ */
+class AuthorizedObjectReaderImpl {
+  readonly #authorization: RuntimeAuthorization
+  readonly #authority: ResolvedExecutionAuthority
+  readonly #runtime: RuntimeReadAuthorization
+  readonly #ontology: OntologyRegistry
+  readonly #storage: ObjectReadStorage
+
+  constructor(
+    key: typeof readerConstructionKey,
+    input: {
+      readonly scope: ExecutionScope
+      readonly ontology: OntologyRegistry
+      readonly storage: ObjectReadStorage
+      readonly authority: ResolvedExecutionAuthority
+    }
+  ) {
+    if (key !== readerConstructionKey) {
+      throw new Error("[Sixb] AuthorizedObjectReader can only be created by Core.")
+    }
+
+    this.#authorization = input.scope.authorization
+    this.#authority = input.authority
+    this.#ontology = input.ontology
+    this.#storage = input.storage
+    this.#runtime = Object.freeze({
+      projectId: input.scope.execution.projectId,
+      runtimeAuthorization: input.scope.authorization,
+      ...(input.authority.type === "principal" ? { authorization: input.authority.context } : {}),
+    })
+  }
+
+  static assertBound(reader: AuthorizedObjectReaderImpl, scope: ExecutionScope): void {
+    const capturedScope = captureExecutionScope(scope)
+    resolveExecutionScopeAuthorization(reader.#runtime.projectId, capturedScope)
+    if (capturedScope.authorization !== reader.#authorization) {
+      throw new Error(
+        "[Sixb] AuthorizedObjectReader is not bound to this exact execution authority."
+      )
+    }
+  }
+
+  /** Project identity carried by this nominal reader capability. */
+  get projectId(): string {
+    return this.#runtime.projectId
+  }
+
+  async getByPrimaryId(input: GetObjectInput): ReturnType<ObjectReadStorage["getByPrimaryId"]> {
+    const request = snapshotReadValue({
+      objectTypeId: input.objectTypeId,
+      primaryId: input.primaryId,
+    })
+    this.#assertObjectTypesViewable([request.objectTypeId])
+    return detachReadResult(
+      await this.#storage.getByPrimaryId({
+        ...request,
+        projectId: this.#runtime.projectId,
+      })
+    )
+  }
+
+  async getByPrimaryIdBatch(
+    input: GetObjectsInput
+  ): ReturnType<ObjectReadStorage["getByPrimaryIdBatch"]> {
+    const request = snapshotReadValue({
+      items: input.items.map((item) => ({
+        objectTypeId: item.objectTypeId,
+        primaryId: item.primaryId,
+      })),
+    })
+    this.#assertObjectTypesViewable(request.items.map((item) => item.objectTypeId))
+    return detachReadResult(
+      await this.#storage.getByPrimaryIdBatch({
+        ...request,
+        projectId: this.#runtime.projectId,
+      })
+    )
+  }
+
+  async canReadObjectProperty(input: CanReadObjectPropertyInput): Promise<boolean> {
+    const request = snapshotReadValue({
+      objectTypeId: input.objectTypeId,
+      primaryId: input.primaryId,
+      propertyId: input.propertyId,
+    })
+    this.#assertObjectTypesViewable([request.objectTypeId])
+    const [readable] = await this.#storage.selectsObjectProperties({
+      projectId: this.#runtime.projectId,
+      items: [request],
+    })
+    return readable ?? false
+  }
+
+  async canReadObjectPropertiesBatch(
+    input: CanReadObjectPropertiesBatchInput
+  ): Promise<readonly boolean[]> {
+    const request = snapshotReadValue({
+      items: input.items.map((item) => ({
+        objectTypeId: item.objectTypeId,
+        primaryId: item.primaryId,
+        propertyId: item.propertyId,
+      })),
+    })
+    this.#assertObjectTypesViewable(request.items.map((item) => item.objectTypeId))
+    return detachReadResult(
+      await this.#storage.selectsObjectProperties({
+        ...request,
+        projectId: this.#runtime.projectId,
+      })
+    )
+  }
+
+  async list(input: ListObjectsInput): ReturnType<ObjectReadStorage["list"]> {
+    const request = snapshotReadValue({
+      objectTypeId:
+        typeof input.objectTypeId === "string"
+          ? input.objectTypeId
+          : input.objectTypeId === undefined
+            ? undefined
+            : [...input.objectTypeId],
+      primaryIdPrefix: input.primaryIdPrefix,
+      primaryIdSuffix: input.primaryIdSuffix,
+      updatedAfter: input.updatedAfter,
+      updatedBefore: input.updatedBefore,
+      createdAfter: input.createdAfter,
+      createdBefore: input.createdBefore,
+      limit: input.limit,
+      offset: input.offset,
+      orderBy: input.orderBy,
+      order: input.order,
+    })
+    const objectTypeId = this.#resolveListObjectTypes(request.objectTypeId)
+
+    // An empty type selection means "none", never "all". Short-circuiting here prevents a
+    // provider with different empty-array semantics from turning a principal read into a broad one.
+    if (Array.isArray(objectTypeId) && objectTypeId.length === 0) {
+      return { objects: [], hasMore: false, total: 0 }
+    }
+
+    return detachReadResult(
+      await this.#storage.list({
+        ...request,
+        ...(objectTypeId === undefined ? {} : { objectTypeId }),
+        projectId: this.#runtime.projectId,
+      })
+    )
+  }
+
+  async listLinks(input: ListLinksInput): ReturnType<ObjectReadStorage["listLinks"]> {
+    const request = snapshotReadValue({
+      objectTypeId: input.objectTypeId,
+      objectId: input.objectId,
+      linkId: input.linkId,
+      direction: input.direction,
+    })
+    this.#assertObjectTypesViewable([request.objectTypeId])
+    const links = detachReadResult(
+      await this.#storage.listLinks({
+        ...request,
+        projectId: this.#runtime.projectId,
+      })
+    )
+    return links.filter((link) => this.#isLinkViewable(link))
+  }
+
+  async listLinksBatch(
+    input: ListLinksBatchInput
+  ): ReturnType<ObjectReadStorage["listLinksBatch"]> {
+    const request = snapshotReadValue({
+      direction: input.direction,
+      items: input.items.map((item) => ({
+        objectTypeId: item.objectTypeId,
+        objectId: item.objectId,
+        linkId: item.linkId,
+      })),
+    })
+    this.#assertObjectTypesViewable(request.items.map((item) => item.objectTypeId))
+    const pages = detachReadResult(
+      await this.#storage.listLinksBatch({
+        ...request,
+        projectId: this.#runtime.projectId,
+      })
+    )
+    const filtered = new Map<LinkBatchKey, ObjectLinkRow[]>()
+    for (const [key, links] of pages) {
+      filtered.set(
+        key,
+        links.filter((link) => this.#isLinkViewable(link))
+      )
+    }
+    return filtered
+  }
+
+  async executeQuery(
+    input: Omit<ExecuteObjectQueryInput, "projectId">
+  ): Promise<ExecuteObjectQueryResult> {
+    const query = snapshotAuthoredQuery(input.query)
+    const includeTotal = snapshotReadValue(input.includeTotal)
+    return detachReadResult(
+      await executeObjectQuery(
+        {
+          query,
+          ...(includeTotal === undefined ? {} : { includeTotal }),
+          projectId: this.#runtime.projectId,
+        },
+        this.#queryExecutorOptions()
+      )
+    )
+  }
+
+  async queryLinks(
+    input: Omit<ExecuteObjectQueryLinksInput, "projectId">
+  ): Promise<ExecuteObjectQueryLinksResult> {
+    const query = snapshotAuthoredQuery(input.query)
+    const request = snapshotReadValue({
+      direction: input.direction,
+      linkId: input.linkId,
+      includeObjects: input.includeObjects,
+      pageSize: input.pageSize,
+      pageToken: input.pageToken,
+    })
+    const result = detachReadResult(
+      await executeObjectQueryLinks(
+        { query, ...request, projectId: this.#runtime.projectId },
+        this.#queryExecutorOptions()
+      )
+    )
+
+    // Link pagination is computed by the provider-facing executor. Filtering afterward would make
+    // its cursor and hasMore metadata describe hidden rows, so a provider contract violation must
+    // fail closed instead of returning a partially filtered page.
+    if (
+      result.objects.some((row) => !this.#isObjectTypeViewable(row.objectTypeId)) ||
+      result.links.some((link) => !this.#isLinkViewable(link))
+    ) {
+      throw new Error("[Sixb] Object storage returned a link page outside its authorized scope.")
+    }
+    return result
+  }
+
+  async count(
+    input: Omit<ExecuteObjectCountInput, "projectId">
+  ): Promise<ExecuteObjectCountResult> {
+    const query = snapshotAuthoredQuery(input.query)
+    return detachReadResult(
+      await countObjects(
+        { query, projectId: this.#runtime.projectId },
+        this.#queryExecutorOptions()
+      )
+    )
+  }
+
+  async exists(
+    input: Omit<ExecuteObjectExistsInput, "projectId">
+  ): Promise<ExecuteObjectExistsResult> {
+    const query = snapshotAuthoredQuery(input.query)
+    return detachReadResult(
+      await existsObjects(
+        { query, projectId: this.#runtime.projectId },
+        this.#queryExecutorOptions()
+      )
+    )
+  }
+
+  async facet(
+    input: Omit<ExecuteObjectFacetsInput, "projectId">
+  ): Promise<ExecuteObjectFacetsResult> {
+    const query = snapshotAuthoredQuery(input.query)
+    const facets = snapshotReadValue(
+      input.facets.map((facet) => ({ propertyId: facet.propertyId, limit: facet.limit }))
+    )
+    return detachReadResult(
+      await facetObjects(
+        { query, facets, projectId: this.#runtime.projectId },
+        this.#queryExecutorOptions()
+      )
+    )
+  }
+
+  #queryExecutorOptions() {
+    return {
+      ontology: this.#ontology,
+      storage: this.#storage,
+      runtimeAuthorization: this.#runtime.runtimeAuthorization,
+      ...(this.#runtime.authorization === undefined
+        ? {}
+        : { authorization: this.#runtime.authorization }),
+    }
+  }
+
+  #assertObjectTypesViewable(objectTypeIds: readonly string[]): void {
+    for (const objectTypeId of new Set(objectTypeIds)) {
+      assertAuthorized(this.#runtime, { kind: "object.view", objectTypeId })
+    }
+  }
+
+  #resolveListObjectTypes(
+    requested: ListObjectsInput["objectTypeId"]
+  ): ListObjectsInput["objectTypeId"] {
+    if (requested !== undefined) {
+      const objectTypeIds = typeof requested === "string" ? [requested] : [...new Set(requested)]
+      for (const objectTypeId of objectTypeIds) {
+        this.#ontology.resolveObjectType(objectTypeId)
+      }
+      this.#assertObjectTypesViewable(objectTypeIds)
+      return typeof requested === "string" ? requested : objectTypeIds
+    }
+
+    if (this.#authority.type === "unrestricted") return undefined
+    return this.#ontology
+      .listObjectTypes()
+      .map((objectType) => objectType.id)
+      .filter((objectTypeId) => this.#isObjectTypeViewable(objectTypeId))
+  }
+
+  #isObjectTypeViewable(objectTypeId: string): boolean {
+    return isAllowed(this.#runtime.authorization, { kind: "object.view", objectTypeId })
+  }
+
+  #isLinkViewable(link: ObjectLinkRow): boolean {
+    return (
+      this.#isObjectTypeViewable(link.sourceTypeId) && this.#isObjectTypeViewable(link.targetTypeId)
+    )
+  }
+}
+
+Object.freeze(AuthorizedObjectReaderImpl.prototype)
+Object.freeze(AuthorizedObjectReaderImpl)
+
+export type AuthorizedObjectReader = AuthorizedObjectReaderImpl
+
+/** Build the sole application-facing object reader for one registered execution scope. */
+export function createAuthorizedObjectReader(input: {
+  readonly scope: ExecutionScope
+  readonly ontology: OntologyRegistry
+  readonly objectStorage: ObjectStorage
+}): AuthorizedObjectReader {
+  const scope = captureExecutionScope(input.scope)
+  const projectId = scope.execution.projectId
+  const authority = resolveExecutionScopeAuthorization(projectId, scope)
+  const storage = objectStorageForAuthority(authority, input.objectStorage)
+  const reader = new AuthorizedObjectReaderImpl(readerConstructionKey, {
+    scope,
+    ontology: input.ontology,
+    storage,
+    authority,
+  })
+  Object.freeze(reader)
+  return reader
+}
+
+/** Reject recombining an authorized reader with any other execution authority. */
+export function assertAuthorizedObjectReaderBinding(input: {
+  readonly reader: AuthorizedObjectReader
+  readonly scope: ExecutionScope
+}): void {
+  AuthorizedObjectReaderImpl.assertBound(input.reader, input.scope)
+}
+
+function objectStorageForAuthority(
+  authority: ResolvedExecutionAuthority,
+  objectStorage: ObjectStorage
+): ObjectReadStorage {
+  switch (authority.type) {
+    case "principal":
+    case "unrestricted":
+      return objectStorage
+  }
+  return assertNever(authority)
+}
+
+function assertNever(value: never): never {
+  throw new Error(
+    `[Sixb] Unsupported object reader authority '${String((value as { type?: unknown }).type)}'.`
+  )
+}
+
+/**
+ * Storage providers may optimize trusted reads with live references. Values crossing the
+ * application-facing authorization boundary must not retain them.
+ */
+function detachReadResult<T>(value: T): T {
+  return structuredClone(value)
+}
+
+/** Capture caller-owned values before authorization and execution. */
+function snapshotReadValue<T>(value: T): T {
+  return structuredClone(value)
+}
+
+/**
+ * Capture one bounded, serializable query before either authorization or execution sees it. The
+ * second structural check handles getter-backed inputs whose shape changes while being cloned.
+ */
+function snapshotAuthoredQuery(query: ObjectQuery): ObjectQuery {
+  assertObjectQueryComplexity(query)
+  try {
+    const snapshot = structuredClone(query)
+    assertObjectQueryComplexity(snapshot)
+    return snapshot
+  } catch (error) {
+    if (error instanceof ObjectQueryValidationError) throw error
+    throw new ObjectQueryValidationError([
+      {
+        path: "$",
+        code: "query_not_cloneable",
+        message: "Object query must contain only structured-cloneable data",
+      },
+    ])
+  }
+}

--- a/packages/core/src/execution/scopes.ts
+++ b/packages/core/src/execution/scopes.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto"
 import type { AuthorizationContext } from "../authorization"
+import type { ObjectReadExecutionLimits, SelectedObjectReadScope } from "../storage"
 import {
+  createDelegatedRuntimeAuthorization,
   createDisabledRuntimeAuthorization,
   createKernelRuntimeAuthorization,
   createPrincipalRuntimeAuthorization,
@@ -47,6 +49,26 @@ export function createDisabledRequestScope(input: {
   return Object.freeze({
     execution,
     authorization: createDisabledRuntimeAuthorization(execution),
+  })
+}
+
+/** Internal request scope carrying only a finite object-read selection. */
+export function createDelegatedRequestScope(input: {
+  readonly projectId: string
+  readonly requestId: string
+  readonly correlationId: string
+  readonly objectRead: {
+    readonly selection: SelectedObjectReadScope
+    readonly limits: ObjectReadExecutionLimits
+  }
+}): ExecutionScope {
+  const execution = createRequestExecution(input)
+  return Object.freeze({
+    execution,
+    authorization: createDelegatedRuntimeAuthorization({
+      execution,
+      objectRead: input.objectRead,
+    }),
   })
 }
 

--- a/packages/core/src/objects/execution.ts
+++ b/packages/core/src/objects/execution.ts
@@ -1,5 +1,6 @@
 import { assertAuthorized, isAllowed } from "../authorization"
 import type { ExecutionContext } from "../execution"
+import { assertAuthorizedObjectReaderBinding } from "../execution/authorized-object-reader"
 import type { ValueType } from "../ontology"
 import { assertObjectTypeRegistered } from "../ontology"
 import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
@@ -20,22 +21,17 @@ import type {
   TimeseriesHistoryBatchResult,
   TimeseriesPoint,
 } from "../storage"
-import {
-  countObjects,
-  type ExecuteObjectCountInput,
-  type ExecuteObjectCountResult,
-  type ExecuteObjectExistsInput,
-  type ExecuteObjectExistsResult,
-  type ExecuteObjectFacetsInput,
-  type ExecuteObjectFacetsResult,
-  type ExecuteObjectQueryInput,
-  type ExecuteObjectQueryLinksInput,
-  type ExecuteObjectQueryLinksResult,
-  type ExecuteObjectQueryResult,
-  executeObjectQuery,
-  executeObjectQueryLinks,
-  existsObjects,
-  facetObjects,
+import type {
+  ExecuteObjectCountInput,
+  ExecuteObjectCountResult,
+  ExecuteObjectExistsInput,
+  ExecuteObjectExistsResult,
+  ExecuteObjectFacetsInput,
+  ExecuteObjectFacetsResult,
+  ExecuteObjectQueryInput,
+  ExecuteObjectQueryLinksInput,
+  ExecuteObjectQueryLinksResult,
+  ExecuteObjectQueryResult,
 } from "./query"
 import { createObjectSet } from "./sdk"
 import type { ListObjectsParams } from "./service"
@@ -173,6 +169,10 @@ export function createObjectsRuntime<TOntologySources extends readonly OntologyS
   runtime: SixbRuntimeContext,
   execution: ExecutionContext
 ): ObjectsRuntime<TOntologySources> {
+  assertAuthorizedObjectReaderBinding({
+    reader: runtime.objectReader,
+    scope: { execution, authorization: runtime.runtimeAuthorization },
+  })
   const objects = Object.assign(
     <TObjectType extends RegisteredObjectType<TOntologySources>>(objectType: TObjectType) => {
       assertObjectTypeRegistered(runtime.ontology.getObjectTypesById(), objectType)
@@ -209,77 +209,21 @@ export function createObjectsRuntime<TOntologySources extends readonly OntologyS
       isValidLinkTarget: (expected: string | string[], actual: string) =>
         runtime.ontology.isValidLinkTarget(expected, actual),
       executeQuery: (input: Omit<ExecuteObjectQueryInput, "projectId">) =>
-        executeObjectQuery(
-          { projectId: runtime.projectId, ...input },
-          {
-            ontology: runtime.ontology,
-            storage: runtime.storage.objects,
-            runtimeAuthorization: runtime.runtimeAuthorization,
-            authorization: runtime.authorization,
-          }
-        ),
-      queryLinks: (input: ObjectQueryLinksInput) =>
-        executeObjectQueryLinks(
-          { projectId: runtime.projectId, ...input },
-          {
-            ontology: runtime.ontology,
-            storage: runtime.storage.objects,
-            runtimeAuthorization: runtime.runtimeAuthorization,
-            authorization: runtime.authorization,
-          }
-        ),
+        runtime.objectReader.executeQuery(input),
+      queryLinks: (input: ObjectQueryLinksInput) => runtime.objectReader.queryLinks(input),
       count: (input: Omit<ExecuteObjectCountInput, "projectId">) =>
-        countObjects(
-          { projectId: runtime.projectId, ...input },
-          {
-            ontology: runtime.ontology,
-            storage: runtime.storage.objects,
-            runtimeAuthorization: runtime.runtimeAuthorization,
-            authorization: runtime.authorization,
-          }
-        ),
+        runtime.objectReader.count(input),
       exists: (input: Omit<ExecuteObjectExistsInput, "projectId">) =>
-        existsObjects(
-          { projectId: runtime.projectId, ...input },
-          {
-            ontology: runtime.ontology,
-            storage: runtime.storage.objects,
-            runtimeAuthorization: runtime.runtimeAuthorization,
-            authorization: runtime.authorization,
-          }
-        ),
+        runtime.objectReader.exists(input),
       facet: (input: Omit<ExecuteObjectFacetsInput, "projectId">) =>
-        facetObjects(
-          { projectId: runtime.projectId, ...input },
-          {
-            ontology: runtime.ontology,
-            storage: runtime.storage.objects,
-            runtimeAuthorization: runtime.runtimeAuthorization,
-            authorization: runtime.authorization,
-          }
-        ),
+        runtime.objectReader.facet(input),
       listLinks: async (input: {
         objectTypeId: string
         objectId: string
         linkId?: string
         direction?: LinkDirection
       }) => {
-        assertAuthorized(runtime, { kind: "object.view", objectTypeId: input.objectTypeId })
-        const links = await runtime.storage.objects.listLinks({
-          projectId: runtime.projectId,
-          ...input,
-        })
-        return links.filter(
-          (link) =>
-            isAllowed(runtime.authorization, {
-              kind: "object.view",
-              objectTypeId: link.sourceTypeId,
-            }) &&
-            isAllowed(runtime.authorization, {
-              kind: "object.view",
-              objectTypeId: link.targetTypeId,
-            })
-        )
+        return runtime.objectReader.listLinks(input)
       },
       getTelemetryHistoryBatch: (input: Omit<TimeseriesHistoryBatchInput, "projectId">) =>
         getTelemetryHistoryBatch(
@@ -317,14 +261,8 @@ export function createObjectsRuntime<TOntologySources extends readonly OntologyS
         })
       },
       list: (params: ListObjectsParams) => objectService.listObjects(runtime, params),
-      get: async (objectTypeId: string, primaryId: string) => {
-        assertAuthorized(runtime, { kind: "object.view", objectTypeId })
-        return runtime.storage.objects.getByPrimaryId({
-          projectId: runtime.projectId,
-          objectTypeId,
-          primaryId,
-        })
-      },
+      get: (objectTypeId: string, primaryId: string) =>
+        runtime.objectReader.getByPrimaryId({ objectTypeId, primaryId }),
       getPrimaryPropertyId: (objectTypeId: string) => {
         assertAuthorized(runtime, { kind: "object.view", objectTypeId })
         return runtime.ontology.getPrimaryPropertyId(objectTypeId)

--- a/packages/core/src/objects/query/executor.ts
+++ b/packages/core/src/objects/query/executor.ts
@@ -16,7 +16,7 @@ import type {
   ObjectRowLinks,
   QueryObjectsResult,
 } from "../../storage"
-import { linkBatchKey, objectBatchKey } from "../../storage"
+import { linkBatchKey, MAX_OBJECT_READ_FACETS, objectBatchKey } from "../../storage"
 import {
   ObjectQueryExecutionError,
   ObjectQueryPlanningError,
@@ -328,7 +328,7 @@ export async function facetObjects(
     normalize: false,
   })
   assertQueryViewable(input.projectId, validated, options)
-  const facets = validateFacetRequests(input.facets, validated.result.objectTypeIds, options)
+  const facets = validateObjectFacetRequests(input.facets, validated.result.objectTypeIds, options)
   const aggregateQuery = stripOuterRowShape(validated.query)
   const capabilities = options.storage.queryCapabilities()
   const hasQueryObjects = typeof options.storage.queryObjects === "function"
@@ -1177,16 +1177,27 @@ function stripOuterRowShape(query: ObjectQuery): ObjectQuery {
   }
 }
 
-function validateFacetRequests(
+/** @internal Shared pre-storage validation; intentionally absent from query barrels. */
+export function validateObjectFacetRequests(
   facets: readonly ObjectFacetRequest[],
   objectTypeIds: readonly string[],
-  options: QueryExecutorOptions
+  options: Pick<QueryExecutorOptions, "ontology" | "maxFacetLimit">
 ): ObjectFacetRequest[] {
   const issues: ObjectQueryValidationIssue[] = []
   const maxLimit = options.maxFacetLimit ?? DEFAULT_MAX_FACET_LIMIT
 
   if (facets.length === 0) {
     addFacetIssue(issues, "$.facets", "empty_facets", "At least one facet is required")
+  }
+
+  if (facets.length > MAX_OBJECT_READ_FACETS) {
+    throw new ObjectQueryValidationError([
+      {
+        path: "$.facets",
+        code: "too_many_facets",
+        message: `facets must include at most ${MAX_OBJECT_READ_FACETS} facet requests`,
+      },
+    ])
   }
 
   if (!Number.isInteger(maxLimit) || maxLimit <= 0) {

--- a/packages/core/src/objects/query/links.ts
+++ b/packages/core/src/objects/query/links.ts
@@ -15,7 +15,7 @@ import { ObjectQueryExecutionError } from "./errors"
 import { executeObjectQuery, type QueryExecutorOptions } from "./executor"
 import type { ObjectQuery } from "./ir"
 import { normalizeObjectQuery } from "./normalize"
-import { validateObjectQuery } from "./validate"
+import { type ValidatedObjectQuery, validateObjectQuery } from "./validate"
 
 export interface ExecuteObjectQueryLinksInput {
   projectId: string
@@ -34,10 +34,98 @@ export interface ExecuteObjectQueryLinksResult {
   nextPageToken?: string
 }
 
+export interface PreflightObjectQueryLinksResult {
+  projectId: string
+  validated: ValidatedObjectQuery
+  direction: LinkDirection
+  linkId?: string
+  includeObjects: boolean
+  pageSize: number
+  cursor?: ObjectLinkCursor
+  pageScope: string
+}
+
 const MAX_LINK_QUERY_OBJECTS = 1_000
 const MAX_LINK_PAGE_SIZE = 1_000
 const DEFAULT_LINK_PAGE_SIZE = 100
 const LINK_PAGE_TOKEN_PREFIX = "link:v1:"
+
+/**
+ * Canonicalize and validate a physical-link query without reading storage.
+ *
+ * This direct-file-only boundary lets higher-level readers complete ordinary request validation
+ * before applying terminal-specific authorization, while the executor consumes the exact same
+ * preflight contract.
+ *
+ * @internal Intentionally absent from query barrels.
+ */
+export function preflightObjectQueryLinks(
+  input: ExecuteObjectQueryLinksInput,
+  options: Pick<QueryExecutorOptions, "ontology" | "maxLimit" | "maxPageSize" | "maxRefs">
+): PreflightObjectQueryLinksResult {
+  // Capture caller-owned scalar fields once so validation, token scoping, and execution agree on
+  // one request even when this internal API is reached without an AuthorizedObjectReader snapshot.
+  const projectId = input.projectId
+  const query = input.query
+  const requestedDirection = input.direction
+  const linkId = input.linkId
+  const requestedIncludeObjects = input.includeObjects
+  const requestedPageSize = input.pageSize
+  const pageToken = input.pageToken
+
+  const direction = requestedDirection ?? "both"
+  if (direction !== "outgoing" && direction !== "incoming" && direction !== "both") {
+    throw new ObjectQueryExecutionError(
+      "invalid_link_direction",
+      "direction must be 'outgoing', 'incoming', or 'both'",
+      "$.direction"
+    )
+  }
+  if (linkId !== undefined && typeof linkId !== "string") {
+    throw new ObjectQueryExecutionError("invalid_link_id", "linkId must be a string", "$.linkId")
+  }
+  if (linkId !== undefined && linkId.length === 0) {
+    throw new ObjectQueryExecutionError("invalid_link_id", "linkId must not be empty", "$.linkId")
+  }
+  if (requestedIncludeObjects !== undefined && typeof requestedIncludeObjects !== "boolean") {
+    throw new ObjectQueryExecutionError(
+      "invalid_link_include_objects",
+      "includeObjects must be a boolean",
+      "$.includeObjects"
+    )
+  }
+
+  const pageSize = requestedPageSize ?? DEFAULT_LINK_PAGE_SIZE
+  if (!Number.isInteger(pageSize) || pageSize <= 0 || pageSize > MAX_LINK_PAGE_SIZE) {
+    throw new ObjectQueryExecutionError(
+      "invalid_link_page_size",
+      `pageSize must be an integer between 1 and ${MAX_LINK_PAGE_SIZE}`,
+      "$.pageSize"
+    )
+  }
+
+  const validated = validateObjectQuery(normalizeObjectQuery(query), {
+    ontology: options.ontology,
+    maxLimit: options.maxLimit,
+    maxPageSize: options.maxPageSize,
+    maxRefs: options.maxRefs,
+    normalize: false,
+  })
+  assertLinkSelectorShape(validated.query)
+  const pageScope = linkPageScope(projectId, validated.query, direction, linkId)
+  const cursor = decodeLinkPageToken(pageToken, pageScope)
+
+  return {
+    projectId,
+    validated,
+    direction,
+    ...(linkId === undefined ? {} : { linkId }),
+    includeObjects: requestedIncludeObjects ?? false,
+    pageSize,
+    ...(cursor === undefined ? {} : { cursor }),
+    pageScope,
+  }
+}
 
 /**
  * Select a bounded object set with the query IR, then return physical links
@@ -48,37 +136,8 @@ export async function executeObjectQueryLinks(
   input: ExecuteObjectQueryLinksInput,
   options: QueryExecutorOptions
 ): Promise<ExecuteObjectQueryLinksResult> {
-  const direction = input.direction ?? "both"
-  if (direction !== "outgoing" && direction !== "incoming" && direction !== "both") {
-    throw new ObjectQueryExecutionError(
-      "invalid_link_direction",
-      "direction must be 'outgoing', 'incoming', or 'both'",
-      "$.direction"
-    )
-  }
-  if (input.linkId !== undefined && input.linkId.length === 0) {
-    throw new ObjectQueryExecutionError("invalid_link_id", "linkId must not be empty", "$.linkId")
-  }
-
-  const pageSize = input.pageSize ?? DEFAULT_LINK_PAGE_SIZE
-  if (!Number.isInteger(pageSize) || pageSize <= 0 || pageSize > MAX_LINK_PAGE_SIZE) {
-    throw new ObjectQueryExecutionError(
-      "invalid_link_page_size",
-      `pageSize must be an integer between 1 and ${MAX_LINK_PAGE_SIZE}`,
-      "$.pageSize"
-    )
-  }
-  const validated = validateObjectQuery(normalizeObjectQuery(input.query), {
-    ontology: options.ontology,
-    maxLimit: options.maxLimit,
-    maxPageSize: options.maxPageSize,
-    maxRefs: options.maxRefs,
-    normalize: false,
-  })
-  assertLinkSelectorShape(validated.query)
-  const selectorQuery = validated.query
-  const pageScope = linkPageScope(input.projectId, selectorQuery, direction, input.linkId)
-  const cursor = decodeLinkPageToken(input.pageToken, pageScope)
+  const preflight = preflightObjectQueryLinks(input, options)
+  const selectorQuery = preflight.validated.query
 
   // A root page already has an explicit result bound and must execute directly: nesting it under a
   // probe limit would expose the provider's internal pageSize+1 row. All other selector shapes are
@@ -89,7 +148,7 @@ export async function executeObjectQueryLinks(
       : { kind: "limit" as const, limit: MAX_LINK_QUERY_OBJECTS + 1, input: selectorQuery }
   const selection = await executeObjectQuery(
     {
-      projectId: input.projectId,
+      projectId: preflight.projectId,
       query: boundedSelector,
       includeTotal: false,
     },
@@ -113,16 +172,16 @@ export async function executeObjectQueryLinks(
 
   const endpointObjectTypeIds = visibleEndpointTypeIds(options)
   const page = await options.storage.queryLinks({
-    projectId: input.projectId,
+    projectId: preflight.projectId,
     objectRefs: selected.map((row) => ({
       objectTypeId: row.objectTypeId,
       primaryId: row.primaryId,
     })),
-    direction,
-    ...(input.linkId === undefined ? {} : { linkId: input.linkId }),
+    direction: preflight.direction,
+    ...(preflight.linkId === undefined ? {} : { linkId: preflight.linkId }),
     ...(endpointObjectTypeIds === undefined ? {} : { endpointObjectTypeIds }),
-    ...(cursor === undefined ? {} : { after: cursor }),
-    limit: pageSize,
+    ...(preflight.cursor === undefined ? {} : { after: preflight.cursor }),
+    limit: preflight.pageSize,
   })
   const lastLink = page.links.at(-1)
   let nextPageToken: string | undefined
@@ -130,10 +189,10 @@ export async function executeObjectQueryLinks(
     if (!lastLink) {
       throw new Error("[Sixb] Object storage returned hasMore for an empty link page.")
     }
-    nextPageToken = encodeLinkPageToken(objectLinkCursor(lastLink), pageScope)
+    nextPageToken = encodeLinkPageToken(objectLinkCursor(lastLink), preflight.pageScope)
   }
-  const objects = input.includeObjects
-    ? await hydrateLinkQueryObjects(input.projectId, selected, page.links, options.storage)
+  const objects = preflight.includeObjects
+    ? await hydrateLinkQueryObjects(preflight.projectId, selected, page.links, options.storage)
     : []
 
   return {

--- a/packages/core/src/objects/query/selected-read-admission.ts
+++ b/packages/core/src/objects/query/selected-read-admission.ts
@@ -1,0 +1,310 @@
+import { AuthorizationError } from "../../authorization/errors"
+import type {
+  CompiledObjectReadObjectSelection,
+  CompiledObjectReadStep,
+  CompiledSelectedObjectReadScope,
+} from "../../storage/objects/types"
+import type {
+  ObjectQueryAdmissionState,
+  ObjectQueryAdmissionTransition,
+  ObjectQueryEdgeUse,
+  ObjectQueryPropertyUse,
+  ObjectQuerySemanticAdmission,
+} from "./validate"
+
+const selectedStateBrand = Symbol("sixb.selected-object-query-admission-state")
+
+interface SelectedObjectQueryState extends ObjectQueryAdmissionState {
+  readonly [selectedStateBrand]: true
+  readonly selections: readonly CompiledObjectReadObjectSelection[]
+}
+
+export interface SelectedObjectQueryAdmission extends ObjectQuerySemanticAdmission {
+  /** Terminal hook for property-bearing operations outside the query IR, such as facets. */
+  assertPropertySelected(input: {
+    readonly state: ObjectQueryAdmissionState
+    readonly propertyId: string
+    readonly objectTypeId?: string
+    readonly use: ObjectQueryPropertyUse
+    readonly path: string
+  }): void
+  /** Terminal hook for the physical-link selector that sits outside `queryLinks.query`. */
+  assertIncidentEdgeSelected(input: {
+    readonly state: ObjectQueryAdmissionState
+    readonly linkId?: string
+    readonly direction: "outgoing" | "incoming" | "both"
+    readonly path: string
+  }): void
+}
+
+/**
+ * Build an immutable semantic admission over one already-compiled selected reader scope.
+ *
+ * Object identities remain provider-owned: query admission follows exact path occurrences while
+ * the selected storage relation decides which live roots and linked instances exist.
+ */
+export function createSelectedObjectQueryAdmission(
+  scope: CompiledSelectedObjectReadScope
+): SelectedObjectQueryAdmission {
+  const selectionByKey = new Map<string, CompiledObjectReadObjectSelection>()
+  const selectionsByType = new Map<string, CompiledObjectReadObjectSelection[]>()
+  const propertiesBySelection = new Map<string, ReadonlySet<string>>()
+
+  for (const selection of scope.objects) {
+    const key = selectionKey(selection.nodeId, selection.objectTypeId)
+    selectionByKey.set(key, selection)
+    propertiesBySelection.set(key, new Set(selection.propertyIds))
+    const byType = selectionsByType.get(selection.objectTypeId) ?? []
+    byType.push(selection)
+    selectionsByType.set(selection.objectTypeId, byType)
+  }
+
+  const outgoing = indexSteps(scope.steps, "outgoing", selectionByKey)
+  const incoming = indexSteps(scope.steps, "incoming", selectionByKey)
+  const emptyState = selectedState([])
+
+  const admission: SelectedObjectQueryAdmission = {
+    empty: () => emptyState,
+    source: (input) => {
+      const selections = input.result.objectTypeIds.flatMap(
+        (objectTypeId) => selectionsByType.get(objectTypeId) ?? []
+      )
+      const state = selectedState(selections)
+
+      if (input.kind === "refs") {
+        const missingType = [...new Set(input.refs?.map((ref) => ref.objectTypeId) ?? [])]
+          .sort()
+          .find((objectTypeId) => !selectionsByType.has(objectTypeId))
+        if (missingType) {
+          return denied(
+            state,
+            new AuthorizationError(
+              `view:object:${missingType}`,
+              `[Sixb] Delegated query cannot reference object type '${missingType}' at '${input.path}': the selected object scope does not contain that type.`
+            )
+          )
+        }
+      }
+
+      if (state.selections.length > 0) return { state }
+      const objectTypeId = input.objectTypeId ?? input.result.objectTypeIds[0] ?? "unknown"
+      return denied(
+        state,
+        new AuthorizationError(
+          `view:object:${objectTypeId}`,
+          `[Sixb] Delegated query cannot start from object type '${objectTypeId}' at '${input.path}': the selected object scope does not contain that type.`
+        )
+      )
+    },
+    property: (input) =>
+      propertyDenial(
+        asSelectedState(input.state),
+        input.propertyId,
+        input.objectTypeId,
+        input.use,
+        input.path,
+        propertiesBySelection
+      ),
+    edge: (input) => {
+      const state = asSelectedState(input.state)
+      const next = followEdge(
+        state,
+        input.linkId,
+        input.direction,
+        input.sourceObjectTypeId,
+        outgoing,
+        incoming,
+        input.result.objectTypeIds
+      )
+      if (next.selections.length > 0 || state.selections.length === 0) return { state: next }
+      return denied(
+        next,
+        edgeDenial(
+          state,
+          input.linkId,
+          input.direction,
+          input.sourceObjectTypeId,
+          input.use,
+          input.path
+        )
+      )
+    },
+    set: ({ op, states }) => {
+      if (op === "subtract") return asSelectedState(states[0] ?? emptyState)
+      return selectedState(states.flatMap((state) => asSelectedState(state).selections))
+    },
+    assertPropertySelected: (input) => {
+      const denial = propertyDenial(
+        asSelectedState(input.state),
+        input.propertyId,
+        input.objectTypeId,
+        input.use,
+        input.path,
+        propertiesBySelection
+      )
+      if (denial) throw denial
+    },
+    assertIncidentEdgeSelected: (input) => {
+      if (input.linkId === undefined) return
+      const state = asSelectedState(input.state)
+      const directions: readonly ("outgoing" | "incoming")[] =
+        input.direction === "both" ? ["outgoing", "incoming"] : [input.direction]
+      const next = selectedState(
+        directions.flatMap(
+          (direction) =>
+            followEdge(state, input.linkId!, direction, undefined, outgoing, incoming).selections
+        )
+      )
+      if (next.selections.length > 0 || state.selections.length === 0) return
+      throw edgeDenial(state, input.linkId, input.direction, undefined, "queryLinks", input.path)
+    },
+  }
+
+  return Object.freeze(admission)
+}
+
+function indexSteps(
+  steps: readonly CompiledObjectReadStep[],
+  direction: "outgoing" | "incoming",
+  selectionByKey: ReadonlyMap<string, CompiledObjectReadObjectSelection>
+): ReadonlyMap<string, readonly CompiledObjectReadObjectSelection[]> {
+  const index = new Map<string, CompiledObjectReadObjectSelection[]>()
+  for (const step of steps) {
+    const fromKey =
+      direction === "outgoing"
+        ? selectionKey(step.parentNodeId, step.sourceObjectTypeId)
+        : selectionKey(step.nodeId, step.targetObjectTypeId)
+    const toKey =
+      direction === "outgoing"
+        ? selectionKey(step.nodeId, step.targetObjectTypeId)
+        : selectionKey(step.parentNodeId, step.sourceObjectTypeId)
+    const target = selectionByKey.get(toKey)
+    if (!selectionByKey.has(fromKey) || !target) {
+      throw new Error("[Sixb] Compiled selected object scope contains an invalid query path step.")
+    }
+    const key = edgeKey(
+      direction === "outgoing" ? step.parentNodeId : step.nodeId,
+      direction === "outgoing" ? step.sourceObjectTypeId : step.targetObjectTypeId,
+      step.linkId
+    )
+    const targets = index.get(key) ?? []
+    targets.push(target)
+    index.set(key, targets)
+  }
+  return index
+}
+
+function followEdge(
+  state: SelectedObjectQueryState,
+  linkId: string,
+  direction: "outgoing" | "incoming",
+  sourceObjectTypeId: string | undefined,
+  outgoing: ReadonlyMap<string, readonly CompiledObjectReadObjectSelection[]>,
+  incoming: ReadonlyMap<string, readonly CompiledObjectReadObjectSelection[]>,
+  resultObjectTypeIds?: readonly string[]
+): SelectedObjectQueryState {
+  const index = direction === "outgoing" ? outgoing : incoming
+  const resultTypes = resultObjectTypeIds ? new Set(resultObjectTypeIds) : undefined
+  const selections = state.selections.flatMap((selection) => {
+    const candidates = index.get(edgeKey(selection.nodeId, selection.objectTypeId, linkId)) ?? []
+    return candidates.filter(
+      (candidate) =>
+        (resultTypes === undefined || resultTypes.has(candidate.objectTypeId)) &&
+        (direction === "outgoing" ||
+          sourceObjectTypeId === undefined ||
+          candidate.objectTypeId === sourceObjectTypeId)
+    )
+  })
+  return selectedState(selections)
+}
+
+function propertyDenial(
+  state: SelectedObjectQueryState,
+  propertyId: string,
+  objectTypeId: string | undefined,
+  use: ObjectQueryPropertyUse,
+  path: string,
+  propertiesBySelection: ReadonlyMap<string, ReadonlySet<string>>
+): AuthorizationError | undefined {
+  const candidates = objectTypeId
+    ? state.selections.filter((selection) => selection.objectTypeId === objectTypeId)
+    : state.selections
+  // A selected reader has no rows for result types absent from this provenance. Those empty
+  // branches cannot observe a property and must not make includeSubtypes queries fail closed.
+  if (candidates.length === 0) return undefined
+
+  const missing = candidates.find(
+    (selection) =>
+      !propertiesBySelection
+        .get(selectionKey(selection.nodeId, selection.objectTypeId))
+        ?.has(propertyId)
+  )
+  if (!missing) return undefined
+
+  const objectTypeIds = [...new Set(candidates.map((selection) => selection.objectTypeId))].sort()
+  return new AuthorizationError(
+    `view:object:${objectTypeIds.join(",")}:property:${propertyId}`,
+    `[Sixb] Delegated query cannot use property '${propertyId}' for ${use} at '${path}': it is not selected on every matching read-scope path (missing on ${formatSelection(missing)}).`
+  )
+}
+
+function edgeDenial(
+  state: SelectedObjectQueryState,
+  linkId: string,
+  direction: "outgoing" | "incoming" | "both",
+  sourceObjectTypeId: string | undefined,
+  use: ObjectQueryEdgeUse,
+  path: string
+): AuthorizationError {
+  const source = sourceObjectTypeId ? `:${sourceObjectTypeId}` : ""
+  return new AuthorizationError(
+    `view:link:${direction}${source}:${linkId}`,
+    `[Sixb] Delegated query cannot use ${direction} link '${linkId}' for ${use} from ${formatState(state)} at '${path}': that exact read-scope path is not selected.`
+  )
+}
+
+function formatState(state: SelectedObjectQueryState): string {
+  if (state.selections.length === 0) return "an empty read-scope provenance"
+  return `read-scope provenance ${state.selections.map(formatSelection).join(", ")}`
+}
+
+function formatSelection(selection: CompiledObjectReadObjectSelection): string {
+  return `'${selection.objectTypeId}'@node ${selection.nodeId}`
+}
+
+function selectedState(
+  selections: readonly CompiledObjectReadObjectSelection[]
+): SelectedObjectQueryState {
+  const unique = new Map<string, CompiledObjectReadObjectSelection>()
+  for (const selection of selections) {
+    unique.set(selectionKey(selection.nodeId, selection.objectTypeId), selection)
+  }
+  return Object.freeze({
+    [selectedStateBrand]: true as const,
+    selections: Object.freeze(
+      [...unique.values()].sort(
+        (left, right) =>
+          left.nodeId - right.nodeId || left.objectTypeId.localeCompare(right.objectTypeId)
+      )
+    ),
+  })
+}
+
+function asSelectedState(state: ObjectQueryAdmissionState): SelectedObjectQueryState {
+  if ((state as Partial<SelectedObjectQueryState>)[selectedStateBrand] !== true) {
+    throw new Error("[Sixb] Object query admission state belongs to another semantic admission.")
+  }
+  return state as SelectedObjectQueryState
+}
+
+function denied(state: SelectedObjectQueryState, denial: Error): ObjectQueryAdmissionTransition {
+  return { state, denial }
+}
+
+function selectionKey(nodeId: number, objectTypeId: string): string {
+  return JSON.stringify([nodeId, objectTypeId])
+}
+
+function edgeKey(nodeId: number, objectTypeId: string, linkId: string): string {
+  return JSON.stringify([nodeId, objectTypeId, linkId])
+}

--- a/packages/core/src/objects/query/validate.ts
+++ b/packages/core/src/objects/query/validate.ts
@@ -14,8 +14,10 @@ import { ObjectQueryValidationError } from "./errors"
 import type {
   ObjectExpansion,
   ObjectQuery,
+  ObjectQueryDirection,
   ObjectQueryPredicate,
   ObjectQueryResultShape,
+  ObjectQuerySetOperation,
   ObjectQuerySortField,
   QueryScalarKind,
 } from "./ir"
@@ -42,6 +44,71 @@ export interface ObjectQueryValidationOptions {
   normalize?: boolean
 }
 
+/** Opaque semantic state carried by the canonical query validator for an internal admission. */
+export type ObjectQueryAdmissionState = object
+
+export type ObjectQueryPropertyUse =
+  | "filter"
+  | "text"
+  | "vector"
+  | "sort"
+  | "project"
+  | "expand.orderBy"
+  | "facet"
+
+export type ObjectQueryEdgeUse = "traverse" | "expand" | "queryLinks"
+
+export interface ObjectQueryAdmissionTransition {
+  readonly state: ObjectQueryAdmissionState
+  /** Recorded during the walk and raised only after ordinary validation succeeds. */
+  readonly denial?: Error
+}
+
+/**
+ * Internal semantic admission reducer driven by the canonical query validator.
+ *
+ * It deliberately has no AST visitor: validation owns recursion through query nodes, predicates,
+ * and expansions, while an admission only reduces the semantic sources, properties, edges, and
+ * set operations it observes.
+ */
+export interface ObjectQuerySemanticAdmission {
+  empty(): ObjectQueryAdmissionState
+  source(input: {
+    readonly kind: "start" | "refs"
+    readonly result: ObjectQueryResultShape
+    readonly objectTypeId?: string
+    readonly refs?: readonly ObjectRef[]
+    readonly path: string
+  }): ObjectQueryAdmissionTransition
+  property(input: {
+    readonly state: ObjectQueryAdmissionState
+    readonly propertyId: string
+    readonly objectTypeId?: string
+    readonly use: ObjectQueryPropertyUse
+    readonly path: string
+  }): Error | undefined
+  edge(input: {
+    readonly state: ObjectQueryAdmissionState
+    /** Ontology-resolved shape after following this edge. */
+    readonly result: ObjectQueryResultShape
+    readonly linkId: string
+    readonly direction: ObjectQueryDirection
+    readonly sourceObjectTypeId?: string
+    readonly use: ObjectQueryEdgeUse
+    readonly path: string
+  }): ObjectQueryAdmissionTransition
+  set(input: {
+    readonly op: ObjectQuerySetOperation
+    readonly states: readonly ObjectQueryAdmissionState[]
+    readonly path: string
+  }): ObjectQueryAdmissionState
+}
+
+export interface AdmittedObjectQuery extends ValidatedObjectQuery {
+  /** Root provenance for terminal-specific checks such as facets and physical link queries. */
+  admissionState: ObjectQueryAdmissionState
+}
+
 type QueryValidationContext = Required<
   Pick<ObjectQueryValidationOptions, "maxLimit" | "maxPageSize" | "maxRefs">
 > & {
@@ -49,11 +116,17 @@ type QueryValidationContext = Required<
   valueTypesById: ReadonlyMap<string, ValueType>
   issues: ObjectQueryValidationIssue[]
   touchedObjectTypeIds: Set<string>
+  admission: ObjectQuerySemanticAdmission
+  admissionDenials: Error[]
 }
 
-interface QueryValidationResult {
+interface QueryNodeValidation {
   result: ObjectQueryResultShape
   query: ObjectQuery
+}
+
+interface QueryValidationResult extends QueryNodeValidation {
+  admissionState: ObjectQueryAdmissionState
 }
 
 interface TextFieldResolution {
@@ -64,23 +137,56 @@ const DEFAULT_MAX_LIMIT = 1_000
 const DEFAULT_MAX_PAGE_SIZE = 1_000
 const DEFAULT_MAX_REFS = 1_000
 
+const NOOP_ADMISSION_STATE = Object.freeze({})
+const NOOP_QUERY_ADMISSION: ObjectQuerySemanticAdmission = Object.freeze({
+  empty: () => NOOP_ADMISSION_STATE,
+  source: () => ({ state: NOOP_ADMISSION_STATE }),
+  property: () => undefined,
+  edge: (input: Parameters<ObjectQuerySemanticAdmission["edge"]>[0]) => ({
+    state: input.state,
+  }),
+  set: (input: Parameters<ObjectQuerySemanticAdmission["set"]>[0]) =>
+    input.states[0] ?? NOOP_ADMISSION_STATE,
+})
+
 export function validateObjectQuery(
   query: ObjectQuery,
   options: ObjectQueryValidationOptions
 ): ValidatedObjectQuery {
+  const admitted = validateObjectQueryWithAdmission(query, options, NOOP_QUERY_ADMISSION)
+  return {
+    query: admitted.query,
+    result: admitted.result,
+    touchedObjectTypeIds: admitted.touchedObjectTypeIds,
+  }
+}
+
+/**
+ * Validate and semantically admit one query in the same canonical walk.
+ *
+ * This is an internal direct-file API. It is intentionally absent from public query barrels.
+ */
+export function validateObjectQueryWithAdmission(
+  query: ObjectQuery,
+  options: ObjectQueryValidationOptions,
+  admission: ObjectQuerySemanticAdmission
+): AdmittedObjectQuery {
   if (options.normalize === false) assertObjectQueryComplexity(query)
   const normalized = options.normalize === false ? query : normalizeObjectQuery(query)
-  const ctx = createValidationContext(options)
+  const ctx = createValidationContext(options, admission)
   const validation = validateQueryNode(normalized, "$", ctx)
 
   if (ctx.issues.length > 0) {
     throw new ObjectQueryValidationError(ctx.issues)
   }
+  const denial = ctx.admissionDenials[0]
+  if (denial) throw denial
 
   return {
     query: validation.query,
     result: validation.result,
     touchedObjectTypeIds: [...ctx.touchedObjectTypeIds],
+    admissionState: validation.admissionState,
   }
 }
 
@@ -96,7 +202,7 @@ export function collectObjectQueryValidationIssues(
     if (error instanceof ObjectQueryValidationError) return error.issues
     throw error
   }
-  const ctx = createValidationContext(options)
+  const ctx = createValidationContext(options, NOOP_QUERY_ADMISSION)
   validateQueryNode(normalized, "$", ctx)
   return ctx.issues
 }
@@ -108,7 +214,10 @@ export function resolveObjectQueryResultShape(
   return validateObjectQuery(query, options).result
 }
 
-function createValidationContext(options: ObjectQueryValidationOptions): QueryValidationContext {
+function createValidationContext(
+  options: ObjectQueryValidationOptions,
+  admission: ObjectQuerySemanticAdmission
+): QueryValidationContext {
   return {
     ontology: options.ontology,
     valueTypesById: options.ontology.getValueTypesById(),
@@ -117,6 +226,8 @@ function createValidationContext(options: ObjectQueryValidationOptions): QueryVa
     maxRefs: options.maxRefs ?? DEFAULT_MAX_REFS,
     issues: [],
     touchedObjectTypeIds: new Set<string>(),
+    admission,
+    admissionDenials: [],
   }
 }
 
@@ -142,18 +253,61 @@ function dispatchQueryNode(
   ctx: QueryValidationContext
 ): QueryValidationResult {
   switch (query.kind) {
-    case "start":
-      return validateStart(query.objectTypeId, query.includeSubtypes, path, ctx)
-    case "refs":
-      return validateRefs(query.refs, path, ctx)
+    case "start": {
+      const validation = validateStart(query.objectTypeId, query.includeSubtypes, path, ctx)
+      return {
+        ...validation,
+        admissionState: admitTransition(
+          ctx,
+          ctx.admission.source({
+            kind: "start",
+            result: validation.result,
+            objectTypeId: query.objectTypeId,
+            path,
+          })
+        ),
+      }
+    }
+    case "refs": {
+      const validation = validateRefs(query.refs, path, ctx)
+      return {
+        ...validation,
+        admissionState: admitTransition(
+          ctx,
+          ctx.admission.source({
+            kind: "refs",
+            result: validation.result,
+            refs: validation.query.kind === "refs" ? validation.query.refs : query.refs,
+            path,
+          })
+        ),
+      }
+    }
     case "filter": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
-      const predicate = validatePredicate(query.predicate, input.result, `${path}.predicate`, ctx)
-      return { result: input.result, query: { ...query, input: input.query, predicate } }
+      const predicate = validatePredicate(
+        query.predicate,
+        input.result,
+        input.admissionState,
+        `${path}.predicate`,
+        ctx
+      )
+      return {
+        result: input.result,
+        query: { ...query, input: input.query, predicate },
+        admissionState: input.admissionState,
+      }
     }
     case "text": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
-      const textFields = validateTextQuery(query.query, query.fields, input.result, path, ctx)
+      const textFields = validateTextQuery(
+        query.query,
+        query.fields,
+        input.result,
+        input.admissionState,
+        path,
+        ctx
+      )
       return {
         result: input.result,
         query: {
@@ -162,48 +316,97 @@ function dispatchQueryNode(
           fields: query.fields,
           fieldsByObjectType: query.fields ? undefined : textFields.fieldsByObjectType,
         },
+        admissionState: input.admissionState,
       }
     }
     case "vector": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
-      validateVectorQuery(query.vector, query.propertyId, query.k, input.result, path, ctx)
-      return { result: input.result, query: { ...query, input: input.query } }
+      validateVectorQuery(
+        query.vector,
+        query.propertyId,
+        query.k,
+        input.result,
+        input.admissionState,
+        path,
+        ctx
+      )
+      return {
+        result: input.result,
+        query: { ...query, input: input.query },
+        admissionState: input.admissionState,
+      }
     }
     case "traverse": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
+      const result = validateTraverse(
+        query.linkId,
+        query.direction,
+        query.sourceObjectTypeId,
+        input.result,
+        path,
+        ctx
+      )
       return {
-        result: validateTraverse(
-          query.linkId,
-          query.direction,
-          query.sourceObjectTypeId,
-          input.result,
-          path,
-          ctx
-        ),
+        result,
         query: { ...query, input: input.query },
+        admissionState: admitTransition(
+          ctx,
+          ctx.admission.edge({
+            state: input.admissionState,
+            result,
+            linkId: query.linkId,
+            direction: query.direction,
+            sourceObjectTypeId: query.sourceObjectTypeId,
+            use: "traverse",
+            path,
+          })
+        ),
       }
     }
     case "set":
       return validateSet(query.inputs, query.op, path, ctx)
     case "sort": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
-      const fields = validateSortFields(query.fields, input.result, path, ctx)
-      return { result: input.result, query: { ...query, input: input.query, fields } }
+      const fields = validateSortFields(
+        query.fields,
+        input.result,
+        input.admissionState,
+        "sort",
+        path,
+        ctx
+      )
+      return {
+        result: input.result,
+        query: { ...query, input: input.query, fields },
+        admissionState: input.admissionState,
+      }
     }
     case "limit": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
       validateLimit(query.limit, path, ctx)
-      return { result: input.result, query: { ...query, input: input.query } }
+      return {
+        result: input.result,
+        query: { ...query, input: input.query },
+        admissionState: input.admissionState,
+      }
     }
     case "page": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
       validatePage(query.pageSize, query.pageToken, path, ctx)
-      return { result: input.result, query: { ...query, input: input.query } }
+      return {
+        result: input.result,
+        query: { ...query, input: input.query },
+        admissionState: input.admissionState,
+      }
     }
     case "project": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
-      validateProjection(query.properties, input.result, path, ctx)
-      return { result: input.result, query: { ...query, input: input.query } }
+      validateProjection(query.properties, input.result, input.admissionState, path, ctx)
+      return {
+        result: input.result,
+        query: { ...query, input: input.query },
+        admissionState: input.admissionState,
+      }
     }
     case "expand": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
@@ -212,10 +415,15 @@ function dispatchQueryNode(
       const expansions = validateExpansions(
         query.expansions,
         input.result,
+        input.admissionState,
         `${path}.expansions`,
         ctx
       )
-      return { result: input.result, query: { ...query, input: input.query, expansions } }
+      return {
+        result: input.result,
+        query: { ...query, input: input.query, expansions },
+        admissionState: input.admissionState,
+      }
     }
   }
 }
@@ -224,7 +432,7 @@ function validateRefs(
   refs: readonly ObjectRef[],
   path: string,
   ctx: QueryValidationContext
-): QueryValidationResult {
+): QueryNodeValidation {
   if (refs.length === 0) {
     addIssue(ctx, `${path}.refs`, "empty_refs", "refs must include at least one object reference")
   }
@@ -269,7 +477,7 @@ function validateStart(
   includeSubtypes: boolean | undefined,
   path: string,
   ctx: QueryValidationContext
-): QueryValidationResult {
+): QueryNodeValidation {
   if (!objectTypeId) {
     addIssue(ctx, path, "missing_object_type", "start.objectTypeId is required")
     return { result: { objectTypeIds: [] }, query: { kind: "start", objectTypeId } }
@@ -290,6 +498,7 @@ function validateStart(
 function validatePredicate(
   predicate: ObjectQueryPredicate,
   shape: ObjectQueryResultShape,
+  admissionState: ObjectQueryAdmissionState,
   path: string,
   ctx: QueryValidationContext
 ): ObjectQueryPredicate {
@@ -307,13 +516,13 @@ function validatePredicate(
       return {
         ...predicate,
         items: predicate.items.map((item, index) =>
-          validatePredicate(item, shape, `${path}.items[${index}]`, ctx)
+          validatePredicate(item, shape, admissionState, `${path}.items[${index}]`, ctx)
         ),
       }
     case "not":
       return {
         ...predicate,
-        item: validatePredicate(predicate.item, shape, `${path}.item`, ctx),
+        item: validatePredicate(predicate.item, shape, admissionState, `${path}.item`, ctx),
       }
     case "eq":
     case "neq":
@@ -330,6 +539,12 @@ function validatePredicate(
         ctx
       )
       validatePredicateValue(predicate.propertyId, predicate.value, shape, path, ctx)
+      admitProperty(ctx, {
+        state: admissionState,
+        propertyId: predicate.propertyId,
+        use: "filter",
+        path,
+      })
       return {
         ...authoredPredicate,
         value: normalizeObjectQueryValue(predicate.value, scalarKind),
@@ -351,6 +566,12 @@ function validatePredicate(
       predicate.values.forEach((value, index) => {
         validatePredicateValue(predicate.propertyId, value, shape, `${path}.values[${index}]`, ctx)
       })
+      admitProperty(ctx, {
+        state: admissionState,
+        propertyId: predicate.propertyId,
+        use: "filter",
+        path,
+      })
       return {
         ...authoredPredicate,
         values: predicate.values.map((value) => normalizeObjectQueryValue(value, scalarKind)),
@@ -359,6 +580,12 @@ function validatePredicate(
     }
     case "exists":
       resolveAndValidatePredicateProperty(predicate.propertyId, predicate.op, shape, path, ctx)
+      admitProperty(ctx, {
+        state: admissionState,
+        propertyId: predicate.propertyId,
+        use: "filter",
+        path,
+      })
       if (typeof predicate.value !== "boolean") {
         addIssue(ctx, path, "invalid_exists_value", "Predicate 'exists' value must be boolean")
       }
@@ -366,6 +593,12 @@ function validatePredicate(
     case "contains":
       resolveAndValidatePredicateProperty(predicate.propertyId, predicate.op, shape, path, ctx)
       validateContainsValue(predicate.propertyId, predicate.value, shape, path, ctx)
+      admitProperty(ctx, {
+        state: admissionState,
+        propertyId: predicate.propertyId,
+        use: "filter",
+        path,
+      })
       return predicate
   }
 }
@@ -561,6 +794,7 @@ function validateTextQuery(
   query: string,
   fields: readonly string[] | undefined,
   shape: ObjectQueryResultShape,
+  admissionState: ObjectQueryAdmissionState,
   path: string,
   ctx: QueryValidationContext
 ): TextFieldResolution {
@@ -585,6 +819,13 @@ function validateTextQuery(
     if (fieldsByObjectType) fieldsByObjectType[objectType.id] = uniqueStrings(fieldIds)
 
     for (const fieldId of fieldIds) {
+      admitProperty(ctx, {
+        state: admissionState,
+        propertyId: fieldId,
+        objectTypeId: objectType.id,
+        use: "text",
+        path: `${path}.fields`,
+      })
       const property = getProperty(objectType, fieldId)
       if (!property) {
         addIssue(
@@ -618,6 +859,7 @@ function validateVectorQuery(
   propertyId: string,
   k: number,
   shape: ObjectQueryResultShape,
+  admissionState: ObjectQueryAdmissionState,
   path: string,
   ctx: QueryValidationContext
 ): void {
@@ -634,6 +876,13 @@ function validateVectorQuery(
   }
 
   for (const objectType of getObjectTypesForResult(shape, ctx)) {
+    admitProperty(ctx, {
+      state: admissionState,
+      propertyId,
+      objectTypeId: objectType.id,
+      use: "vector",
+      path,
+    })
     const property = getProperty(objectType, propertyId)
     if (!property) {
       addIssue(
@@ -804,17 +1053,19 @@ function validateIncomingTraverse(
 function validateExpansions(
   expansions: readonly ObjectExpansion[],
   shape: ObjectQueryResultShape,
+  admissionState: ObjectQueryAdmissionState,
   path: string,
   ctx: QueryValidationContext
 ): ObjectExpansion[] {
   return expansions.map((expansion, index) =>
-    validateExpansion(expansion, shape, `${path}[${index}]`, ctx)
+    validateExpansion(expansion, shape, admissionState, `${path}[${index}]`, ctx)
   )
 }
 
 function validateExpansion(
   expansion: ObjectExpansion,
   shape: ObjectQueryResultShape,
+  admissionState: ObjectQueryAdmissionState,
   path: string,
   ctx: QueryValidationContext
 ): ObjectExpansion {
@@ -839,6 +1090,18 @@ function validateExpansion(
           path,
           ctx
         )
+  const targetAdmissionState = admitTransition(
+    ctx,
+    ctx.admission.edge({
+      state: admissionState,
+      result: targetShape,
+      linkId: expansion.linkId,
+      direction: expansion.direction,
+      sourceObjectTypeId: expansion.sourceObjectTypeId,
+      use: "expand",
+      path,
+    })
+  )
 
   // Expansion targets are touched types: the principal must be able to `view`
   // every type a query hydrates, exactly like `start`/`traverse`. `dispatch`'s
@@ -850,10 +1113,17 @@ function validateExpansion(
 
   validateExpansionLimit(expansion.limit, path, ctx)
   const orderBy = expansion.orderBy
-    ? validateSortFields(expansion.orderBy, targetShape, `${path}.orderBy`, ctx)
+    ? validateSortFields(
+        expansion.orderBy,
+        targetShape,
+        targetAdmissionState,
+        "expand.orderBy",
+        `${path}.orderBy`,
+        ctx
+      )
     : undefined
   const expand = expansion.expand
-    ? validateExpansions(expansion.expand, targetShape, `${path}.expand`, ctx)
+    ? validateExpansions(expansion.expand, targetShape, targetAdmissionState, `${path}.expand`, ctx)
     : undefined
 
   return { ...expansion, orderBy, expand }
@@ -1005,7 +1275,11 @@ function validateSet(
 ): QueryValidationResult {
   if (inputs.length === 0) {
     addIssue(ctx, path, "empty_set", `Set operation '${op}' must include at least one input`)
-    return { result: { objectTypeIds: [] }, query: { kind: "set", op, inputs } }
+    return {
+      result: { objectTypeIds: [] },
+      query: { kind: "set", op, inputs },
+      admissionState: ctx.admission.empty(),
+    }
   }
 
   const results = inputs.map((input, index) =>
@@ -1028,12 +1302,19 @@ function validateSet(
   return {
     result: first,
     query: { kind: "set", op, inputs: results.map((result) => result.query) },
+    admissionState: ctx.admission.set({
+      op,
+      states: results.map((result) => result.admissionState),
+      path,
+    }),
   }
 }
 
 function validateSortFields(
   fields: readonly ObjectQuerySortField[],
   shape: ObjectQueryResultShape,
+  admissionState: ObjectQueryAdmissionState,
+  use: Extract<ObjectQueryPropertyUse, "sort" | "expand.orderBy">,
   path: string,
   ctx: QueryValidationContext
 ): ObjectQuerySortField[] {
@@ -1065,6 +1346,13 @@ function validateSortFields(
     seen.add(key)
 
     if (field.kind === "relevance") return field
+
+    admitProperty(ctx, {
+      state: admissionState,
+      propertyId: field.propertyId,
+      use,
+      path: `${path}.fields[${index}]`,
+    })
 
     const { scalarKind: _authoredScalarKind, ...authoredField } = field
 
@@ -1141,6 +1429,7 @@ function validatePage(
 function validateProjection(
   properties: readonly string[] | undefined,
   shape: ObjectQueryResultShape,
+  admissionState: ObjectQueryAdmissionState,
   path: string,
   ctx: QueryValidationContext
 ): void {
@@ -1151,6 +1440,12 @@ function validateProjection(
 
   const seen = new Set<string>()
   properties.forEach((propertyId, index) => {
+    admitProperty(ctx, {
+      state: admissionState,
+      propertyId,
+      use: "project",
+      path: `${path}.properties[${index}]`,
+    })
     if (seen.has(propertyId)) {
       addIssue(
         ctx,
@@ -1334,6 +1629,28 @@ function keyForTypeIds(typeIds: readonly string[]): string {
 
 function uniqueStrings(values: readonly string[]): string[] {
   return [...new Set(values)]
+}
+
+function admitTransition(
+  ctx: QueryValidationContext,
+  transition: ObjectQueryAdmissionTransition
+): ObjectQueryAdmissionState {
+  if (transition.denial) recordAdmissionDenial(ctx, transition.denial)
+  return transition.state
+}
+
+function admitProperty(
+  ctx: QueryValidationContext,
+  input: Parameters<ObjectQuerySemanticAdmission["property"]>[0]
+): void {
+  const denial = ctx.admission.property(input)
+  if (denial) recordAdmissionDenial(ctx, denial)
+}
+
+function recordAdmissionDenial(ctx: QueryValidationContext, denial: Error): void {
+  // Only the first deterministic denial is observable. Keep walking so ordinary validation keeps
+  // priority, but do not retain attacker-controlled messages for every rejected field or edge.
+  if (ctx.admissionDenials.length === 0) ctx.admissionDenials.push(denial)
 }
 
 function addIssue(ctx: QueryValidationContext, path: string, code: string, message: string): void {

--- a/packages/core/src/objects/sdk/object-handle.ts
+++ b/packages/core/src/objects/sdk/object-handle.ts
@@ -4,7 +4,6 @@
  * per-property telemetry appenders with compile-time unit and value type safety.
  */
 import type { ActionDefinition } from "../../actions"
-import { assertAuthorized, assertPrivileged } from "../../authorization"
 import type { ObjectLink, ObjectRef, ValueType } from "../../ontology"
 import { OntologyValidationError } from "../../ontology/errors"
 import type { LinkToken, ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
@@ -28,9 +27,7 @@ export function createObjectByIdHandle<
 >(ctx: ExecutionObjectContext, primaryId: string): ObjectByIdHandle<TObjectType, TValueTypes> {
   const objectHandle = {
     get: async () => {
-      assertAuthorized(ctx, { kind: "object.view", objectTypeId: ctx.objectType.id })
-      const row = await ctx.storage.objects.getByPrimaryId({
-        projectId: ctx.projectId,
+      const row = await ctx.objectReader.getByPrimaryId({
         objectTypeId: ctx.objectType.id,
         primaryId,
       })
@@ -38,13 +35,10 @@ export function createObjectByIdHandle<
     },
 
     listLinks: async (linkToken?: AnyLinkToken) => {
-      // Link rows reveal target types; no link grant semantics exist yet.
-      assertPrivileged(ctx, "listLinks")
       if (linkToken) {
         assertLinkTokenBelongsToObjectType(ctx.objectType, linkToken)
       }
-      return ctx.storage.objects.listLinks({
-        projectId: ctx.projectId,
+      return ctx.objectReader.listLinks({
         objectTypeId: ctx.objectType.id,
         objectId: primaryId,
         linkId: linkToken?.id,

--- a/packages/core/src/objects/sdk/object-set.ts
+++ b/packages/core/src/objects/sdk/object-set.ts
@@ -6,9 +6,9 @@
 
 import type { ActionDefinition } from "../../actions"
 import type { AuthorizationContext } from "../../authorization"
-import { assertAuthorized } from "../../authorization"
 import { shareSixbErrorReporter } from "../../error-reporting/capability"
 import type { ExecutionContext } from "../../execution"
+import { assertAuthorizedObjectReaderBinding } from "../../execution/authorized-object-reader"
 import type { ValueType } from "../../ontology"
 import { OntologyValidationError } from "../../ontology/errors"
 import type { ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
@@ -43,6 +43,10 @@ export function createObjectSet<
     readonly authorization?: AuthorizationContext
   }
 ): ObjectSet<TObjectType, TValueTypes, TRegisteredObjectTypes> {
+  assertAuthorizedObjectReaderBinding({
+    reader: params.objectReader,
+    scope: { execution: params.execution, authorization: params.runtimeAuthorization },
+  })
   const { objectType } = params
   const primaryProp = objectType.properties.find((p) => p.primary)
   if (!primaryProp) {
@@ -58,16 +62,14 @@ export function createObjectSet<
     events,
     storage,
     queues,
+    objectReader,
     runtimeAuthorization,
     authorization,
     execution,
   } = params
   const queryExecutor = createRuntimeQueryExecutor({
-    projectId,
     ontology,
-    storage,
-    runtimeAuthorization,
-    authorization,
+    objectReader,
   })
 
   const resolvedCtx: ExecutionObjectContext = {
@@ -78,6 +80,7 @@ export function createObjectSet<
     events,
     storage,
     queues,
+    objectReader,
     runtimeAuthorization,
     authorization,
     execution,
@@ -89,9 +92,7 @@ export function createObjectSet<
 
   const objectSet = {
     get: async (id: string) => {
-      assertAuthorized(resolvedCtx, { kind: "object.view", objectTypeId: objectType.id })
-      const row = await storage.objects.getByPrimaryId({
-        projectId,
+      const row = await objectReader.getByPrimaryId({
         objectTypeId: objectType.id,
         primaryId: id,
       })
@@ -112,9 +113,7 @@ export function createObjectSet<
     byId: (id: string) => createObjectByIdHandle<TObjectType, TValueTypes>(resolvedCtx, id),
 
     list: async (input?: ObjectSetListInput) => {
-      assertAuthorized(resolvedCtx, { kind: "object.view", objectTypeId: objectType.id })
-      const result = await storage.objects.list({
-        projectId,
+      const result = await objectReader.list({
         objectTypeId: objectType.id,
         primaryIdPrefix: input?.idPrefix,
         primaryIdSuffix: input?.idSuffix,

--- a/packages/core/src/objects/sdk/runtime-query-executor.ts
+++ b/packages/core/src/objects/sdk/runtime-query-executor.ts
@@ -4,44 +4,24 @@
  * HTTP executor in `@sixb/client` is the remote counterpart.
  */
 
-import type { AuthorizationContext } from "../../authorization"
-import type { RuntimeAuthorization } from "../../execution/types"
+import type { AuthorizedObjectReader } from "../../execution/authorized-object-reader"
 import type { OntologyRegistry } from "../../ontology"
-import type { Storage } from "../../storage"
-import {
-  countObjects,
-  executeObjectQuery,
-  existsObjects,
-  facetObjects,
-  ObjectQueryPlanningError,
-} from "../query"
+import { ObjectQueryPlanningError } from "../query"
 import { explainObjectQuery } from "../query/explain"
 import type { ObjectQuery } from "../query/ir"
 import { validateObjectQuery } from "../query/validate"
 import type { ObjectQueryExecutor, ObjectQueryExecutorFacetRequest } from "./query-executor"
 
 export function createRuntimeQueryExecutor(params: {
-  projectId: string
   ontology: OntologyRegistry
-  storage: Storage
-  runtimeAuthorization?: RuntimeAuthorization
-  authorization?: AuthorizationContext
+  objectReader: AuthorizedObjectReader
 }): ObjectQueryExecutor {
-  const { projectId, ontology, storage, runtimeAuthorization, authorization } = params
-  const executorOptions = {
-    ontology,
-    storage: storage.objects,
-    runtimeAuthorization,
-    authorization,
-  }
+  const { ontology, objectReader } = params
 
   return {
     async list(query: ObjectQuery, options?: { includeTotal?: boolean }) {
       try {
-        return await executeObjectQuery(
-          { projectId, query, includeTotal: options?.includeTotal },
-          executorOptions
-        )
+        return await objectReader.executeQuery({ query, includeTotal: options?.includeTotal })
       } catch (error) {
         if (error instanceof ObjectQueryPlanningError) {
           throw addSdkPlanningHints(error)
@@ -51,17 +31,17 @@ export function createRuntimeQueryExecutor(params: {
     },
 
     async count(query: ObjectQuery) {
-      const result = await countObjects({ projectId, query }, executorOptions)
+      const result = await objectReader.count({ query })
       return result.count
     },
 
     async exists(query: ObjectQuery) {
-      const result = await existsObjects({ projectId, query }, executorOptions)
+      const result = await objectReader.exists({ query })
       return result.exists
     },
 
     async facets(query: ObjectQuery, facets: readonly ObjectQueryExecutorFacetRequest[]) {
-      const result = await facetObjects({ projectId, query, facets }, executorOptions)
+      const result = await objectReader.facet({ query, facets })
       return result.facets.map((facet) => ({
         propertyId: facet.propertyId,
         buckets: [...facet.buckets],

--- a/packages/core/src/objects/service/list-service.ts
+++ b/packages/core/src/objects/service/list-service.ts
@@ -1,12 +1,10 @@
 /**
  * Cross-type object listing for dashboards and search.
  *
- * On principal-bound runtimes the type filter is authorized before the storage call:
- * explicitly requested types must all be viewable, and unfiltered listings
- * narrow to the principal's viewable types instead of post-filtering rows.
+ * Type hierarchies are expanded before the request reaches the canonical object
+ * reader, which owns authorization and provider-scope enforcement.
  */
 
-import { assertAuthorized } from "../../authorization"
 import type { ListResult, SixbRuntimeContext } from "../../runtime/types"
 import type { ObjectRow } from "../../storage"
 
@@ -28,14 +26,13 @@ export async function listObjects(
   runtime: SixbRuntimeContext,
   params: ListObjectsParams
 ): Promise<ListResult<ObjectRow>> {
-  const objectTypeIds = resolveAuthorizedTypeFilter(runtime, params.objectTypeIds)
+  const objectTypeIds = resolveTypeFilter(runtime, params.objectTypeIds)
 
-  if (runtime.authorization && objectTypeIds !== undefined && objectTypeIds.length === 0) {
+  if (objectTypeIds !== undefined && objectTypeIds.length === 0) {
     return { objects: [], hasMore: false, total: 0 }
   }
 
-  const result = await runtime.storage.objects.list({
-    projectId: runtime.projectId,
+  const result = await runtime.objectReader.list({
     objectTypeId: objectTypeIds?.length === 1 ? objectTypeIds[0] : objectTypeIds,
     primaryIdPrefix: params.idPrefix,
     primaryIdSuffix: params.idSuffix,
@@ -56,7 +53,7 @@ export async function listObjects(
   }
 }
 
-function resolveAuthorizedTypeFilter(
+function resolveTypeFilter(
   runtime: SixbRuntimeContext,
   requested: readonly string[] | undefined
 ): readonly string[] | undefined {
@@ -66,24 +63,7 @@ function resolveAuthorizedTypeFilter(
     }
   }
 
-  const expanded = requested
+  return requested
     ? [...new Set(requested.flatMap((id) => [id, ...runtime.ontology.listSubTypes(id)]))]
     : undefined
-
-  if (!runtime.authorization) {
-    return expanded
-  }
-
-  if (!expanded) {
-    // Broad listings narrow to the visible universe rather than failing. The
-    // set already contains every registered type when "all" was granted.
-    return [...runtime.authorization.grants["view:object"]]
-  }
-
-  // Explicitly requested types must all be viewable.
-  for (const objectTypeId of expanded) {
-    assertAuthorized(runtime, { kind: "object.view", objectTypeId })
-  }
-
-  return expanded
 }

--- a/packages/core/src/runtime/host.ts
+++ b/packages/core/src/runtime/host.ts
@@ -36,7 +36,11 @@ import {
   type DomainEventService,
   OntologyOutboxDispatcher,
 } from "../events"
-import { resolveExecutionScopeAuthorization } from "../execution/authorization"
+import {
+  captureExecutionScope,
+  resolveExecutionScopeAuthorization,
+} from "../execution/authorization"
+import { createAuthorizedObjectReader } from "../execution/authorized-object-reader"
 import type { ExecutionScope } from "../execution/types"
 import type { LakeStorage } from "../lake-storage"
 import { type LoggerProvider, LoggingService, type ObservabilityOptions } from "../logging"
@@ -238,24 +242,36 @@ export class SixbHost<
 
   /** Bind an existing opaque scope. This method never creates or escalates authority. */
   withScope(scope: ExecutionScope): Sixb<TOntologySources> {
-    const authorization = resolveExecutionScopeAuthorization(this.projectId, scope)
+    const capturedScope = captureExecutionScope(scope)
+    const authorization = resolveExecutionScopeAuthorization(this.projectId, capturedScope)
     if (authorization.ref.type === "kernel") {
       throw new Error("[Sixb] Kernel authority cannot be bound to the domain SDK.")
     }
 
+    const objectReader = createAuthorizedObjectReader({
+      scope: capturedScope,
+      ontology: this.hostContext.ontology,
+      objectStorage: this.storage.objects,
+    })
+
     const runtime: SixbRuntimeContext = {
       ...this.hostContext,
-      runtimeAuthorization: scope.authorization,
+      runtimeAuthorization: capturedScope.authorization,
+      objectReader,
       ...(authorization.type === "principal" ? { authorization: authorization.context } : {}),
     }
     registerOntologyMutationRuntime(
       runtime,
       createOntologyMutationRuntime({
-        materializer: this.materializer.withScope(scope),
+        materializer: this.materializer.withScope(capturedScope),
         notifyCommittedFacts: () => this.committedFacts.notify(),
       })
     )
-    return createBoundSixb<TOntologySources>(runtime, this.sixbDependencies(), scope.execution)
+    return createBoundSixb<TOntologySources>(
+      runtime,
+      this.sixbDependencies(),
+      capturedScope.execution
+    )
   }
 
   get id(): string {

--- a/packages/core/src/runtime/host.ts
+++ b/packages/core/src/runtime/host.ts
@@ -244,7 +244,12 @@ export class SixbHost<
   withScope(scope: ExecutionScope): Sixb<TOntologySources> {
     const capturedScope = captureExecutionScope(scope)
     const authorization = resolveExecutionScopeAuthorization(this.projectId, capturedScope)
-    if (authorization.ref.type === "kernel") {
+    if (authorization.type === "delegated") {
+      throw new Error(
+        "[Sixb] Delegated runtime authorization cannot be bound to the domain SDK until every delegated surface is activated."
+      )
+    }
+    if (authorization.type === "unrestricted" && authorization.ref.type === "kernel") {
       throw new Error("[Sixb] Kernel authority cannot be bound to the domain SDK.")
     }
 

--- a/packages/core/src/runtime/internal.ts
+++ b/packages/core/src/runtime/internal.ts
@@ -9,6 +9,7 @@ export type {
   StartConnectorAuthorizationResult,
 } from "../connectors/connections/contracts"
 export type { ConnectorConnectionsRuntime } from "../connectors/connections/execution"
+export type { AuthorizedObjectReader } from "../execution/authorized-object-reader"
 export type { OntologyMutationRuntime } from "./ontology-mutations"
 export {
   createOntologyMutationRuntime,

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -12,6 +12,7 @@ import { createDatasetsRuntime, type DatasetsRuntime } from "../datasets/executi
 import { createEventsRuntime, type EventsRuntime } from "../events/execution"
 import type { ExecutionContext } from "../execution"
 import { resolveExecutionScopeAuthorization } from "../execution/authorization"
+import { assertAuthorizedObjectReaderBinding } from "../execution/authorized-object-reader"
 import { createLogsRuntime, type LogsRuntime } from "../logging/execution"
 import type { LoggingService } from "../logging/service"
 import { createObjectsRuntime, type ObjectsRuntime } from "../objects/execution"
@@ -65,6 +66,10 @@ export function createBoundSixb<TOntologySources extends readonly OntologySource
   resolveExecutionScopeAuthorization(runtime.projectId, {
     execution,
     authorization: runtime.runtimeAuthorization,
+  })
+  assertAuthorizedObjectReaderBinding({
+    reader: runtime.objectReader,
+    scope: { execution, authorization: runtime.runtimeAuthorization },
   })
   const sixb: Sixb<TOntologySources> = {
     execution,

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -15,6 +15,7 @@ import type { AuthorizationContext } from "../authorization"
 import type { Broker } from "../broker"
 import type { DomainEventLog } from "../events"
 import type { RuntimeAuthorization } from "../execution"
+import type { AuthorizedObjectReader } from "../execution/authorized-object-reader"
 import type {
   ObjectQuery,
   ObjectQueryExplanation,
@@ -60,6 +61,8 @@ export interface SixbHostContext {
 /** Host dependencies paired with the process-local authority of one bound execution. */
 export interface SixbRuntimeContext extends SixbHostContext {
   readonly runtimeAuthorization: RuntimeAuthorization
+  /** Core-owned read boundary carrying this exact execution authority. */
+  readonly objectReader: AuthorizedObjectReader
   /**
    * Resolved principal grants. Absent for trusted primitive and explicitly disabled executions.
    * The opaque `runtimeAuthorization` remains the source of authority.

--- a/packages/core/src/storage/in-memory/index.ts
+++ b/packages/core/src/storage/in-memory/index.ts
@@ -21,6 +21,7 @@ import { ProviderMaterializationTransactionLifecycle } from "../ontology/provide
 import {
   createAgentOperationScope,
   createAuthOperationScope,
+  createObjectOperationScope,
   createOntologyOperationScope,
   createOperationScopedFacade,
   createStorageOperationScope,
@@ -118,7 +119,7 @@ export class InMemoryStorage implements Storage {
       (run) => this.withStorageOperation(run),
       () => this.assertRootOperationAvailable()
     )
-    this.objects = createOperationScopedFacade(this.objectStorage, scope)
+    this.objects = createObjectOperationScope(this.objectStorage, scope)
     this.timeseries = createOperationScopedFacade(this.timeseriesStorage, scope)
     this.auth = createAuthOperationScope(this.authStorage, scope)
     this.executions = createOperationScopedFacade(this.executionStorage, scope)

--- a/packages/core/src/storage/objects/guard.ts
+++ b/packages/core/src/storage/objects/guard.ts
@@ -1,0 +1,55 @@
+import type { ObjectReadScopeFactory, ObjectReadStorage, ObjectStorage } from "./types"
+
+export interface ObjectReadStorageCallGuard {
+  assertAvailable(): void
+  run<TResult>(operation: () => Promise<TResult>): Promise<TResult>
+}
+
+/** Validate the required runtime capability before any facade can expose broad object reads. */
+export function requireObjectReadScopeFactory(storage: ObjectStorage): ObjectReadScopeFactory {
+  if (typeof storage.createSelectedReadScope !== "function") {
+    throw new Error(
+      "[Sixb] Object storage provider must implement ObjectReadScopeFactory to create selected object readers."
+    )
+  }
+  return storage
+}
+
+/**
+ * Guard every selected-reader terminal without proxying the provider reader.
+ *
+ * First-party providers freeze their readers. A Proxy cannot substitute a frozen own method
+ * without violating JavaScript's invariants, so operation and lifetime guards use this explicit
+ * facade instead.
+ */
+export function createGuardedObjectReadStorage(
+  reader: ObjectReadStorage,
+  guard: ObjectReadStorageCallGuard
+): ObjectReadStorage {
+  const guarded: ObjectReadStorage = {
+    queryCapabilities: () => {
+      guard.assertAvailable()
+      return reader.queryCapabilities()
+    },
+    getByPrimaryId: (input) => guard.run(() => reader.getByPrimaryId(input)),
+    selectsObjectProperties: (input) => guard.run(() => reader.selectsObjectProperties(input)),
+    listLinks: (input) => guard.run(() => reader.listLinks(input)),
+    getByPrimaryIdBatch: (input) => guard.run(() => reader.getByPrimaryIdBatch(input)),
+    listLinksBatch: (input) => guard.run(() => reader.listLinksBatch(input)),
+    queryLinks: (input) => guard.run(() => reader.queryLinks(input)),
+    list: (input) => guard.run(() => reader.list(input)),
+  }
+  if (reader.queryObjects) {
+    guarded.queryObjects = (input) => guard.run(() => reader.queryObjects!(input))
+  }
+  if (reader.countObjects) {
+    guarded.countObjects = (input) => guard.run(() => reader.countObjects!(input))
+  }
+  if (reader.existsObjects) {
+    guarded.existsObjects = (input) => guard.run(() => reader.existsObjects!(input))
+  }
+  if (reader.facetObjects) {
+    guarded.facetObjects = (input) => guard.run(() => reader.facetObjects!(input))
+  }
+  return Object.freeze(guarded)
+}

--- a/packages/core/src/storage/objects/in-memory.ts
+++ b/packages/core/src/storage/objects/in-memory.ts
@@ -32,7 +32,6 @@ import type {
   ObjectFacetResult,
   ObjectLinkRow,
   ObjectQueryCapabilities,
-  ObjectReadScopeFactory,
   ObjectReadStorage,
   ObjectRow,
   ObjectStorage,
@@ -218,7 +217,7 @@ export function getInMemoryObjectMaterializerAdapter(
   return adapter
 }
 
-export class InMemoryObjectStorage implements ObjectStorage, ObjectReadScopeFactory {
+export class InMemoryObjectStorage implements ObjectStorage {
   private readonly rows = new Map<string, Map<string, ObjectRow>>()
   private readonly links = new Map<string, Map<string, ObjectLinkRow>>()
 

--- a/packages/core/src/storage/objects/read-scope.ts
+++ b/packages/core/src/storage/objects/read-scope.ts
@@ -4,8 +4,10 @@ import type {
   CompiledObjectReadStep,
   CompiledSelectedObjectReadScope,
   ObjectReadLinkDefinitionSelection,
+  ObjectReadLinkSelection,
   ObjectReadNode,
   ObjectReadObjectSelection,
+  ObjectReadRoot,
   SelectedObjectReadScope,
 } from "./types"
 
@@ -26,8 +28,9 @@ export const OBJECT_READ_SCOPE_LIMITS = Object.freeze({
  * provenance and let an object reached through one branch borrow nested authority from another.
  */
 export function compileSelectedObjectReadScope(
-  scope: SelectedObjectReadScope
+  rawScope: SelectedObjectReadScope
 ): CompiledSelectedObjectReadScope {
+  const scope = captureSelectedObjectReadScope(rawScope)
   if (!isRecord(scope) || scope.kind !== "selected" || !Array.isArray(scope.roots)) {
     throw invalidScope("scope must be a selected scope with a roots array")
   }
@@ -223,6 +226,276 @@ export function compileSelectedObjectReadScope(
     objects: Object.freeze(objects),
     steps: Object.freeze(steps),
   })
+}
+
+interface ScopeCaptureState {
+  readonly visiting: Set<object>
+  nodeCount: number
+  objectSelectionCount: number
+  concreteStepCount: number
+  propertyOccurrenceCount: number
+  identifierCharacterCount: number
+}
+
+interface CapturedArray {
+  readonly value: readonly unknown[]
+  readonly length: number
+}
+
+/**
+ * Read every caller-controlled property once and detach it before another getter can mutate it.
+ * The compiler only ever observes the resulting plain, deeply frozen snapshot.
+ */
+function captureSelectedObjectReadScope(value: unknown): SelectedObjectReadScope {
+  if (!isRecord(value)) {
+    throw invalidScope("scope must be a selected scope with a roots array")
+  }
+
+  const kind = value.kind
+  if (kind !== "selected") {
+    throw invalidScope("scope must be a selected scope with a roots array")
+  }
+
+  const rootsValue = value.roots
+  const rootsSource = captureArray(rootsValue, "roots")
+  if (rootsSource.length > OBJECT_READ_SCOPE_LIMITS.maxNodes) {
+    throw invalidScope(
+      `scope exceeds the maximum of ${OBJECT_READ_SCOPE_LIMITS.maxNodes} selection nodes`
+    )
+  }
+
+  const state: ScopeCaptureState = {
+    visiting: new Set<object>(),
+    nodeCount: 0,
+    objectSelectionCount: 0,
+    concreteStepCount: 0,
+    propertyOccurrenceCount: 0,
+    identifierCharacterCount: 0,
+  }
+  const roots: ObjectReadRoot[] = []
+  for (let rootIndex = 0; rootIndex < rootsSource.length; rootIndex += 1) {
+    const path = `roots[${rootIndex}]`
+    const rootValue = rootsSource.value[rootIndex]
+    if (!isRecord(rootValue)) {
+      throw invalidScope(`${path} must contain an exact anchor and a selection node`)
+    }
+
+    const anchorValue = rootValue.anchor
+    if (!isRecord(anchorValue)) {
+      throw invalidScope(`${path} must contain an exact anchor and a selection node`)
+    }
+    const objectTypeId = captureIdentifier(
+      state,
+      anchorValue.objectTypeId,
+      `${path}.anchor.objectTypeId`
+    )
+    const primaryId = captureIdentifier(state, anchorValue.primaryId, `${path}.anchor.primaryId`)
+    const anchor = Object.freeze({ objectTypeId, primaryId })
+
+    const nodeValue = rootValue.node
+    if (!isRecord(nodeValue)) {
+      throw invalidScope(`${path} must contain an exact anchor and a selection node`)
+    }
+    const node = captureNode(state, nodeValue, `${path}.node`, 0)
+    roots.push(Object.freeze({ anchor, node }))
+  }
+
+  return Object.freeze({ kind, roots: Object.freeze(roots) })
+}
+
+function captureNode(
+  state: ScopeCaptureState,
+  value: Record<string, unknown>,
+  path: string,
+  depth: number
+): ObjectReadNode {
+  if (depth > OBJECT_READ_SCOPE_LIMITS.maxDepth) {
+    throw invalidScope(
+      `${path} exceeds the maximum link depth of ${OBJECT_READ_SCOPE_LIMITS.maxDepth}`
+    )
+  }
+  if (state.nodeCount >= OBJECT_READ_SCOPE_LIMITS.maxNodes) {
+    throw invalidScope(
+      `scope exceeds the maximum of ${OBJECT_READ_SCOPE_LIMITS.maxNodes} selection nodes`
+    )
+  }
+  if (state.visiting.has(value)) {
+    throw invalidScope(`${path} contains a cyclic selection node`)
+  }
+  state.visiting.add(value)
+  state.nodeCount += 1
+
+  try {
+    const objectsValue = value.objects
+    const objectsSource = captureArray(objectsValue, `${path}.objects`)
+    state.objectSelectionCount = reserveCount(
+      state.objectSelectionCount,
+      objectsSource.length,
+      OBJECT_READ_SCOPE_LIMITS.maxObjectSelections,
+      `scope exceeds the maximum of ${OBJECT_READ_SCOPE_LIMITS.maxObjectSelections} object selections`
+    )
+    const objects: ObjectReadObjectSelection[] = []
+    for (let objectIndex = 0; objectIndex < objectsSource.length; objectIndex += 1) {
+      const objectPath = `${path}.objects[${objectIndex}]`
+      const objectValue = objectsSource.value[objectIndex]
+      if (!isRecord(objectValue)) {
+        throw invalidScope(`${objectPath} must contain an object type and property ids`)
+      }
+
+      const objectTypeId = captureIdentifier(
+        state,
+        objectValue.objectTypeId,
+        `${objectPath}.objectTypeId`
+      )
+      const propertyIdsValue = objectValue.propertyIds
+      const propertyIds = capturePropertyIds(state, propertyIdsValue, `${objectPath}.propertyIds`)
+      objects.push(Object.freeze({ objectTypeId, propertyIds }))
+    }
+
+    const linksValue = value.links
+    const linksSource = captureArray(linksValue, `${path}.links`)
+    if (linksSource.length > OBJECT_READ_SCOPE_LIMITS.maxNodes - state.nodeCount) {
+      throw invalidScope(
+        `scope exceeds the maximum of ${OBJECT_READ_SCOPE_LIMITS.maxNodes} selection nodes`
+      )
+    }
+    const links: ObjectReadLinkSelection[] = []
+    for (let linkIndex = 0; linkIndex < linksSource.length; linkIndex += 1) {
+      const linkPath = `${path}.links[${linkIndex}]`
+      const linkValue = linksSource.value[linkIndex]
+      if (!isRecord(linkValue)) {
+        throw invalidScope(`${linkPath} must contain definitions and a target node`)
+      }
+
+      const definitionsValue = linkValue.definitions
+      const definitionsSource = captureArray(definitionsValue, `${linkPath}.definitions`)
+      if (definitionsSource.length === 0) {
+        throw invalidScope(`${linkPath}.definitions must not be empty`)
+      }
+      if (definitionsSource.length > OBJECT_READ_SCOPE_LIMITS.maxSteps - state.concreteStepCount) {
+        throw invalidScope(
+          `scope exceeds the maximum of ${OBJECT_READ_SCOPE_LIMITS.maxSteps} concrete link steps`
+        )
+      }
+      const definitions: ObjectReadLinkDefinitionSelection[] = []
+      for (
+        let definitionIndex = 0;
+        definitionIndex < definitionsSource.length;
+        definitionIndex += 1
+      ) {
+        const definitionPath = `${linkPath}.definitions[${definitionIndex}]`
+        const definitionValue = definitionsSource.value[definitionIndex]
+        definitions.push(captureDefinition(state, definitionValue, definitionPath))
+      }
+
+      const targetValue = linkValue.target
+      if (!isRecord(targetValue)) {
+        throw invalidScope(`${linkPath} must contain definitions and a target node`)
+      }
+      const target = captureNode(state, targetValue, `${linkPath}.target`, depth + 1)
+      links.push(Object.freeze({ definitions: Object.freeze(definitions), target }))
+    }
+
+    return Object.freeze({ objects: Object.freeze(objects), links: Object.freeze(links) })
+  } finally {
+    state.visiting.delete(value)
+  }
+}
+
+function captureDefinition(
+  state: ScopeCaptureState,
+  value: unknown,
+  path: string
+): ObjectReadLinkDefinitionSelection {
+  if (!isRecord(value)) {
+    throw invalidScope(`${path} must contain a concrete link definition`)
+  }
+
+  const sourceObjectTypeId = captureIdentifier(
+    state,
+    value.sourceObjectTypeId,
+    `${path}.sourceObjectTypeId`
+  )
+  const linkId = captureIdentifier(state, value.linkId, `${path}.linkId`)
+
+  const targetObjectTypeIdsValue = value.targetObjectTypeIds
+  const targetObjectTypeIdsSource = captureArray(
+    targetObjectTypeIdsValue,
+    `${path}.targetObjectTypeIds`
+  )
+  if (targetObjectTypeIdsSource.length === 0) {
+    throw invalidScope(`${path}.targetObjectTypeIds must not be empty`)
+  }
+  state.concreteStepCount = reserveCount(
+    state.concreteStepCount,
+    targetObjectTypeIdsSource.length,
+    OBJECT_READ_SCOPE_LIMITS.maxSteps,
+    `scope exceeds the maximum of ${OBJECT_READ_SCOPE_LIMITS.maxSteps} concrete link steps`
+  )
+  const targetObjectTypeIds = captureIdentifiers(
+    state,
+    targetObjectTypeIdsSource,
+    `${path}.targetObjectTypeIds`
+  )
+
+  const propertyIdsValue = value.propertyIds
+  const propertyIds = capturePropertyIds(state, propertyIdsValue, `${path}.propertyIds`)
+  return Object.freeze({ sourceObjectTypeId, linkId, targetObjectTypeIds, propertyIds })
+}
+
+function capturePropertyIds(
+  state: ScopeCaptureState,
+  value: unknown,
+  path: string
+): readonly string[] {
+  const source = captureArray(value, path)
+  state.propertyOccurrenceCount = reserveCount(
+    state.propertyOccurrenceCount,
+    source.length,
+    OBJECT_READ_SCOPE_LIMITS.maxPropertyOccurrences,
+    `scope exceeds the maximum of ${OBJECT_READ_SCOPE_LIMITS.maxPropertyOccurrences} selected property occurrences`
+  )
+  return captureIdentifiers(state, source, path)
+}
+
+function captureIdentifiers(
+  state: ScopeCaptureState,
+  source: CapturedArray,
+  path: string
+): readonly string[] {
+  const identifiers: string[] = []
+  for (let index = 0; index < source.length; index += 1) {
+    identifiers.push(captureIdentifier(state, source.value[index], `${path}[${index}]`))
+  }
+  return Object.freeze(identifiers)
+}
+
+function captureIdentifier(state: ScopeCaptureState, value: unknown, path: string): string {
+  const identifier = nonEmptyString(value, path)
+  state.identifierCharacterCount = reserveCount(
+    state.identifierCharacterCount,
+    identifier.length,
+    OBJECT_READ_SCOPE_LIMITS.maxIdentifierCharacters,
+    `scope exceeds the maximum of ${OBJECT_READ_SCOPE_LIMITS.maxIdentifierCharacters} identifier characters`
+  )
+  return identifier
+}
+
+function captureArray(value: unknown, path: string): CapturedArray {
+  if (!Array.isArray(value)) {
+    throw invalidScope(`${path} must be an array`)
+  }
+  const array = value as readonly unknown[]
+  const length = array.length
+  if (!Number.isSafeInteger(length) || length < 0) {
+    throw invalidScope(`${path}.length must be a non-negative safe integer`)
+  }
+  return { value: array, length }
+}
+
+function reserveCount(current: number, count: number, limit: number, message: string): number {
+  if (count > limit - current) throw invalidScope(message)
+  return current + count
 }
 
 /** Fail closed when a project-bound selected reader is accidentally reused across projects. */

--- a/packages/core/src/storage/objects/types.ts
+++ b/packages/core/src/storage/objects/types.ts
@@ -344,7 +344,7 @@ export interface ObjectReadStorage {
   }): Promise<{ objects: readonly ObjectRow[]; hasMore: boolean; total: number }>
 }
 
-/** Optional provider capability for enforcing a finite, precompiled object-read selection. */
+/** Provider capability for enforcing a finite, precompiled object-read selection. */
 export interface ObjectReadScopeFactory {
   createSelectedReadScope(params: {
     projectId: string
@@ -353,8 +353,8 @@ export interface ObjectReadScopeFactory {
   }): ObjectReadStorage
 }
 
-/** Latest-state projection storage, including trusted internal read primitives. */
-export interface ObjectStorage extends ObjectReadStorage {
+/** Latest-state projection storage, including selected reads and trusted internal primitives. */
+export interface ObjectStorage extends ObjectReadStorage, ObjectReadScopeFactory {
   /**
    * Batch fetch every link incident to any of the given objects, in BOTH directions (the object as
    * link source or target). Returns a flat, de-duplicated list: a physical link incident to two

--- a/packages/core/src/storage/operation-scope.ts
+++ b/packages/core/src/storage/operation-scope.ts
@@ -1,6 +1,8 @@
 import { AsyncLocalStorage } from "node:async_hooks"
 import type { AgentStorage } from "./agents"
 import type { AuthStorage } from "./auth"
+import type { ObjectStorage } from "./objects"
+import { createGuardedObjectReadStorage, requireObjectReadScopeFactory } from "./objects/guard"
 import type { OntologyStorage } from "./ontology"
 import type { WorkflowRunStorage } from "./workflow-runs"
 
@@ -228,6 +230,20 @@ export function createOntologyOperationScope<T extends OntologyStorage>(
     sources: createOperationScopedFacade(target.sources, scope),
     materializations: createOperationScopedFacade(target.materializations, scope),
     outbox: createOperationScopedFacade(target.outbox, scope),
+  }) as T
+}
+
+/** Keep synchronously created selected readers inside the provider's root operation scope. */
+export function createObjectOperationScope<T extends ObjectStorage>(
+  target: T,
+  scope: StorageOperationScope
+): T {
+  const factory = requireObjectReadScopeFactory(target)
+  return createOperationScopedFacade<ObjectStorage>(target, scope, {
+    createSelectedReadScope: (params) => {
+      scope.assertAvailable()
+      return createGuardedObjectReadStorage(factory.createSelectedReadScope(params), scope)
+    },
   }) as T
 }
 

--- a/packages/core/src/storage/transaction.ts
+++ b/packages/core/src/storage/transaction.ts
@@ -1,12 +1,21 @@
 import { StorageTransactionError } from "./errors"
+import { createObjectOperationScope } from "./operation-scope"
+import type { Storage } from "./types"
 
 type ObjectLike = Record<PropertyKey, unknown>
 
-export function createTransactionStorageProxy<T extends object>(
+export function createTransactionStorageProxy<T extends Storage>(
   target: T,
   isActive: () => boolean
 ): T {
   const proxies = new WeakMap<object, object>()
+  const objectStorage = createObjectOperationScope(target.objects, {
+    assertAvailable: () => assertTransactionActive(isActive),
+    run: async <TResult>(operation: () => Promise<TResult> | TResult): Promise<TResult> => {
+      assertTransactionActive(isActive)
+      return operation()
+    },
+  })
 
   const wrap = <TValue extends object>(value: TValue): TValue => {
     const existing = proxies.get(value)
@@ -19,7 +28,10 @@ export function createTransactionStorageProxy<T extends object>(
       // from `tx` are wrapped (a handful), not the row/link data graph, and never per-record.
       get(current, property, receiver) {
         assertTransactionActive(isActive)
-        const result = Reflect.get(current, property, receiver)
+        const result =
+          current === target && property === "objects"
+            ? objectStorage
+            : Reflect.get(current, property, receiver)
         if (typeof result === "function") {
           return (...args: unknown[]) => {
             assertTransactionActive(isActive)

--- a/packages/core/tests/authorization-decision.test.ts
+++ b/packages/core/tests/authorization-decision.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { type AuthorizationContext, emptyGrantIndex, isAllowed } from "../src"
 import {
+  assertAuthorized,
   assertCanAppendTelemetry,
   assertCanEdit,
   canViewEvent,
@@ -18,7 +19,7 @@ import type {
   StoredTelemetryAppendedEvent,
   StoredWorkflowRunStartedEvent,
 } from "../src/events"
-import { createTestingScope } from "../src/execution/scopes"
+import { createDelegatedRequestScope, createTestingScope } from "../src/execution/scopes"
 
 function context(grants: {
   applications?: readonly string[]
@@ -69,6 +70,30 @@ const unrestrictedScope = createTestingScope({ projectId: "decision-test" })
 const unrestrictedRuntime = {
   projectId: "decision-test",
   runtimeAuthorization: unrestrictedScope.authorization,
+}
+const delegatedScope = createDelegatedRequestScope({
+  projectId: "decision-test",
+  requestId: "delegated-request",
+  correlationId: "delegated-correlation",
+  objectRead: {
+    selection: {
+      kind: "selected",
+      roots: [
+        {
+          anchor: { objectTypeId: "quote", primaryId: "quote-1" },
+          node: {
+            objects: [{ objectTypeId: "quote", propertyIds: ["id"] }],
+            links: [],
+          },
+        },
+      ],
+    },
+    limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+  },
+})
+const delegatedRuntime = {
+  projectId: "decision-test",
+  runtimeAuthorization: delegatedScope.authorization,
 }
 
 describe("evaluate", () => {
@@ -230,6 +255,22 @@ describe("evaluate", () => {
 })
 
 describe("write asserts", () => {
+  test("generic authorization denies delegated operations instead of treating them as unrestricted", () => {
+    for (const operation of [
+      () => assertAuthorized(delegatedRuntime, { kind: "object.view", objectTypeId: "quote" }),
+      () =>
+        assertAuthorized(delegatedRuntime, {
+          kind: "object.query",
+          touchedObjectTypeIds: ["quote"],
+        }),
+      () => assertAuthorized(delegatedRuntime, { kind: "action.apply", actionId: "approve" }),
+      () => assertCanEdit(delegatedRuntime, "quote"),
+      () => assertCanAppendTelemetry(delegatedRuntime, "sensor"),
+    ]) {
+      expect(operation).toThrow("not covered by delegated authorization")
+    }
+  })
+
   test("assertCanEdit demands view as well as edit, and names the missing one", () => {
     const both = principalRuntime({ view: ["quote"], edit: ["quote"] })
     expect(() => assertCanEdit(both, "quote")).not.toThrow()

--- a/packages/core/tests/authorized-object-reader-runtime.test.ts
+++ b/packages/core/tests/authorized-object-reader-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createAuthorizedObjectReader } from "../src/execution/authorized-object-reader"
-import { createTestingScope } from "../src/execution/scopes"
+import { createDelegatedRequestScope, createTestingScope } from "../src/execution/scopes"
 import { OntologyRegistry } from "../src/ontology"
 import { SixbHost } from "../src/runtime/host"
 import { createBoundSixb, type SixbDependencies } from "../src/runtime/sixb"
@@ -46,6 +46,23 @@ describe("AuthorizedObjectReader runtime binding", () => {
     expect(host.withScope(accessorScope).execution).toBe(source.execution)
     expect(executionReads).toBe(1)
     expect(authorizationReads).toBe(1)
+  })
+
+  test("SixbHost keeps delegated authority off the domain SDK until every surface is active", () => {
+    const host = new SixbHost({ id: projectId, ontology: [], ...createTestRuntimeDeps() })
+    const scope = createDelegatedRequestScope({
+      projectId,
+      requestId: "delegated-request",
+      correlationId: "delegated-correlation",
+      objectRead: {
+        selection: { kind: "selected", roots: [] },
+        limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+      },
+    })
+
+    expect(() => host.withScope(scope)).toThrow(
+      "Delegated runtime authorization cannot be bound to the domain SDK"
+    )
   })
 
   test("createBoundSixb rejects a reader from another exact authority", () => {

--- a/packages/core/tests/authorized-object-reader-runtime.test.ts
+++ b/packages/core/tests/authorized-object-reader-runtime.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+import { createAuthorizedObjectReader } from "../src/execution/authorized-object-reader"
+import { createTestingScope } from "../src/execution/scopes"
+import { OntologyRegistry } from "../src/ontology"
+import { SixbHost } from "../src/runtime/host"
+import { createBoundSixb, type SixbDependencies } from "../src/runtime/sixb"
+import type { SixbRuntimeContext } from "../src/runtime/types"
+import { InMemoryStorage } from "../src/storage"
+import { createTestRuntimeDeps } from "./test-runtime-deps"
+
+const projectId = "authorized-object-reader-runtime"
+
+describe("AuthorizedObjectReader runtime binding", () => {
+  test("SixbHost creates the bound reader before composing the SDK", () => {
+    const host = new SixbHost({ id: projectId, ontology: [], ...createTestRuntimeDeps() })
+    const scope = createTestingScope({ projectId, executionId: "execution-1" })
+
+    expect(host.withScope(scope).execution).toBe(scope.execution)
+  })
+
+  test("SixbHost captures an accessor-backed scope once before composition", () => {
+    const host = new SixbHost({ id: projectId, ontology: [], ...createTestRuntimeDeps() })
+    const source = createTestingScope({ projectId, executionId: "execution-accessor" })
+    let executionReads = 0
+    let authorizationReads = 0
+    const accessorScope = Object.defineProperties(
+      {},
+      {
+        execution: {
+          enumerable: true,
+          get: () => {
+            executionReads += 1
+            return source.execution
+          },
+        },
+        authorization: {
+          enumerable: true,
+          get: () => {
+            authorizationReads += 1
+            return source.authorization
+          },
+        },
+      }
+    ) as typeof source
+
+    expect(host.withScope(accessorScope).execution).toBe(source.execution)
+    expect(executionReads).toBe(1)
+    expect(authorizationReads).toBe(1)
+  })
+
+  test("createBoundSixb rejects a reader from another exact authority", () => {
+    const ontology = new OntologyRegistry({ sources: [] })
+    const storage = new InMemoryStorage()
+    const boundScope = createTestingScope({ projectId, executionId: "execution-bound" })
+    const foreignScope = createTestingScope({ projectId, executionId: "execution-foreign" })
+    const foreignReader = createAuthorizedObjectReader({
+      scope: foreignScope,
+      ontology,
+      objectStorage: storage.objects,
+    })
+    const runtime = {
+      projectId,
+      runtimeAuthorization: boundScope.authorization,
+      objectReader: foreignReader,
+    } as SixbRuntimeContext
+
+    expect(() =>
+      createBoundSixb<readonly []>(runtime, {} as SixbDependencies, boundScope.execution)
+    ).toThrow("AuthorizedObjectReader is not bound to this exact execution authority")
+  })
+})

--- a/packages/core/tests/delegated-object-query-reader.test.ts
+++ b/packages/core/tests/delegated-object-query-reader.test.ts
@@ -1,0 +1,160 @@
+import { expect, test } from "bun:test"
+import { createAuthorizedObjectReader } from "../src/execution/authorized-object-reader"
+import { createDelegatedRequestScope } from "../src/execution/scopes"
+import { InMemoryStorage } from "../src/storage/in-memory"
+import { createMaterializerTestFixture, objectReadScopeContractOntology } from "../src/testing"
+
+const projectId = "delegated-object-query-reader"
+const Proposal = "ScopeProposal"
+const LineItem = "ScopeLineItem"
+
+test("delegated object-query terminals never reveal a guessed sibling outside the selected graph", async () => {
+  const storage = new InMemoryStorage()
+  const fixture = createMaterializerTestFixture({
+    projectId,
+    ontology: objectReadScopeContractOntology,
+    storage,
+  })
+  await fixture.seed({
+    objects: [
+      {
+        ref: { objectTypeId: Proposal, primaryId: "proposal-1" },
+        properties: {
+          id: "proposal-1",
+          title: "Selected proposal",
+          category: "selected",
+        },
+      },
+      {
+        ref: { objectTypeId: Proposal, primaryId: "proposal-2" },
+        properties: {
+          id: "proposal-2",
+          title: "Guessed sibling",
+          category: "hidden",
+        },
+      },
+      {
+        ref: { objectTypeId: LineItem, primaryId: "item-1" },
+        properties: { id: "item-1", name: "Selected item" },
+      },
+      {
+        ref: { objectTypeId: LineItem, primaryId: "item-2" },
+        properties: { id: "item-2", name: "Hidden item" },
+      },
+    ],
+    links: [
+      {
+        ref: {
+          source: { objectTypeId: Proposal, primaryId: "proposal-1" },
+          linkId: "items",
+          target: { objectTypeId: LineItem, primaryId: "item-1" },
+        },
+        properties: { position: 1 },
+      },
+      {
+        ref: {
+          source: { objectTypeId: Proposal, primaryId: "proposal-2" },
+          linkId: "items",
+          target: { objectTypeId: LineItem, primaryId: "item-2" },
+        },
+        properties: { position: 2 },
+      },
+    ],
+  })
+
+  const scope = createDelegatedRequestScope({
+    projectId,
+    requestId: "request-1",
+    correlationId: "correlation-1",
+    objectRead: {
+      selection: {
+        kind: "selected",
+        roots: [
+          {
+            anchor: { objectTypeId: Proposal, primaryId: "proposal-1" },
+            node: {
+              objects: [
+                {
+                  objectTypeId: Proposal,
+                  propertyIds: ["id", "title", "category"],
+                },
+              ],
+              links: [
+                {
+                  definitions: [
+                    {
+                      sourceObjectTypeId: Proposal,
+                      linkId: "items",
+                      targetObjectTypeIds: [LineItem],
+                      propertyIds: ["position"],
+                    },
+                  ],
+                  target: {
+                    objects: [{ objectTypeId: LineItem, propertyIds: ["id", "name"] }],
+                    links: [],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 100_000 },
+    },
+  })
+  const reader = createAuthorizedObjectReader({
+    scope,
+    ontology: objectReadScopeContractOntology,
+    objectStorage: storage.objects,
+  })
+  const selectedQuery = {
+    kind: "refs" as const,
+    refs: [{ objectTypeId: Proposal, primaryId: "proposal-1" }],
+  }
+  const guessedSiblingQuery = {
+    kind: "refs" as const,
+    refs: [{ objectTypeId: Proposal, primaryId: "proposal-2" }],
+  }
+
+  expect(
+    (await reader.executeQuery({ query: selectedQuery })).objects.map((row) => row.primaryId)
+  ).toEqual(["proposal-1"])
+  expect(await reader.count({ query: selectedQuery })).toMatchObject({ count: 1 })
+  expect(await reader.exists({ query: selectedQuery })).toMatchObject({ exists: true })
+  expect(
+    (await reader.facet({ query: selectedQuery, facets: [{ propertyId: "category", limit: 10 }] }))
+      .facets
+  ).toEqual([{ propertyId: "category", buckets: [{ value: "selected", count: 1 }] }])
+  const selectedLinks = await reader.queryLinks({
+    query: selectedQuery,
+    direction: "outgoing",
+    linkId: "items",
+    includeObjects: true,
+  })
+  expect(selectedLinks.links.map((link) => `${link.sourceId}->${link.targetId}`)).toEqual([
+    "proposal-1->item-1",
+  ])
+  expect(selectedLinks.objects.map((row) => `${row.objectTypeId}:${row.primaryId}`).sort()).toEqual(
+    [`${LineItem}:item-1`, `${Proposal}:proposal-1`].sort()
+  )
+
+  expect((await reader.executeQuery({ query: guessedSiblingQuery })).objects).toEqual([])
+  expect(await reader.count({ query: guessedSiblingQuery })).toMatchObject({ count: 0 })
+  expect(await reader.exists({ query: guessedSiblingQuery })).toMatchObject({ exists: false })
+  expect(
+    (
+      await reader.facet({
+        query: guessedSiblingQuery,
+        facets: [{ propertyId: "category", limit: 10 }],
+      })
+    ).facets
+  ).toEqual([{ propertyId: "category", buckets: [] }])
+  expect(
+    await reader.queryLinks({
+      query: guessedSiblingQuery,
+      direction: "outgoing",
+      linkId: "items",
+      includeObjects: true,
+    })
+  ).toEqual({ objects: [], links: [], hasMore: false })
+})

--- a/packages/core/tests/execution-authorization.test.ts
+++ b/packages/core/tests/execution-authorization.test.ts
@@ -7,6 +7,7 @@ import { restoreAgentExecutionScope } from "../src/execution/agent"
 import {
   assertExecutionScopeProject,
   createAgentRuntimeAuthorization,
+  createDelegatedRuntimeAuthorization,
   createPrincipalRuntimeAuthorization,
   createTrustedPrimitiveRuntimeAuthorization,
   getAuthorizationRef,
@@ -19,6 +20,7 @@ import {
   restoreTrustedPrimitiveExecutionScope,
 } from "../src/execution/durable"
 import {
+  createDelegatedRequestScope,
   createDisabledRequestScope,
   createKernelScope,
   createPrincipalRequestScope,
@@ -30,6 +32,7 @@ import {
   type ExecutionScope,
   type RuntimeAuthorization,
 } from "../src/execution/types"
+import type { SelectedObjectReadScope } from "../src/storage"
 
 describe("runtime authorization capabilities", () => {
   test("snapshots principal authority and exposes only a defensive durable reference", () => {
@@ -175,6 +178,99 @@ describe("runtime authorization capabilities", () => {
 })
 
 describe("execution scopes", () => {
+  test("compiles and freezes process-local delegated object-read authority once", () => {
+    const propertyIds = ["id"]
+    const roots: SelectedObjectReadScope["roots"][number][] = [
+      {
+        anchor: { objectTypeId: "Proposal", primaryId: "proposal-1" },
+        node: {
+          objects: [{ objectTypeId: "Proposal", propertyIds }],
+          links: [],
+        },
+      },
+    ]
+    const scope = createDelegatedRequestScope({
+      projectId: "project-1",
+      requestId: "delegated-request-1",
+      correlationId: "delegated-correlation-1",
+      objectRead: {
+        selection: { kind: "selected", roots },
+        limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 1_024 },
+      },
+    })
+
+    propertyIds.push("secret")
+    roots.push({
+      anchor: { objectTypeId: "Proposal", primaryId: "proposal-2" },
+      node: {
+        objects: [{ objectTypeId: "Proposal", propertyIds: ["id"] }],
+        links: [],
+      },
+    })
+
+    const resolved = resolveRuntimeAuthorization(scope.authorization)
+    expect(resolved.type).toBe("delegated")
+    if (resolved.type !== "delegated") throw new Error("expected delegated authorization")
+    expect(resolved.objectRead.scope.roots).toHaveLength(1)
+    expect(resolved.objectRead.scope.objects).toEqual([
+      { nodeId: 0, objectTypeId: "Proposal", propertyIds: ["id"] },
+    ])
+    expect(resolved.objectRead.limits).toEqual({
+      maxTraversalFacts: 100,
+      maxOutputJsonBytes: 1_024,
+    })
+    expect(Object.isFrozen(resolved)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead.scope)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead.scope.roots)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead.scope.objects[0]?.propertyIds)).toBe(true)
+    expect(Object.isFrozen(resolved.objectRead.limits)).toBe(true)
+
+    expect(() => getAuthorizationRef(scope.authorization)).toThrow(
+      "cannot cross a durable execution boundary"
+    )
+    expect(() =>
+      executionRecordInputFromRuntime({
+        execution: scope.execution,
+        runtimeAuthorization: scope.authorization,
+      })
+    ).toThrow("cannot cross a durable execution boundary")
+  })
+
+  test("binds delegated authority only to its exact principal-free request", () => {
+    const scope = createDelegatedRequestScope({
+      projectId: "project-1",
+      requestId: "delegated-request-bound",
+      correlationId: "delegated-correlation-bound",
+      objectRead: {
+        selection: delegatedSelection(),
+        limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+      },
+    })
+    const other = createDisabledRequestScope({
+      projectId: "project-1",
+      requestId: "delegated-request-other",
+      correlationId: "delegated-correlation-other",
+    })
+
+    expect(() => resolveExecutionScopeAuthorization("project-1", scope)).not.toThrow()
+    expect(() =>
+      resolveExecutionScopeAuthorization("project-1", {
+        execution: other.execution,
+        authorization: scope.authorization,
+      })
+    ).toThrow("authority is bound to different execution provenance")
+    expect(() =>
+      createDelegatedRuntimeAuthorization({
+        execution: requestExecution("delegated-principal", { type: "user", id: "user-1" }),
+        objectRead: {
+          selection: delegatedSelection(),
+          limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+        },
+      })
+    ).toThrow("requires a request execution without a principal")
+  })
+
   test("durable serialization rejects a mismatched execution and authority pair", () => {
     const projectOne = createTestingScope({ projectId: "project-1" })
     const projectTwo = createTestingScope({ projectId: "project-2" })
@@ -532,5 +628,20 @@ function requestExecution(
     executor: { type: "request", requestId: `request-${id}` },
     source: { type: "http", requestId: `request-${id}` },
     correlationId: `correlation-${id}`,
+  }
+}
+
+function delegatedSelection(): SelectedObjectReadScope {
+  return {
+    kind: "selected",
+    roots: [
+      {
+        anchor: { objectTypeId: "Proposal", primaryId: "proposal-1" },
+        node: {
+          objects: [{ objectTypeId: "Proposal", propertyIds: ["id"] }],
+          links: [],
+        },
+      },
+    ],
   }
 }

--- a/packages/core/tests/in-memory-object-read-scope.test.ts
+++ b/packages/core/tests/in-memory-object-read-scope.test.ts
@@ -6,7 +6,6 @@ import {
   getInMemoryObjectMaterializerAdapter,
   InMemoryObjectStorage,
 } from "../src/storage/objects/in-memory"
-import type { ObjectReadScopeFactory, ObjectStorage } from "../src/storage/objects/types"
 import {
   createMaterializerTestFixture,
   objectReadScopeContractOntology,
@@ -16,7 +15,7 @@ import {
 runObjectReadScopeContractSuite("InMemoryStorage selected object-read scope contract", {
   createHarness: () => {
     const storage = new InMemoryStorage()
-    return { storage, objectReadScopeFactory: requireScopeFactory(storage.objects) }
+    return { storage, objectReadScopeFactory: storage.objects }
   },
 })
 
@@ -82,7 +81,7 @@ describe("InMemoryObjectStorage selected read behavior", () => {
       ],
     })
 
-    const reader = requireScopeFactory(storage.objects).createSelectedReadScope({
+    const reader = storage.objects.createSelectedReadScope({
       projectId: "in-memory-vector-scope",
       scope: compileSelectedObjectReadScope({
         kind: "selected",
@@ -188,14 +187,3 @@ describe("InMemoryObjectStorage selected read behavior", () => {
     ).toMatchObject({ properties: { id: "prototype-1" } })
   })
 })
-
-function requireScopeFactory(storage: ObjectStorage): ObjectReadScopeFactory {
-  if (!("createSelectedReadScope" in storage)) {
-    throw new Error("[Sixb] Expected the in-memory object-read scope factory.")
-  }
-  const factory = storage as ObjectStorage & Partial<ObjectReadScopeFactory>
-  if (typeof factory.createSelectedReadScope !== "function") {
-    throw new Error("[Sixb] Expected the in-memory object-read scope factory.")
-  }
-  return factory as ObjectReadScopeFactory
-}

--- a/packages/core/tests/object-query-selected-read-admission.test.ts
+++ b/packages/core/tests/object-query-selected-read-admission.test.ts
@@ -1,0 +1,525 @@
+import { describe, expect, test } from "bun:test"
+import { AuthorizationError } from "../src/authorization/errors"
+import type { ObjectQuery } from "../src/objects/query/ir"
+import { createSelectedObjectQueryAdmission } from "../src/objects/query/selected-read-admission"
+import {
+  type AdmittedObjectQuery,
+  validateObjectQueryWithAdmission,
+} from "../src/objects/query/validate"
+import { defineObjectType, link, OntologyRegistry, prop } from "../src/ontology"
+import { compileSelectedObjectReadScope } from "../src/storage/objects/read-scope"
+
+const Product = defineObjectType({
+  id: "Product",
+  name: "Product",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", {
+      query: { searchable: true, text: true, filterable: true, sortable: true },
+    }),
+    prop("price", "double", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
+  ],
+})
+
+const LineItem = defineObjectType({
+  id: "LineItem",
+  name: "Line item",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", {
+      query: { searchable: true, text: true, filterable: true, sortable: true },
+    }),
+    prop("role", "string", {
+      query: { searchable: true, text: true, filterable: true, sortable: true },
+    }),
+    prop("cost", "double", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
+    prop(
+      "embedding",
+      { type: "array", items: "double" },
+      { query: { searchable: true, vector: true } }
+    ),
+    prop(
+      "privateEmbedding",
+      { type: "array", items: "double" },
+      { query: { searchable: true, vector: true } }
+    ),
+  ],
+  links: [link("product", Product)],
+  search: {
+    defaultText: ["name"],
+    vector: { property: "embedding", source: ["name"] },
+  },
+})
+
+const Proposal = defineObjectType({
+  id: "Proposal",
+  name: "Proposal",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("title", "string", {
+      query: { searchable: true, text: true, filterable: true, sortable: true },
+    }),
+    prop("secret", "string", {
+      query: { searchable: true, text: true, filterable: true, sortable: true },
+    }),
+  ],
+  links: [link("items", LineItem), link("reviewers", LineItem)],
+  search: { defaultText: ["title", "secret"] },
+})
+
+const Asset = defineObjectType({
+  id: "Asset",
+  name: "Asset",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("label", "string", {
+      query: { searchable: true, text: true, filterable: true, sortable: true },
+    }),
+  ],
+})
+
+const SpecialAsset = defineObjectType({
+  id: "SpecialAsset",
+  name: "Special asset",
+  extends: Asset,
+  properties: [],
+})
+
+const Unselected = defineObjectType({
+  id: "Unselected",
+  name: "Unselected",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+const ontology = new OntologyRegistry({
+  sources: [Proposal, LineItem, Product, Asset, SpecialAsset, Unselected],
+})
+
+const admission = createSelectedObjectQueryAdmission(
+  compileSelectedObjectReadScope({
+    kind: "selected",
+    roots: [
+      {
+        anchor: { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+        node: {
+          objects: [{ objectTypeId: Proposal.id, propertyIds: ["id", "title"] }],
+          links: [
+            {
+              definitions: [
+                {
+                  sourceObjectTypeId: Proposal.id,
+                  linkId: "items",
+                  targetObjectTypeIds: [LineItem.id],
+                  propertyIds: ["position"],
+                },
+              ],
+              target: {
+                objects: [
+                  {
+                    objectTypeId: LineItem.id,
+                    propertyIds: ["id", "name", "embedding"],
+                  },
+                ],
+                links: [
+                  {
+                    definitions: [
+                      {
+                        sourceObjectTypeId: LineItem.id,
+                        linkId: "product",
+                        targetObjectTypeIds: [Product.id],
+                        propertyIds: [],
+                      },
+                    ],
+                    target: {
+                      objects: [{ objectTypeId: Product.id, propertyIds: ["id", "name"] }],
+                      links: [],
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              definitions: [
+                {
+                  sourceObjectTypeId: Proposal.id,
+                  linkId: "reviewers",
+                  targetObjectTypeIds: [LineItem.id],
+                  propertyIds: [],
+                },
+              ],
+              target: {
+                objects: [
+                  {
+                    objectTypeId: LineItem.id,
+                    propertyIds: ["id", "role"],
+                  },
+                ],
+                links: [],
+              },
+            },
+          ],
+        },
+      },
+      {
+        anchor: { objectTypeId: SpecialAsset.id, primaryId: "asset-1" },
+        node: {
+          objects: [{ objectTypeId: SpecialAsset.id, propertyIds: ["id", "label"] }],
+          links: [],
+        },
+      },
+    ],
+  })
+)
+
+describe("selected object query admission", () => {
+  test("admits sources by possible selected provenance while leaving exact refs to storage", () => {
+    expectAuthorized({ kind: "start", objectTypeId: Proposal.id })
+    expectAuthorized({
+      kind: "refs",
+      refs: [{ objectTypeId: Proposal.id, primaryId: "guessed-sibling" }],
+    })
+    expectAuthorized({ kind: "start", objectTypeId: Asset.id, includeSubtypes: true })
+
+    expectDenied({ kind: "start", objectTypeId: Asset.id })
+    expectDenied({
+      kind: "refs",
+      refs: [{ objectTypeId: Unselected.id, primaryId: "known-id" }],
+    })
+  })
+
+  test("covers every predicate form in the canonical predicate walk", () => {
+    const allowed = [
+      { op: "eq", propertyId: "title", value: "A" },
+      { op: "neq", propertyId: "title", value: "A" },
+      { op: "lt", propertyId: "title", value: "A" },
+      { op: "lte", propertyId: "title", value: "A" },
+      { op: "gt", propertyId: "title", value: "A" },
+      { op: "gte", propertyId: "title", value: "A" },
+      { op: "in", propertyId: "title", values: ["A"] },
+      { op: "exists", propertyId: "title", value: true },
+      { op: "contains", propertyId: "title", value: "A" },
+    ] as const
+
+    for (const predicate of allowed) {
+      expectAuthorized({ kind: "filter", input: start(Proposal.id), predicate })
+    }
+
+    expectDenied({
+      kind: "filter",
+      input: start(Proposal.id),
+      predicate: {
+        op: "and",
+        items: [
+          { op: "eq", propertyId: "title", value: "A" },
+          {
+            op: "or",
+            items: [
+              {
+                op: "not",
+                item: { op: "contains", propertyId: "secret", value: "hidden" },
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
+  test("authorizes text, vector, sort, and project properties in their existing validators", () => {
+    expectAuthorized({
+      kind: "text",
+      input: start(Proposal.id),
+      query: "visible",
+      fields: ["title"],
+    })
+    expectDenied({ kind: "text", input: start(Proposal.id), query: "hidden" })
+    expectDenied({
+      kind: "text",
+      input: start(Proposal.id),
+      query: "hidden",
+      fields: ["secret"],
+    })
+
+    expectAuthorized({
+      kind: "vector",
+      input: traverse("items", start(Proposal.id)),
+      propertyId: "embedding",
+      vector: [1],
+      k: 1,
+    })
+    expectDenied({
+      kind: "vector",
+      input: start(LineItem.id),
+      propertyId: "embedding",
+      vector: [1],
+      k: 1,
+    })
+
+    expectAuthorized({
+      kind: "sort",
+      input: start(Proposal.id),
+      fields: [{ kind: "property", propertyId: "title" }],
+    })
+    expectAuthorized({
+      kind: "sort",
+      input: start(Proposal.id),
+      fields: [{ kind: "relevance" }],
+    })
+    expectDenied({
+      kind: "sort",
+      input: start(Proposal.id),
+      fields: [{ kind: "property", propertyId: "secret" }],
+    })
+
+    expectAuthorized({ kind: "project", input: start(Proposal.id) })
+    expectAuthorized({ kind: "project", input: start(Proposal.id), properties: ["title"] })
+    expectDenied({ kind: "project", input: start(Proposal.id), properties: ["secret"] })
+  })
+
+  test("requires a property on every possible occurrence instead of borrowing from a sibling path", () => {
+    expectDenied({
+      kind: "filter",
+      input: start(LineItem.id),
+      predicate: { op: "eq", propertyId: "name", value: "visible" },
+    })
+    expectAuthorized({
+      kind: "filter",
+      input: traverse("items", start(Proposal.id)),
+      predicate: { op: "eq", propertyId: "name", value: "visible" },
+    })
+    expectAuthorized({
+      kind: "filter",
+      input: traverse("reviewers", start(Proposal.id)),
+      predicate: { op: "eq", propertyId: "role", value: "approver" },
+    })
+  })
+
+  test("preserves exact outgoing and incoming path provenance", () => {
+    expectAuthorized(traverse("product", traverse("items", start(Proposal.id))))
+    expectDenied(traverse("product", traverse("reviewers", start(Proposal.id))))
+
+    expectAuthorized({
+      kind: "traverse",
+      linkId: "items",
+      direction: "incoming",
+      sourceObjectTypeId: Proposal.id,
+      input: {
+        kind: "traverse",
+        linkId: "product",
+        direction: "incoming",
+        sourceObjectTypeId: LineItem.id,
+        input: start(Product.id),
+      },
+    })
+    expectDenied({
+      kind: "traverse",
+      linkId: "items",
+      direction: "incoming",
+      sourceObjectTypeId: Proposal.id,
+      input: traverse("reviewers", start(Proposal.id)),
+    })
+  })
+
+  test("fails closed when a compiled step disagrees with the ontology-resolved target", () => {
+    const staleAdmission = createSelectedObjectQueryAdmission(
+      compileSelectedObjectReadScope({
+        kind: "selected",
+        roots: [
+          {
+            anchor: { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+            node: {
+              objects: [{ objectTypeId: Proposal.id, propertyIds: ["id"] }],
+              links: [
+                {
+                  definitions: [
+                    {
+                      sourceObjectTypeId: Proposal.id,
+                      linkId: "items",
+                      targetObjectTypeIds: [Product.id],
+                      propertyIds: [],
+                    },
+                  ],
+                  target: {
+                    objects: [{ objectTypeId: Product.id, propertyIds: ["id"] }],
+                    links: [],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      })
+    )
+
+    expect(() =>
+      validateObjectQueryWithAdmission(
+        traverse("items", start(Proposal.id)),
+        { ontology },
+        staleAdmission
+      )
+    ).toThrow(AuthorizationError)
+  })
+
+  test("uses the same edge and property hooks for nested expansions", () => {
+    expectAuthorized({
+      kind: "expand",
+      input: start(Proposal.id),
+      expansions: [
+        {
+          linkId: "items",
+          direction: "outgoing",
+          expand: [
+            {
+              linkId: "product",
+              direction: "outgoing",
+              orderBy: [{ kind: "property", propertyId: "name" }],
+            },
+          ],
+        },
+      ],
+    })
+
+    expectDenied({
+      kind: "expand",
+      input: start(Proposal.id),
+      expansions: [
+        {
+          linkId: "items",
+          direction: "outgoing",
+          expand: [
+            {
+              linkId: "product",
+              direction: "outgoing",
+              orderBy: [{ kind: "property", propertyId: "price" }],
+            },
+          ],
+        },
+      ],
+    })
+    expectDenied({
+      kind: "expand",
+      input: start(Proposal.id),
+      expansions: [
+        {
+          linkId: "reviewers",
+          direction: "outgoing",
+          expand: [{ linkId: "product", direction: "outgoing" }],
+        },
+      ],
+    })
+  })
+
+  test("carries result-producing provenance through every set operation", () => {
+    const items = traverse("items", start(Proposal.id))
+    const reviewers = traverse("reviewers", start(Proposal.id))
+
+    expectAuthorized(traverse("product", { kind: "set", op: "union", inputs: [items, reviewers] }))
+    expectAuthorized(
+      traverse("product", { kind: "set", op: "intersect", inputs: [items, reviewers] })
+    )
+    expectDenied(traverse("product", { kind: "set", op: "subtract", inputs: [reviewers, items] }))
+  })
+
+  test("passes neutral limit/page nodes and exposes root state for terminal checks", () => {
+    const validated = authorize({
+      kind: "page",
+      pageSize: 10,
+      input: { kind: "limit", limit: 10, input: start(Proposal.id) },
+    })
+
+    expect(() =>
+      admission.assertPropertySelected({
+        state: validated.admissionState,
+        propertyId: "title",
+        use: "facet",
+        path: "$.facets[0]",
+      })
+    ).not.toThrow()
+    expect(() =>
+      admission.assertPropertySelected({
+        state: validated.admissionState,
+        propertyId: "secret",
+        use: "facet",
+        path: "$.facets[0]",
+      })
+    ).toThrow(AuthorizationError)
+    expect(() =>
+      admission.assertIncidentEdgeSelected({
+        state: validated.admissionState,
+        linkId: "items",
+        direction: "outgoing",
+        path: "$.linkId",
+      })
+    ).not.toThrow()
+    expect(() =>
+      admission.assertIncidentEdgeSelected({
+        state: validated.admissionState,
+        linkId: "product",
+        direction: "outgoing",
+        path: "$.linkId",
+      })
+    ).toThrow(AuthorizationError)
+    expect(() =>
+      admission.assertIncidentEdgeSelected({
+        state: validated.admissionState,
+        direction: "both",
+        path: "$.linkId",
+      })
+    ).not.toThrow()
+    try {
+      admission.assertIncidentEdgeSelected({
+        state: validated.admissionState,
+        linkId: "product",
+        direction: "both",
+        path: "$.linkId",
+      })
+      throw new Error("Expected both-direction link admission to fail")
+    } catch (error) {
+      expect(error).toBeInstanceOf(AuthorizationError)
+      if (!(error instanceof AuthorizationError)) throw error
+      expect(error.grantKey).toBe("view:link:both:product")
+      expect(error.message).toContain("both link 'product'")
+    }
+  })
+
+  test("raises ordinary validation before a deferred admission denial", () => {
+    expect(() =>
+      authorize({
+        kind: "filter",
+        input: start(Proposal.id),
+        predicate: { op: "eq", propertyId: "unknown", value: "x" },
+      })
+    ).toThrow("Object query validation failed")
+  })
+})
+
+function start(objectTypeId: string): ObjectQuery {
+  return { kind: "start", objectTypeId }
+}
+
+function traverse(linkId: string, input: ObjectQuery): ObjectQuery {
+  return { kind: "traverse", linkId, direction: "outgoing", input }
+}
+
+function authorize(query: ObjectQuery): AdmittedObjectQuery {
+  return validateObjectQueryWithAdmission(query, { ontology }, admission)
+}
+
+function expectAuthorized(query: ObjectQuery): void {
+  expect(() => authorize(query)).not.toThrow()
+}
+
+function expectDenied(query: ObjectQuery): AuthorizationError {
+  try {
+    authorize(query)
+  } catch (error) {
+    expect(error).toBeInstanceOf(AuthorizationError)
+    if (error instanceof AuthorizationError) return error
+    throw error
+  }
+  throw new Error("Expected the selected query admission to deny the query")
+}

--- a/packages/core/tests/object-query.test.ts
+++ b/packages/core/tests/object-query.test.ts
@@ -37,6 +37,7 @@ import type {
   QueryObjectsInput,
   QueryObjectsResult,
 } from "../src/storage"
+import { MAX_OBJECT_READ_FACETS } from "../src/storage"
 import { createMaterializerTestFixture, type MaterializerTestFixture } from "../src/testing"
 
 const Order = defineObjectType({
@@ -1121,6 +1122,33 @@ describe("object query planner and executor", () => {
     })
   })
 
+  test("validates physical-link terminal scalars before storage", async () => {
+    const { objects: storage } = createTestStorage()
+    const query = { kind: "start" as const, objectTypeId: "Customer" }
+
+    await expect(
+      executeObjectQueryLinks(
+        { projectId: "p1", query, linkId: 42 as unknown as string },
+        { ontology, storage }
+      )
+    ).rejects.toMatchObject({ code: "invalid_link_id", path: "$.linkId" })
+    await expect(
+      executeObjectQueryLinks(
+        { projectId: "p1", query, includeObjects: "yes" as unknown as boolean },
+        { ontology, storage }
+      )
+    ).rejects.toMatchObject({
+      code: "invalid_link_include_objects",
+      path: "$.includeObjects",
+    })
+    await expect(
+      executeObjectQueryLinks(
+        { projectId: "p1", query, pageToken: 42 as unknown as string },
+        { ontology, storage }
+      )
+    ).rejects.toMatchObject({ code: "invalid_link_page_token", path: "$.pageToken" })
+  })
+
   test("hydrates delimiter-bearing endpoint identities without collisions", async () => {
     const { objects: storage, fixture } = createTestStorage()
     await fixture.seed({
@@ -1520,6 +1548,31 @@ describe("object query planner and executor", () => {
         expect(error.issues.map((issue) => issue.code)).toContain("property_not_facetable")
       }
     }
+  })
+
+  test("bounds facet fan-out before consulting storage", async () => {
+    const testStorage = createTestStorage()
+    const { storage, calls } = countQueryCalls(testStorage.objects)
+
+    await expect(
+      facetObjects(
+        {
+          projectId: "p1",
+          query: { kind: "start", objectTypeId: "Customer" },
+          facets: Array.from({ length: MAX_OBJECT_READ_FACETS + 1 }, () => ({
+            propertyId: "status",
+            limit: 1,
+          })),
+        },
+        { ontology, storage }
+      )
+    ).rejects.toMatchObject({
+      issues: [expect.objectContaining({ code: "too_many_facets", path: "$.facets" })],
+    })
+    expect(calls.facetObjects).toBe(0)
+    expect(calls.queryObjects).toBe(0)
+    expect(calls.countObjects).toBe(0)
+    expect(calls.existsObjects).toBe(0)
   })
 
   test("falls back when provider capabilities are incomplete but fallback is safe", () => {

--- a/packages/core/tests/object-read-scope.test.ts
+++ b/packages/core/tests/object-read-scope.test.ts
@@ -279,6 +279,95 @@ describe("compileSelectedObjectReadScope", () => {
     ).toThrow("maximum of 2048 concrete link steps")
   })
 
+  test("captures a getter-backed object selection once before enforcing its bound", () => {
+    const oversized = Array.from({ length: 4_097 }, () => ({
+      objectTypeId: "Node",
+      propertyIds: [] as string[],
+    }))
+    let reads = 0
+    const node = {
+      get objects() {
+        reads += 1
+        return reads === 1 ? oversized : [{ objectTypeId: "Node", propertyIds: [] }]
+      },
+      links: [],
+    } as ObjectReadNode
+
+    expect(() => compileSelectedObjectReadScope(scope(node))).toThrow(
+      "maximum of 4096 object selections"
+    )
+    expect(reads).toBe(1)
+  })
+
+  test("captures a getter-backed link target exactly once", () => {
+    let reads = 0
+    const rootNode: ObjectReadNode = {
+      objects: [{ objectTypeId: "Node", propertyIds: ["id"] }],
+      links: [
+        {
+          definitions: [definition()],
+          get target() {
+            reads += 1
+            return reads === 1
+              ? leafNode()
+              : {
+                  objects: [{ objectTypeId: "Secret", propertyIds: ["id"] }],
+                  links: [],
+                }
+          },
+        },
+      ],
+    }
+
+    const compiled = compileSelectedObjectReadScope(scope(rootNode))
+
+    expect(reads).toBe(1)
+    expect(compiled.objects.map((selection) => selection.objectTypeId)).toEqual(["Node", "Node"])
+  })
+
+  test("does not invoke caller-controlled array iteration hooks", () => {
+    let calls = 0
+    const roots = [
+      {
+        anchor: { objectTypeId: "Node", primaryId: "root" },
+        node: leafNode(),
+      },
+    ]
+    const rejectIteration = () => {
+      calls += 1
+      throw new Error("hostile iterator invoked")
+    }
+    Object.defineProperty(roots, "entries", { value: rejectIteration })
+    Object.defineProperty(roots, Symbol.iterator, { value: rejectIteration })
+
+    const compiled = compileSelectedObjectReadScope({ kind: "selected", roots })
+
+    expect(compiled.roots).toHaveLength(1)
+    expect(calls).toBe(0)
+  })
+
+  test("detaches a captured field before a later getter can mutate its source", () => {
+    const object = { objectTypeId: "Node", propertyIds: ["id"] }
+    const objects = [object]
+    let linkReads = 0
+    const node = {
+      objects,
+      get links() {
+        linkReads += 1
+        object.objectTypeId = "Secret"
+        object.propertyIds.push("secret")
+        objects.splice(0, objects.length)
+        return []
+      },
+    } as ObjectReadNode
+
+    const compiled = compileSelectedObjectReadScope(scope(node))
+    object.propertyIds.push("later")
+
+    expect(linkReads).toBe(1)
+    expect(compiled.objects).toEqual([{ nodeId: 0, objectTypeId: "Node", propertyIds: ["id"] }])
+  })
+
   test("detaches, deeply freezes, and normalizes the compiled artifact", () => {
     const raw: SelectedObjectReadScope = {
       kind: "selected",

--- a/packages/core/tests/object-read-storage-guard.test.ts
+++ b/packages/core/tests/object-read-storage-guard.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test"
+import type { ObjectReadStorage } from "../src/storage"
+import { createGuardedObjectReadStorage } from "../src/storage/objects/guard"
+
+describe("selected object reader guards", () => {
+  test("forwards every terminal from a frozen provider reader through one guard", async () => {
+    const provider = fullReader()
+    let availabilityChecks = 0
+    let guardedRuns = 0
+    const reader = createGuardedObjectReadStorage(provider, {
+      assertAvailable: () => {
+        availabilityChecks += 1
+      },
+      run: async (operation) => {
+        guardedRuns += 1
+        return operation()
+      },
+    })
+
+    expect(reader.queryCapabilities()).toEqual({ queryObjects: true })
+    const query = { kind: "start", objectTypeId: "GuardedObject" } as const
+    await reader.queryObjects?.({ projectId: "guard-project", query })
+    await reader.countObjects?.({ projectId: "guard-project", query })
+    await reader.existsObjects?.({ projectId: "guard-project", query })
+    await reader.facetObjects?.({
+      projectId: "guard-project",
+      query,
+      facets: [{ propertyId: "id", limit: 10 }],
+    })
+    await reader.getByPrimaryId({
+      projectId: "guard-project",
+      objectTypeId: "GuardedObject",
+      primaryId: "root",
+    })
+    await reader.selectsObjectProperties({ projectId: "guard-project", items: [] })
+    await reader.listLinks({
+      projectId: "guard-project",
+      objectTypeId: "GuardedObject",
+      objectId: "root",
+    })
+    await reader.getByPrimaryIdBatch({ projectId: "guard-project", items: [] })
+    await reader.listLinksBatch({ projectId: "guard-project", items: [] })
+    await reader.queryLinks({
+      projectId: "guard-project",
+      objectRefs: [],
+      direction: "outgoing",
+      limit: 1,
+    })
+    await reader.list({ projectId: "guard-project" })
+
+    expect(Object.isFrozen(provider)).toBe(true)
+    expect(Object.isFrozen(reader)).toBe(true)
+    expect(availabilityChecks).toBe(1)
+    expect(guardedRuns).toBe(11)
+  })
+
+  test("does not invent optional query terminals", () => {
+    const provider = requiredReader()
+    const reader = createGuardedObjectReadStorage(provider, {
+      assertAvailable: () => undefined,
+      run: (operation) => operation(),
+    })
+
+    expect(reader.queryObjects).toBeUndefined()
+    expect(reader.countObjects).toBeUndefined()
+    expect(reader.existsObjects).toBeUndefined()
+    expect(reader.facetObjects).toBeUndefined()
+  })
+})
+
+function fullReader(): ObjectReadStorage {
+  return Object.freeze({
+    ...requiredReader(),
+    queryCapabilities: () => ({ queryObjects: true }),
+    queryObjects: async () => ({ objects: [], hasMore: false, total: 0 }),
+    countObjects: async () => ({ count: 0 }),
+    existsObjects: async () => ({ exists: false }),
+    facetObjects: async () => ({ facets: [] }),
+  })
+}
+
+function requiredReader(): ObjectReadStorage {
+  return Object.freeze({
+    queryCapabilities: () => ({ queryObjects: false }),
+    getByPrimaryId: async () => null,
+    selectsObjectProperties: async () => [],
+    listLinks: async () => [],
+    getByPrimaryIdBatch: async () => new Map(),
+    listLinksBatch: async () => new Map(),
+    queryLinks: async () => ({ links: [], hasMore: false }),
+    list: async () => ({ objects: [], hasMore: false, total: 0 }),
+  })
+}

--- a/packages/core/tests/object-reader-binding.test.ts
+++ b/packages/core/tests/object-reader-binding.test.ts
@@ -1,0 +1,657 @@
+import { describe, expect, test } from "bun:test"
+import { emptyGrantIndex } from "../src/authorization"
+import { AuthorizationError } from "../src/authorization/errors"
+import {
+  type AuthorizedObjectReader,
+  assertAuthorizedObjectReaderBinding,
+  createAuthorizedObjectReader,
+} from "../src/execution/authorized-object-reader"
+import { createDisabledRequestScope, createPrincipalRequestScope } from "../src/execution/scopes"
+import type { ExecutionScope } from "../src/execution/types"
+import type { ObjectQuery } from "../src/objects/query"
+import { defineObjectType, link, OntologyRegistry, prop } from "../src/ontology"
+import {
+  linkBatchKey,
+  type ObjectLinkRow,
+  type ObjectQueryCapabilities,
+  type ObjectRow,
+  type ObjectStorage,
+  objectBatchKey,
+} from "../src/storage"
+
+const projectId = "authorized-object-reader"
+const at = new Date("2026-01-01T00:00:00.000Z")
+
+const LineItem = defineObjectType({
+  id: "LineItem",
+  name: "Line item",
+  properties: [prop("id", "string", { required: true, primary: true }), prop("name", "string")],
+})
+
+const Secret = defineObjectType({
+  id: "Secret",
+  name: "Secret",
+  properties: [prop("id", "string", { required: true, primary: true }), prop("value", "string")],
+})
+
+const Proposal = defineObjectType({
+  id: "Proposal",
+  name: "Proposal",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("title", "string", { query: { searchable: true, facet: true } }),
+  ],
+  links: [link("items", LineItem), link("secret", Secret)],
+})
+
+const ontology = new OntologyRegistry({ sources: [Proposal, LineItem, Secret] })
+
+type PublicReaderMethod =
+  | "getByPrimaryId"
+  | "getByPrimaryIdBatch"
+  | "canReadObjectProperty"
+  | "canReadObjectPropertiesBatch"
+  | "list"
+  | "listLinks"
+  | "listLinksBatch"
+  | "executeQuery"
+  | "queryLinks"
+  | "count"
+  | "exists"
+  | "facet"
+
+type InputsWithoutProjectId = {
+  [Method in PublicReaderMethod]: "projectId" extends keyof Parameters<
+    AuthorizedObjectReader[Method]
+  >[0]
+    ? never
+    : true
+}
+
+const inputsWithoutProjectId: InputsWithoutProjectId = {
+  getByPrimaryId: true,
+  getByPrimaryIdBatch: true,
+  canReadObjectProperty: true,
+  canReadObjectPropertiesBatch: true,
+  list: true,
+  listLinks: true,
+  listLinksBatch: true,
+  executeQuery: true,
+  queryLinks: true,
+  count: true,
+  exists: true,
+  facet: true,
+}
+
+type FacadeIsNominal =
+  Pick<AuthorizedObjectReader, keyof AuthorizedObjectReader> extends AuthorizedObjectReader
+    ? never
+    : true
+
+const facadeIsNominal: FacadeIsNominal = true
+
+describe("AuthorizedObjectReader", () => {
+  test("is a frozen nominal facade that injects project identity", () => {
+    const backend = createReadStorage()
+    const reader = createAuthorizedObjectReader({
+      scope: principalScope("shape", [Proposal.id]),
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    expect(facadeIsNominal).toBe(true)
+    expect(Object.values(inputsWithoutProjectId).every(Boolean)).toBe(true)
+    expect(reader.projectId).toBe(projectId)
+    expect(Object.isFrozen(reader)).toBe(true)
+    expect(Object.isFrozen(Object.getPrototypeOf(reader))).toBe(true)
+    expect(backend.selectedScopeCalls).toBe(0)
+
+    const ReaderConstructor = Object.getPrototypeOf(reader).constructor as new (
+      ...args: unknown[]
+    ) => unknown
+    expect(() => Reflect.construct(ReaderConstructor, [])).toThrow(
+      "AuthorizedObjectReader can only be created by Core"
+    )
+  })
+
+  test("is bound to one exact registered execution authority", () => {
+    const backend = createReadStorage()
+    const first = principalScope("first", [Proposal.id])
+    const second = principalScope("second", [Proposal.id])
+    const reader = createAuthorizedObjectReader({
+      scope: first,
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    expect(() => assertAuthorizedObjectReaderBinding({ reader, scope: first })).not.toThrow()
+    expect(() => assertAuthorizedObjectReaderBinding({ reader, scope: second })).toThrow(
+      "AuthorizedObjectReader is not bound to this exact execution authority"
+    )
+
+    const mismatchedExecution: ExecutionScope = {
+      execution: second.execution,
+      authorization: first.authorization,
+    }
+    expect(() =>
+      assertAuthorizedObjectReaderBinding({ reader, scope: mismatchedExecution })
+    ).toThrow("authority is bound to different execution provenance")
+  })
+
+  test("captures authority instead of retaining a mutable scope wrapper", () => {
+    const backend = createReadStorage()
+    const first = principalScope("captured", [Proposal.id])
+    const second = principalScope("replacement", [Proposal.id])
+    const mutableScope = {
+      execution: first.execution,
+      authorization: first.authorization,
+    }
+    const reader = createAuthorizedObjectReader({
+      scope: mutableScope,
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    mutableScope.authorization = second.authorization
+
+    expect(() => assertAuthorizedObjectReaderBinding({ reader, scope: first })).not.toThrow()
+    expect(() => assertAuthorizedObjectReaderBinding({ reader, scope: second })).toThrow(
+      "AuthorizedObjectReader is not bound to this exact execution authority"
+    )
+  })
+
+  test("captures an accessor-backed scope atomically", () => {
+    const backend = createReadStorage()
+    const source = principalScope("accessor", [Proposal.id])
+    let executionReads = 0
+    let authorizationReads = 0
+    const accessorScope = Object.defineProperties(
+      {},
+      {
+        execution: {
+          enumerable: true,
+          get: () => {
+            executionReads += 1
+            return source.execution
+          },
+        },
+        authorization: {
+          enumerable: true,
+          get: () => {
+            authorizationReads += 1
+            return source.authorization
+          },
+        },
+      }
+    ) as ExecutionScope
+
+    const reader = createAuthorizedObjectReader({
+      scope: accessorScope,
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    expect(reader.projectId).toBe(projectId)
+    expect(executionReads).toBe(1)
+    expect(authorizationReads).toBe(1)
+  })
+
+  test("denies principal reads before storage and bounds an unfiltered empty listing", async () => {
+    const backend = createReadStorage()
+    const reader = createAuthorizedObjectReader({
+      scope: principalScope("denied"),
+      ontology,
+      objectStorage: backend.storage,
+    })
+    const query = { kind: "start" as const, objectTypeId: Proposal.id }
+
+    for (const operation of [
+      () => reader.getByPrimaryId({ objectTypeId: Proposal.id, primaryId: "proposal-1" }),
+      () =>
+        reader.getByPrimaryIdBatch({
+          items: [{ objectTypeId: Proposal.id, primaryId: "proposal-1" }],
+        }),
+      () =>
+        reader.canReadObjectProperty({
+          objectTypeId: Proposal.id,
+          primaryId: "proposal-1",
+          propertyId: "title",
+        }),
+      () =>
+        reader.canReadObjectPropertiesBatch({
+          items: [{ objectTypeId: Proposal.id, primaryId: "proposal-1", propertyId: "title" }],
+        }),
+      () => reader.list({ objectTypeId: Proposal.id }),
+      () => reader.listLinks({ objectTypeId: Proposal.id, objectId: "proposal-1" }),
+      () =>
+        reader.listLinksBatch({
+          items: [{ objectTypeId: Proposal.id, objectId: "proposal-1", linkId: "items" }],
+        }),
+      () => reader.executeQuery({ query }),
+      () => reader.queryLinks({ query }),
+      () => reader.count({ query }),
+      () => reader.exists({ query }),
+      () => reader.facet({ query, facets: [{ propertyId: "title", limit: 10 }] }),
+    ]) {
+      await expect(operation()).rejects.toBeInstanceOf(AuthorizationError)
+    }
+
+    expect(await reader.list({})).toEqual({ objects: [], hasMore: false, total: 0 })
+    expect(backend.calls).toEqual([])
+  })
+
+  test("covers every read terminal, scopes principal lists, and filters hidden link endpoints", async () => {
+    const backend = createReadStorage()
+    const reader = createAuthorizedObjectReader({
+      scope: principalScope("allowed", [Proposal.id, LineItem.id]),
+      ontology,
+      objectStorage: backend.storage,
+    })
+    const query = { kind: "start" as const, objectTypeId: Proposal.id }
+
+    expect(
+      await reader.getByPrimaryId({ objectTypeId: Proposal.id, primaryId: "proposal-1" })
+    ).toMatchObject({ objectTypeId: Proposal.id, primaryId: "proposal-1" })
+    expect(
+      await reader.getByPrimaryIdBatch({
+        items: [
+          { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+          { objectTypeId: LineItem.id, primaryId: "line-1" },
+        ],
+      })
+    ).toHaveLength(2)
+    expect(
+      await reader.canReadObjectPropertiesBatch({
+        items: [{ objectTypeId: Proposal.id, primaryId: "proposal-1", propertyId: "title" }],
+      })
+    ).toEqual([true])
+    expect(
+      await reader.canReadObjectProperty({
+        objectTypeId: Proposal.id,
+        primaryId: "proposal-1",
+        propertyId: "title",
+      })
+    ).toBe(true)
+
+    const listed = await reader.list({})
+    expect(listed.objects.map((row) => row.objectTypeId)).toEqual([Proposal.id, LineItem.id])
+    expect(backend.calls.find((call) => call.operation === "list")?.input).toMatchObject({
+      projectId,
+      objectTypeId: [Proposal.id, LineItem.id],
+    })
+
+    const links = await reader.listLinks({
+      objectTypeId: Proposal.id,
+      objectId: "proposal-1",
+    })
+    expect(links.map((row) => row.targetTypeId)).toEqual([LineItem.id])
+
+    const linkPages = await reader.listLinksBatch({
+      items: [{ objectTypeId: Proposal.id, objectId: "proposal-1", linkId: "items" }],
+    })
+    expect(
+      linkPages
+        .get(linkBatchKey(Proposal.id, "proposal-1", "items"))
+        ?.map((row) => row.targetTypeId)
+    ).toEqual([LineItem.id])
+
+    expect((await reader.executeQuery({ query, includeTotal: true })).objects).toHaveLength(1)
+    expect((await reader.count({ query })).count).toBe(1)
+    expect((await reader.exists({ query })).exists).toBe(true)
+    expect(
+      (await reader.facet({ query, facets: [{ propertyId: "title", limit: 10 }] })).facets
+    ).toEqual([{ propertyId: "title", buckets: [{ value: "Proposal", count: 1 }] }])
+
+    const queriedLinks = await reader.queryLinks({ query, includeObjects: true })
+    expect(queriedLinks.links.map((row) => row.targetTypeId)).toEqual([LineItem.id])
+    expect(queriedLinks.objects.map((row) => row.objectTypeId)).toEqual([Proposal.id, LineItem.id])
+    expect(backend.calls.find((call) => call.operation === "queryLinks")?.input).toMatchObject({
+      projectId,
+      endpointObjectTypeIds: [Proposal.id, LineItem.id],
+    })
+
+    expect(backend.selectedScopeCalls).toBe(0)
+    for (const call of backend.calls) {
+      if (call.operation === "queryCapabilities") continue
+      expect(call.input).toMatchObject({ projectId })
+    }
+  })
+
+  test("preserves unrestricted broad reads", async () => {
+    const backend = createReadStorage()
+    const reader = createAuthorizedObjectReader({
+      scope: createDisabledRequestScope({
+        projectId,
+        requestId: "request-unrestricted",
+        correlationId: "correlation-unrestricted",
+      }),
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    const listed = await reader.list({})
+    expect(listed.objects.map((row) => row.objectTypeId)).toEqual([
+      Proposal.id,
+      LineItem.id,
+      Secret.id,
+    ])
+    expect(backend.calls.find((call) => call.operation === "list")?.input).toEqual({
+      objectTypeId: undefined,
+      primaryIdPrefix: undefined,
+      primaryIdSuffix: undefined,
+      updatedAfter: undefined,
+      updatedBefore: undefined,
+      createdAfter: undefined,
+      createdBefore: undefined,
+      limit: undefined,
+      offset: undefined,
+      orderBy: undefined,
+      order: undefined,
+      projectId,
+    })
+
+    const links = await reader.listLinks({
+      objectTypeId: Proposal.id,
+      objectId: "proposal-1",
+    })
+    expect(links.map((row) => row.targetTypeId)).toEqual([LineItem.id, Secret.id])
+  })
+
+  test("ignores caller project extras and executes the exact query snapshot it authorized", async () => {
+    let objectTypeReads = 0
+    const authoredQuery = Object.defineProperties(
+      {},
+      {
+        kind: { enumerable: true, value: "start" },
+        objectTypeId: {
+          enumerable: true,
+          get: () => (objectTypeReads++ === 0 ? Proposal.id : Secret.id),
+        },
+      }
+    ) as ObjectQuery
+    const backend = createReadStorage()
+    const reader = createAuthorizedObjectReader({
+      scope: principalScope("snapshot", [Proposal.id]),
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    await reader.getByPrimaryId({
+      objectTypeId: Proposal.id,
+      primaryId: "proposal-1",
+      projectId: "other-project",
+    } as Parameters<AuthorizedObjectReader["getByPrimaryId"]>[0])
+    await reader.executeQuery({
+      query: authoredQuery,
+      projectId: "other-project",
+    } as Parameters<AuthorizedObjectReader["executeQuery"]>[0])
+
+    expect(objectTypeReads).toBe(1)
+    expect(backend.calls.find((call) => call.operation === "getByPrimaryId")?.input).toEqual({
+      objectTypeId: Proposal.id,
+      primaryId: "proposal-1",
+      projectId,
+    })
+    expect(backend.calls.find((call) => call.operation === "queryObjects")?.input).toMatchObject({
+      projectId,
+      query: { kind: "start", objectTypeId: Proposal.id },
+    })
+  })
+
+  test("detaches provider-owned rows, maps, and links", async () => {
+    const backend = createReadStorage()
+    const reader = createAuthorizedObjectReader({
+      scope: principalScope("detach", [Proposal.id, LineItem.id]),
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    const object = await reader.getByPrimaryId({
+      objectTypeId: Proposal.id,
+      primaryId: "proposal-1",
+    })
+    object!.properties.title = "mutated"
+    expect(backend.rows.proposal.properties.title).toBe("Proposal")
+
+    const batch = await reader.getByPrimaryIdBatch({
+      items: [{ objectTypeId: LineItem.id, primaryId: "line-1" }],
+    })
+    batch.get(objectBatchKey(LineItem.id, "line-1"))!.properties.name = "mutated"
+    expect(backend.rows.line.properties.name).toBe("Line")
+
+    const links = await reader.listLinks({
+      objectTypeId: Proposal.id,
+      objectId: "proposal-1",
+    })
+    links[0].properties!.position = 99
+    expect(backend.links[0].properties?.position).toBe(1)
+  })
+
+  test("fails closed when a provider returns a hidden endpoint in a paginated link page", async () => {
+    const backend = createReadStorage({ ignoreEndpointTypeFilter: true, queryLinksHasMore: true })
+    const reader = createAuthorizedObjectReader({
+      scope: principalScope("invalid-link-page", [Proposal.id, LineItem.id]),
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    await expect(
+      reader.queryLinks({
+        query: { kind: "start", objectTypeId: Proposal.id },
+        includeObjects: true,
+      })
+    ).rejects.toThrow("Object storage returned a link page outside its authorized scope")
+  })
+})
+
+function principalScope(id: string, view: readonly string[] = []): ExecutionScope {
+  return createPrincipalRequestScope({
+    projectId,
+    requestId: `request-${id}`,
+    correlationId: `correlation-${id}`,
+    context: {
+      principal: { type: "user", id: `user-${id}` },
+      groupIds: [],
+      roleIds: [],
+      grants: { ...emptyGrantIndex(), "view:object": new Set(view) },
+    },
+  })
+}
+
+type ReadCall = {
+  readonly operation: string
+  readonly input?: unknown
+}
+
+function createReadStorage(options?: {
+  readonly ignoreEndpointTypeFilter?: boolean
+  readonly queryLinksHasMore?: boolean
+}): {
+  readonly storage: ObjectStorage
+  readonly calls: ReadCall[]
+  readonly selectedScopeCalls: number
+  readonly rows: {
+    readonly proposal: ObjectRow
+    readonly line: ObjectRow
+    readonly secret: ObjectRow
+  }
+  readonly links: readonly ObjectLinkRow[]
+} {
+  const calls: ReadCall[] = []
+  const rows = {
+    proposal: row(Proposal.id, "proposal-1", { id: "proposal-1", title: "Proposal" }),
+    line: row(LineItem.id, "line-1", { id: "line-1", name: "Line" }),
+    secret: row(Secret.id, "secret-1", { id: "secret-1", value: "hidden" }),
+  }
+  const allRows = [rows.proposal, rows.line, rows.secret]
+  const links: ObjectLinkRow[] = [
+    objectLink("items", LineItem.id, "line-1", { position: 1 }),
+    objectLink("secret", Secret.id, "secret-1"),
+  ]
+  let selectedScopeCalls = 0
+  const record = (operation: string, input?: unknown): void => {
+    calls.push({ operation, ...(input === undefined ? {} : { input }) })
+  }
+  const capabilities: ObjectQueryCapabilities = {
+    queryObjects: true,
+    countObjects: true,
+    existsObjects: true,
+    facetObjects: true,
+    nodes: { start: true, limit: true },
+  }
+
+  const storage: ObjectStorage = {
+    queryCapabilities() {
+      record("queryCapabilities")
+      return capabilities
+    },
+    async queryObjects(input) {
+      record("queryObjects", input)
+      return { objects: [rows.proposal], hasMore: false, total: 1 }
+    },
+    async countObjects(input) {
+      record("countObjects", input)
+      return { count: 1 }
+    },
+    async existsObjects(input) {
+      record("existsObjects", input)
+      return { exists: true }
+    },
+    async facetObjects(input) {
+      record("facetObjects", input)
+      return {
+        facets: input.facets.map((facet) => ({
+          propertyId: facet.propertyId,
+          buckets: [{ value: "Proposal", count: 1 }],
+        })),
+      }
+    },
+    async getByPrimaryId(input) {
+      record("getByPrimaryId", input)
+      return findRow(allRows, input.objectTypeId, input.primaryId)
+    },
+    async getByPrimaryIdBatch(input) {
+      record("getByPrimaryIdBatch", input)
+      const result = new Map()
+      for (const item of input.items) {
+        const found = findRow(allRows, item.objectTypeId, item.primaryId)
+        if (found) result.set(objectBatchKey(item.objectTypeId, item.primaryId), found)
+      }
+      return result
+    },
+    async selectsObjectProperties(input) {
+      record("selectsObjectProperties", input)
+      return input.items.map((item) => Boolean(findRow(allRows, item.objectTypeId, item.primaryId)))
+    },
+    async listLinks(input) {
+      record("listLinks", input)
+      return links
+    },
+    async listLinksBatch(input) {
+      record("listLinksBatch", input)
+      return new Map(
+        input.items.map((item) => [
+          linkBatchKey(item.objectTypeId, item.objectId, item.linkId),
+          links,
+        ])
+      )
+    },
+    async queryLinks(input) {
+      record("queryLinks", input)
+      const endpointObjectTypeIds =
+        options?.ignoreEndpointTypeFilter || input.endpointObjectTypeIds === undefined
+          ? undefined
+          : new Set(input.endpointObjectTypeIds)
+      const visibleLinks = endpointObjectTypeIds
+        ? links.filter(
+            (link) =>
+              endpointObjectTypeIds.has(link.sourceTypeId) &&
+              endpointObjectTypeIds.has(link.targetTypeId)
+          )
+        : links
+      return { links: visibleLinks, hasMore: options?.queryLinksHasMore ?? false }
+    },
+    async list(input) {
+      record("list", input)
+      const requested =
+        input.objectTypeId === undefined
+          ? undefined
+          : new Set(
+              typeof input.objectTypeId === "string" ? [input.objectTypeId] : input.objectTypeId
+            )
+      const objects = requested
+        ? allRows.filter((candidate) => requested.has(candidate.objectTypeId))
+        : allRows
+      return { objects, hasMore: false, total: objects.length }
+    },
+    createSelectedReadScope() {
+      selectedScopeCalls += 1
+      throw new Error("createSelectedReadScope must not be called for existing authorities")
+    },
+    async listIncidentLinksBatch() {
+      return []
+    },
+    async listByPrimaryIdPage() {
+      return { objects: [] }
+    },
+  }
+
+  return {
+    storage,
+    calls,
+    get selectedScopeCalls() {
+      return selectedScopeCalls
+    },
+    rows,
+    links,
+  }
+}
+
+function row(
+  objectTypeId: string,
+  primaryId: string,
+  properties: Record<string, unknown>
+): ObjectRow {
+  return {
+    projectId,
+    objectTypeId,
+    primaryId,
+    properties,
+    createdAt: at,
+    updatedAt: at,
+    version: 1,
+    lastCommitId: `commit-${primaryId}`,
+  }
+}
+
+function objectLink(
+  linkId: string,
+  targetTypeId: string,
+  targetId: string,
+  properties?: Record<string, unknown>
+): ObjectLinkRow {
+  return {
+    projectId,
+    sourceTypeId: Proposal.id,
+    sourceId: "proposal-1",
+    linkId,
+    targetTypeId,
+    targetId,
+    ...(properties === undefined ? {} : { properties }),
+    createdAt: at,
+    updatedAt: at,
+    lastCommitId: `commit-${linkId}`,
+  }
+}
+
+function findRow(
+  rows: readonly ObjectRow[],
+  objectTypeId: string,
+  primaryId: string
+): ObjectRow | null {
+  return (
+    rows.find(
+      (candidate) => candidate.objectTypeId === objectTypeId && candidate.primaryId === primaryId
+    ) ?? null
+  )
+}

--- a/packages/core/tests/object-reader-binding.test.ts
+++ b/packages/core/tests/object-reader-binding.test.ts
@@ -13,10 +13,20 @@ import {
   createPrincipalRequestScope,
 } from "../src/execution/scopes"
 import type { ExecutionScope } from "../src/execution/types"
-import type { ObjectQuery } from "../src/objects/query"
+import {
+  countObjects,
+  executeObjectQuery,
+  executeObjectQueryLinks,
+  existsObjects,
+  facetObjects,
+  type ObjectQuery,
+  ObjectQueryExecutionError,
+  ObjectQueryValidationError,
+} from "../src/objects/query"
 import { defineObjectType, link, OntologyRegistry, prop } from "../src/ontology"
 import {
   linkBatchKey,
+  MAX_OBJECT_READ_FACETS,
   type ObjectLinkRow,
   type ObjectQueryCapabilities,
   type ObjectReadExecutionLimits,
@@ -47,6 +57,9 @@ const Proposal = defineObjectType({
   properties: [
     prop("id", "string", { required: true, primary: true }),
     prop("title", "string", { query: { searchable: true, facet: true } }),
+    prop("internal", "string", {
+      query: { searchable: true, filterable: true, facet: true },
+    }),
   ],
   links: [link("items", LineItem), link("secret", Secret)],
 })
@@ -364,7 +377,7 @@ describe("AuthorizedObjectReader", () => {
     expect(links.map((row) => row.targetTypeId)).toEqual([LineItem.id, Secret.id])
   })
 
-  test("creates one selected provider reader for delegated non-query terminals", async () => {
+  test("binds every delegated read terminal to one selected provider reader", async () => {
     const selectedCalls: ReadCall[] = []
     const selectedRows = [
       row(Proposal.id, "proposal-1", { id: "proposal-1", title: "Proposal" }),
@@ -377,41 +390,7 @@ describe("AuthorizedObjectReader", () => {
     const backend = createReadStorage({
       selectedReader: createSelectedReader(selectedRows, selectedLinks, selectedCalls),
     })
-    const scope = createDelegatedRequestScope({
-      projectId,
-      requestId: "request-delegated",
-      correlationId: "correlation-delegated",
-      objectRead: {
-        selection: {
-          kind: "selected",
-          roots: [
-            {
-              anchor: { objectTypeId: Proposal.id, primaryId: "proposal-1" },
-              node: {
-                objects: [{ objectTypeId: Proposal.id, propertyIds: ["id", "title"] }],
-                links: [
-                  {
-                    definitions: [
-                      {
-                        sourceObjectTypeId: Proposal.id,
-                        linkId: "items",
-                        targetObjectTypeIds: [LineItem.id],
-                        propertyIds: ["position"],
-                      },
-                    ],
-                    target: {
-                      objects: [{ objectTypeId: LineItem.id, propertyIds: ["id", "name"] }],
-                      links: [],
-                    },
-                  },
-                ],
-              },
-            },
-          ],
-        },
-        limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 4_096 },
-      },
-    })
+    const scope = delegatedScope("terminals")
     const reader = createAuthorizedObjectReader({
       scope,
       ontology,
@@ -479,19 +458,6 @@ describe("AuthorizedObjectReader", () => {
       reader.getByPrimaryId({ objectTypeId: Secret.id, primaryId: "secret-1" })
     ).rejects.toThrow("does not select object type 'Secret'")
 
-    const query = { kind: "start" as const, objectTypeId: Proposal.id }
-    for (const operation of [
-      () => reader.executeQuery({ query }),
-      () => reader.queryLinks({ query }),
-      () => reader.count({ query }),
-      () => reader.exists({ query }),
-      () => reader.facet({ query, facets: [{ propertyId: "title", limit: 10 }] }),
-    ]) {
-      await expect(operation()).rejects.toThrow("require explicit selected-path admission")
-    }
-
-    expect(backend.selectedScopeCalls).toBe(1)
-    expect(backend.calls).toEqual([])
     expect(selectedCalls.map((call) => call.operation)).toEqual([
       "getByPrimaryId",
       "getByPrimaryId",
@@ -502,6 +468,233 @@ describe("AuthorizedObjectReader", () => {
       "listLinks",
       "listLinksBatch",
     ])
+
+    selectedCalls.length = 0
+    const query = { kind: "start" as const, objectTypeId: Proposal.id }
+    expect(await reader.executeQuery({ query, includeTotal: true })).toMatchObject({
+      objects: [{ objectTypeId: Proposal.id, primaryId: "proposal-1" }],
+      hasMore: false,
+      total: 1,
+    })
+    expect(await reader.count({ query })).toMatchObject({ count: 1 })
+    expect(await reader.exists({ query })).toMatchObject({ exists: true })
+    expect(
+      await reader.facet({ query, facets: [{ propertyId: "title", limit: 10 }] })
+    ).toMatchObject({
+      facets: [{ propertyId: "title", buckets: [{ value: "Proposal", count: 1 }] }],
+    })
+    expect(
+      await reader.queryLinks({
+        query,
+        direction: "outgoing",
+        linkId: "items",
+        includeObjects: true,
+      })
+    ).toMatchObject({
+      links: [{ linkId: "items", targetId: "line-1" }],
+      objects: [
+        { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+        { objectTypeId: LineItem.id, primaryId: "line-1" },
+      ],
+      hasMore: false,
+    })
+
+    const guessedSibling = await reader.executeQuery({
+      query: {
+        kind: "refs",
+        refs: [{ objectTypeId: Proposal.id, primaryId: "proposal-2" }],
+      },
+    })
+    expect(guessedSibling.objects).toEqual([])
+    expect(selectedCalls.map((call) => call.operation)).toContain("queryObjects")
+    expect(selectedCalls.map((call) => call.operation)).toContain("countObjects")
+    expect(selectedCalls.map((call) => call.operation)).toContain("existsObjects")
+    expect(selectedCalls.map((call) => call.operation)).toContain("facetObjects")
+    expect(selectedCalls.map((call) => call.operation)).toContain("queryLinks")
+    expect(backend.selectedScopeCalls).toBe(1)
+    expect(backend.calls).toEqual([])
+
+    selectedCalls.length = 0
+    const deniedOperations = [
+      () =>
+        reader.executeQuery({
+          query: {
+            kind: "filter" as const,
+            input: query,
+            predicate: { op: "eq" as const, propertyId: "internal", value: "hidden" },
+          },
+        }),
+      () =>
+        reader.count({
+          query: {
+            kind: "traverse" as const,
+            input: query,
+            linkId: "secret",
+            direction: "outgoing" as const,
+          },
+        }),
+      () =>
+        reader.exists({
+          query: {
+            kind: "refs" as const,
+            refs: [{ objectTypeId: Secret.id, primaryId: "secret-1" }],
+          },
+        }),
+      () => reader.facet({ query, facets: [{ propertyId: "internal", limit: 10 }] }),
+      () => reader.queryLinks({ query, direction: "outgoing", linkId: "secret" }),
+    ]
+    for (const operation of deniedOperations) {
+      await expect(operation()).rejects.toBeInstanceOf(AuthorizationError)
+      expect(selectedCalls).toEqual([])
+    }
+  })
+
+  test("validates delegated terminal parameters before terminal-specific admission", async () => {
+    const selectedCalls: ReadCall[] = []
+    const backend = createReadStorage({
+      selectedReader: createSelectedReader(
+        [row(Proposal.id, "proposal-1", { id: "proposal-1", title: "Proposal" })],
+        [objectLink("items", LineItem.id, "line-1")],
+        selectedCalls
+      ),
+    })
+    const reader = createAuthorizedObjectReader({
+      scope: delegatedScope("validation-order"),
+      ontology,
+      objectStorage: backend.storage,
+    })
+    const query = { kind: "start" as const, objectTypeId: Proposal.id }
+
+    const invalidLinks = reader.queryLinks({
+      query,
+      direction: "sideways",
+      linkId: "secret",
+    } as unknown as Parameters<AuthorizedObjectReader["queryLinks"]>[0])
+    await expect(invalidLinks).rejects.toMatchObject({
+      code: "invalid_link_direction",
+      path: "$.direction",
+    })
+    await expect(invalidLinks).rejects.toBeInstanceOf(ObjectQueryExecutionError)
+
+    const invalidFacets = reader.facet({
+      query,
+      facets: [{ propertyId: "internal", limit: 0 }],
+    })
+    await expect(invalidFacets).rejects.toBeInstanceOf(ObjectQueryValidationError)
+    await expect(invalidFacets).rejects.toMatchObject({
+      issues: expect.arrayContaining([expect.objectContaining({ code: "invalid_facet_limit" })]),
+    })
+
+    let oversizedFacetReads = 0
+    const oversizedFacets = Array.from({ length: MAX_OBJECT_READ_FACETS + 1 }, () => ({
+      propertyId: "internal",
+      limit: 1,
+    }))
+    Object.defineProperty(oversizedFacets, 0, {
+      get: () => {
+        oversizedFacetReads += 1
+        throw new Error("oversized facet must not be read")
+      },
+    })
+    await expect(reader.facet({ query, facets: oversizedFacets })).rejects.toBeInstanceOf(
+      ObjectQueryValidationError
+    )
+    expect(oversizedFacetReads).toBe(0)
+
+    expect(selectedCalls).toEqual([])
+    expect(backend.calls).toEqual([])
+  })
+
+  test("keeps delegated runtime authorization unusable at low-level query executors", async () => {
+    const backend = createReadStorage()
+    const scope = delegatedScope("low-level")
+    const query = { kind: "start" as const, objectTypeId: Proposal.id }
+    const options = {
+      ontology,
+      storage: backend.storage,
+      runtimeAuthorization: scope.authorization,
+    }
+
+    for (const operation of [
+      () => executeObjectQuery({ projectId, query }, options),
+      () => countObjects({ projectId, query }, options),
+      () => existsObjects({ projectId, query }, options),
+      () =>
+        facetObjects({ projectId, query, facets: [{ propertyId: "title", limit: 10 }] }, options),
+      () => executeObjectQueryLinks({ projectId, query }, options),
+    ]) {
+      await expect(operation()).rejects.toBeInstanceOf(AuthorizationError)
+    }
+
+    expect(backend.calls).toEqual([])
+    expect(backend.selectedScopeCalls).toBe(0)
+  })
+
+  test("executes the exact delegated query snapshot it admits", async () => {
+    let objectTypeReads = 0
+    const authoredQuery = Object.defineProperties(
+      {},
+      {
+        kind: { enumerable: true, value: "start" },
+        objectTypeId: {
+          enumerable: true,
+          get: () => (objectTypeReads++ === 0 ? Proposal.id : Secret.id),
+        },
+      }
+    ) as ObjectQuery
+    const selectedCalls: ReadCall[] = []
+    const backend = createReadStorage({
+      selectedReader: createSelectedReader(
+        [row(Proposal.id, "proposal-1", { id: "proposal-1", title: "Proposal" })],
+        [],
+        selectedCalls
+      ),
+    })
+    const reader = createAuthorizedObjectReader({
+      scope: delegatedScope("snapshot"),
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    await expect(reader.executeQuery({ query: authoredQuery })).resolves.toMatchObject({
+      objects: [{ objectTypeId: Proposal.id, primaryId: "proposal-1" }],
+    })
+
+    expect(objectTypeReads).toBe(1)
+    expect(selectedCalls.find((call) => call.operation === "queryObjects")?.input).toMatchObject({
+      projectId,
+      query: { kind: "start", objectTypeId: Proposal.id },
+    })
+
+    let queryReads = 0
+    let linkIdReads = 0
+    const linkRequest = Object.defineProperties(
+      {},
+      {
+        query: {
+          enumerable: true,
+          get: () => {
+            queryReads += 1
+            return {
+              kind: "start",
+              objectTypeId: queryReads === 1 ? Proposal.id : Secret.id,
+            }
+          },
+        },
+        linkId: {
+          enumerable: true,
+          get: () => (linkIdReads++ === 0 ? "items" : "secret"),
+        },
+      }
+    ) as Parameters<AuthorizedObjectReader["queryLinks"]>[0]
+    await expect(reader.queryLinks(linkRequest)).resolves.toMatchObject({ links: [] })
+
+    expect(queryReads).toBe(1)
+    expect(linkIdReads).toBe(1)
+    expect(
+      [...selectedCalls].reverse().find((call) => call.operation === "queryLinks")?.input
+    ).toMatchObject({ projectId, linkId: "items" })
+    expect(backend.calls).toEqual([])
   })
 
   test("ignores caller project extras and executes the exact query snapshot it authorized", async () => {
@@ -601,6 +794,44 @@ function principalScope(id: string, view: readonly string[] = []): ExecutionScop
       groupIds: [],
       roleIds: [],
       grants: { ...emptyGrantIndex(), "view:object": new Set(view) },
+    },
+  })
+}
+
+function delegatedScope(id: string): ExecutionScope {
+  return createDelegatedRequestScope({
+    projectId,
+    requestId: `request-${id}`,
+    correlationId: `correlation-${id}`,
+    objectRead: {
+      selection: {
+        kind: "selected",
+        roots: [
+          {
+            anchor: { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+            node: {
+              objects: [{ objectTypeId: Proposal.id, propertyIds: ["id", "title"] }],
+              links: [
+                {
+                  definitions: [
+                    {
+                      sourceObjectTypeId: Proposal.id,
+                      linkId: "items",
+                      targetObjectTypeIds: [LineItem.id],
+                      propertyIds: ["position"],
+                    },
+                  ],
+                  target: {
+                    objects: [{ objectTypeId: LineItem.id, propertyIds: ["id", "name"] }],
+                    links: [],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 4_096 },
     },
   })
 }
@@ -779,7 +1010,40 @@ function createSelectedReader(
   return {
     queryCapabilities() {
       record("queryCapabilities")
-      return { queryObjects: false }
+      return {
+        queryObjects: true,
+        countObjects: true,
+        existsObjects: true,
+        facetObjects: true,
+        nodes: { start: true, refs: true, limit: true },
+      }
+    },
+    async queryObjects(input) {
+      record("queryObjects", input)
+      const objects = selectedQueryRows(rows, input.query)
+      return {
+        objects,
+        hasMore: false,
+        ...(input.includeTotal ? { total: objects.length } : {}),
+      }
+    },
+    async countObjects(input) {
+      record("countObjects", input)
+      return { count: selectedQueryRows(rows, input.query).length }
+    },
+    async existsObjects(input) {
+      record("existsObjects", input)
+      return { exists: selectedQueryRows(rows, input.query).length > 0 }
+    },
+    async facetObjects(input) {
+      record("facetObjects", input)
+      const objects = selectedQueryRows(rows, input.query)
+      return {
+        facets: input.facets.map((facet) => ({
+          propertyId: facet.propertyId,
+          buckets: facetBuckets(objects, facet.propertyId, facet.limit),
+        })),
+      }
     },
     async getByPrimaryId(input) {
       record("getByPrimaryId", input)
@@ -818,7 +1082,20 @@ function createSelectedReader(
     },
     async queryLinks(input) {
       record("queryLinks", input)
-      return { links, hasMore: false }
+      const selectedRefs = new Set(
+        input.objectRefs.map((ref) => objectBatchKey(ref.objectTypeId, ref.primaryId))
+      )
+      const visibleLinks = links
+        .filter((link) => link.linkId === "items")
+        .filter((link) => input.linkId === undefined || link.linkId === input.linkId)
+        .filter((link) => {
+          const sourceSelected = selectedRefs.has(objectBatchKey(link.sourceTypeId, link.sourceId))
+          const targetSelected = selectedRefs.has(objectBatchKey(link.targetTypeId, link.targetId))
+          if (input.direction === "outgoing") return sourceSelected
+          if (input.direction === "incoming") return targetSelected
+          return sourceSelected || targetSelected
+        })
+      return { links: visibleLinks.slice(0, input.limit), hasMore: false }
     },
     async list(input) {
       record("list", input)
@@ -832,6 +1109,34 @@ function createSelectedReader(
       return { objects, hasMore: false, total: objects.length }
     },
   }
+}
+
+function selectedQueryRows(rows: readonly ObjectRow[], query: ObjectQuery): ObjectRow[] {
+  switch (query.kind) {
+    case "start":
+      return rows.filter((row) => row.objectTypeId === query.objectTypeId)
+    case "refs": {
+      const refs = new Set(query.refs.map((ref) => objectBatchKey(ref.objectTypeId, ref.primaryId)))
+      return rows.filter((row) => refs.has(objectBatchKey(row.objectTypeId, row.primaryId)))
+    }
+    case "limit":
+      return selectedQueryRows(rows, query.input).slice(0, query.limit)
+    default:
+      return []
+  }
+}
+
+function facetBuckets(
+  rows: readonly ObjectRow[],
+  propertyId: string,
+  limit: number
+): readonly { value: unknown; count: number }[] {
+  const counts = new Map<unknown, number>()
+  for (const row of rows) {
+    const value = row.properties[propertyId]
+    counts.set(value, (counts.get(value) ?? 0) + 1)
+  }
+  return [...counts].slice(0, limit).map(([value, count]) => ({ value, count }))
 }
 
 function row(

--- a/packages/core/tests/object-reader-binding.test.ts
+++ b/packages/core/tests/object-reader-binding.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, test } from "bun:test"
 import { emptyGrantIndex } from "../src/authorization"
 import { AuthorizationError } from "../src/authorization/errors"
+import { resolveRuntimeAuthorization } from "../src/execution/authorization"
 import {
   type AuthorizedObjectReader,
   assertAuthorizedObjectReaderBinding,
   createAuthorizedObjectReader,
 } from "../src/execution/authorized-object-reader"
-import { createDisabledRequestScope, createPrincipalRequestScope } from "../src/execution/scopes"
+import {
+  createDelegatedRequestScope,
+  createDisabledRequestScope,
+  createPrincipalRequestScope,
+} from "../src/execution/scopes"
 import type { ExecutionScope } from "../src/execution/types"
 import type { ObjectQuery } from "../src/objects/query"
 import { defineObjectType, link, OntologyRegistry, prop } from "../src/ontology"
@@ -14,6 +19,8 @@ import {
   linkBatchKey,
   type ObjectLinkRow,
   type ObjectQueryCapabilities,
+  type ObjectReadExecutionLimits,
+  type ObjectReadStorage,
   type ObjectRow,
   type ObjectStorage,
   objectBatchKey,
@@ -357,6 +364,146 @@ describe("AuthorizedObjectReader", () => {
     expect(links.map((row) => row.targetTypeId)).toEqual([LineItem.id, Secret.id])
   })
 
+  test("creates one selected provider reader for delegated non-query terminals", async () => {
+    const selectedCalls: ReadCall[] = []
+    const selectedRows = [
+      row(Proposal.id, "proposal-1", { id: "proposal-1", title: "Proposal" }),
+      row(LineItem.id, "line-1", { id: "line-1", name: "Line" }),
+    ]
+    const selectedLinks = [
+      objectLink("items", LineItem.id, "line-1", { position: 1 }),
+      objectLink("unselected", LineItem.id, "line-1"),
+    ]
+    const backend = createReadStorage({
+      selectedReader: createSelectedReader(selectedRows, selectedLinks, selectedCalls),
+    })
+    const scope = createDelegatedRequestScope({
+      projectId,
+      requestId: "request-delegated",
+      correlationId: "correlation-delegated",
+      objectRead: {
+        selection: {
+          kind: "selected",
+          roots: [
+            {
+              anchor: { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+              node: {
+                objects: [{ objectTypeId: Proposal.id, propertyIds: ["id", "title"] }],
+                links: [
+                  {
+                    definitions: [
+                      {
+                        sourceObjectTypeId: Proposal.id,
+                        linkId: "items",
+                        targetObjectTypeIds: [LineItem.id],
+                        propertyIds: ["position"],
+                      },
+                    ],
+                    target: {
+                      objects: [{ objectTypeId: LineItem.id, propertyIds: ["id", "name"] }],
+                      links: [],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 4_096 },
+      },
+    })
+    const reader = createAuthorizedObjectReader({
+      scope,
+      ontology,
+      objectStorage: backend.storage,
+    })
+
+    expect(backend.selectedScopeCalls).toBe(1)
+    expect(backend.selectedScopeInputs).toHaveLength(1)
+    expect(backend.selectedScopeInputs[0]).toMatchObject({
+      projectId,
+      limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 4_096 },
+    })
+    const resolved = resolveRuntimeAuthorization(scope.authorization)
+    expect(resolved.type).toBe("delegated")
+    if (resolved.type !== "delegated") throw new Error("expected delegated authorization")
+    expect(backend.selectedScopeInputs[0]?.scope).toBe(resolved.objectRead.scope)
+    expect(backend.selectedScopeInputs[0]?.limits).toBe(resolved.objectRead.limits)
+
+    await expect(
+      reader.getByPrimaryId({ objectTypeId: Proposal.id, primaryId: "proposal-1" })
+    ).resolves.toMatchObject({ primaryId: "proposal-1" })
+    await expect(
+      reader.getByPrimaryId({ objectTypeId: Proposal.id, primaryId: "proposal-2" })
+    ).resolves.toBeNull()
+    const batch = await reader.getByPrimaryIdBatch({
+      items: [
+        { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+        { objectTypeId: Proposal.id, primaryId: "proposal-2" },
+      ],
+    })
+    expect(batch.size).toBe(1)
+    await expect(
+      reader.canReadObjectProperty({
+        objectTypeId: Proposal.id,
+        primaryId: "proposal-1",
+        propertyId: "title",
+      })
+    ).resolves.toBe(true)
+    await expect(
+      reader.canReadObjectPropertiesBatch({
+        items: [
+          {
+            objectTypeId: Proposal.id,
+            primaryId: "proposal-1",
+            propertyId: "title",
+          },
+          {
+            objectTypeId: Proposal.id,
+            primaryId: "proposal-1",
+            propertyId: "secret",
+          },
+        ],
+      })
+    ).resolves.toEqual([true, false])
+    await expect(reader.list({})).resolves.toMatchObject({ total: 2 })
+    await expect(
+      reader.listLinks({ objectTypeId: Proposal.id, objectId: "proposal-1" })
+    ).resolves.toHaveLength(1)
+    const linkBatch = await reader.listLinksBatch({
+      items: [{ objectTypeId: Proposal.id, objectId: "proposal-1", linkId: "items" }],
+    })
+    expect(linkBatch.size).toBe(1)
+    expect(linkBatch.get(linkBatchKey(Proposal.id, "proposal-1", "items"))).toHaveLength(1)
+    await expect(
+      reader.getByPrimaryId({ objectTypeId: Secret.id, primaryId: "secret-1" })
+    ).rejects.toThrow("does not select object type 'Secret'")
+
+    const query = { kind: "start" as const, objectTypeId: Proposal.id }
+    for (const operation of [
+      () => reader.executeQuery({ query }),
+      () => reader.queryLinks({ query }),
+      () => reader.count({ query }),
+      () => reader.exists({ query }),
+      () => reader.facet({ query, facets: [{ propertyId: "title", limit: 10 }] }),
+    ]) {
+      await expect(operation()).rejects.toThrow("require explicit selected-path admission")
+    }
+
+    expect(backend.selectedScopeCalls).toBe(1)
+    expect(backend.calls).toEqual([])
+    expect(selectedCalls.map((call) => call.operation)).toEqual([
+      "getByPrimaryId",
+      "getByPrimaryId",
+      "getByPrimaryIdBatch",
+      "selectsObjectProperties",
+      "selectsObjectProperties",
+      "list",
+      "listLinks",
+      "listLinksBatch",
+    ])
+  })
+
   test("ignores caller project extras and executes the exact query snapshot it authorized", async () => {
     let objectTypeReads = 0
     const authoredQuery = Object.defineProperties(
@@ -466,10 +613,16 @@ type ReadCall = {
 function createReadStorage(options?: {
   readonly ignoreEndpointTypeFilter?: boolean
   readonly queryLinksHasMore?: boolean
+  readonly selectedReader?: ObjectReadStorage
 }): {
   readonly storage: ObjectStorage
   readonly calls: ReadCall[]
   readonly selectedScopeCalls: number
+  readonly selectedScopeInputs: readonly {
+    readonly projectId: string
+    readonly scope: Parameters<ObjectStorage["createSelectedReadScope"]>[0]["scope"]
+    readonly limits: ObjectReadExecutionLimits
+  }[]
   readonly rows: {
     readonly proposal: ObjectRow
     readonly line: ObjectRow
@@ -489,6 +642,11 @@ function createReadStorage(options?: {
     objectLink("secret", Secret.id, "secret-1"),
   ]
   let selectedScopeCalls = 0
+  const selectedScopeInputs: {
+    projectId: string
+    scope: Parameters<ObjectStorage["createSelectedReadScope"]>[0]["scope"]
+    limits: ObjectReadExecutionLimits
+  }[] = []
   const record = (operation: string, input?: unknown): void => {
     calls.push({ operation, ...(input === undefined ? {} : { input }) })
   }
@@ -584,8 +742,10 @@ function createReadStorage(options?: {
         : allRows
       return { objects, hasMore: false, total: objects.length }
     },
-    createSelectedReadScope() {
+    createSelectedReadScope(input) {
       selectedScopeCalls += 1
+      selectedScopeInputs.push(input)
+      if (options?.selectedReader) return options.selectedReader
       throw new Error("createSelectedReadScope must not be called for existing authorities")
     },
     async listIncidentLinksBatch() {
@@ -602,8 +762,75 @@ function createReadStorage(options?: {
     get selectedScopeCalls() {
       return selectedScopeCalls
     },
+    selectedScopeInputs,
     rows,
     links,
+  }
+}
+
+function createSelectedReader(
+  rows: readonly ObjectRow[],
+  links: readonly ObjectLinkRow[],
+  calls: ReadCall[]
+): ObjectReadStorage {
+  const record = (operation: string, input?: unknown): void => {
+    calls.push({ operation, ...(input === undefined ? {} : { input }) })
+  }
+  return {
+    queryCapabilities() {
+      record("queryCapabilities")
+      return { queryObjects: false }
+    },
+    async getByPrimaryId(input) {
+      record("getByPrimaryId", input)
+      return findRow(rows, input.objectTypeId, input.primaryId)
+    },
+    async getByPrimaryIdBatch(input) {
+      record("getByPrimaryIdBatch", input)
+      const result = new Map()
+      for (const item of input.items) {
+        const found = findRow(rows, item.objectTypeId, item.primaryId)
+        if (found) result.set(objectBatchKey(item.objectTypeId, item.primaryId), found)
+      }
+      return result
+    },
+    async selectsObjectProperties(input) {
+      record("selectsObjectProperties", input)
+      return input.items.map(
+        (item) =>
+          item.objectTypeId === Proposal.id &&
+          item.primaryId === "proposal-1" &&
+          item.propertyId === "title"
+      )
+    },
+    async listLinks(input) {
+      record("listLinks", input)
+      return links
+    },
+    async listLinksBatch(input) {
+      record("listLinksBatch", input)
+      return new Map(
+        input.items.map((item) => [
+          linkBatchKey(item.objectTypeId, item.objectId, item.linkId),
+          [...links],
+        ])
+      )
+    },
+    async queryLinks(input) {
+      record("queryLinks", input)
+      return { links, hasMore: false }
+    },
+    async list(input) {
+      record("list", input)
+      const requested =
+        input.objectTypeId === undefined
+          ? undefined
+          : new Set(
+              typeof input.objectTypeId === "string" ? [input.objectTypeId] : input.objectTypeId
+            )
+      const objects = requested ? rows.filter((row) => requested.has(row.objectTypeId)) : [...rows]
+      return { objects, hasMore: false, total: objects.length }
+    },
   }
 }
 

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -358,6 +358,25 @@ describe("bound Sixb object reads", () => {
 
     expect(query.list()).rejects.toThrow(AuthorizationError)
   })
+
+  test("typed and dynamic listLinks share endpoint filtering", async () => {
+    const host = createRuntime()
+    const sixb = createTestSixb(host)
+    await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
+    await sixb.objects(Invoice).upsert({ properties: { id: "i1" } })
+    await sixb.objects(Invoice).upsertLink({
+      sourceId: "i1",
+      linkId: "contract",
+      targetTypeId: "contract",
+      targetId: "c1",
+    })
+    const principalSixb = bindPrincipal(host, contextFor(host, ["finance"]))
+
+    expect(await principalSixb.objects(Invoice).byId("i1").listLinks()).toEqual([])
+    expect(
+      await principalSixb.objects.listLinks({ objectTypeId: "invoice", objectId: "i1" })
+    ).toEqual([])
+  })
 })
 
 describe("bound Sixb cross-type list", () => {
@@ -1083,20 +1102,6 @@ describe("direct writes are attributable", () => {
 })
 
 describe("bound Sixb fails closed on ungranted surfaces", () => {
-  test("listLinks denies even when reached at runtime", async () => {
-    const host = createRuntime()
-    const sixb = createTestSixb(host)
-    await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
-    const principalSixb = bindPrincipal(host, contextFor(host, ["editors"]))
-
-    // Trusted executions need this method on the shared Sixb surface. A principal can reach it too,
-    // but link rows name target types no read grant covers, so the protected leaf fails closed even
-    // when the principal may edit the source type.
-    expect(principalSixb.objects(Contract).byId("c1").listLinks()).rejects.toThrow(
-      AuthorizationError
-    )
-  })
-
   test("an explicit auth-disabled execution remains unrestricted", async () => {
     const host = createRuntime()
     const sixb = createTestSixb(host)

--- a/packages/core/tests/storage-operation-scope.test.ts
+++ b/packages/core/tests/storage-operation-scope.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import {
+  compileSelectedObjectReadScope,
+  type ObjectReadStorage,
+  type ObjectStorage,
+  StorageTransactionError,
+} from "../src/storage"
+import { InMemoryStorage } from "../src/storage/in-memory"
+import {
+  createObjectOperationScope,
   createOperationScopedFacade,
   createStorageOperationScope,
 } from "../src/storage/operation-scope"
@@ -11,6 +19,17 @@ class TestStorage {
 }
 
 describe("storage operation scope", () => {
+  test("fails closed when object storage omits the selected-read factory", () => {
+    const malformed = { createSelectedReadScope: undefined } as unknown as ObjectStorage
+
+    expect(() =>
+      createObjectOperationScope(
+        malformed,
+        createStorageOperationScope(async (run) => run())
+      )
+    ).toThrow("must implement ObjectReadScopeFactory")
+  })
+
   test("keeps decorated provider methods inside their operation scope", async () => {
     const target = new TestStorage()
     let scopeRuns = 0
@@ -82,4 +101,93 @@ describe("storage operation scope", () => {
 
     await expect(facade.read()).rejects.toThrow("scope became unavailable")
   })
+
+  test("runs selected-reader terminals through the same root operation lock", async () => {
+    const storage = new InMemoryStorage()
+    const input = selectedReaderInput()
+    const reader = storage.objects.createSelectedReadScope(input)
+    let transactionEntered!: () => void
+    const entered = new Promise<void>((resolve) => {
+      transactionEntered = resolve
+    })
+    let releaseTransaction!: () => void
+    const blocked = new Promise<void>((resolve) => {
+      releaseTransaction = resolve
+    })
+    const transaction = storage.transaction(async () => {
+      transactionEntered()
+      await blocked
+    })
+    await entered
+
+    let readFinished = false
+    const read = reader.list({ projectId: input.projectId }).then((result) => {
+      readFinished = true
+      return result
+    })
+    try {
+      await Bun.sleep(0)
+      expect(readFinished).toBe(false)
+    } finally {
+      releaseTransaction()
+      await transaction
+    }
+    await expect(read).resolves.toEqual({ objects: [], hasMore: false, total: 0 })
+  })
+
+  test("guards transaction-created readers and captured factory methods after completion", async () => {
+    const storage = new InMemoryStorage()
+    const input = selectedReaderInput()
+    let escapedReader: ObjectReadStorage | undefined
+    let escapedRead: ObjectReadStorage["list"] | undefined
+    let escapedFactory: ObjectStorage["createSelectedReadScope"] | undefined
+
+    await storage.transaction(async (tx) => {
+      expect(() => storage.objects.createSelectedReadScope(input)).toThrow(
+        "use the provided tx storage"
+      )
+
+      const reader = tx.objects.createSelectedReadScope(input)
+      await expect(reader.list({ projectId: input.projectId })).resolves.toEqual({
+        objects: [],
+        hasMore: false,
+        total: 0,
+      })
+      escapedReader = reader
+      escapedRead = reader.list
+      escapedFactory = tx.objects.createSelectedReadScope
+    })
+
+    if (!escapedReader || !escapedRead || !escapedFactory) {
+      throw new Error("Expected transaction reader handles to be captured.")
+    }
+    const reader = escapedReader
+    const read = escapedRead
+    const createReader = escapedFactory
+    expect(() => reader.queryCapabilities()).toThrow(StorageTransactionError)
+    expect(() => createReader(input)).toThrow(StorageTransactionError)
+    await expect(
+      Promise.resolve().then(() => read({ projectId: input.projectId }))
+    ).rejects.toMatchObject({ code: "transaction_inactive" })
+  })
 })
+
+function selectedReaderInput() {
+  const projectId = "operation-scope-project"
+  return {
+    projectId,
+    scope: compileSelectedObjectReadScope({
+      kind: "selected",
+      roots: [
+        {
+          anchor: { objectTypeId: "OperationScopeObject", primaryId: "root" },
+          node: {
+            objects: [{ objectTypeId: "OperationScopeObject", propertyIds: ["id"] }],
+            links: [],
+          },
+        },
+      ],
+    }),
+    limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 10_000 },
+  }
+}

--- a/storage/pg/src/index.ts
+++ b/storage/pg/src/index.ts
@@ -13,6 +13,7 @@ import { ProviderMaterializationTransactionLifecycle } from "@sixb/core/internal
 import {
   createAgentOperationScope,
   createAuthOperationScope,
+  createObjectOperationScope,
   createOntologyOperationScope,
   createOperationScopedFacade,
   createStorageOperationScope,
@@ -208,7 +209,7 @@ export class PostgresStorage implements MigrationCapableStorage {
       },
       () => this.assertRootOperationAvailable()
     )
-    this.objects = createOperationScopedFacade(stores.objects, scope)
+    this.objects = createObjectOperationScope(stores.objects, scope)
     this.ontology = createOntologyOperationScope(stores.ontology, scope)
     this.auth = createAuthOperationScope(stores.auth, scope)
     this.executions = createOperationScopedFacade(stores.executions, scope)

--- a/storage/pg/src/pg-object-query-compiler.ts
+++ b/storage/pg/src/pg-object-query-compiler.ts
@@ -45,6 +45,7 @@ interface CompiledHasMoreProbe {
 
 interface CompileContext {
   probeLimit: boolean
+  source: PgObjectQuerySource
 }
 
 interface CompiledPredicate {
@@ -89,7 +90,6 @@ interface EncodedCursorValue {
 }
 
 const PAGE_TOKEN_PREFIX = "keyset:"
-const exactContext: CompileContext = { probeLimit: false }
 // Per-parent fanout the core executor bakes into every pushed-down expansion;
 // this default only guards a malformed (un-baked) IR and mirrors the core cap.
 const DEFAULT_EXPANSION_FANOUT = 1_000
@@ -97,11 +97,15 @@ const DEFAULT_EXPANSION_FANOUT = 1_000
 export function compilePgObjectQuery(
   projectId: string,
   query: ObjectQuery,
-  options: { includeTotal?: boolean } = {}
+  options: { includeTotal?: boolean; source?: PgObjectQuerySource } = {}
 ): CompiledPgObjectQuery {
-  const compiled = compileObjectQueryInternal(projectId, query, {
-    probeLimit: options.includeTotal === false,
-  })
+  const source = options.source ?? DEFAULT_OBJECT_QUERY_SOURCE
+  const compiled = source.wrapQuery(
+    compileObjectQueryInternal(projectId, query, {
+      probeLimit: options.includeTotal === false,
+      source,
+    })
+  )
   return {
     ...compiled,
     sql: numberPlaceholders(compiled.sql),
@@ -115,44 +119,90 @@ export function compilePgObjectQuery(
   }
 }
 
+/** Physical relations used by the PostgreSQL object-query compiler. */
+export interface PgObjectQuerySource {
+  readonly objectsTable: string
+  readonly linksTable: string
+  /** Wrap a terminal SELECT without its own WITH clause; the selected source owns the only WITH. */
+  wrapStatement(
+    sql: string,
+    args?: readonly unknown[]
+  ): {
+    readonly sql: string
+    readonly args: unknown[]
+  }
+  wrapQuery(query: CompiledPgObjectQuery): CompiledPgObjectQuery
+}
+
+/** Prefix an optional query source, then assign PostgreSQL positional placeholders. */
+export function compilePgObjectStatement(
+  sql: string,
+  args: readonly unknown[] = [],
+  source?: PgObjectQuerySource
+): CompiledPgScalarQuery {
+  return numberCompiledQuery((source ?? DEFAULT_OBJECT_QUERY_SOURCE).wrapStatement(sql, args))
+}
+
+const DEFAULT_OBJECT_QUERY_SOURCE: PgObjectQuerySource = {
+  objectsTable: "objects",
+  linksTable: "links",
+  wrapStatement: (sql, args = []) => ({ sql, args: [...args] }),
+  wrapQuery: (query) => query,
+}
+
+function exactContext(ctx: CompileContext): CompileContext {
+  return ctx.probeLimit ? { ...ctx, probeLimit: false } : ctx
+}
+
 export function compilePgObjectCountQuery(
   projectId: string,
-  query: ObjectQuery
+  query: ObjectQuery,
+  options: { source?: PgObjectQuerySource } = {}
 ): CompiledPgScalarQuery {
-  const source = compileAggregateSource(projectId, query)
-  return numberCompiledQuery({
-    sql: `
+  const querySource = options.source ?? DEFAULT_OBJECT_QUERY_SOURCE
+  const source = compileAggregateSource(projectId, query, querySource)
+  return numberCompiledQuery(
+    querySource.wrapStatement(
+      `
       SELECT COUNT(*)::bigint AS count
       FROM (${source.sql}) AS input
     `,
-    args: source.args,
-  })
+      source.args
+    )
+  )
 }
 
 export function compilePgObjectExistsQuery(
   projectId: string,
-  query: ObjectQuery
+  query: ObjectQuery,
+  options: { source?: PgObjectQuerySource } = {}
 ): CompiledPgScalarQuery {
-  const source = compileAggregateSource(projectId, query)
-  return numberCompiledQuery({
-    sql: `
+  const querySource = options.source ?? DEFAULT_OBJECT_QUERY_SOURCE
+  const source = compileAggregateSource(projectId, query, querySource)
+  return numberCompiledQuery(
+    querySource.wrapStatement(
+      `
       SELECT 1
       FROM (${source.sql}) AS input
       LIMIT 1
     `,
-    args: source.args,
-  })
+      source.args
+    )
+  )
 }
 
 export function compilePgObjectFacetQuery(
   projectId: string,
   query: ObjectQuery,
   propertyId: string,
-  limit: number
+  limit: number,
+  options: { source?: PgObjectQuerySource } = {}
 ): CompiledPgFacetQuery {
-  const source = compileAggregateSource(projectId, query)
-  return numberCompiledQuery({
-    sql: `
+  const querySource = options.source ?? DEFAULT_OBJECT_QUERY_SOURCE
+  const source = compileAggregateSource(projectId, query, querySource)
+  return numberCompiledQuery(
+    querySource.wrapStatement(
+      `
       SELECT facet.value_type, facet.value_text, COUNT(*)::bigint AS count
       FROM (
         SELECT
@@ -165,8 +215,9 @@ export function compilePgObjectFacetQuery(
       ORDER BY count DESC, facet.value_text ASC
       LIMIT ?
     `,
-    args: [propertyId, propertyId, ...source.args, propertyId, limit],
-  })
+      [propertyId, propertyId, ...source.args, propertyId, limit]
+    )
+  )
 }
 
 function compileObjectQueryInternal(
@@ -176,27 +227,28 @@ function compileObjectQueryInternal(
 ): CompiledPgObjectQuery {
   switch (query.kind) {
     case "start":
-      return compileStart(projectId, query)
+      return compileStart(projectId, query, ctx)
     case "refs":
-      return compileRefs(projectId, query)
+      return compileRefs(projectId, query, ctx)
     case "filter":
-      return compileFilter(projectId, query.input, query.predicate)
+      return compileFilter(projectId, query.input, query.predicate, ctx)
     case "sort":
       return compileSort(projectId, query.input, query.fields, ctx)
     case "limit":
       return compileLimit(projectId, query.input, query.limit, ctx)
     case "page":
-      return compilePage(projectId, query.input, query.pageSize, query.pageToken)
+      return compilePage(projectId, query.input, query.pageSize, query.pageToken, ctx)
     case "traverse":
       return compileTraversal(
         projectId,
         query.input,
         query.linkId,
         query.direction,
-        query.sourceObjectTypeId
+        query.sourceObjectTypeId,
+        ctx
       )
     case "set":
-      return compileSet(projectId, query.op, query.inputs)
+      return compileSet(projectId, query.op, query.inputs, ctx)
     case "project":
       return compileProject(projectId, query.input, query.properties, ctx)
     case "text":
@@ -205,10 +257,11 @@ function compileObjectQueryInternal(
         query.input,
         query.query,
         query.fields,
-        query.fieldsByObjectType
+        query.fieldsByObjectType,
+        ctx
       )
     case "expand":
-      return compileExpand(projectId, query.input, query.expansions)
+      return compileExpand(projectId, query.input, query.expansions, ctx)
     case "vector":
       throw new Error(
         `[SixbPg] PostgreSQL object storage does not support query node '${query.kind}'`
@@ -218,7 +271,8 @@ function compileObjectQueryInternal(
 
 function compileStart(
   projectId: string,
-  query: Extract<ObjectQuery, { kind: "start" }>
+  query: Extract<ObjectQuery, { kind: "start" }>,
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
   if (query.includeSubtypes === true) {
     throw new Error("[SixbPg] PostgreSQL object storage does not support start.includeSubtypes")
@@ -227,7 +281,7 @@ function compileStart(
   const order = compileOrder(identityOrderFields())
   const sql = `
     SELECT *, properties AS _cursor_properties
-    FROM objects
+    FROM ${ctx.source.objectsTable}
     WHERE project_id = ? AND object_type_id = ?
     ORDER BY ${order.sql}
   `
@@ -235,8 +289,7 @@ function compileStart(
   return {
     sql,
     args: [projectId, query.objectTypeId, ...order.args],
-    totalSql:
-      "SELECT COUNT(*)::bigint AS total FROM objects WHERE project_id = ? AND object_type_id = ?",
+    totalSql: `SELECT COUNT(*)::bigint AS total FROM ${ctx.source.objectsTable} WHERE project_id = ? AND object_type_id = ?`,
     totalArgs: [projectId, query.objectTypeId],
     order,
     hasMore: () => false,
@@ -247,7 +300,8 @@ function compileStart(
 
 function compileRefs(
   projectId: string,
-  query: Extract<ObjectQuery, { kind: "refs" }>
+  query: Extract<ObjectQuery, { kind: "refs" }>,
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
   if (query.refs.length === 0) {
     throw new Error("[SixbPg] PostgreSQL object storage requires at least one ref")
@@ -263,10 +317,9 @@ function compileRefs(
     FROM jsonb_array_elements(?::text::jsonb) AS ref(value)
   `
   const sql = `
-    WITH requested AS (${requested})
     SELECT selected.*, selected.properties AS _cursor_properties
-    FROM requested
-    JOIN objects AS selected
+    FROM (${requested}) AS requested
+    JOIN ${ctx.source.objectsTable} AS selected
       ON selected.project_id = ?
      AND selected.object_type_id = requested.object_type_id
      AND selected.primary_id = requested.primary_id
@@ -277,10 +330,9 @@ function compileRefs(
     sql,
     args: [refsJson, projectId, ...selectedOrder.args],
     totalSql: `
-      WITH requested AS (${requested})
       SELECT COUNT(*)::bigint AS total
-      FROM requested
-      JOIN objects AS selected
+      FROM (${requested}) AS requested
+      JOIN ${ctx.source.objectsTable} AS selected
         ON selected.project_id = ?
        AND selected.object_type_id = requested.object_type_id
        AND selected.primary_id = requested.primary_id
@@ -296,17 +348,19 @@ function compileRefs(
 function compileFilter(
   projectId: string,
   inputQuery: ObjectQuery,
-  predicateNode: ObjectQueryPredicate
+  predicateNode: ObjectQueryPredicate,
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
-  return compileWhere(projectId, inputQuery, compilePredicate(predicateNode))
+  return compileWhere(projectId, inputQuery, compilePredicate(predicateNode), ctx)
 }
 
 function compileWhere(
   projectId: string,
   inputQuery: ObjectQuery,
-  predicate: CompiledPredicate
+  predicate: CompiledPredicate,
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const sql = `
     SELECT *
     FROM (${input.sql}) AS input
@@ -335,12 +389,14 @@ function compileText(
   inputQuery: ObjectQuery,
   query: string,
   fields: readonly string[] | undefined,
-  fieldsByObjectType: Readonly<Record<string, readonly string[]>> | undefined
+  fieldsByObjectType: Readonly<Record<string, readonly string[]>> | undefined,
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
   return compileWhere(
     projectId,
     inputQuery,
-    compileTextSearchPredicate(query, fields, fieldsByObjectType)
+    compileTextSearchPredicate(query, fields, fieldsByObjectType),
+    ctx
   )
 }
 
@@ -350,7 +406,7 @@ function compileSort(
   fields: readonly ObjectQuerySortField[],
   ctx: CompileContext
 ): CompiledPgObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const probeInput =
     ctx.probeLimit && needsLimitProbe(inputQuery)
       ? compileObjectQueryInternal(projectId, inputQuery, ctx)
@@ -389,7 +445,7 @@ function compileLimit(
   rawLimit: number,
   ctx: CompileContext
 ): CompiledPgObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const limit = Math.max(0, rawLimit)
   const rowLimit = ctx.probeLimit ? limit + 1 : limit
 
@@ -418,9 +474,10 @@ function compilePage(
   projectId: string,
   inputQuery: ObjectQuery,
   rawPageSize: number,
-  pageToken: string | undefined
+  pageToken: string | undefined,
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const pageSize = Math.max(0, rawPageSize)
   const cursor = pageToken ? decodePageToken(pageToken, input.order.fields) : undefined
   const cursorPredicate = cursor
@@ -457,30 +514,31 @@ function compileTraversal(
   inputQuery: ObjectQuery,
   linkId: string,
   direction: "outgoing" | "incoming",
-  sourceObjectTypeId?: string
+  sourceObjectTypeId: string | undefined,
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const outputAlias = direction === "outgoing" ? "target_object" : "source_object"
   const joinSql =
     direction === "outgoing"
       ? `
-        JOIN links AS edge
+        JOIN ${ctx.source.linksTable} AS edge
           ON edge.project_id = input.project_id
          AND edge.source_type_id = input.object_type_id
          AND edge.source_id = input.primary_id
          AND edge.link_id = ?
-        JOIN objects AS target_object
+        JOIN ${ctx.source.objectsTable} AS target_object
           ON target_object.project_id = edge.project_id
          AND target_object.object_type_id = edge.target_type_id
          AND target_object.primary_id = edge.target_id
       `
       : `
-        JOIN links AS edge
+        JOIN ${ctx.source.linksTable} AS edge
           ON edge.project_id = input.project_id
          AND edge.target_type_id = input.object_type_id
          AND edge.target_id = input.primary_id
          AND edge.link_id = ?${sourceObjectTypeId === undefined ? "" : "\n         AND edge.source_type_id = ?"}
-        JOIN objects AS source_object
+        JOIN ${ctx.source.objectsTable} AS source_object
           ON source_object.project_id = edge.project_id
          AND source_object.object_type_id = edge.source_type_id
          AND source_object.primary_id = edge.source_id
@@ -527,13 +585,15 @@ interface ExpansionParent {
 function compileExpand(
   projectId: string,
   inputQuery: ObjectQuery,
-  expansions: readonly ObjectExpansion[]
+  expansions: readonly ObjectExpansion[],
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const expand = compileExpansionsObject(
     expansions,
     { project: "input.project_id", type: "input.object_type_id", id: "input.primary_id" },
-    ""
+    "",
+    ctx
   )
   const inputOrder = compileOrder(input.order.fields, "input", "input._cursor_properties")
   const sql = `
@@ -561,13 +621,14 @@ function compileExpand(
 function compileExpansionsObject(
   expansions: readonly ObjectExpansion[],
   parent: ExpansionParent,
-  pathPrefix: string
+  pathPrefix: string,
+  ctx: CompileContext
 ): CompiledPredicate {
   const parts: string[] = []
   const args: unknown[] = []
   expansions.forEach((expansion, index) => {
     const path = pathPrefix === "" ? `${index}` : `${pathPrefix}_${index}`
-    const value = compileExpansionValue(expansion, parent, path)
+    const value = compileExpansionValue(expansion, parent, path, ctx)
     parts.push("?::text", value.sql)
     args.push(expansion.linkId, ...value.args)
   })
@@ -583,7 +644,8 @@ function compileExpansionsObject(
 function compileExpansionValue(
   expansion: ObjectExpansion,
   parent: ExpansionParent,
-  path: string
+  path: string,
+  ctx: CompileContext
 ): CompiledPredicate {
   const edge = `edge_${path}`
   const target = `tgt_${path}`
@@ -596,7 +658,7 @@ function compileExpansionValue(
   const parentType = incoming ? `${edge}.target_type_id` : `${edge}.source_type_id`
   const parentId = incoming ? `${edge}.target_id` : `${edge}.source_id`
 
-  const child = compileExpansionChildJson(expansion, edge, target, path)
+  const child = compileExpansionChildJson(expansion, edge, target, path, ctx)
   const order = compileExpansionOrder(expansion, target, neighborType, neighborId)
 
   const whereParts = [
@@ -613,8 +675,8 @@ function compileExpansionValue(
 
   const inner = `
     SELECT ${child.sql} AS elem, row_number() OVER (ORDER BY ${order.sql}) AS _ord
-    FROM links AS ${edge}
-    JOIN objects AS ${target}
+    FROM ${ctx.source.linksTable} AS ${edge}
+    JOIN ${ctx.source.objectsTable} AS ${target}
       ON ${target}.project_id = ${edge}.project_id
      AND ${target}.object_type_id = ${neighborType}
      AND ${target}.primary_id = ${neighborId}
@@ -644,7 +706,8 @@ function compileExpansionChildJson(
   expansion: ObjectExpansion,
   edge: string,
   target: string,
-  path: string
+  path: string,
+  ctx: CompileContext
 ): CompiledPredicate {
   const fields = [
     `'projectId', ${target}.project_id`,
@@ -667,7 +730,8 @@ function compileExpansionChildJson(
         type: `${target}.object_type_id`,
         id: `${target}.primary_id`,
       },
-      path
+      path,
+      ctx
     )
     fields.push(`'links', ${nested.sql}`)
     args.push(...nested.args)
@@ -711,14 +775,15 @@ function compileExpansionOrder(
 function compileSet(
   projectId: string,
   op: ObjectQuerySetOperation,
-  inputs: readonly ObjectQuery[]
+  inputs: readonly ObjectQuery[],
+  ctx: CompileContext
 ): CompiledPgObjectQuery {
   if (inputs.length === 0) {
     const order = compileOrder(identityOrderFields())
     return {
       sql: `
         SELECT *, properties AS _cursor_properties
-        FROM objects
+        FROM ${ctx.source.objectsTable}
         WHERE 1 = 0
         ORDER BY ${order.sql}
       `,
@@ -733,7 +798,7 @@ function compileSet(
   }
 
   const compiledInputs = inputs.map((input) =>
-    compileObjectQueryInternal(projectId, input, exactContext)
+    compileObjectQueryInternal(projectId, input, exactContext(ctx))
   )
   const identities = compileSetIdentities(op, compiledInputs)
   const order = compileOrder(identityOrderFields())
@@ -741,7 +806,7 @@ function compileSet(
   const sql = `
     SELECT selected.*, selected.properties AS _cursor_properties
     FROM (${identities.sql}) AS ids
-    JOIN objects AS selected
+    JOIN ${ctx.source.objectsTable} AS selected
       ON selected.project_id = ?
      AND selected.object_type_id = ids.object_type_id
      AND selected.primary_id = ids.primary_id
@@ -799,19 +864,29 @@ function compileProject(
   }
 }
 
-function compileAggregateSource(projectId: string, query: ObjectQuery): CompiledAggregateSource {
+function compileAggregateSource(
+  projectId: string,
+  query: ObjectQuery,
+  source: PgObjectQuerySource
+): CompiledAggregateSource {
   switch (query.kind) {
     case "start":
-      return compileAggregateStart(projectId, query)
+      return compileAggregateStart(projectId, query, source)
     case "refs":
-      return compileAggregateRefs(projectId, query)
+      return compileAggregateRefs(projectId, query, source)
     case "filter":
-      return compileAggregateWhere(projectId, query.input, compilePredicate(query.predicate))
+      return compileAggregateWhere(
+        projectId,
+        query.input,
+        compilePredicate(query.predicate),
+        source
+      )
     case "text": {
       return compileAggregateWhere(
         projectId,
         query.input,
-        compileTextSearchPredicate(query.query, query.fields, query.fieldsByObjectType)
+        compileTextSearchPredicate(query.query, query.fields, query.fieldsByObjectType),
+        source
       )
     }
     case "traverse":
@@ -820,18 +895,19 @@ function compileAggregateSource(projectId: string, query: ObjectQuery): Compiled
         query.input,
         query.linkId,
         query.direction,
-        query.sourceObjectTypeId
+        query.sourceObjectTypeId,
+        source
       )
     case "set":
-      return compileAggregateSet(projectId, query.op, query.inputs)
+      return compileAggregateSet(projectId, query.op, query.inputs, source)
     case "sort":
     case "project":
     // `expand` is output-shaping, like sort/project: aggregates ignore it.
     case "expand":
-      return compileAggregateSource(projectId, query.input)
+      return compileAggregateSource(projectId, query.input, source)
     case "limit":
     case "page":
-      return compileRowQueryAggregateSource(projectId, query)
+      return compileRowQueryAggregateSource(projectId, query, source)
     case "vector":
       throw new Error(
         `[SixbPg] PostgreSQL object storage does not support query node '${query.kind}'`
@@ -841,7 +917,8 @@ function compileAggregateSource(projectId: string, query: ObjectQuery): Compiled
 
 function compileAggregateStart(
   projectId: string,
-  query: Extract<ObjectQuery, { kind: "start" }>
+  query: Extract<ObjectQuery, { kind: "start" }>,
+  source: PgObjectQuerySource
 ): CompiledAggregateSource {
   if (query.includeSubtypes === true) {
     throw new Error("[SixbPg] PostgreSQL object storage does not support start.includeSubtypes")
@@ -850,7 +927,7 @@ function compileAggregateStart(
   return {
     sql: `
       SELECT project_id, object_type_id, primary_id, properties
-      FROM objects
+      FROM ${source.objectsTable}
       WHERE project_id = ? AND object_type_id = ?
     `,
     args: [projectId, query.objectTypeId],
@@ -859,7 +936,8 @@ function compileAggregateStart(
 
 function compileAggregateRefs(
   projectId: string,
-  query: Extract<ObjectQuery, { kind: "refs" }>
+  query: Extract<ObjectQuery, { kind: "refs" }>,
+  source: PgObjectQuerySource
 ): CompiledAggregateSource {
   if (query.refs.length === 0) {
     throw new Error("[SixbPg] PostgreSQL object storage requires at least one ref")
@@ -874,7 +952,7 @@ function compileAggregateRefs(
           ref.value ->> 'primaryId' AS primary_id
         FROM jsonb_array_elements(?::text::jsonb) AS ref(value)
       ) AS requested
-      JOIN objects AS selected
+      JOIN ${source.objectsTable} AS selected
         ON selected.project_id = ?
        AND selected.object_type_id = requested.object_type_id
        AND selected.primary_id = requested.primary_id
@@ -886,9 +964,10 @@ function compileAggregateRefs(
 function compileAggregateWhere(
   projectId: string,
   inputQuery: ObjectQuery,
-  predicate: CompiledPredicate
+  predicate: CompiledPredicate,
+  source: PgObjectQuerySource
 ): CompiledAggregateSource {
-  const input = compileAggregateSource(projectId, inputQuery)
+  const input = compileAggregateSource(projectId, inputQuery, source)
   return {
     sql: `
       SELECT input.project_id, input.object_type_id, input.primary_id, input.properties
@@ -904,30 +983,31 @@ function compileAggregateTraversal(
   inputQuery: ObjectQuery,
   linkId: string,
   direction: "outgoing" | "incoming",
-  sourceObjectTypeId?: string
+  sourceObjectTypeId: string | undefined,
+  source: PgObjectQuerySource
 ): CompiledAggregateSource {
-  const input = compileAggregateSource(projectId, inputQuery)
+  const input = compileAggregateSource(projectId, inputQuery, source)
   const outputAlias = direction === "outgoing" ? "target_object" : "source_object"
   const joinSql =
     direction === "outgoing"
       ? `
-        JOIN links AS edge
+        JOIN ${source.linksTable} AS edge
           ON edge.project_id = input.project_id
          AND edge.source_type_id = input.object_type_id
          AND edge.source_id = input.primary_id
          AND edge.link_id = ?
-        JOIN objects AS target_object
+        JOIN ${source.objectsTable} AS target_object
           ON target_object.project_id = edge.project_id
          AND target_object.object_type_id = edge.target_type_id
          AND target_object.primary_id = edge.target_id
       `
       : `
-        JOIN links AS edge
+        JOIN ${source.linksTable} AS edge
           ON edge.project_id = input.project_id
          AND edge.target_type_id = input.object_type_id
          AND edge.target_id = input.primary_id
          AND edge.link_id = ?${sourceObjectTypeId === undefined ? "" : "\n         AND edge.source_type_id = ?"}
-        JOIN objects AS source_object
+        JOIN ${source.objectsTable} AS source_object
           ON source_object.project_id = edge.project_id
          AND source_object.object_type_id = edge.source_type_id
          AND source_object.primary_id = edge.source_id
@@ -954,26 +1034,27 @@ function compileAggregateTraversal(
 function compileAggregateSet(
   projectId: string,
   op: ObjectQuerySetOperation,
-  inputs: readonly ObjectQuery[]
+  inputs: readonly ObjectQuery[],
+  source: PgObjectQuerySource
 ): CompiledAggregateSource {
   if (inputs.length === 0) {
     return {
       sql: `
         SELECT project_id, object_type_id, primary_id, properties
-        FROM objects
+        FROM ${source.objectsTable}
         WHERE 1 = 0
       `,
       args: [],
     }
   }
 
-  const compiledInputs = inputs.map((input) => compileAggregateSource(projectId, input))
+  const compiledInputs = inputs.map((input) => compileAggregateSource(projectId, input, source))
   const identities = compileSetIdentities(op, compiledInputs)
   return {
     sql: `
       SELECT selected.project_id, selected.object_type_id, selected.primary_id, selected.properties
       FROM (${identities.sql}) AS ids
-      JOIN objects AS selected
+      JOIN ${source.objectsTable} AS selected
         ON selected.project_id = ?
        AND selected.object_type_id = ids.object_type_id
        AND selected.primary_id = ids.primary_id
@@ -984,9 +1065,13 @@ function compileAggregateSet(
 
 function compileRowQueryAggregateSource(
   projectId: string,
-  query: ObjectQuery
+  query: ObjectQuery,
+  source: PgObjectQuerySource
 ): CompiledAggregateSource {
-  const rowQuery = compileObjectQueryInternal(projectId, query, exactContext)
+  const rowQuery = compileObjectQueryInternal(projectId, query, {
+    probeLimit: false,
+    source,
+  })
   return {
     sql: `
       SELECT input.project_id, input.object_type_id, input.primary_id, input.properties

--- a/storage/pg/src/pg-object-read-scope.ts
+++ b/storage/pg/src/pg-object-read-scope.ts
@@ -1,0 +1,324 @@
+import type { CompiledSelectedObjectReadScope } from "@sixb/core/storage"
+import {
+  type CompiledPgObjectQuery,
+  compilePgObjectStatement,
+  type PgObjectQuerySource,
+} from "./pg-object-query-compiler"
+
+export interface PgSelectedObjectReadSource extends PgObjectQuerySource {
+  readonly objectPropertyPermissionsTable: string
+  readonly traversalProbe: {
+    readonly sql: string
+    readonly args: readonly unknown[]
+  }
+}
+
+/**
+ * Prepare one immutable selected scope as live, path-sensitive PostgreSQL relations.
+ *
+ * The complete compiled scope is serialized once. Every statement receives that one JSONB
+ * document and the bound project id, keeping the parameter count constant as selections grow.
+ */
+export function compilePgSelectedObjectReadSource(
+  projectId: string,
+  scope: CompiledSelectedObjectReadScope,
+  maxTraversalFacts: number
+): PgSelectedObjectReadSource {
+  const scopeJson = JSON.stringify({
+    roots: scope.roots,
+    objects: scope.objects,
+    steps: scope.steps,
+  })
+  const compiled = compileSelectedReadScopeCte(scopeJson, projectId)
+  const wrapStatement = (sql: string, args: readonly unknown[] = []) => ({
+    sql: `${compiled.sql}\n${sql}`,
+    args: [...compiled.args, ...args],
+  })
+
+  const source: PgSelectedObjectReadSource = {
+    objectsTable: "_sixb_scope_objects",
+    linksTable: "_sixb_scope_links",
+    objectPropertyPermissionsTable: "_sixb_scope_object_permissions",
+    wrapStatement,
+    wrapQuery: (query: CompiledPgObjectQuery): CompiledPgObjectQuery => ({
+      ...query,
+      ...wrapStatement(query.sql, query.args),
+      totalSql: `${compiled.sql}\n${query.totalSql}`,
+      totalArgs: [...compiled.args, ...query.totalArgs],
+      ...(query.hasMoreProbe
+        ? {
+            hasMoreProbe: {
+              ...query.hasMoreProbe,
+              ...wrapStatement(query.hasMoreProbe.sql, query.hasMoreProbe.args),
+            },
+          }
+        : {}),
+    }),
+    traversalProbe: { sql: "", args: [] },
+  }
+
+  const traversalProbe = compilePgObjectStatement(
+    `
+      SELECT COUNT(*)::bigint AS total
+      FROM (
+        SELECT 1 AS traversal_fact
+        FROM _sixb_scope_root_facts
+
+        UNION ALL
+
+        SELECT 1 AS traversal_fact
+        FROM _sixb_scope_reached_links
+
+        LIMIT ?
+      ) AS bounded_traversal_facts
+    `,
+    [BigInt(maxTraversalFacts) + 1n],
+    source
+  )
+
+  return Object.freeze({ ...source, traversalProbe })
+}
+
+interface CompiledReadScopeCte {
+  readonly sql: string
+  readonly args: readonly unknown[]
+}
+
+function compileSelectedReadScopeCte(scopeJson: string, projectId: string): CompiledReadScopeCte {
+  return {
+    sql: `
+      WITH RECURSIVE
+      _sixb_scope_document(scope) AS (
+        SELECT ?::text::jsonb
+      ),
+      _sixb_scope_roots(root_id, node_id, object_type_id, primary_id) AS (
+        SELECT
+          (root.ordinality - 1)::integer,
+          (root.value ->> 'nodeId')::integer,
+          root.value ->> 'objectTypeId',
+          root.value ->> 'primaryId'
+        FROM _sixb_scope_document AS document
+        CROSS JOIN LATERAL jsonb_array_elements(document.scope -> 'roots')
+          WITH ORDINALITY AS root(value, ordinality)
+      ),
+      _sixb_scope_root_facts(project_id, root_id, node_id, object_type_id, primary_id) AS (
+        SELECT anchor.project_id, root.root_id, root.node_id, root.object_type_id, root.primary_id
+        FROM _sixb_scope_roots AS root
+        JOIN objects AS anchor
+          ON anchor.project_id = ?
+         AND anchor.object_type_id = root.object_type_id
+         AND anchor.primary_id = root.primary_id
+      ),
+      _sixb_scope_object_selections(node_id, object_type_id, property_ids) AS (
+        SELECT
+          (selection.value ->> 'nodeId')::integer,
+          selection.value ->> 'objectTypeId',
+          selection.value -> 'propertyIds'
+        FROM _sixb_scope_document AS document
+        CROSS JOIN LATERAL jsonb_array_elements(document.scope -> 'objects') AS selection(value)
+      ),
+      _sixb_scope_link_selections(
+        step_id,
+        node_id,
+        parent_node_id,
+        source_object_type_id,
+        link_id,
+        target_object_type_id,
+        property_ids
+      ) AS (
+        SELECT
+          (step.ordinality - 1)::integer,
+          (step.value ->> 'nodeId')::integer,
+          (step.value ->> 'parentNodeId')::integer,
+          step.value ->> 'sourceObjectTypeId',
+          step.value ->> 'linkId',
+          step.value ->> 'targetObjectTypeId',
+          step.value -> 'propertyIds'
+        FROM _sixb_scope_document AS document
+        CROSS JOIN LATERAL jsonb_array_elements(document.scope -> 'steps')
+          WITH ORDINALITY AS step(value, ordinality)
+      ),
+      _sixb_scope_reachable(project_id, node_id, object_type_id, primary_id) AS (
+        SELECT root.project_id, root.node_id, root.object_type_id, root.primary_id
+        FROM _sixb_scope_root_facts AS root
+
+        UNION
+
+        SELECT edge.project_id, selection.node_id, edge.target_type_id, edge.target_id
+        FROM _sixb_scope_reachable AS parent
+        JOIN _sixb_scope_link_selections AS selection
+          ON selection.parent_node_id = parent.node_id
+         AND selection.source_object_type_id = parent.object_type_id
+        JOIN links AS edge
+          ON edge.project_id = parent.project_id
+         AND edge.source_type_id = parent.object_type_id
+         AND edge.source_id = parent.primary_id
+         AND edge.link_id = selection.link_id
+         AND edge.target_type_id = selection.target_object_type_id
+        JOIN objects AS target
+          ON target.project_id = edge.project_id
+         AND target.object_type_id = edge.target_type_id
+         AND target.primary_id = edge.target_id
+      ),
+      _sixb_scope_object_permissions(project_id, object_type_id, primary_id, property_id) AS (
+        SELECT DISTINCT
+          reachable.project_id,
+          reachable.object_type_id,
+          reachable.primary_id,
+          selected_property.value
+        FROM _sixb_scope_reachable AS reachable
+        JOIN _sixb_scope_object_selections AS selection
+          ON selection.node_id = reachable.node_id
+         AND selection.object_type_id = reachable.object_type_id
+        CROSS JOIN LATERAL jsonb_array_elements_text(selection.property_ids)
+          AS selected_property(value)
+      ),
+      _sixb_scope_object_ids(project_id, object_type_id, primary_id) AS (
+        SELECT DISTINCT project_id, object_type_id, primary_id
+        FROM _sixb_scope_reachable
+      ),
+      _sixb_scope_objects AS (
+        SELECT
+          stored.project_id,
+          stored.object_type_id,
+          stored.primary_id,
+          COALESCE(
+            (
+              SELECT jsonb_object_agg(property.key, property.value)
+              FROM jsonb_each(stored.properties) AS property(key, value)
+              JOIN _sixb_scope_object_permissions AS permission
+                ON permission.project_id = stored.project_id
+               AND permission.object_type_id = stored.object_type_id
+               AND permission.primary_id = stored.primary_id
+               AND permission.property_id = property.key
+            ),
+            '{}'::jsonb
+          ) AS properties,
+          stored.created_at,
+          stored.updated_at,
+          stored.version,
+          stored.last_commit_id
+        FROM objects AS stored
+        JOIN _sixb_scope_object_ids AS visible
+          ON visible.project_id = stored.project_id
+         AND visible.object_type_id = stored.object_type_id
+         AND visible.primary_id = stored.primary_id
+      ),
+      _sixb_scope_reached_links(
+        project_id,
+        step_id,
+        node_id,
+        parent_node_id,
+        source_type_id,
+        source_id,
+        link_id,
+        target_type_id,
+        target_id,
+        property_ids
+      ) AS (
+        SELECT
+          edge.project_id,
+          selection.step_id,
+          selection.node_id,
+          selection.parent_node_id,
+          edge.source_type_id,
+          edge.source_id,
+          edge.link_id,
+          edge.target_type_id,
+          edge.target_id,
+          selection.property_ids
+        FROM _sixb_scope_reachable AS parent
+        JOIN _sixb_scope_link_selections AS selection
+          ON selection.parent_node_id = parent.node_id
+         AND selection.source_object_type_id = parent.object_type_id
+        JOIN links AS edge
+          ON edge.project_id = parent.project_id
+         AND edge.source_type_id = parent.object_type_id
+         AND edge.source_id = parent.primary_id
+         AND edge.link_id = selection.link_id
+         AND edge.target_type_id = selection.target_object_type_id
+        JOIN objects AS target
+          ON target.project_id = edge.project_id
+         AND target.object_type_id = edge.target_type_id
+         AND target.primary_id = edge.target_id
+      ),
+      _sixb_scope_link_permissions(
+        project_id,
+        source_type_id,
+        source_id,
+        link_id,
+        target_type_id,
+        target_id,
+        property_id
+      ) AS (
+        SELECT DISTINCT
+          reached.project_id,
+          reached.source_type_id,
+          reached.source_id,
+          reached.link_id,
+          reached.target_type_id,
+          reached.target_id,
+          selected_property.value
+        FROM _sixb_scope_reached_links AS reached
+        CROSS JOIN LATERAL jsonb_array_elements_text(reached.property_ids)
+          AS selected_property(value)
+      ),
+      _sixb_scope_link_ids(
+        project_id,
+        source_type_id,
+        source_id,
+        link_id,
+        target_type_id,
+        target_id
+      ) AS (
+        SELECT DISTINCT
+          project_id,
+          source_type_id,
+          source_id,
+          link_id,
+          target_type_id,
+          target_id
+        FROM _sixb_scope_reached_links
+      ),
+      _sixb_scope_links AS (
+        SELECT
+          stored.project_id,
+          stored.source_type_id,
+          stored.source_id,
+          stored.link_id,
+          stored.target_type_id,
+          stored.target_id,
+          CASE
+            WHEN stored.properties IS NULL THEN NULL
+            ELSE NULLIF(
+              (
+                SELECT jsonb_object_agg(property.key, property.value)
+                FROM jsonb_each(stored.properties) AS property(key, value)
+                JOIN _sixb_scope_link_permissions AS permission
+                  ON permission.project_id = stored.project_id
+                 AND permission.source_type_id = stored.source_type_id
+                 AND permission.source_id = stored.source_id
+                 AND permission.link_id = stored.link_id
+                 AND permission.target_type_id = stored.target_type_id
+                 AND permission.target_id = stored.target_id
+                 AND permission.property_id = property.key
+              ),
+              '{}'::jsonb
+            )
+          END AS properties,
+          stored.created_at,
+          stored.updated_at,
+          stored.last_commit_id
+        FROM links AS stored
+        JOIN _sixb_scope_link_ids AS visible
+          ON visible.project_id = stored.project_id
+         AND visible.source_type_id = stored.source_type_id
+         AND visible.source_id = stored.source_id
+         AND visible.link_id = stored.link_id
+         AND visible.target_type_id = stored.target_type_id
+         AND visible.target_id = stored.target_id
+      )
+    `,
+    args: [scopeJson, projectId],
+  }
+}

--- a/storage/pg/src/pg-object-storage.ts
+++ b/storage/pg/src/pg-object-storage.ts
@@ -1,5 +1,6 @@
 import type { ObjectQuery } from "@sixb/core"
 import type {
+  CompiledSelectedObjectReadScope,
   CountObjectsInput,
   CountObjectsResult,
   ExistsObjectsInput,
@@ -11,8 +12,11 @@ import type {
   LinkBatchKey,
   LinkDirection,
   ObjectBatchKey,
+  ObjectFacetResult,
   ObjectLinkRow,
   ObjectQueryCapabilities,
+  ObjectReadExecutionLimits,
+  ObjectReadScopeFactory,
   ObjectReadStorage,
   ObjectRow,
   ObjectRowLinks,
@@ -22,7 +26,15 @@ import type {
   QueryObjectsInput,
   QueryObjectsResult,
 } from "@sixb/core/storage"
-import { linkBatchKey, objectBatchKey } from "@sixb/core/storage"
+import {
+  assertObjectReaderProject,
+  assertObjectReadFacetCount,
+  assertObjectReadOutputWithinLimit,
+  linkBatchKey,
+  ObjectReadLimitExceededError,
+  objectBatchKey,
+  snapshotObjectReadExecutionLimits,
+} from "@sixb/core/storage"
 import type { SQLClient, SqlParameter } from "./pg-client"
 import {
   type CompiledPgObjectQuery,
@@ -30,8 +42,14 @@ import {
   compilePgObjectExistsQuery,
   compilePgObjectFacetQuery,
   compilePgObjectQuery,
+  compilePgObjectStatement,
+  type PgObjectQuerySource,
 } from "./pg-object-query-compiler"
-import type { PgStoreClient } from "./transactions"
+import {
+  compilePgSelectedObjectReadSource,
+  type PgSelectedObjectReadSource,
+} from "./pg-object-read-scope"
+import { type PgStoreClient, runPgRepeatableReadTransaction } from "./transactions"
 
 const PG_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
   queryObjects: true,
@@ -156,19 +174,110 @@ function valuesJoin<Row = unknown>(
  * - Reads return JSONB as native JS types (objects, numbers, booleans) when
  *   the data was stored correctly.
  */
-export class PgObjectStorage implements ObjectStorage {
+export class PgObjectStorage implements ObjectStorage, ObjectReadScopeFactory {
   constructor(private readonly sql: PgStoreClient) {}
 
   queryCapabilities(): ObjectQueryCapabilities {
     return PG_OBJECT_QUERY_CAPABILITIES
   }
 
+  createSelectedReadScope(params: {
+    projectId: string
+    scope: CompiledSelectedObjectReadScope
+    limits: ObjectReadExecutionLimits
+  }): ObjectReadStorage {
+    const projectId = params.projectId
+    const limits = snapshotObjectReadExecutionLimits(params.limits)
+    const source = compilePgSelectedObjectReadSource(
+      projectId,
+      params.scope,
+      limits.maxTraversalFacts
+    )
+    const assertProject = (actualProjectId: string): void =>
+      assertObjectReaderProject(projectId, actualProjectId)
+    const read = <T>(run: (sql: SQLClient) => Promise<T>): Promise<T> =>
+      runPgRepeatableReadTransaction(this.sql, async (sql) => {
+        await assertTraversalBudget(sql, source, limits.maxTraversalFacts)
+        const value = await run(sql)
+        assertObjectReadOutputWithinLimit(value, limits)
+        return value
+      })
+    const readMap = <TKey, TValue>(
+      run: (sql: SQLClient) => Promise<Map<TKey, TValue>>
+    ): Promise<Map<TKey, TValue>> =>
+      runPgRepeatableReadTransaction(this.sql, async (sql) => {
+        await assertTraversalBudget(sql, source, limits.maxTraversalFacts)
+        const value = await run(sql)
+        assertObjectReadOutputWithinLimit([...value.entries()], limits)
+        return value
+      })
+
+    return Object.freeze({
+      queryCapabilities: () => this.queryCapabilities(),
+      queryObjects: async (input) => {
+        assertProject(input.projectId)
+        return read((sql) => this.queryObjectsFromSource(sql, input, source))
+      },
+      countObjects: async (input) => {
+        assertProject(input.projectId)
+        return read((sql) => this.countObjectsFromSource(sql, input, source))
+      },
+      existsObjects: async (input) => {
+        assertProject(input.projectId)
+        return read((sql) => this.existsObjectsFromSource(sql, input, source))
+      },
+      facetObjects: async (input) => {
+        assertProject(input.projectId)
+        assertObjectReadFacetCount(input.facets.length)
+        return read((sql) => this.facetObjectsFromSource(sql, input, source))
+      },
+      getByPrimaryId: async (input) => {
+        assertProject(input.projectId)
+        return read((sql) => this.getByPrimaryIdFromSource(sql, input, source))
+      },
+      selectsObjectProperties: async (input) => {
+        assertProject(input.projectId)
+        return read((sql) => this.selectsObjectPropertiesFromSource(sql, input, source))
+      },
+      listLinks: async (input) => {
+        assertProject(input.projectId)
+        return read((sql) => this.listLinksFromSource(sql, input, source))
+      },
+      getByPrimaryIdBatch: async (input) => {
+        assertProject(input.projectId)
+        return readMap((sql) => this.getByPrimaryIdBatchFromSource(sql, input, source))
+      },
+      listLinksBatch: async (input) => {
+        assertProject(input.projectId)
+        return readMap((sql) => this.listLinksBatchFromSource(sql, input, source))
+      },
+      queryLinks: async (input) => {
+        assertProject(input.projectId)
+        assertLinkQueryLimit(input.limit)
+        return read((sql) => this.queryLinksFromSource(sql, input, source))
+      },
+      list: async (input) => {
+        assertProject(input.projectId)
+        return read((sql) => this.listFromSource(sql, input, source))
+      },
+    } satisfies ObjectReadStorage)
+  }
+
   async queryObjects(params: QueryObjectsInput): Promise<QueryObjectsResult> {
+    return this.queryObjectsFromSource(this.sql, params)
+  }
+
+  private async queryObjectsFromSource(
+    sql: SQLClient,
+    params: QueryObjectsInput,
+    source?: PgObjectQuerySource
+  ): Promise<QueryObjectsResult> {
     const compiled = compilePgObjectQuery(params.projectId, params.query, {
       includeTotal: params.includeTotal,
+      ...(source ? { source } : {}),
     })
-    const total = params.includeTotal === false ? undefined : await readTotal(this.sql, compiled)
-    const rawRows = await this.sql.unsafe<ObjectQueryDatabaseRow[]>(
+    const total = params.includeTotal === false ? undefined : await readTotal(sql, compiled)
+    const rawRows = await sql.unsafe<ObjectQueryDatabaseRow[]>(
       compiled.sql,
       compiled.args as SqlParameter[]
     )
@@ -177,7 +286,7 @@ export class PgObjectStorage implements ObjectStorage {
       total === undefined && compiled.hasMoreProbe
         ? compiled.hasMoreProbe.hasMore(
             (
-              await this.sql.unsafe(
+              await sql.unsafe(
                 compiled.hasMoreProbe.sql,
                 compiled.hasMoreProbe.args as SqlParameter[]
               )
@@ -194,8 +303,18 @@ export class PgObjectStorage implements ObjectStorage {
   }
 
   async countObjects(params: CountObjectsInput): Promise<CountObjectsResult> {
-    const compiled = compilePgObjectCountQuery(params.projectId, stripOuterRowShape(params.query))
-    const [row] = await this.sql.unsafe<{ count: string | number | bigint }[]>(
+    return this.countObjectsFromSource(this.sql, params)
+  }
+
+  private async countObjectsFromSource(
+    sql: SQLClient,
+    params: CountObjectsInput,
+    source?: PgObjectQuerySource
+  ): Promise<CountObjectsResult> {
+    const compiled = compilePgObjectCountQuery(params.projectId, stripOuterRowShape(params.query), {
+      ...(source ? { source } : {}),
+    })
+    const [row] = await sql.unsafe<{ count: string | number | bigint }[]>(
       compiled.sql,
       compiled.args as SqlParameter[]
     )
@@ -203,28 +322,49 @@ export class PgObjectStorage implements ObjectStorage {
   }
 
   async existsObjects(params: ExistsObjectsInput): Promise<ExistsObjectsResult> {
-    const compiled = compilePgObjectExistsQuery(params.projectId, stripOuterRowShape(params.query))
-    const [row] = await this.sql.unsafe<unknown[]>(compiled.sql, compiled.args as SqlParameter[])
+    return this.existsObjectsFromSource(this.sql, params)
+  }
+
+  private async existsObjectsFromSource(
+    sql: SQLClient,
+    params: ExistsObjectsInput,
+    source?: PgObjectQuerySource
+  ): Promise<ExistsObjectsResult> {
+    const compiled = compilePgObjectExistsQuery(
+      params.projectId,
+      stripOuterRowShape(params.query),
+      { ...(source ? { source } : {}) }
+    )
+    const [row] = await sql.unsafe<unknown[]>(compiled.sql, compiled.args as SqlParameter[])
     return { exists: row !== undefined }
   }
 
   async facetObjects(params: FacetObjectsInput): Promise<FacetObjectsResult> {
-    return {
-      facets: await Promise.all(
-        params.facets.map(async (facet) => ({
-          propertyId: facet.propertyId,
-          buckets: await readFacetBuckets(
-            this.sql,
-            compilePgObjectFacetQuery(
-              params.projectId,
-              stripOuterRowShape(params.query),
-              facet.propertyId,
-              facet.limit
-            )
-          ),
-        }))
-      ),
+    return this.facetObjectsFromSource(this.sql, params)
+  }
+
+  private async facetObjectsFromSource(
+    sql: SQLClient,
+    params: FacetObjectsInput,
+    source?: PgObjectQuerySource
+  ): Promise<FacetObjectsResult> {
+    const facets: ObjectFacetResult[] = []
+    for (const facet of params.facets) {
+      facets.push({
+        propertyId: facet.propertyId,
+        buckets: await readFacetBuckets(
+          sql,
+          compilePgObjectFacetQuery(
+            params.projectId,
+            stripOuterRowShape(params.query),
+            facet.propertyId,
+            facet.limit,
+            { ...(source ? { source } : {}) }
+          )
+        ),
+      })
     }
+    return { facets }
   }
 
   async getByPrimaryId(params: {
@@ -232,12 +372,31 @@ export class PgObjectStorage implements ObjectStorage {
     objectTypeId: string
     primaryId: string
   }): Promise<ObjectRow | null> {
-    const [row] = await this.sql<ObjectDatabaseRow[]>`
-      SELECT * FROM objects
-      WHERE project_id = ${params.projectId}
-        AND object_type_id = ${params.objectTypeId}
-        AND primary_id = ${params.primaryId}
-    `
+    return this.getByPrimaryIdFromSource(this.sql, params)
+  }
+
+  private async getByPrimaryIdFromSource(
+    sql: SQLClient,
+    params: {
+      projectId: string
+      objectTypeId: string
+      primaryId: string
+    },
+    source?: PgObjectQuerySource
+  ): Promise<ObjectRow | null> {
+    const statement = compilePgObjectStatement(
+      `
+        SELECT *
+        FROM ${source?.objectsTable ?? "objects"}
+        WHERE project_id = ? AND object_type_id = ? AND primary_id = ?
+      `,
+      [params.projectId, params.objectTypeId, params.primaryId],
+      source
+    )
+    const [row] = await sql.unsafe<ObjectDatabaseRow[]>(
+      statement.sql,
+      statement.args as SqlParameter[]
+    )
 
     return row ? rowToObject(row) : null
   }
@@ -245,13 +404,45 @@ export class PgObjectStorage implements ObjectStorage {
   async selectsObjectProperties(
     params: Parameters<ObjectReadStorage["selectsObjectProperties"]>[0]
   ): Promise<readonly boolean[]> {
-    const objects = await this.getByPrimaryIdBatch({
-      projectId: params.projectId,
-      items: params.items,
-    })
-    return params.items.map((item) =>
-      objects.has(objectBatchKey(item.objectTypeId, item.primaryId))
+    return this.selectsObjectPropertiesFromSource(this.sql, params)
+  }
+
+  private async selectsObjectPropertiesFromSource(
+    sql: SQLClient,
+    params: Parameters<ObjectReadStorage["selectsObjectProperties"]>[0],
+    source?: PgSelectedObjectReadSource
+  ): Promise<readonly boolean[]> {
+    const result = params.items.map(() => false)
+    if (params.items.length === 0) return result
+
+    const items = params.items.map((item, batchIndex) => ({ ...item, batchIndex }))
+    const storedTable = source?.objectPropertyPermissionsTable ?? "objects"
+    const propertyJoin = source ? 'AND stored.property_id = requested."propertyId"' : ""
+    const statement = compilePgObjectStatement(
+      `
+        SELECT DISTINCT requested."batchIndex" AS _batch_index
+        FROM ${storedTable} AS stored
+        JOIN jsonb_to_recordset(?::text::jsonb)
+          AS requested(
+            "objectTypeId" text,
+            "primaryId" text,
+            "propertyId" text,
+            "batchIndex" integer
+          )
+          ON stored.object_type_id = requested."objectTypeId"
+         AND stored.primary_id = requested."primaryId"
+         ${propertyJoin}
+        WHERE stored.project_id = ?
+      `,
+      [JSON.stringify(items), params.projectId],
+      source
     )
+    const rows = await sql.unsafe<PropertyPermissionBatchDatabaseRow[]>(
+      statement.sql,
+      statement.args as SqlParameter[]
+    )
+    for (const row of rows) result[row._batch_index] = true
+    return result
   }
 
   async listLinks(params: {
@@ -261,20 +452,46 @@ export class PgObjectStorage implements ObjectStorage {
     linkId?: string
     direction?: LinkDirection
   }): Promise<readonly ObjectLinkRow[]> {
+    return this.listLinksFromSource(this.sql, params)
+  }
+
+  private async listLinksFromSource(
+    sql: SQLClient,
+    params: {
+      projectId: string
+      objectTypeId: string
+      objectId: string
+      linkId?: string
+      direction?: LinkDirection
+    },
+    source?: PgObjectQuerySource
+  ): Promise<readonly ObjectLinkRow[]> {
     const direction = params.direction ?? "outgoing"
     const directionWhere =
       direction === "incoming"
-        ? "target_type_id = $2 AND target_id = $3"
+        ? "target_type_id = ? AND target_id = ?"
         : direction === "both"
-          ? "((source_type_id = $2 AND source_id = $3) OR (target_type_id = $2 AND target_id = $3))"
-          : "source_type_id = $2 AND source_id = $3"
-    const query = `SELECT * FROM links WHERE project_id = $1 AND ${directionWhere}${
-      params.linkId ? " AND link_id = $4" : ""
+          ? "((source_type_id = ? AND source_id = ?) OR (target_type_id = ? AND target_id = ?))"
+          : "source_type_id = ? AND source_id = ?"
+    const args: unknown[] =
+      direction === "both"
+        ? [
+            params.projectId,
+            params.objectTypeId,
+            params.objectId,
+            params.objectTypeId,
+            params.objectId,
+          ]
+        : [params.projectId, params.objectTypeId, params.objectId]
+    const query = `SELECT * FROM ${source?.linksTable ?? "links"} WHERE project_id = ? AND ${directionWhere}${
+      params.linkId ? " AND link_id = ?" : ""
     }`
-    const args = params.linkId
-      ? [params.projectId, params.objectTypeId, params.objectId, params.linkId]
-      : [params.projectId, params.objectTypeId, params.objectId]
-    const rows = await this.sql.unsafe<LinkDatabaseRow[]>(query, args)
+    if (params.linkId) args.push(params.linkId)
+    const statement = compilePgObjectStatement(query, args, source)
+    const rows = await sql.unsafe<LinkDatabaseRow[]>(
+      statement.sql,
+      statement.args as SqlParameter[]
+    )
 
     return rows.map((row) => rowToLink(row))
   }
@@ -283,19 +500,41 @@ export class PgObjectStorage implements ObjectStorage {
     projectId: string
     items: readonly { objectTypeId: string; primaryId: string }[]
   }): Promise<Map<ObjectBatchKey, ObjectRow>> {
+    return this.getByPrimaryIdBatchFromSource(this.sql, params)
+  }
+
+  private async getByPrimaryIdBatchFromSource(
+    sql: SQLClient,
+    params: {
+      projectId: string
+      items: readonly { objectTypeId: string; primaryId: string }[]
+    },
+    source?: PgObjectQuerySource
+  ): Promise<Map<ObjectBatchKey, ObjectRow>> {
     const result = new Map<ObjectBatchKey, ObjectRow>()
     if (params.items.length === 0) return result
-    const rows = await valuesJoin<ObjectDatabaseRow>(
-      this.sql,
-      "SELECT o.* FROM objects o",
-      ["object_type_id", "primary_id"],
-      params.items.map((i) => [i.objectTypeId, i.primaryId]),
-      `WHERE o.project_id = $1`,
-      [params.projectId]
+    const items = params.items.map((item, batchIndex) => ({ ...item, batchIndex }))
+    const statement = compilePgObjectStatement(
+      `
+        SELECT object.*, requested."batchIndex" AS _batch_index
+        FROM jsonb_to_recordset(?::text::jsonb)
+          AS requested("objectTypeId" text, "primaryId" text, "batchIndex" integer)
+        JOIN ${source?.objectsTable ?? "objects"} AS object
+          ON object.project_id = ?
+         AND object.object_type_id = requested."objectTypeId"
+         AND object.primary_id = requested."primaryId"
+      `,
+      [JSON.stringify(items), params.projectId],
+      source
     )
-
-    for (const row of rows) {
-      result.set(objectBatchKey(row.object_type_id, row.primary_id), rowToObject(row))
+    const rows = await sql.unsafe<ObjectBatchDatabaseRow[]>(
+      statement.sql,
+      statement.args as SqlParameter[]
+    )
+    const rowsByIndex = new Map(rows.map((row) => [row._batch_index, row]))
+    for (const [index, item] of params.items.entries()) {
+      const row = rowsByIndex.get(index)
+      if (row) result.set(objectBatchKey(item.objectTypeId, item.primaryId), rowToObject(row))
     }
     return result
   }
@@ -305,105 +544,204 @@ export class PgObjectStorage implements ObjectStorage {
     direction?: LinkDirection
     items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
   }): Promise<Map<LinkBatchKey, ObjectLinkRow[]>> {
-    const result = new Map<LinkBatchKey, Map<string, ObjectLinkRow>>()
-    if (params.items.length === 0) return new Map()
+    return this.listLinksBatchFromSource(this.sql, params)
+  }
 
-    const readSide = async (side: "source" | "target"): Promise<void> => {
-      const rows = await valuesJoin<LinkDatabaseRow>(
-        this.sql,
-        "SELECT l.* FROM links l",
-        [`${side}_type_id`, `${side}_id`, "link_id"],
-        params.items.map((item) => [item.objectTypeId, item.objectId, item.linkId]),
-        `WHERE l.project_id = $1`,
-        [params.projectId]
-      )
-      for (const row of rows) {
-        const link = rowToLink(row)
-        const objectTypeId = side === "source" ? row.source_type_id : row.target_type_id
-        const objectId = side === "source" ? row.source_id : row.target_id
-        const key = linkBatchKey(objectTypeId, objectId, row.link_id)
-        const bucket = result.get(key) ?? new Map<string, ObjectLinkRow>()
-        bucket.set(linkIdentity(link), link)
-        result.set(key, bucket)
-      }
-    }
+  private async listLinksBatchFromSource(
+    sql: SQLClient,
+    params: {
+      projectId: string
+      direction?: LinkDirection
+      items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
+    },
+    source?: PgObjectQuerySource
+  ): Promise<Map<LinkBatchKey, ObjectLinkRow[]>> {
+    const result = new Map<LinkBatchKey, ObjectLinkRow[]>()
+    if (params.items.length === 0) return result
 
     const direction = params.direction ?? "outgoing"
-    if (direction === "outgoing" || direction === "both") await readSide("source")
-    if (direction === "incoming" || direction === "both") await readSide("target")
+    const outgoing =
+      'stored.source_type_id = requested."objectTypeId" AND stored.source_id = requested."objectId"'
+    const incoming =
+      'stored.target_type_id = requested."objectTypeId" AND stored.target_id = requested."objectId"'
+    const items = params.items.map((item, batchIndex) => ({ ...item, batchIndex }))
+    const requestedSql = `
+      jsonb_to_recordset(?::text::jsonb)
+        AS requested(
+          "objectTypeId" text,
+          "objectId" text,
+          "linkId" text,
+          "batchIndex" integer
+        )
+    `
+    const table = source?.linksTable ?? "links"
+    const selectedSql =
+      direction === "both"
+        ? `
+          SELECT stored.*, requested."batchIndex" AS _batch_index
+          FROM ${requestedSql}
+          CROSS JOIN LATERAL (
+            SELECT outgoing_link.*
+            FROM ${table} AS outgoing_link
+            WHERE outgoing_link.project_id = ?
+              AND outgoing_link.source_type_id = requested."objectTypeId"
+              AND outgoing_link.source_id = requested."objectId"
+              AND outgoing_link.link_id = requested."linkId"
 
-    return new Map([...result].map(([key, links]) => [key, [...links.values()]] as const))
+            UNION
+
+            SELECT incoming_link.*
+            FROM ${table} AS incoming_link
+            WHERE incoming_link.project_id = ?
+              AND incoming_link.target_type_id = requested."objectTypeId"
+              AND incoming_link.target_id = requested."objectId"
+              AND incoming_link.link_id = requested."linkId"
+          ) AS stored
+        `
+        : `
+          SELECT stored.*, requested."batchIndex" AS _batch_index
+          FROM ${requestedSql}
+          JOIN ${table} AS stored
+            ON ${direction === "incoming" ? incoming : outgoing}
+           AND stored.link_id = requested."linkId"
+          WHERE stored.project_id = ?
+        `
+    const statement = compilePgObjectStatement(
+      `
+        ${selectedSql}
+        ORDER BY
+          _batch_index,
+          source_type_id COLLATE "C",
+          source_id COLLATE "C",
+          link_id COLLATE "C",
+          target_type_id COLLATE "C",
+          target_id COLLATE "C"
+      `,
+      direction === "both"
+        ? [JSON.stringify(items), params.projectId, params.projectId]
+        : [JSON.stringify(items), params.projectId],
+      source
+    )
+    const rows = await sql.unsafe<LinkBatchDatabaseRow[]>(
+      statement.sql,
+      statement.args as SqlParameter[]
+    )
+    const rowsByIndex = params.items.map(() => new Map<string, ObjectLinkRow>())
+    for (const row of rows) {
+      const link = rowToLink(row)
+      rowsByIndex[row._batch_index]?.set(linkIdentity(link), link)
+    }
+    for (const [index, item] of params.items.entries()) {
+      const links = [...(rowsByIndex[index]?.values() ?? [])]
+      if (links.length > 0) {
+        result.set(linkBatchKey(item.objectTypeId, item.objectId, item.linkId), links)
+      }
+    }
+    return result
   }
 
   async queryLinks(params: QueryObjectLinksInput): Promise<QueryObjectLinksResult> {
     assertLinkQueryLimit(params.limit)
+    return this.queryLinksFromSource(this.sql, params)
+  }
+
+  private async queryLinksFromSource(
+    sql: SQLClient,
+    params: QueryObjectLinksInput,
+    source?: PgObjectQuerySource
+  ): Promise<QueryObjectLinksResult> {
     if (params.objectRefs.length === 0 || params.endpointObjectTypeIds?.length === 0) {
       return { links: [], hasMore: false }
     }
 
-    const args: SqlParameter[] = [JSON.stringify(params.objectRefs), params.projectId]
-    const addArg = (value: SqlParameter): string => {
+    const requestedJson = JSON.stringify(params.objectRefs)
+    const args: unknown[] =
+      params.direction === "both"
+        ? [requestedJson, params.projectId, params.projectId]
+        : [requestedJson, params.projectId]
+    const addArg = (value: unknown): string => {
       args.push(value)
-      return `$${args.length}`
+      return "?"
     }
-    const sourceJoin = `
-      SELECT link.*
-      FROM links AS link
-      JOIN requested
-        ON requested.object_type_id = link.source_type_id
-       AND requested.object_id = link.source_id
-      WHERE link.project_id = $2
+    const requestedSql = `
+      jsonb_to_recordset(?::text::jsonb)
+        AS requested("objectTypeId" text, "primaryId" text)
     `
-    const targetJoin = `
-      SELECT link.*
-      FROM links AS link
-      JOIN requested
-        ON requested.object_type_id = link.target_type_id
-       AND requested.object_id = link.target_id
-      WHERE link.project_id = $2
-    `
+    const table = source?.linksTable ?? "links"
     const incidentSql =
-      params.direction === "outgoing"
-        ? sourceJoin
-        : params.direction === "incoming"
-          ? targetJoin
-          : `${sourceJoin} UNION ${targetJoin}`
+      params.direction === "both"
+        ? `
+          SELECT DISTINCT link.*
+          FROM ${requestedSql}
+          CROSS JOIN LATERAL (
+            SELECT outgoing_link.*
+            FROM ${table} AS outgoing_link
+            WHERE outgoing_link.project_id = ?
+              AND outgoing_link.source_type_id = requested."objectTypeId"
+              AND outgoing_link.source_id = requested."primaryId"
+
+            UNION
+
+            SELECT incoming_link.*
+            FROM ${table} AS incoming_link
+            WHERE incoming_link.project_id = ?
+              AND incoming_link.target_type_id = requested."objectTypeId"
+              AND incoming_link.target_id = requested."primaryId"
+          ) AS link
+        `
+        : `
+          SELECT DISTINCT link.*
+          FROM ${requestedSql}
+          JOIN ${table} AS link
+            ON requested."objectTypeId" = link.${params.direction === "incoming" ? "target_type_id" : "source_type_id"}
+           AND requested."primaryId" = link.${params.direction === "incoming" ? "target_id" : "source_id"}
+          WHERE link.project_id = ?
+        `
 
     const predicates: string[] = []
     if (params.linkId !== undefined) {
       predicates.push(`link_id = ${addArg(params.linkId)}::text`)
     }
     if (params.endpointObjectTypeIds !== undefined) {
-      const allowedTypes = addArg(JSON.stringify([...new Set(params.endpointObjectTypeIds)]))
+      const allowedTypes = JSON.stringify([...new Set(params.endpointObjectTypeIds)])
       predicates.push(
-        `source_type_id IN (SELECT jsonb_array_elements_text(${allowedTypes}::text::jsonb))`,
-        `target_type_id IN (SELECT jsonb_array_elements_text(${allowedTypes}::text::jsonb))`
+        `source_type_id IN (SELECT jsonb_array_elements_text(${addArg(allowedTypes)}::text::jsonb))`,
+        `target_type_id IN (SELECT jsonb_array_elements_text(${addArg(allowedTypes)}::text::jsonb))`
       )
     }
     if (params.after) {
-      const cursor = params.after.map((value) => `${addArg(value)}::text`)
+      const cursor = params.after.map((value) => `${addArg(value)}::text COLLATE "C"`)
       predicates.push(
-        `(source_type_id, source_id, link_id, target_type_id, target_id) > (${cursor.join(", ")})`
+        `(
+          source_type_id COLLATE "C",
+          source_id COLLATE "C",
+          link_id COLLATE "C",
+          target_type_id COLLATE "C",
+          target_id COLLATE "C"
+        ) > (${cursor.join(", ")})`
       )
     }
     const limit = addArg(params.limit + 1)
     const whereSql = predicates.length > 0 ? `WHERE ${predicates.join(" AND ")}` : ""
-    const rows = await this.sql.unsafe<LinkDatabaseRow[]>(
+    const statement = compilePgObjectStatement(
       `
-        WITH requested AS (
-          SELECT DISTINCT
-            requested."objectTypeId" AS object_type_id,
-            requested."primaryId" AS object_id
-          FROM jsonb_to_recordset($1::text::jsonb)
-            AS requested("objectTypeId" text, "primaryId" text)
-        ), incident AS (${incidentSql})
         SELECT *
-        FROM incident
+        FROM (${incidentSql}) AS incident
         ${whereSql}
-        ORDER BY source_type_id, source_id, link_id, target_type_id, target_id
+        ORDER BY
+          source_type_id COLLATE "C",
+          source_id COLLATE "C",
+          link_id COLLATE "C",
+          target_type_id COLLATE "C",
+          target_id COLLATE "C"
         LIMIT ${limit}
       `,
-      args
+      args,
+      source
+    )
+    const rows = await sql.unsafe<LinkDatabaseRow[]>(
+      statement.sql,
+      statement.args as SqlParameter[]
     )
 
     return {
@@ -487,81 +825,103 @@ export class PgObjectStorage implements ObjectStorage {
     orderBy?: "createdAt" | "updatedAt" | "primaryId"
     order?: "asc" | "desc"
   }): Promise<{ objects: readonly ObjectRow[]; hasMore: boolean; total: number }> {
+    return this.listFromSource(this.sql, params)
+  }
+
+  private async listFromSource(
+    sql: SQLClient,
+    params: Parameters<ObjectReadStorage["list"]>[0],
+    source?: PgObjectQuerySource
+  ): Promise<{ objects: readonly ObjectRow[]; hasMore: boolean; total: number }> {
     const queryOffset = params.offset ?? 0
     const limit = params.limit ?? 50
     const orderBy = params.orderBy ?? "updatedAt"
     const order = params.order ?? "desc"
     const orderColumn =
       orderBy === "primaryId" ? "primary_id" : orderBy === "createdAt" ? "created_at" : "updated_at"
+    const filters = ["project_id = ?"]
+    const args: unknown[] = [params.projectId]
+    if (typeof params.objectTypeId === "string") {
+      filters.push("object_type_id = ?")
+      args.push(params.objectTypeId)
+    } else if (params.objectTypeId !== undefined) {
+      filters.push("object_type_id IN (SELECT jsonb_array_elements_text(?::text::jsonb))")
+      args.push(JSON.stringify(params.objectTypeId))
+    }
+    if (params.primaryIdPrefix) {
+      filters.push("primary_id LIKE ?")
+      args.push(`${params.primaryIdPrefix}%`)
+    }
+    if (params.primaryIdSuffix) {
+      filters.push("primary_id LIKE ?")
+      args.push(`%${params.primaryIdSuffix}`)
+    }
+    if (params.updatedAfter) {
+      filters.push("updated_at >= ?")
+      args.push(params.updatedAfter)
+    }
+    if (params.updatedBefore) {
+      filters.push("updated_at <= ?")
+      args.push(params.updatedBefore)
+    }
+    if (params.createdAfter) {
+      filters.push("created_at >= ?")
+      args.push(params.createdAfter)
+    }
+    if (params.createdBefore) {
+      filters.push("created_at <= ?")
+      args.push(params.createdBefore)
+    }
 
-    // Build WHERE conditions using conditional fragments
-    const typeFilter =
-      params.objectTypeId === undefined
-        ? this.sql``
-        : typeof params.objectTypeId === "string"
-          ? this.sql`AND object_type_id = ${params.objectTypeId}`
-          : this.sql`AND object_type_id IN ${this.sql(params.objectTypeId as string[])}`
-
-    const primaryIdPrefixFilter = params.primaryIdPrefix
-      ? this.sql`AND primary_id LIKE ${`${params.primaryIdPrefix}%`}`
-      : this.sql``
-
-    const primaryIdSuffixFilter = params.primaryIdSuffix
-      ? this.sql`AND primary_id LIKE ${`%${params.primaryIdSuffix}`}`
-      : this.sql``
-
-    const updatedAfterFilter = params.updatedAfter
-      ? this.sql`AND updated_at >= ${params.updatedAfter}`
-      : this.sql``
-
-    const updatedBeforeFilter = params.updatedBefore
-      ? this.sql`AND updated_at <= ${params.updatedBefore}`
-      : this.sql``
-
-    const createdAfterFilter = params.createdAfter
-      ? this.sql`AND created_at >= ${params.createdAfter}`
-      : this.sql``
-
-    const createdBeforeFilter = params.createdBefore
-      ? this.sql`AND created_at <= ${params.createdBefore}`
-      : this.sql``
-
-    const filters = this.sql`
-      ${typeFilter}
-      ${primaryIdPrefixFilter}
-      ${primaryIdSuffixFilter}
-      ${updatedAfterFilter}
-      ${updatedBeforeFilter}
-      ${createdAfterFilter}
-      ${createdBeforeFilter}
-    `
-
-    // Get total count
-    const [countResult] = await this.sql<{ total: number }[]>`
-      SELECT COUNT(*)::int AS total FROM objects
-      WHERE project_id = ${params.projectId}
-      ${filters}
-    `
-    const total = countResult.total
+    const objectsTable = source?.objectsTable ?? "objects"
+    const whereSql = filters.join(" AND ")
+    const countStatement = compilePgObjectStatement(
+      `SELECT COUNT(*)::int AS total FROM ${objectsTable} WHERE ${whereSql}`,
+      args,
+      source
+    )
+    const [countResult] = await sql.unsafe<{ total: number }[]>(
+      countStatement.sql,
+      countStatement.args as SqlParameter[]
+    )
+    const total = countResult?.total ?? 0
 
     if (limit === 0) return { objects: [], hasMore: queryOffset < total, total }
 
-    // Get paginated results (+1 for hasMore check)
-    // Column and direction derived from a fixed mapping — safe to use as identifiers
     const fetchLimit = limit + 1
-    const rows = await this.sql<ObjectDatabaseRow[]>`
-      SELECT * FROM objects
-      WHERE project_id = ${params.projectId}
-      ${filters}
-      ORDER BY ${this.sql(orderColumn)} ${order === "asc" ? this.sql`ASC` : this.sql`DESC`}
-      LIMIT ${fetchLimit}
-      OFFSET ${queryOffset}
-    `
+    const rowsStatement = compilePgObjectStatement(
+      `
+        SELECT * FROM ${objectsTable}
+        WHERE ${whereSql}
+        ORDER BY ${orderColumn} ${order === "asc" ? "ASC" : "DESC"}
+        LIMIT ? OFFSET ?
+      `,
+      [...args, fetchLimit, queryOffset],
+      source
+    )
+    const rows = await sql.unsafe<ObjectDatabaseRow[]>(
+      rowsStatement.sql,
+      rowsStatement.args as SqlParameter[]
+    )
 
     const hasMore = rows.length > limit
     const objects = rows.slice(0, limit).map((row) => rowToObject(row))
 
     return { objects, hasMore, total }
+  }
+}
+
+async function assertTraversalBudget(
+  sql: SQLClient,
+  source: PgSelectedObjectReadSource,
+  maxTraversalFacts: number
+): Promise<void> {
+  const [row] = await sql.unsafe<{ total: string | number | bigint }[]>(
+    source.traversalProbe.sql,
+    source.traversalProbe.args as SqlParameter[]
+  )
+  if (BigInt(row?.total ?? 0) > BigInt(maxTraversalFacts)) {
+    throw new ObjectReadLimitExceededError("traversalFacts", maxTraversalFacts)
   }
 }
 
@@ -698,7 +1058,7 @@ function rowToLink(row: LinkDatabaseRow): ObjectLinkRow {
     linkId: row.link_id,
     targetTypeId: row.target_type_id,
     targetId: row.target_id,
-    properties: row.properties ? (row.properties as Record<string, unknown>) : undefined,
+    ...(row.properties === null ? {} : { properties: row.properties as Record<string, unknown> }),
     createdAt: new Date(row.created_at),
     updatedAt: new Date(row.updated_at),
     lastCommitId: row.last_commit_id,
@@ -738,6 +1098,14 @@ interface ObjectQueryDatabaseRow extends ObjectDatabaseRow {
   _expand?: unknown
 }
 
+interface ObjectBatchDatabaseRow extends ObjectDatabaseRow {
+  _batch_index: number
+}
+
+interface PropertyPermissionBatchDatabaseRow {
+  _batch_index: number
+}
+
 interface FacetDatabaseRow {
   value_type: string | null
   value_text: string | null
@@ -755,4 +1123,8 @@ interface LinkDatabaseRow {
   created_at: Date | string
   updated_at: Date | string
   last_commit_id: string
+}
+
+interface LinkBatchDatabaseRow extends LinkDatabaseRow {
+  _batch_index: number
 }

--- a/storage/pg/src/pg-object-storage.ts
+++ b/storage/pg/src/pg-object-storage.ts
@@ -16,7 +16,6 @@ import type {
   ObjectLinkRow,
   ObjectQueryCapabilities,
   ObjectReadExecutionLimits,
-  ObjectReadScopeFactory,
   ObjectReadStorage,
   ObjectRow,
   ObjectRowLinks,
@@ -174,7 +173,7 @@ function valuesJoin<Row = unknown>(
  * - Reads return JSONB as native JS types (objects, numbers, booleans) when
  *   the data was stored correctly.
  */
-export class PgObjectStorage implements ObjectStorage, ObjectReadScopeFactory {
+export class PgObjectStorage implements ObjectStorage {
   constructor(private readonly sql: PgStoreClient) {}
 
   queryCapabilities(): ObjectQueryCapabilities {

--- a/storage/pg/src/transactions.ts
+++ b/storage/pg/src/transactions.ts
@@ -4,9 +4,13 @@ import type { SQL, SQLClient } from "./pg-client"
 export type PgStoreClient = SQL | SQLClient
 
 export interface RunPgTransactionOptions {
-  /** Open the transaction at `SERIALIZABLE`; omit for the server default (`READ COMMITTED`). */
-  readonly isolation?: "serializable"
+  /** Open the transaction at an explicit isolation; omit for the server default. */
+  readonly isolation?: "repeatableRead" | "serializable"
 }
+
+type PgTransactionIsolation = "unverifiedDefault" | "repeatableRead" | "serializable"
+
+const activePgTransactions = new WeakMap<PgStoreClient, PgTransactionIsolation>()
 
 export async function runPgTransaction<T>(
   sql: PgStoreClient,
@@ -24,10 +28,47 @@ export async function runPgTransaction<T>(
   // The isolation level is folded into `BEGIN` (`BEGIN ISOLATION LEVEL SERIALIZABLE`) rather than
   // a separate `SET TRANSACTION` statement: one round-trip instead of two, and the level is
   // guaranteed to take effect before any data statement of the transaction runs.
-  if (options.isolation === "serializable") {
-    return sql.begin("isolation level serializable", run) as Promise<T>
+  const isolation = options.isolation ?? "unverifiedDefault"
+  const trackedRun = async (tx: SQLClient): Promise<T> => {
+    activePgTransactions.set(tx, isolation)
+    try {
+      return await run(tx)
+    } finally {
+      activePgTransactions.delete(tx)
+    }
   }
-  return sql.begin(run) as Promise<T>
+
+  if (isolation === "serializable") {
+    return sql.begin("isolation level serializable", trackedRun) as Promise<T>
+  }
+  if (isolation === "repeatableRead") {
+    return sql.begin("isolation level repeatable read", trackedRun) as Promise<T>
+  }
+  return sql.begin(trackedRun) as Promise<T>
+}
+
+/**
+ * Run a multi-statement read against one proven PostgreSQL snapshot.
+ *
+ * A provider-owned repeatable-read or serializable transaction may be reused. An external
+ * transaction client is rejected because postgres.js does not expose its current isolation.
+ */
+export async function runPgRepeatableReadTransaction<T>(
+  sql: PgStoreClient,
+  run: (tx: SQLClient) => Promise<T>
+): Promise<T> {
+  if (canStartPgTransaction(sql)) {
+    return runPgTransaction(sql, run, { isolation: "repeatableRead" })
+  }
+
+  const isolation = activePgTransactions.get(sql)
+  if (isolation === "repeatableRead" || isolation === "serializable") {
+    return run(sql)
+  }
+
+  throw new Error(
+    "[SixbPg] Selected object reads cannot join an unverified PostgreSQL transaction."
+  )
 }
 
 export function authLockKey(kind: string, ...parts: readonly string[]): string {

--- a/storage/pg/src/transactions.ts
+++ b/storage/pg/src/transactions.ts
@@ -67,7 +67,7 @@ export async function runPgRepeatableReadTransaction<T>(
   }
 
   throw new Error(
-    "[SixbPg] Selected object reads cannot join an unverified PostgreSQL transaction."
+    '[SixbPg] Selected object reads cannot join an unverified PostgreSQL transaction. Use storage.transaction(..., { isolation: "serializable" }) when reading through tx.objects.'
   )
 }
 

--- a/storage/pg/tests/pg-object-read-scope-provider.e2e.ts
+++ b/storage/pg/tests/pg-object-read-scope-provider.e2e.ts
@@ -1,0 +1,486 @@
+import { describe, expect, test } from "bun:test"
+import {
+  compileSelectedObjectReadScope,
+  linkBatchKey,
+  type ObjectReadExecutionLimits,
+  type ObjectReadScopeFactory,
+  type ObjectReadStorage,
+  type ObjectStorage,
+  objectBatchKey,
+  type SelectedObjectReadScope,
+} from "@sixb/core/storage"
+import type { PostgresStorage } from "../src"
+import type { SQL, SQLClient, SqlParameter } from "../src/pg-client"
+import { PgObjectStorage } from "../src/pg-object-storage"
+import type { PgStoreClient } from "../src/transactions"
+import { createTestStorage } from "./helpers"
+
+const projectId = "pg-selected-reader"
+const otherProjectId = `${projectId}-other`
+const RootType = "PgScopeRoot"
+const TargetType = "PgScopeTarget"
+const timestamp = "2026-08-31T00:00:00.000Z"
+const generousLimits: ObjectReadExecutionLimits = {
+  maxTraversalFacts: 100_000,
+  maxOutputJsonBytes: 10_000_000,
+}
+
+describe("PgObjectStorage selected reader invariants", () => {
+  test("counts exact path facts and preserves redacted JSONB within one project", async () => {
+    const { storage } = await createTestStorage()
+    try {
+      const sql = sqlOf(storage)
+      await insertObject(sql, RootType, "root-1", {
+        id: "root-1",
+        nested: { key: "value" },
+        values: [1, true, null],
+        enabled: true,
+        disabled: false,
+        nullable: null,
+        amount: 2.5,
+        "clé:🧪": { 值: true },
+        hidden: "root-secret",
+      })
+      await insertObject(sql, TargetType, "target-1", {
+        id: "target-1",
+        label: "visible",
+        hidden: "target-secret",
+      })
+      await insertLink(sql, "root-1", "items", "target-1", {
+        nested: { edge: true },
+        values: [false, null, 3],
+        enabled: true,
+        disabled: false,
+        nullable: null,
+        amount: 7.5,
+        hidden: "edge-secret",
+      })
+      await insertLink(sql, "root-1", "items", "target-missing", { enabled: true })
+      await insertObject(sql, RootType, "root-1", { id: "other-root" }, otherProjectId)
+      await insertObject(sql, TargetType, "target-1", { id: "other-target" }, otherProjectId)
+      await insertObject(
+        sql,
+        TargetType,
+        "target-missing",
+        { id: "other-project-only-target" },
+        otherProjectId
+      )
+      await insertLink(sql, "root-1", "items", "target-1", { enabled: false }, otherProjectId)
+
+      const exact = createReader(storage, repeatedPathScope(), {
+        ...generousLimits,
+        maxTraversalFacts: 3,
+      })
+      const listed = await exact.list({ projectId, orderBy: "primaryId", order: "asc" })
+      expect(listed.objects.map((row) => row.primaryId)).toEqual(["root-1", "target-1"])
+      expect(listed.objects.every((row) => row.projectId === projectId)).toBe(true)
+      expect(
+        await exact.getByPrimaryId({ projectId, objectTypeId: RootType, primaryId: "root-1" })
+      ).toMatchObject({
+        properties: {
+          id: "root-1",
+          nested: { key: "value" },
+          values: [1, true, null],
+          enabled: true,
+          disabled: false,
+          nullable: null,
+          amount: 2.5,
+          "clé:🧪": { 值: true },
+        },
+      })
+      const links = await exact.listLinks({
+        projectId,
+        objectTypeId: RootType,
+        objectId: "root-1",
+        linkId: "items",
+      })
+      expect(links).toHaveLength(1)
+      expect(links[0]?.properties).toEqual({
+        nested: { edge: true },
+        values: [false, null, 3],
+        enabled: true,
+        disabled: false,
+        nullable: null,
+        amount: 7.5,
+      })
+
+      const batch = await exact.getByPrimaryIdBatch({
+        projectId,
+        items: [
+          { objectTypeId: TargetType, primaryId: "target-1" },
+          { objectTypeId: RootType, primaryId: "root-1" },
+          { objectTypeId: TargetType, primaryId: "target-1" },
+        ],
+      })
+      expect([...batch.keys()]).toEqual([
+        objectBatchKey(TargetType, "target-1"),
+        objectBatchKey(RootType, "root-1"),
+      ])
+      const linkBatch = await exact.listLinksBatch({
+        projectId,
+        direction: "both",
+        items: [
+          { objectTypeId: TargetType, objectId: "target-1", linkId: "items" },
+          { objectTypeId: RootType, objectId: "root-1", linkId: "items" },
+        ],
+      })
+      expect([...linkBatch.keys()]).toEqual([
+        linkBatchKey(TargetType, "target-1", "items"),
+        linkBatchKey(RootType, "root-1", "items"),
+      ])
+
+      const overBudget = createReader(storage, repeatedPathScope(), {
+        ...generousLimits,
+        maxTraversalFacts: 2,
+      })
+      await expect(overBudget.list({ projectId })).rejects.toMatchObject({
+        code: "object_read_limit_exceeded",
+        metric: "traversalFacts",
+        limit: 2,
+      })
+    } finally {
+      await storage.dropSchema()
+      await storage.close()
+    }
+  })
+
+  test("keeps 22k-item batches bounded and link cursors deterministic", async () => {
+    const { storage } = await createTestStorage()
+    try {
+      const sql = sqlOf(storage)
+      await insertObject(sql, RootType, "root-1", { id: "root-1" })
+      for (const targetId of ["target-a", "target-é", `target-${String.fromCodePoint(0xe000)}`]) {
+        await insertObject(sql, TargetType, targetId, { id: targetId, hidden: "secret" })
+        await insertLink(sql, "root-1", "items", targetId)
+      }
+      const reader = createReader(storage, singlePathScope())
+      const targetIds = ["target-a", "target-é", `target-${String.fromCodePoint(0xe000)}`]
+      const objectItems = Array.from({ length: 22_000 }, (_, index) => {
+        if (index < targetIds.length) {
+          return { objectTypeId: TargetType, primaryId: targetIds[index] as string }
+        }
+        if (index === targetIds.length) {
+          return { objectTypeId: RootType, primaryId: "root-1" }
+        }
+        return { objectTypeId: TargetType, primaryId: `missing-${index}` }
+      })
+      const objects = await reader.getByPrimaryIdBatch({ projectId, items: objectItems })
+      expect([...objects.keys()]).toEqual([
+        ...targetIds.map((targetId) => objectBatchKey(TargetType, targetId)),
+        objectBatchKey(RootType, "root-1"),
+      ])
+
+      const linkItems = objectItems.map((item) => ({
+        objectTypeId: item.objectTypeId,
+        objectId: item.primaryId,
+        linkId: "items",
+      }))
+      const links = await reader.listLinksBatch({
+        projectId,
+        direction: "both",
+        items: linkItems,
+      })
+      expect([...links.keys()]).toEqual([
+        ...targetIds.map((targetId) => linkBatchKey(TargetType, targetId, "items")),
+        linkBatchKey(RootType, "root-1", "items"),
+      ])
+      expect([...links.values()].flat().every((link) => !Object.hasOwn(link, "properties"))).toBe(
+        true
+      )
+
+      const firstPage = await reader.queryLinks({
+        projectId,
+        objectRefs: [
+          { objectTypeId: RootType, primaryId: "root-1" },
+          { objectTypeId: RootType, primaryId: "root-1" },
+          { objectTypeId: TargetType, primaryId: "target-a" },
+        ],
+        direction: "both",
+        endpointObjectTypeIds: [RootType, TargetType],
+        limit: 2,
+      })
+      expect(firstPage.links.map((link) => link.targetId)).toEqual(targetIds.slice(0, 2))
+      expect(firstPage.hasMore).toBe(true)
+
+      const secondPage = await reader.queryLinks({
+        projectId,
+        objectRefs: [{ objectTypeId: RootType, primaryId: "root-1" }],
+        direction: "outgoing",
+        endpointObjectTypeIds: [RootType, TargetType],
+        after: [RootType, "root-1", "items", TargetType, targetIds[1] as string],
+        limit: 2,
+      })
+      expect(secondPage).toMatchObject({
+        hasMore: false,
+        links: [{ targetId: targetIds[2] }],
+      })
+    } finally {
+      await storage.dropSchema()
+      await storage.close()
+    }
+  }, 30_000)
+
+  test("keeps traversal probe and terminal reads on one repeatable-read snapshot", async () => {
+    const { storage } = await createTestStorage()
+    try {
+      const sql = sqlOf(storage)
+      await insertObject(sql, RootType, "root-1", { id: "root-1" })
+      await insertObject(sql, TargetType, "target-1", { id: "target-1" })
+      let writerCommitted = false
+      const beginModes: string[] = []
+      const intercepted = {
+        begin: (mode: string, run: (client: SQLClient) => Promise<unknown>): Promise<unknown> =>
+          sql.begin(mode, async (tx) => {
+            beginModes.push(mode)
+            const client = {
+              unsafe: async (query: string, args: SqlParameter[]) => {
+                const result = await tx.unsafe(query, args)
+                if (!writerCommitted && query.includes("bounded_traversal_facts")) {
+                  writerCommitted = true
+                  await insertLink(sql, "root-1", "items", "target-1")
+                }
+                return result
+              },
+            } as unknown as SQLClient
+            return run(client)
+          }) as Promise<unknown>,
+      } as unknown as PgStoreClient
+      const reader = createReader(new PgObjectStorage(intercepted), singlePathScope(), {
+        ...generousLimits,
+        maxTraversalFacts: 1,
+      })
+
+      expect(await reader.list({ projectId, orderBy: "primaryId", order: "asc" })).toEqual({
+        objects: [expect.objectContaining({ primaryId: "root-1" })],
+        hasMore: false,
+        total: 1,
+      })
+      expect(beginModes).toEqual(["isolation level repeatable read"])
+      expect(writerCommitted).toBe(true)
+
+      const freshReader = createReader(storage, singlePathScope(), {
+        ...generousLimits,
+        maxTraversalFacts: 1,
+      })
+      await expect(freshReader.list({ projectId })).rejects.toMatchObject({
+        code: "object_read_limit_exceeded",
+        metric: "traversalFacts",
+        limit: 1,
+      })
+    } finally {
+      await storage.dropSchema()
+      await storage.close()
+    }
+  })
+
+  test("rejects a transaction client whose isolation was not opened by the provider", async () => {
+    const { storage } = await createTestStorage()
+    try {
+      const sql = sqlOf(storage)
+      await insertObject(sql, RootType, "root-1", { id: "root-1" })
+      await sql.begin(async (tx) => {
+        const reader = createReader(new PgObjectStorage(tx), rootOnlyScope())
+        await expect(reader.list({ projectId })).rejects.toThrow(
+          "cannot join an unverified PostgreSQL transaction"
+        )
+      })
+    } finally {
+      await storage.dropSchema()
+      await storage.close()
+    }
+  })
+
+  test("reuses a serializable PostgresStorage transaction end to end", async () => {
+    const { storage } = await createTestStorage()
+    try {
+      await insertObject(sqlOf(storage), RootType, "root-1", { id: "root-1", hidden: "secret" })
+
+      const row = await storage.transaction(
+        async (tx) => {
+          const factory = tx.objects as ObjectStorage & ObjectReadScopeFactory
+          const reader = factory.createSelectedReadScope({
+            projectId,
+            scope: compileSelectedObjectReadScope(rootOnlyScope()),
+            limits: generousLimits,
+          })
+          return reader.getByPrimaryId({
+            projectId,
+            objectTypeId: RootType,
+            primaryId: "root-1",
+          })
+        },
+        { isolation: "serializable" }
+      )
+      expect(row).toMatchObject({ primaryId: "root-1", properties: { id: "root-1" } })
+
+      await expect(
+        storage.transaction(async (tx) => {
+          const factory = tx.objects as ObjectStorage & ObjectReadScopeFactory
+          const reader = factory.createSelectedReadScope({
+            projectId,
+            scope: compileSelectedObjectReadScope(rootOnlyScope()),
+            limits: generousLimits,
+          })
+          return reader.list({ projectId })
+        })
+      ).rejects.toThrow("cannot join an unverified PostgreSQL transaction")
+    } finally {
+      await storage.dropSchema()
+      await storage.close()
+    }
+  })
+})
+
+function createReader(
+  storage: PostgresStorage | PgObjectStorage,
+  scope: SelectedObjectReadScope,
+  limits: ObjectReadExecutionLimits = generousLimits
+): ObjectReadStorage {
+  const factory =
+    storage instanceof PgObjectStorage
+      ? storage
+      : (storage.objects as ObjectStorage & ObjectReadScopeFactory)
+  return factory.createSelectedReadScope({
+    projectId,
+    scope: compileSelectedObjectReadScope(scope),
+    limits,
+  })
+}
+
+function rootOnlyScope(): SelectedObjectReadScope {
+  return { kind: "selected", roots: [rootSelection("root-1")] }
+}
+
+function singlePathScope(): SelectedObjectReadScope {
+  return {
+    kind: "selected",
+    roots: [
+      {
+        ...rootSelection("root-1"),
+        node: {
+          objects: [{ objectTypeId: RootType, propertyIds: ["id"] }],
+          links: [targetPath()],
+        },
+      },
+    ],
+  }
+}
+
+function repeatedPathScope(): SelectedObjectReadScope {
+  return {
+    kind: "selected",
+    roots: [
+      {
+        ...rootSelection("root-1"),
+        node: {
+          objects: [
+            {
+              objectTypeId: RootType,
+              propertyIds: [
+                "id",
+                "nested",
+                "values",
+                "enabled",
+                "disabled",
+                "nullable",
+                "amount",
+                "clé:🧪",
+              ],
+            },
+          ],
+          links: [targetPath(true), targetPath(true)],
+        },
+      },
+      rootSelection("root-missing"),
+    ],
+  }
+}
+
+function rootSelection(primaryId: string) {
+  return {
+    anchor: { objectTypeId: RootType, primaryId },
+    node: {
+      objects: [{ objectTypeId: RootType, propertyIds: ["id"] }],
+      links: [],
+    },
+  }
+}
+
+function targetPath(selectLinkValues = false) {
+  return {
+    definitions: [
+      {
+        sourceObjectTypeId: RootType,
+        linkId: "items",
+        targetObjectTypeIds: [TargetType],
+        propertyIds: selectLinkValues
+          ? ["nested", "values", "enabled", "disabled", "nullable", "amount"]
+          : [],
+      },
+    ],
+    target: {
+      objects: [{ objectTypeId: TargetType, propertyIds: ["id", "label", "enabled"] }],
+      links: [],
+    },
+  }
+}
+
+function sqlOf(storage: PostgresStorage): SQL {
+  return (storage as unknown as { sql: SQL }).sql
+}
+
+async function insertObject(
+  sql: SQLClient,
+  objectTypeId: string,
+  primaryId: string,
+  properties: Readonly<Record<string, unknown>>,
+  rowProjectId = projectId
+): Promise<void> {
+  await sql.unsafe(
+    `
+      INSERT INTO objects (
+        project_id, object_type_id, primary_id, properties,
+        created_at, updated_at, version, last_commit_id
+      ) VALUES ($1, $2, $3, $4::text::jsonb, $5, $6, 1, $7)
+    `,
+    [
+      rowProjectId,
+      objectTypeId,
+      primaryId,
+      JSON.stringify(properties),
+      timestamp,
+      timestamp,
+      "scope-test",
+    ]
+  )
+}
+
+async function insertLink(
+  sql: SQLClient,
+  sourceId: string,
+  linkId: string,
+  targetId: string,
+  properties?: Readonly<Record<string, unknown>>,
+  rowProjectId = projectId
+): Promise<void> {
+  await sql.unsafe(
+    `
+      INSERT INTO links (
+        project_id, source_type_id, source_id, link_id, target_type_id, target_id,
+        properties, created_at, updated_at, last_commit_id
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7::text::jsonb, $8, $9, $10)
+    `,
+    [
+      rowProjectId,
+      RootType,
+      sourceId,
+      linkId,
+      TargetType,
+      targetId,
+      properties === undefined ? null : JSON.stringify(properties),
+      timestamp,
+      timestamp,
+      "scope-test",
+    ]
+  )
+}

--- a/storage/pg/tests/pg-object-read-scope-provider.e2e.ts
+++ b/storage/pg/tests/pg-object-read-scope-provider.e2e.ts
@@ -3,9 +3,7 @@ import {
   compileSelectedObjectReadScope,
   linkBatchKey,
   type ObjectReadExecutionLimits,
-  type ObjectReadScopeFactory,
   type ObjectReadStorage,
-  type ObjectStorage,
   objectBatchKey,
   type SelectedObjectReadScope,
 } from "@sixb/core/storage"
@@ -292,17 +290,20 @@ describe("PgObjectStorage selected reader invariants", () => {
 
   test("reuses a serializable PostgresStorage transaction end to end", async () => {
     const { storage } = await createTestStorage()
+    let escapedReader: ObjectReadStorage | undefined
+    let escapedList: ObjectReadStorage["list"] | undefined
     try {
       await insertObject(sqlOf(storage), RootType, "root-1", { id: "root-1", hidden: "secret" })
 
       const row = await storage.transaction(
         async (tx) => {
-          const factory = tx.objects as ObjectStorage & ObjectReadScopeFactory
-          const reader = factory.createSelectedReadScope({
+          const reader = tx.objects.createSelectedReadScope({
             projectId,
             scope: compileSelectedObjectReadScope(rootOnlyScope()),
             limits: generousLimits,
           })
+          escapedReader = reader
+          escapedList = reader.list
           return reader.getByPrimaryId({
             projectId,
             objectTypeId: RootType,
@@ -312,18 +313,24 @@ describe("PgObjectStorage selected reader invariants", () => {
         { isolation: "serializable" }
       )
       expect(row).toMatchObject({ primaryId: "root-1", properties: { id: "root-1" } })
+      if (!escapedReader || !escapedList) throw new Error("expected escaped selected reader")
+      const reader = escapedReader
+      const list = escapedList
+      expect(() => reader.queryCapabilities()).toThrow("after transaction completion")
+      await expect(Promise.resolve().then(() => list({ projectId }))).rejects.toMatchObject({
+        code: "transaction_inactive",
+      })
 
       await expect(
         storage.transaction(async (tx) => {
-          const factory = tx.objects as ObjectStorage & ObjectReadScopeFactory
-          const reader = factory.createSelectedReadScope({
+          const reader = tx.objects.createSelectedReadScope({
             projectId,
             scope: compileSelectedObjectReadScope(rootOnlyScope()),
             limits: generousLimits,
           })
           return reader.list({ projectId })
         })
-      ).rejects.toThrow("cannot join an unverified PostgreSQL transaction")
+      ).rejects.toThrow('{ isolation: "serializable" }')
     } finally {
       await storage.dropSchema()
       await storage.close()
@@ -336,10 +343,7 @@ function createReader(
   scope: SelectedObjectReadScope,
   limits: ObjectReadExecutionLimits = generousLimits
 ): ObjectReadStorage {
-  const factory =
-    storage instanceof PgObjectStorage
-      ? storage
-      : (storage.objects as ObjectStorage & ObjectReadScopeFactory)
+  const factory = storage instanceof PgObjectStorage ? storage : storage.objects
   return factory.createSelectedReadScope({
     projectId,
     scope: compileSelectedObjectReadScope(scope),

--- a/storage/pg/tests/pg-object-read-scope-provider.test.ts
+++ b/storage/pg/tests/pg-object-read-scope-provider.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test } from "bun:test"
+import {
+  compileSelectedObjectReadScope,
+  type ObjectReadExecutionLimits,
+  type SelectedObjectReadScope,
+} from "@sixb/core/storage"
+import type { SQLClient, SqlParameter } from "../src/pg-client"
+import {
+  compilePgObjectCountQuery,
+  compilePgObjectExistsQuery,
+  compilePgObjectFacetQuery,
+  compilePgObjectQuery,
+  compilePgObjectStatement,
+} from "../src/pg-object-query-compiler"
+import { compilePgSelectedObjectReadSource } from "../src/pg-object-read-scope"
+import { PgObjectStorage } from "../src/pg-object-storage"
+import type { PgStoreClient } from "../src/transactions"
+
+const projectId = "pg-selected-reader"
+const RootType = "PgScopeRoot"
+const limits: ObjectReadExecutionLimits = {
+  maxTraversalFacts: 100,
+  maxOutputJsonBytes: 1_000_000,
+}
+
+describe("PgObjectStorage selected reader compilation", () => {
+  test("serializes a large compiled scope into one bounded statement parameter", () => {
+    const scope = compileSelectedObjectReadScope({
+      kind: "selected",
+      roots: Array.from({ length: 400 }, (_, index) => rootSelection(`root-${index}`)),
+    })
+    const source = compilePgSelectedObjectReadSource(projectId, scope, Number.MAX_SAFE_INTEGER)
+    const statement = compilePgObjectStatement("SELECT ?::text AS terminal", ["value"], source)
+
+    expect(statement.args).toHaveLength(3)
+    expect(statement.args[0]).toBeString()
+    expect(statement.args[1]).toBe(projectId)
+    expect(statement.args[2]).toBe("value")
+    expect(statement.sql.match(/\$1::text::jsonb/g)).toHaveLength(1)
+    expect(highestPlaceholder(statement.sql)).toBe(statement.args.length)
+    expect(source.traversalProbe.args.at(-1)).toBe(BigInt(Number.MAX_SAFE_INTEGER) + 1n)
+  })
+
+  test("wraps main, total, and has-more query statements in the selected source", () => {
+    const source = compilePgSelectedObjectReadSource(
+      projectId,
+      compileSelectedObjectReadScope(rootOnlyScope()),
+      limits.maxTraversalFacts
+    )
+    const compiled = compilePgObjectQuery(
+      projectId,
+      {
+        kind: "sort",
+        fields: [{ kind: "property", propertyId: "id", direction: "asc" }],
+        input: {
+          kind: "limit",
+          limit: 1,
+          input: { kind: "start", objectTypeId: RootType },
+        },
+      },
+      { includeTotal: false, source }
+    )
+
+    for (const statement of [
+      { sql: compiled.sql, args: compiled.args },
+      { sql: compiled.totalSql, args: compiled.totalArgs },
+      compiled.hasMoreProbe,
+    ]) {
+      if (!statement) throw new Error("expected a has-more probe")
+      expect(statement.sql).toContain("WITH RECURSIVE")
+      expect(statement.sql).toContain("_sixb_scope_objects")
+      expect(statement.args[0]).toBeString()
+      expect(statement.args[1]).toBe(projectId)
+      expect(highestPlaceholder(statement.sql)).toBe(statement.args.length)
+    }
+  })
+
+  test("wraps aggregate query statements in the selected source", () => {
+    const source = compilePgSelectedObjectReadSource(
+      projectId,
+      compileSelectedObjectReadScope(rootOnlyScope()),
+      limits.maxTraversalFacts
+    )
+    const query = { kind: "start", objectTypeId: RootType } as const
+
+    for (const statement of [
+      compilePgObjectCountQuery(projectId, query, { source }),
+      compilePgObjectExistsQuery(projectId, query, { source }),
+      compilePgObjectFacetQuery(projectId, query, "id", 10, { source }),
+    ]) {
+      expect(statement.sql).toContain("WITH RECURSIVE")
+      expect(statement.sql).toContain("_sixb_scope_objects")
+      expect(statement.args[0]).toBeString()
+      expect(statement.args[1]).toBe(projectId)
+      expect(highestPlaceholder(statement.sql)).toBe(statement.args.length)
+    }
+  })
+
+  test("compiles endpoint-filtered link reads with exact args and canonical collation", async () => {
+    const { sql, calls, beginCalls } = recordingPool()
+    const storage = new PgObjectStorage(sql)
+    const reader = storage.createSelectedReadScope({
+      projectId,
+      scope: compileSelectedObjectReadScope(rootOnlyScope()),
+      limits,
+    })
+    const allowedTypes = [RootType, "PgScopeTarget"]
+
+    expect(
+      await reader.queryLinks({
+        projectId,
+        objectRefs: [
+          { objectTypeId: RootType, primaryId: "root-1" },
+          { objectTypeId: RootType, primaryId: "root-1" },
+        ],
+        direction: "both",
+        linkId: "items",
+        endpointObjectTypeIds: allowedTypes,
+        after: [RootType, "root-0", "items", "PgScopeTarget", "target-é"],
+        limit: 20,
+      })
+    ).toEqual({ links: [], hasMore: false })
+
+    expect(beginCalls).toEqual(["isolation level repeatable read"])
+    expect(calls).toHaveLength(2)
+    const terminal = calls[1]
+    if (!terminal) throw new Error("expected a terminal query")
+    expect(terminal.sql).toContain("CROSS JOIN LATERAL")
+    expect(terminal.sql).toContain("SELECT DISTINCT link.*")
+    expect(terminal.sql).toContain('COLLATE "C"')
+    expect(terminal.sql).toContain("_sixb_scope_links")
+    expect(highestPlaceholder(terminal.sql)).toBe(terminal.args.length)
+    expect(terminal.args.filter((value) => value === JSON.stringify(allowedTypes))).toHaveLength(2)
+    expect(terminal.args.at(-1)).toBe(21)
+  })
+
+  test("rejects an invalid link-query limit before opening a transaction or probing", async () => {
+    const { sql, calls, beginCalls } = recordingPool()
+    const reader = new PgObjectStorage(sql).createSelectedReadScope({
+      projectId,
+      scope: compileSelectedObjectReadScope(rootOnlyScope()),
+      limits,
+    })
+
+    await expect(
+      reader.queryLinks({
+        projectId,
+        objectRefs: [{ objectTypeId: RootType, primaryId: "root-1" }],
+        direction: "outgoing",
+        limit: 0,
+      })
+    ).rejects.toThrow("positive safe integer")
+    expect(beginCalls).toHaveLength(0)
+    expect(calls).toHaveLength(0)
+  })
+
+  test("wraps every interactive terminal in the selected source", async () => {
+    const { sql, calls } = recordingPool()
+    const reader = new PgObjectStorage(sql).createSelectedReadScope({
+      projectId,
+      scope: compileSelectedObjectReadScope(rootOnlyScope()),
+      limits,
+    })
+    const operations: readonly (() => Promise<unknown>)[] = [
+      () =>
+        reader.queryObjects?.({
+          projectId,
+          query: { kind: "start", objectTypeId: RootType },
+        }) ?? Promise.reject(new Error("queryObjects missing")),
+      () =>
+        reader.countObjects?.({
+          projectId,
+          query: { kind: "start", objectTypeId: RootType },
+        }) ?? Promise.reject(new Error("countObjects missing")),
+      () =>
+        reader.existsObjects?.({
+          projectId,
+          query: { kind: "start", objectTypeId: RootType },
+        }) ?? Promise.reject(new Error("existsObjects missing")),
+      () =>
+        reader.facetObjects?.({
+          projectId,
+          query: { kind: "start", objectTypeId: RootType },
+          facets: [{ propertyId: "id", limit: 10 }],
+        }) ?? Promise.reject(new Error("facetObjects missing")),
+      () => reader.getByPrimaryId({ projectId, objectTypeId: RootType, primaryId: "root-1" }),
+      () =>
+        reader.selectsObjectProperties({
+          projectId,
+          items: [{ objectTypeId: RootType, primaryId: "root-1", propertyId: "id" }],
+        }),
+      () =>
+        reader.listLinks({
+          projectId,
+          objectTypeId: RootType,
+          objectId: "root-1",
+          direction: "both",
+        }),
+      () =>
+        reader.getByPrimaryIdBatch({
+          projectId,
+          items: [{ objectTypeId: RootType, primaryId: "root-1" }],
+        }),
+      () =>
+        reader.listLinksBatch({
+          projectId,
+          direction: "both",
+          items: [{ objectTypeId: RootType, objectId: "root-1", linkId: "items" }],
+        }),
+      () =>
+        reader.queryLinks({
+          projectId,
+          objectRefs: [{ objectTypeId: RootType, primaryId: "root-1" }],
+          direction: "both",
+          limit: 10,
+        }),
+      () => reader.list({ projectId }),
+    ]
+
+    for (const operation of operations) {
+      const start = calls.length
+      await operation()
+      const operationCalls = calls.slice(start)
+      expect(operationCalls.length).toBeGreaterThanOrEqual(2)
+      for (const call of operationCalls) {
+        expect(call.sql).toContain("WITH RECURSIVE")
+        expect(call.sql).toContain("_sixb_scope_document")
+        expect(call.args[0]).toBeString()
+        expect(call.args[1]).toBe(projectId)
+        expect(highestPlaceholder(call.sql)).toBe(call.args.length)
+      }
+    }
+  })
+})
+
+function recordingPool(): {
+  readonly sql: PgStoreClient
+  readonly calls: { readonly sql: string; readonly args: readonly SqlParameter[] }[]
+  readonly beginCalls: string[]
+} {
+  const calls: { sql: string; args: readonly SqlParameter[] }[] = []
+  const beginCalls: string[] = []
+  const tx = {
+    unsafe: async <T extends readonly unknown[]>(sql: string, args: SqlParameter[]): Promise<T> => {
+      calls.push({ sql, args })
+      if (sql.includes("bounded_traversal_facts")) {
+        return [{ total: "0" }] as unknown as T
+      }
+      return [] as unknown as T
+    },
+  } as unknown as SQLClient
+  const sql = {
+    begin: async (mode: string, run: (client: SQLClient) => Promise<unknown>) => {
+      beginCalls.push(mode)
+      return run(tx)
+    },
+  } as unknown as PgStoreClient
+  return { sql, calls, beginCalls }
+}
+
+function highestPlaceholder(sql: string): number {
+  return Math.max(0, ...[...sql.matchAll(/\$(\d+)/g)].map((match) => Number(match[1])))
+}
+
+function rootOnlyScope(): SelectedObjectReadScope {
+  return { kind: "selected", roots: [rootSelection("root-1")] }
+}
+
+function rootSelection(primaryId: string) {
+  return {
+    anchor: { objectTypeId: RootType, primaryId },
+    node: {
+      objects: [{ objectTypeId: RootType, propertyIds: ["id"] }],
+      links: [],
+    },
+  }
+}

--- a/storage/pg/tests/pg-object-read-scope.e2e.ts
+++ b/storage/pg/tests/pg-object-read-scope.e2e.ts
@@ -1,4 +1,3 @@
-import type { ObjectReadScopeFactory, ObjectStorage } from "@sixb/core/storage"
 import { runObjectReadScopeContractSuite } from "@sixb/core/testing"
 import { createTestStorage } from "./helpers"
 
@@ -7,7 +6,7 @@ runObjectReadScopeContractSuite("PostgresStorage selected object-read scope cont
     const { storage } = await createTestStorage()
     return {
       storage,
-      objectReadScopeFactory: storage.objects as ObjectStorage & ObjectReadScopeFactory,
+      objectReadScopeFactory: storage.objects,
     }
   },
   teardown: async ({ storage }) => {

--- a/storage/pg/tests/pg-object-read-scope.e2e.ts
+++ b/storage/pg/tests/pg-object-read-scope.e2e.ts
@@ -1,0 +1,17 @@
+import type { ObjectReadScopeFactory, ObjectStorage } from "@sixb/core/storage"
+import { runObjectReadScopeContractSuite } from "@sixb/core/testing"
+import { createTestStorage } from "./helpers"
+
+runObjectReadScopeContractSuite("PostgresStorage selected object-read scope contract", {
+  createHarness: async () => {
+    const { storage } = await createTestStorage()
+    return {
+      storage,
+      objectReadScopeFactory: storage.objects as ObjectStorage & ObjectReadScopeFactory,
+    }
+  },
+  teardown: async ({ storage }) => {
+    await storage.dropSchema()
+    await storage.close()
+  },
+})

--- a/storage/pg/tests/pg-transactions.test.ts
+++ b/storage/pg/tests/pg-transactions.test.ts
@@ -80,7 +80,7 @@ describe("runPgTransaction isolation", () => {
   test("rejects unverified, read-committed, and escaped transaction clients", async () => {
     await expect(
       runPgRepeatableReadTransaction({} as PgStoreClient, async () => "unverified")
-    ).rejects.toThrow("cannot join an unverified PostgreSQL transaction")
+    ).rejects.toThrow('{ isolation: "serializable" }')
 
     const readCommitted = fakeSql()
     await runPgTransaction(readCommitted.sql, async (tx) => {

--- a/storage/pg/tests/pg-transactions.test.ts
+++ b/storage/pg/tests/pg-transactions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { PgStoreClient } from "../src/transactions"
-import { runPgTransaction } from "../src/transactions"
+import { runPgRepeatableReadTransaction, runPgTransaction } from "../src/transactions"
 
 /**
  * A minimal stand-in for porsager's pool that records how `begin` was invoked. `runPgTransaction`
@@ -8,16 +8,17 @@ import { runPgTransaction } from "../src/transactions"
  * live database — this is the CI-runnable check that the `serializable` path actually reaches the
  * driver (the full provider path is exercised by the Docker-gated e2e).
  */
-function fakeSql(): { sql: PgStoreClient; beginCalls: unknown[][] } {
+function fakeSql(): { sql: PgStoreClient; client: PgStoreClient; beginCalls: unknown[][] } {
   const beginCalls: unknown[][] = []
+  const client = {} as PgStoreClient
   const sql = {
     begin: (...args: unknown[]) => {
       beginCalls.push(args)
       const run = args[args.length - 1] as (client: unknown) => Promise<unknown>
-      return run({})
+      return run(client)
     },
   }
-  return { sql: sql as unknown as PgStoreClient, beginCalls }
+  return { sql: sql as unknown as PgStoreClient, client, beginCalls }
 }
 
 describe("runPgTransaction isolation", () => {
@@ -40,5 +41,66 @@ describe("runPgTransaction isolation", () => {
     expect(beginCalls).toHaveLength(1)
     expect(beginCalls[0]).toHaveLength(1)
     expect(typeof beginCalls[0]?.[0]).toBe("function")
+  })
+
+  test("opens selected reads at repeatable-read isolation", async () => {
+    const { sql, beginCalls } = fakeSql()
+
+    const result = await runPgRepeatableReadTransaction(sql, async () => "ok")
+
+    expect(result).toBe("ok")
+    expect(beginCalls).toHaveLength(1)
+    expect(beginCalls[0]?.[0]).toBe("isolation level repeatable read")
+  })
+
+  test("reuses only provider-owned repeatable-read or serializable transactions", async () => {
+    const repeatable = fakeSql()
+    const serializable = fakeSql()
+
+    await runPgTransaction(
+      repeatable.sql,
+      async (tx) => {
+        expect(await runPgRepeatableReadTransaction(tx, async () => "repeatable")).toBe(
+          "repeatable"
+        )
+      },
+      { isolation: "repeatableRead" }
+    )
+    await runPgTransaction(
+      serializable.sql,
+      async (tx) => {
+        expect(await runPgRepeatableReadTransaction(tx, async () => "serializable")).toBe(
+          "serializable"
+        )
+      },
+      { isolation: "serializable" }
+    )
+  })
+
+  test("rejects unverified, read-committed, and escaped transaction clients", async () => {
+    await expect(
+      runPgRepeatableReadTransaction({} as PgStoreClient, async () => "unverified")
+    ).rejects.toThrow("cannot join an unverified PostgreSQL transaction")
+
+    const readCommitted = fakeSql()
+    await runPgTransaction(readCommitted.sql, async (tx) => {
+      await expect(runPgRepeatableReadTransaction(tx, async () => "unsafe")).rejects.toThrow(
+        "cannot join an unverified PostgreSQL transaction"
+      )
+    })
+
+    const escaped = fakeSql()
+    let escapedClient: PgStoreClient | undefined
+    await runPgTransaction(
+      escaped.sql,
+      async (tx) => {
+        escapedClient = tx
+      },
+      { isolation: "serializable" }
+    )
+    if (!escapedClient) throw new Error("expected a transaction client")
+    await expect(
+      runPgRepeatableReadTransaction(escapedClient, async () => "escaped")
+    ).rejects.toThrow("cannot join an unverified PostgreSQL transaction")
   })
 })

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -13,6 +13,7 @@ import { ProviderMaterializationTransactionLifecycle } from "@sixb/core/internal
 import {
   createAgentOperationScope,
   createAuthOperationScope,
+  createObjectOperationScope,
   createOntologyOperationScope,
   createOperationScopedFacade,
   createStorageOperationScope,
@@ -143,7 +144,7 @@ export class SqliteStorage implements MigrationCapableStorage {
     const readTimeseries = path
       ? new SqliteTimeseriesStorage({ connection: this.readConnection })
       : stores.timeseries
-    this.objects = createOperationScopedFacade(readObjects, readScope)
+    this.objects = createObjectOperationScope(readObjects, readScope)
     this.ontology = createOntologyOperationScope(stores.ontology, ontologyScope)
     this.auth = createAuthOperationScope(stores.auth, scope)
     this.executions = createOperationScopedFacade(stores.executions, scope)

--- a/storage/sqlite/src/object-query-compiler.ts
+++ b/storage/sqlite/src/object-query-compiler.ts
@@ -36,6 +36,7 @@ interface CompiledHasMoreProbe {
 
 interface CompileContext {
   probeLimit: boolean
+  source: SqliteObjectQuerySource
 }
 
 interface CompiledPredicate {
@@ -74,7 +75,6 @@ interface EncodedCursorValue {
 }
 
 const PAGE_TOKEN_PREFIX = "keyset:"
-const exactContext: CompileContext = { probeLimit: false }
 
 // Fallback fanout cap for a "many" expansion that arrives without an explicit
 // limit. The core executor normally bakes a limit in before pushdown; this only
@@ -84,10 +84,37 @@ const DEFAULT_EXPANSION_FANOUT = 1_000
 export function compileObjectQuery(
   projectId: string,
   query: ObjectQuery,
-  options: { includeTotal?: boolean } = {}
+  options: { includeTotal?: boolean; source?: SqliteObjectQuerySource } = {}
 ): CompiledObjectQuery {
-  const ctx: CompileContext = { probeLimit: options.includeTotal === false }
-  return compileObjectQueryInternal(projectId, query, ctx)
+  const source = options.source ?? DEFAULT_OBJECT_QUERY_SOURCE
+  const ctx: CompileContext = { probeLimit: options.includeTotal === false, source }
+  return source.wrapQuery(compileObjectQueryInternal(projectId, query, ctx))
+}
+
+/** Physical relations used by the object-query compiler. */
+export interface SqliteObjectQuerySource {
+  readonly objectsTable: string
+  readonly linksTable: string
+  /** Wrap a terminal SELECT without its own WITH clause; the selected source owns the only WITH. */
+  wrapStatement(
+    sql: string,
+    args?: readonly SqliteValue[]
+  ): {
+    readonly sql: string
+    readonly args: readonly SqliteValue[]
+  }
+  wrapQuery(query: CompiledObjectQuery): CompiledObjectQuery
+}
+
+const DEFAULT_OBJECT_QUERY_SOURCE: SqliteObjectQuerySource = {
+  objectsTable: "objects",
+  linksTable: "links",
+  wrapStatement: (sql, args = []) => ({ sql, args: [...args] }),
+  wrapQuery: (query) => query,
+}
+
+function exactContext(ctx: CompileContext): CompileContext {
+  return ctx.probeLimit ? { ...ctx, probeLimit: false } : ctx
 }
 
 function compileObjectQueryInternal(
@@ -97,27 +124,28 @@ function compileObjectQueryInternal(
 ): CompiledObjectQuery {
   switch (query.kind) {
     case "start":
-      return compileStart(projectId, query)
+      return compileStart(projectId, query, ctx)
     case "refs":
-      return compileRefs(projectId, query)
+      return compileRefs(projectId, query, ctx)
     case "filter":
-      return compileFilter(projectId, query.input, query.predicate)
+      return compileFilter(projectId, query.input, query.predicate, ctx)
     case "sort":
       return compileSort(projectId, query.input, query.fields, ctx)
     case "limit":
       return compileLimit(projectId, query.input, query.limit, ctx)
     case "page":
-      return compilePage(projectId, query.input, query.pageSize, query.pageToken)
+      return compilePage(projectId, query.input, query.pageSize, query.pageToken, ctx)
     case "traverse":
       return compileTraversal(
         projectId,
         query.input,
         query.linkId,
         query.direction,
-        query.sourceObjectTypeId
+        query.sourceObjectTypeId,
+        ctx
       )
     case "set":
-      return compileSet(projectId, query.op, query.inputs)
+      return compileSet(projectId, query.op, query.inputs, ctx)
     case "project":
       return compileProject(projectId, query.input, query.properties, ctx)
     case "text":
@@ -126,10 +154,11 @@ function compileObjectQueryInternal(
         query.input,
         query.query,
         query.fields,
-        query.fieldsByObjectType
+        query.fieldsByObjectType,
+        ctx
       )
     case "expand":
-      return compileExpand(projectId, query.input, query.expansions)
+      return compileExpand(projectId, query.input, query.expansions, ctx)
     case "vector":
       throw new Error(`[Sixb] SQLite object storage does not support query node '${query.kind}'`)
   }
@@ -137,7 +166,8 @@ function compileObjectQueryInternal(
 
 function compileStart(
   projectId: string,
-  query: Extract<ObjectQuery, { kind: "start" }>
+  query: Extract<ObjectQuery, { kind: "start" }>,
+  ctx: CompileContext
 ): CompiledObjectQuery {
   if (query.includeSubtypes === true) {
     throw new Error("[Sixb] SQLite object storage does not support start.includeSubtypes")
@@ -146,7 +176,7 @@ function compileStart(
   const order = compileOrder(identityOrderFields())
   const sql = `
     SELECT *, properties AS _cursor_properties
-    FROM objects
+    FROM ${ctx.source.objectsTable}
     WHERE project_id = ? AND object_type_id = ?
     ORDER BY ${order.sql}
   `
@@ -155,7 +185,7 @@ function compileStart(
   return {
     sql,
     args,
-    totalSql: "SELECT COUNT(*) as total FROM objects WHERE project_id = ? AND object_type_id = ?",
+    totalSql: `SELECT COUNT(*) as total FROM ${ctx.source.objectsTable} WHERE project_id = ? AND object_type_id = ?`,
     totalArgs: [projectId, query.objectTypeId],
     order,
     hasMore: () => false,
@@ -166,7 +196,8 @@ function compileStart(
 
 function compileRefs(
   projectId: string,
-  query: Extract<ObjectQuery, { kind: "refs" }>
+  query: Extract<ObjectQuery, { kind: "refs" }>,
+  ctx: CompileContext
 ): CompiledObjectQuery {
   if (query.refs.length === 0) {
     throw new Error("[Sixb] SQLite object storage requires at least one ref")
@@ -182,10 +213,9 @@ function compileRefs(
     FROM json_each(?) AS ref
   `
   const sql = `
-    WITH requested AS (${requested})
     SELECT selected.*, selected.properties AS _cursor_properties
-    FROM requested
-    JOIN objects AS selected
+    FROM (${requested}) AS requested
+    JOIN ${ctx.source.objectsTable} AS selected
       ON selected.project_id = ?
      AND selected.object_type_id = requested.object_type_id
      AND selected.primary_id = requested.primary_id
@@ -196,10 +226,9 @@ function compileRefs(
     sql,
     args: [refsJson, projectId, ...selectedOrder.args],
     totalSql: `
-      WITH requested AS (${requested})
       SELECT COUNT(*) AS total
-      FROM requested
-      JOIN objects AS selected
+      FROM (${requested}) AS requested
+      JOIN ${ctx.source.objectsTable} AS selected
         ON selected.project_id = ?
        AND selected.object_type_id = requested.object_type_id
        AND selected.primary_id = requested.primary_id
@@ -215,18 +244,20 @@ function compileRefs(
 function compileFilter(
   projectId: string,
   inputQuery: ObjectQuery,
-  predicateNode: ObjectQueryPredicate
+  predicateNode: ObjectQueryPredicate,
+  ctx: CompileContext
 ): CompiledObjectQuery {
   const predicate = compilePredicate(predicateNode)
-  return compileWhere(projectId, inputQuery, predicate)
+  return compileWhere(projectId, inputQuery, predicate, ctx)
 }
 
 function compileWhere(
   projectId: string,
   inputQuery: ObjectQuery,
-  predicate: CompiledPredicate
+  predicate: CompiledPredicate,
+  ctx: CompileContext
 ): CompiledObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const sql = `
     SELECT *
     FROM (${input.sql}) AS input
@@ -255,7 +286,8 @@ function compileText(
   inputQuery: ObjectQuery,
   query: string,
   fields: readonly string[] | undefined,
-  fieldsByObjectType: Readonly<Record<string, readonly string[]>> | undefined
+  fieldsByObjectType: Readonly<Record<string, readonly string[]>> | undefined,
+  ctx: CompileContext
 ): CompiledObjectQuery {
   const predicate =
     fields && fields.length > 0
@@ -265,7 +297,7 @@ function compileText(
   if (!predicate) {
     throw new Error("[Sixb] SQLite object text search requires fields or resolved text defaults")
   }
-  return compileWhere(projectId, inputQuery, predicate)
+  return compileWhere(projectId, inputQuery, predicate, ctx)
 }
 
 function compileSort(
@@ -274,7 +306,7 @@ function compileSort(
   fields: readonly ObjectQuerySortField[],
   ctx: CompileContext
 ): CompiledObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const probeInput =
     ctx.probeLimit && needsLimitProbe(inputQuery)
       ? compileObjectQueryInternal(projectId, inputQuery, ctx)
@@ -313,7 +345,7 @@ function compileLimit(
   rawLimit: number,
   ctx: CompileContext
 ): CompiledObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const limit = Math.max(0, rawLimit)
   const rowLimit = ctx.probeLimit ? limit + 1 : limit
 
@@ -342,9 +374,10 @@ function compilePage(
   projectId: string,
   inputQuery: ObjectQuery,
   rawPageSize: number,
-  pageToken: string | undefined
+  pageToken: string | undefined,
+  ctx: CompileContext
 ): CompiledObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const pageSize = Math.max(0, rawPageSize)
   const cursor = pageToken ? decodePageToken(pageToken, input.order.fields) : undefined
   const cursorPredicate = cursor
@@ -381,30 +414,31 @@ function compileTraversal(
   inputQuery: ObjectQuery,
   linkId: string,
   direction: "outgoing" | "incoming",
-  sourceObjectTypeId?: string
+  sourceObjectTypeId: string | undefined,
+  ctx: CompileContext
 ): CompiledObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const outputAlias = direction === "outgoing" ? "target_object" : "source_object"
   const joinSql =
     direction === "outgoing"
       ? `
-        JOIN links AS edge
+        JOIN ${ctx.source.linksTable} AS edge
           ON edge.project_id = input.project_id
          AND edge.source_type_id = input.object_type_id
          AND edge.source_id = input.primary_id
          AND edge.link_id = ?
-        JOIN objects AS target_object
+        JOIN ${ctx.source.objectsTable} AS target_object
           ON target_object.project_id = edge.project_id
          AND target_object.object_type_id = edge.target_type_id
          AND target_object.primary_id = edge.target_id
       `
       : `
-        JOIN links AS edge
+        JOIN ${ctx.source.linksTable} AS edge
           ON edge.project_id = input.project_id
          AND edge.target_type_id = input.object_type_id
          AND edge.target_id = input.primary_id
          AND edge.link_id = ?${sourceObjectTypeId === undefined ? "" : "\n         AND edge.source_type_id = ?"}
-        JOIN objects AS source_object
+        JOIN ${ctx.source.objectsTable} AS source_object
           ON source_object.project_id = edge.project_id
          AND source_object.object_type_id = edge.source_type_id
          AND source_object.primary_id = edge.source_id
@@ -451,13 +485,15 @@ interface ExpansionParent {
 function compileExpand(
   projectId: string,
   inputQuery: ObjectQuery,
-  expansions: readonly ObjectExpansion[]
+  expansions: readonly ObjectExpansion[],
+  ctx: CompileContext
 ): CompiledObjectQuery {
-  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext(ctx))
   const expand = compileExpansionsObject(
     expansions,
     { project: "input.project_id", type: "input.object_type_id", id: "input.primary_id" },
-    ""
+    "",
+    ctx
   )
   const inputOrder = compileOrder(input.order.fields, "input", "input._cursor_properties")
   const sql = `
@@ -487,13 +523,14 @@ function compileExpand(
 function compileExpansionsObject(
   expansions: readonly ObjectExpansion[],
   parent: ExpansionParent,
-  pathPrefix: string
+  pathPrefix: string,
+  ctx: CompileContext
 ): CompiledPredicate {
   const parts: string[] = []
   const args: SqliteValue[] = []
   expansions.forEach((expansion, index) => {
     const path = pathPrefix === "" ? `${index}` : `${pathPrefix}_${index}`
-    const value = compileExpansionValue(expansion, parent, path)
+    const value = compileExpansionValue(expansion, parent, path, ctx)
     parts.push("?", `json(${value.sql})`)
     args.push(expansion.linkId, ...value.args)
   })
@@ -509,7 +546,8 @@ function compileExpansionsObject(
 function compileExpansionValue(
   expansion: ObjectExpansion,
   parent: ExpansionParent,
-  path: string
+  path: string,
+  ctx: CompileContext
 ): CompiledPredicate {
   const edge = `edge_${path}`
   const target = `tgt_${path}`
@@ -522,7 +560,7 @@ function compileExpansionValue(
   const parentType = incoming ? `${edge}.target_type_id` : `${edge}.source_type_id`
   const parentId = incoming ? `${edge}.target_id` : `${edge}.source_id`
 
-  const child = compileExpansionChildJson(expansion, edge, target, path)
+  const child = compileExpansionChildJson(expansion, edge, target, path, ctx)
   const order = compileExpansionOrder(expansion, target, neighborType, neighborId)
 
   const whereParts = [
@@ -539,8 +577,8 @@ function compileExpansionValue(
 
   const inner = `
     SELECT ${child.sql} AS elem, row_number() OVER (ORDER BY ${order.sql}) AS _ord
-    FROM links AS ${edge}
-    JOIN objects AS ${target}
+    FROM ${ctx.source.linksTable} AS ${edge}
+    JOIN ${ctx.source.objectsTable} AS ${target}
       ON ${target}.project_id = ${edge}.project_id
      AND ${target}.object_type_id = ${neighborType}
      AND ${target}.primary_id = ${neighborId}
@@ -574,7 +612,8 @@ function compileExpansionChildJson(
   expansion: ObjectExpansion,
   edge: string,
   target: string,
-  path: string
+  path: string,
+  ctx: CompileContext
 ): CompiledPredicate {
   const fields = [
     `'projectId', ${target}.project_id`,
@@ -597,7 +636,8 @@ function compileExpansionChildJson(
         type: `${target}.object_type_id`,
         id: `${target}.primary_id`,
       },
-      path
+      path,
+      ctx
     )
     fields.push(`'links', ${nested.sql}`)
     args.push(...nested.args)
@@ -645,14 +685,15 @@ function compileExpansionOrder(
 function compileSet(
   projectId: string,
   op: ObjectQuerySetOperation,
-  inputs: readonly ObjectQuery[]
+  inputs: readonly ObjectQuery[],
+  ctx: CompileContext
 ): CompiledObjectQuery {
   if (inputs.length === 0) {
     const order = compileOrder(identityOrderFields())
     return {
       sql: `
         SELECT *
-        FROM objects
+        FROM ${ctx.source.objectsTable}
         WHERE 1 = 0
         ORDER BY ${order.sql}
       `,
@@ -667,7 +708,7 @@ function compileSet(
   }
 
   const compiledInputs = inputs.map((input) =>
-    compileObjectQueryInternal(projectId, input, exactContext)
+    compileObjectQueryInternal(projectId, input, exactContext(ctx))
   )
   const identities = compileSetIdentities(op, compiledInputs)
   const order = compileOrder(identityOrderFields())
@@ -675,7 +716,7 @@ function compileSet(
   const sql = `
     SELECT selected.*, selected.properties AS _cursor_properties
     FROM (${identities.sql}) AS ids
-    JOIN objects AS selected
+    JOIN ${ctx.source.objectsTable} AS selected
       ON selected.project_id = ?
      AND selected.object_type_id = ids.object_type_id
      AND selected.primary_id = ids.primary_id
@@ -778,7 +819,7 @@ function compileProjectionExpression(properties: readonly string[]): CompiledPre
     sql: `
       COALESCE(
         (
-          SELECT json_group_object(projected.key, projected.value)
+          SELECT json_group_object(projected.key, ${sqliteJsonEachValue("projected")})
           FROM json_each(input.properties) AS projected
           WHERE projected.key IN (${properties.map(() => "?").join(", ")})
         ),
@@ -787,6 +828,15 @@ function compileProjectionExpression(properties: readonly string[]): CompiledPre
     `,
     args: [...properties],
   }
+}
+
+/** json_each exposes JSON booleans as integer SQL values; restore their JSON representation. */
+export function sqliteJsonEachValue(alias: string): string {
+  return `CASE ${alias}.type
+    WHEN 'true' THEN json('true')
+    WHEN 'false' THEN json('false')
+    ELSE ${alias}.value
+  END`
 }
 
 function compilePredicate(predicate: ObjectQueryPredicate): CompiledPredicate {

--- a/storage/sqlite/src/object-read-scope.ts
+++ b/storage/sqlite/src/object-read-scope.ts
@@ -1,0 +1,316 @@
+import type { CompiledSelectedObjectReadScope } from "@sixb/core/storage"
+import {
+  type CompiledObjectQuery,
+  type SqliteObjectQuerySource,
+  type SqliteValue,
+  sqliteJsonEachValue,
+} from "./object-query-compiler"
+
+export interface SqliteSelectedObjectReadSource extends SqliteObjectQuerySource {
+  readonly objectPropertyPermissionsTable: string
+  readonly traversalProbe: {
+    readonly sql: string
+    readonly args: readonly SqliteValue[]
+  }
+}
+
+/**
+ * Prepare one immutable selected scope as live, path-sensitive SQLite relations.
+ *
+ * The complete compiled scope is serialized once. Every statement receives that one JSON document
+ * and the bound project id, keeping the host-parameter count constant as selections grow.
+ */
+export function compileSqliteSelectedObjectReadSource(
+  projectId: string,
+  scope: CompiledSelectedObjectReadScope,
+  maxTraversalFacts: number
+): SqliteSelectedObjectReadSource {
+  const scopeJson = JSON.stringify({
+    roots: scope.roots,
+    objects: scope.objects,
+    steps: scope.steps,
+  })
+  const compiled = compileSelectedReadScopeCte(scopeJson, projectId)
+  const wrapStatement = (sql: string, args: readonly SqliteValue[] = []) => ({
+    sql: `${compiled.sql}\n${sql}`,
+    args: [...compiled.args, ...args],
+  })
+
+  return Object.freeze({
+    objectsTable: "_sixb_scope_objects",
+    linksTable: "_sixb_scope_links",
+    objectPropertyPermissionsTable: "_sixb_scope_object_permissions",
+    wrapStatement,
+    wrapQuery: (query: CompiledObjectQuery): CompiledObjectQuery => ({
+      ...query,
+      ...wrapStatement(query.sql, query.args),
+      totalSql: `${compiled.sql}\n${query.totalSql}`,
+      totalArgs: [...compiled.args, ...query.totalArgs],
+      ...(query.hasMoreProbe
+        ? {
+            hasMoreProbe: {
+              ...query.hasMoreProbe,
+              ...wrapStatement(query.hasMoreProbe.sql, query.hasMoreProbe.args),
+            },
+          }
+        : {}),
+    }),
+    traversalProbe: wrapStatement(
+      `
+        SELECT COUNT(*) AS total
+        FROM (
+          SELECT 1 AS traversal_fact
+          FROM _sixb_scope_root_facts
+
+          UNION ALL
+
+          SELECT 1 AS traversal_fact
+          FROM _sixb_scope_reached_links
+
+          LIMIT ?
+        ) AS bounded_traversal_facts
+      `,
+      [BigInt(maxTraversalFacts) + 1n]
+    ),
+  })
+}
+
+interface CompiledReadScopeCte {
+  readonly sql: string
+  readonly args: readonly SqliteValue[]
+}
+
+function compileSelectedReadScopeCte(scopeJson: string, projectId: string): CompiledReadScopeCte {
+  return {
+    sql: `
+      WITH RECURSIVE
+      _sixb_scope_document(scope) AS (
+        SELECT json(?)
+      ),
+      _sixb_scope_roots(root_id, node_id, object_type_id, primary_id) AS (
+        SELECT
+          CAST(root.key AS INTEGER),
+          CAST(json_extract(root.value, '$.nodeId') AS INTEGER),
+          CAST(json_extract(root.value, '$.objectTypeId') AS TEXT),
+          CAST(json_extract(root.value, '$.primaryId') AS TEXT)
+        FROM _sixb_scope_document AS document,
+             json_each(json_extract(document.scope, '$.roots')) AS root
+      ),
+      _sixb_scope_root_facts(project_id, root_id, node_id, object_type_id, primary_id) AS (
+        SELECT anchor.project_id, root.root_id, root.node_id, root.object_type_id, root.primary_id
+        FROM _sixb_scope_roots AS root
+        JOIN objects AS anchor
+          ON anchor.project_id = ?
+         AND anchor.object_type_id = root.object_type_id
+         AND anchor.primary_id = root.primary_id
+      ),
+      _sixb_scope_object_selections(node_id, object_type_id, property_ids) AS (
+        SELECT
+          CAST(json_extract(selection.value, '$.nodeId') AS INTEGER),
+          CAST(json_extract(selection.value, '$.objectTypeId') AS TEXT),
+          json_extract(selection.value, '$.propertyIds')
+        FROM _sixb_scope_document AS document,
+             json_each(json_extract(document.scope, '$.objects')) AS selection
+      ),
+      _sixb_scope_link_selections(
+        step_id,
+        node_id,
+        parent_node_id,
+        source_object_type_id,
+        link_id,
+        target_object_type_id,
+        property_ids
+      ) AS (
+        SELECT
+          CAST(step.key AS INTEGER),
+          CAST(json_extract(step.value, '$.nodeId') AS INTEGER),
+          CAST(json_extract(step.value, '$.parentNodeId') AS INTEGER),
+          CAST(json_extract(step.value, '$.sourceObjectTypeId') AS TEXT),
+          CAST(json_extract(step.value, '$.linkId') AS TEXT),
+          CAST(json_extract(step.value, '$.targetObjectTypeId') AS TEXT),
+          json_extract(step.value, '$.propertyIds')
+        FROM _sixb_scope_document AS document,
+             json_each(json_extract(document.scope, '$.steps')) AS step
+      ),
+      _sixb_scope_reachable(project_id, node_id, object_type_id, primary_id) AS (
+        SELECT root.project_id, root.node_id, root.object_type_id, root.primary_id
+        FROM _sixb_scope_root_facts AS root
+
+        UNION
+
+        SELECT edge.project_id, selection.node_id, edge.target_type_id, edge.target_id
+        FROM _sixb_scope_reachable AS parent
+        JOIN _sixb_scope_link_selections AS selection
+          ON selection.parent_node_id = parent.node_id
+         AND selection.source_object_type_id = parent.object_type_id
+        JOIN links AS edge
+          ON edge.project_id = parent.project_id
+         AND edge.source_type_id = parent.object_type_id
+         AND edge.source_id = parent.primary_id
+         AND edge.link_id = selection.link_id
+         AND edge.target_type_id = selection.target_object_type_id
+        JOIN objects AS target
+          ON target.project_id = edge.project_id
+         AND target.object_type_id = edge.target_type_id
+         AND target.primary_id = edge.target_id
+      ),
+      _sixb_scope_object_permissions(project_id, object_type_id, primary_id, property_id) AS (
+        SELECT DISTINCT
+          reachable.project_id,
+          reachable.object_type_id,
+          reachable.primary_id,
+          CAST(selected_property.value AS TEXT)
+        FROM _sixb_scope_reachable AS reachable
+        JOIN _sixb_scope_object_selections AS selection
+          ON selection.node_id = reachable.node_id
+         AND selection.object_type_id = reachable.object_type_id
+        JOIN json_each(selection.property_ids) AS selected_property
+      ),
+      _sixb_scope_object_ids(project_id, object_type_id, primary_id) AS (
+        SELECT DISTINCT project_id, object_type_id, primary_id
+        FROM _sixb_scope_reachable
+      ),
+      _sixb_scope_objects AS (
+        SELECT
+          stored.project_id,
+          stored.object_type_id,
+          stored.primary_id,
+          COALESCE(
+            (
+              SELECT json_group_object(property.key, ${sqliteJsonEachValue("property")})
+              FROM json_each(stored.properties) AS property
+              JOIN _sixb_scope_object_permissions AS permission
+                ON permission.project_id = stored.project_id
+               AND permission.object_type_id = stored.object_type_id
+               AND permission.primary_id = stored.primary_id
+               AND permission.property_id = property.key
+            ),
+            json('{}')
+          ) AS properties,
+          stored.created_at,
+          stored.updated_at,
+          stored.version,
+          stored.last_commit_id
+        FROM objects AS stored
+        JOIN _sixb_scope_object_ids AS visible
+          ON visible.project_id = stored.project_id
+         AND visible.object_type_id = stored.object_type_id
+         AND visible.primary_id = stored.primary_id
+      ),
+      _sixb_scope_reached_links(
+        project_id,
+        step_id,
+        node_id,
+        parent_node_id,
+        source_type_id,
+        source_id,
+        link_id,
+        target_type_id,
+        target_id,
+        property_ids
+      ) AS (
+        SELECT
+          edge.project_id,
+          selection.step_id,
+          selection.node_id,
+          selection.parent_node_id,
+          edge.source_type_id,
+          edge.source_id,
+          edge.link_id,
+          edge.target_type_id,
+          edge.target_id,
+          selection.property_ids
+        FROM _sixb_scope_reachable AS parent
+        JOIN _sixb_scope_link_selections AS selection
+          ON selection.parent_node_id = parent.node_id
+         AND selection.source_object_type_id = parent.object_type_id
+        JOIN links AS edge
+          ON edge.project_id = parent.project_id
+         AND edge.source_type_id = parent.object_type_id
+         AND edge.source_id = parent.primary_id
+         AND edge.link_id = selection.link_id
+         AND edge.target_type_id = selection.target_object_type_id
+        JOIN objects AS target
+          ON target.project_id = edge.project_id
+         AND target.object_type_id = edge.target_type_id
+         AND target.primary_id = edge.target_id
+      ),
+      _sixb_scope_link_permissions(
+        project_id,
+        source_type_id,
+        source_id,
+        link_id,
+        target_type_id,
+        target_id,
+        property_id
+      ) AS (
+        SELECT DISTINCT
+          reached.project_id,
+          reached.source_type_id,
+          reached.source_id,
+          reached.link_id,
+          reached.target_type_id,
+          reached.target_id,
+          CAST(selected_property.value AS TEXT)
+        FROM _sixb_scope_reached_links AS reached
+        JOIN json_each(reached.property_ids) AS selected_property
+      ),
+      _sixb_scope_link_ids(
+        project_id,
+        source_type_id,
+        source_id,
+        link_id,
+        target_type_id,
+        target_id
+      ) AS (
+        SELECT DISTINCT
+          project_id,
+          source_type_id,
+          source_id,
+          link_id,
+          target_type_id,
+          target_id
+        FROM _sixb_scope_reached_links
+      ),
+      _sixb_scope_links AS (
+        SELECT
+          stored.project_id,
+          stored.source_type_id,
+          stored.source_id,
+          stored.link_id,
+          stored.target_type_id,
+          stored.target_id,
+          CASE
+            WHEN stored.properties IS NULL THEN NULL
+            ELSE NULLIF(
+              (
+                SELECT json_group_object(property.key, ${sqliteJsonEachValue("property")})
+                FROM json_each(stored.properties) AS property
+                JOIN _sixb_scope_link_permissions AS permission
+                  ON permission.project_id = stored.project_id
+                 AND permission.source_type_id = stored.source_type_id
+                 AND permission.source_id = stored.source_id
+                 AND permission.link_id = stored.link_id
+                 AND permission.target_type_id = stored.target_type_id
+                 AND permission.target_id = stored.target_id
+                 AND permission.property_id = property.key
+              ),
+              json('{}')
+            )
+          END AS properties,
+          stored.created_at,
+          stored.updated_at,
+          stored.last_commit_id
+        FROM links AS stored
+        JOIN _sixb_scope_link_ids AS visible
+          ON visible.project_id = stored.project_id
+         AND visible.source_type_id = stored.source_type_id
+         AND visible.source_id = stored.source_id
+         AND visible.link_id = stored.link_id
+         AND visible.target_type_id = stored.target_type_id
+         AND visible.target_id = stored.target_id
+      )
+    `,
+    args: [scopeJson, projectId],
+  }
+}

--- a/storage/sqlite/src/object-storage.ts
+++ b/storage/sqlite/src/object-storage.ts
@@ -17,7 +17,6 @@ import type {
   ObjectLinkRow,
   ObjectQueryCapabilities,
   ObjectReadExecutionLimits,
-  ObjectReadScopeFactory,
   ObjectReadStorage,
   ObjectRow,
   ObjectRowLinks,
@@ -133,7 +132,7 @@ const SQLITE_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
  * Stores object projections and links. V1 object-query IR pushdown covers the
  * scalar JSON-property and link-traversal subset declared by queryCapabilities().
  */
-export class SqliteObjectStorage implements ObjectStorage, ObjectReadScopeFactory {
+export class SqliteObjectStorage implements ObjectStorage {
   private readonly connection: SqliteStoreConnection
   private readonly db: Database
 

--- a/storage/sqlite/src/object-storage.ts
+++ b/storage/sqlite/src/object-storage.ts
@@ -1,6 +1,7 @@
 import type { Database } from "bun:sqlite"
 import type { ObjectQuery } from "@sixb/core"
 import type {
+  CompiledSelectedObjectReadScope,
   CountObjectsInput,
   CountObjectsResult,
   ExistsObjectsInput,
@@ -15,6 +16,8 @@ import type {
   ObjectFacetRequest,
   ObjectLinkRow,
   ObjectQueryCapabilities,
+  ObjectReadExecutionLimits,
+  ObjectReadScopeFactory,
   ObjectReadStorage,
   ObjectRow,
   ObjectRowLinks,
@@ -24,12 +27,30 @@ import type {
   QueryObjectsInput,
   QueryObjectsResult,
 } from "@sixb/core/storage"
-import { linkBatchKey, objectBatchKey } from "@sixb/core/storage"
+import {
+  assertObjectReaderProject,
+  assertObjectReadFacetCount,
+  assertObjectReadOutputWithinLimit,
+  linkBatchKey,
+  ObjectReadLimitExceededError,
+  objectBatchKey,
+  snapshotObjectReadExecutionLimits,
+} from "@sixb/core/storage"
 import { installFreshSqliteSchema } from "./migrations"
-import { type CompiledObjectQuery, compileObjectQuery } from "./object-query-compiler"
+import {
+  type CompiledObjectQuery,
+  compileObjectQuery,
+  type SqliteObjectQuerySource,
+  type SqliteValue,
+} from "./object-query-compiler"
+import {
+  compileSqliteSelectedObjectReadSource,
+  type SqliteSelectedObjectReadSource,
+} from "./object-read-scope"
 import {
   closeSqliteStoreConnection,
   openSqliteStoreConnection,
+  runDeferredReadTransaction,
   type SqliteStoreConnection,
 } from "./transactions"
 
@@ -112,7 +133,7 @@ const SQLITE_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
  * Stores object projections and links. V1 object-query IR pushdown covers the
  * scalar JSON-property and link-traversal subset declared by queryCapabilities().
  */
-export class SqliteObjectStorage implements ObjectStorage {
+export class SqliteObjectStorage implements ObjectStorage, ObjectReadScopeFactory {
   private readonly connection: SqliteStoreConnection
   private readonly db: Database
 
@@ -129,9 +150,97 @@ export class SqliteObjectStorage implements ObjectStorage {
     return SQLITE_OBJECT_QUERY_CAPABILITIES
   }
 
+  createSelectedReadScope(params: {
+    projectId: string
+    scope: CompiledSelectedObjectReadScope
+    limits: ObjectReadExecutionLimits
+  }): ObjectReadStorage {
+    const projectId = params.projectId
+    const limits = snapshotObjectReadExecutionLimits(params.limits)
+    const source = compileSqliteSelectedObjectReadSource(
+      projectId,
+      params.scope,
+      limits.maxTraversalFacts
+    )
+    const assertProject = (actualProjectId: string): void =>
+      assertObjectReaderProject(projectId, actualProjectId)
+    const read = <T>(run: () => T): T =>
+      runDeferredReadTransaction(this.db, () => {
+        assertTraversalBudget(this.db, source, limits.maxTraversalFacts)
+        const value = run()
+        assertObjectReadOutputWithinLimit(value, limits)
+        return value
+      })
+    const readMap = <TKey, TValue>(run: () => Map<TKey, TValue>): Map<TKey, TValue> =>
+      runDeferredReadTransaction(this.db, () => {
+        assertTraversalBudget(this.db, source, limits.maxTraversalFacts)
+        const value = run()
+        assertObjectReadOutputWithinLimit([...value.entries()], limits)
+        return value
+      })
+
+    return Object.freeze({
+      queryCapabilities: () => this.queryCapabilities(),
+      queryObjects: async (input) => {
+        assertProject(input.projectId)
+        return read(() => this.queryObjectsFromSource(input, source))
+      },
+      countObjects: async (input) => {
+        assertProject(input.projectId)
+        return read(() => this.countObjectsFromSource(input, source))
+      },
+      existsObjects: async (input) => {
+        assertProject(input.projectId)
+        return read(() => this.existsObjectsFromSource(input, source))
+      },
+      facetObjects: async (input) => {
+        assertProject(input.projectId)
+        assertObjectReadFacetCount(input.facets.length)
+        return read(() => this.facetObjectsFromSource(input, source))
+      },
+      getByPrimaryId: async (input) => {
+        assertProject(input.projectId)
+        return read(() => this.getByPrimaryIdFromSource(input, source))
+      },
+      selectsObjectProperties: async (input) => {
+        assertProject(input.projectId)
+        return read(() => this.selectsObjectPropertiesFromSource(input, source))
+      },
+      listLinks: async (input) => {
+        assertProject(input.projectId)
+        return read(() => this.listLinksFromSource(input, source))
+      },
+      getByPrimaryIdBatch: async (input) => {
+        assertProject(input.projectId)
+        return readMap(() => this.getByPrimaryIdBatchFromSource(input, source))
+      },
+      listLinksBatch: async (input) => {
+        assertProject(input.projectId)
+        return readMap(() => this.listLinksBatchFromSource(input, source))
+      },
+      queryLinks: async (input) => {
+        assertProject(input.projectId)
+        assertLinkQueryLimit(input.limit)
+        return read(() => this.queryLinksFromSource(input, source))
+      },
+      list: async (input) => {
+        assertProject(input.projectId)
+        return read(() => this.listFromSource(input, source))
+      },
+    } satisfies ObjectReadStorage)
+  }
+
   async queryObjects(params: QueryObjectsInput): Promise<QueryObjectsResult> {
+    return this.queryObjectsFromSource(params)
+  }
+
+  private queryObjectsFromSource(
+    params: QueryObjectsInput,
+    source?: SqliteObjectQuerySource
+  ): QueryObjectsResult {
     const compiled = compileObjectQuery(params.projectId, params.query, {
       includeTotal: params.includeTotal,
+      ...(source ? { source } : {}),
     })
     const total = params.includeTotal === false ? undefined : readTotal(this.db, compiled)
     const rawRows = this.db.query(compiled.sql).all(...compiled.args) as ObjectQueryDatabaseRow[]
@@ -152,21 +261,48 @@ export class SqliteObjectStorage implements ObjectStorage {
   }
 
   async countObjects(params: CountObjectsInput): Promise<CountObjectsResult> {
+    return this.countObjectsFromSource(params)
+  }
+
+  private countObjectsFromSource(
+    params: CountObjectsInput,
+    source?: SqliteObjectQuerySource
+  ): CountObjectsResult {
     return {
       count: readTotal(
         this.db,
-        compileObjectQuery(params.projectId, stripOuterRowShape(params.query))
+        compileObjectQuery(params.projectId, stripOuterRowShape(params.query), {
+          ...(source ? { source } : {}),
+        })
       ),
     }
   }
 
   async existsObjects(params: ExistsObjectsInput): Promise<ExistsObjectsResult> {
-    const compiled = compileObjectQuery(params.projectId, existsProbeQuery(params.query))
+    return this.existsObjectsFromSource(params)
+  }
+
+  private existsObjectsFromSource(
+    params: ExistsObjectsInput,
+    source?: SqliteObjectQuerySource
+  ): ExistsObjectsResult {
+    const compiled = compileObjectQuery(params.projectId, existsProbeQuery(params.query), {
+      ...(source ? { source } : {}),
+    })
     return { exists: this.db.query(compiled.sql).get(...compiled.args) !== null }
   }
 
   async facetObjects(params: FacetObjectsInput): Promise<FacetObjectsResult> {
-    const compiled = compileObjectQuery(params.projectId, stripOuterRowShape(params.query))
+    return this.facetObjectsFromSource(params)
+  }
+
+  private facetObjectsFromSource(
+    params: FacetObjectsInput,
+    source?: SqliteObjectQuerySource
+  ): FacetObjectsResult {
+    const compiled = compileObjectQuery(params.projectId, stripOuterRowShape(params.query), {
+      ...(source ? { source } : {}),
+    })
     return {
       facets: params.facets.map((facet) => ({
         propertyId: facet.propertyId,
@@ -180,9 +316,24 @@ export class SqliteObjectStorage implements ObjectStorage {
     objectTypeId: string
     primaryId: string
   }): Promise<ObjectRow | null> {
-    const row = this.db
-      .query("SELECT * FROM objects WHERE project_id = ? AND object_type_id = ? AND primary_id = ?")
-      .get(params.projectId, params.objectTypeId, params.primaryId) as DatabaseRow | null
+    return this.getByPrimaryIdFromSource(params)
+  }
+
+  private getByPrimaryIdFromSource(
+    params: {
+      projectId: string
+      objectTypeId: string
+      primaryId: string
+    },
+    source?: SqliteObjectQuerySource
+  ): ObjectRow | null {
+    const objectsTable = source?.objectsTable ?? "objects"
+    const statement = wrapSourceStatement(
+      source,
+      `SELECT * FROM ${objectsTable} WHERE project_id = ? AND object_type_id = ? AND primary_id = ?`,
+      [params.projectId, params.objectTypeId, params.primaryId]
+    )
+    const row = this.db.query(statement.sql).get(...statement.args) as DatabaseRow | null
 
     return row ? this.rowToObject(row) : null
   }
@@ -190,13 +341,39 @@ export class SqliteObjectStorage implements ObjectStorage {
   async selectsObjectProperties(
     params: Parameters<ObjectReadStorage["selectsObjectProperties"]>[0]
   ): Promise<readonly boolean[]> {
-    const objects = await this.getByPrimaryIdBatch({
-      projectId: params.projectId,
-      items: params.items,
-    })
-    return params.items.map((item) =>
-      objects.has(objectBatchKey(item.objectTypeId, item.primaryId))
+    return this.selectsObjectPropertiesFromSource(params)
+  }
+
+  private selectsObjectPropertiesFromSource(
+    params: Parameters<ObjectReadStorage["selectsObjectProperties"]>[0],
+    source?: SqliteSelectedObjectReadSource
+  ): readonly boolean[] {
+    const result = params.items.map(() => false)
+    if (params.items.length === 0) return result
+
+    const items = params.items.map((item, batchIndex) => ({ ...item, batchIndex }))
+    const requestedType = "CAST(json_extract(requested.value, '$.objectTypeId') AS TEXT)"
+    const requestedId = "CAST(json_extract(requested.value, '$.primaryId') AS TEXT)"
+    const requestedProperty = "CAST(json_extract(requested.value, '$.propertyId') AS TEXT)"
+    const storedTable = source?.objectPropertyPermissionsTable ?? "objects"
+    const propertyJoin = source ? `AND stored.property_id = ${requestedProperty}` : ""
+    const statement = wrapSourceStatement(
+      source,
+      `SELECT DISTINCT
+         CAST(json_extract(requested.value, '$.batchIndex') AS INTEGER) AS _batch_index
+       FROM ${storedTable} AS stored
+       JOIN json_each(?) AS requested
+         ON stored.object_type_id = ${requestedType}
+        AND stored.primary_id = ${requestedId}
+        ${propertyJoin}
+       WHERE stored.project_id = ?`,
+      [JSON.stringify(items), params.projectId]
     )
+    const rows = this.db
+      .query(statement.sql)
+      .all(...statement.args) as PropertyPermissionBatchDatabaseRow[]
+    for (const row of rows) result[row._batch_index] = true
+    return result
   }
 
   async listLinks(params: {
@@ -206,6 +383,19 @@ export class SqliteObjectStorage implements ObjectStorage {
     linkId?: string
     direction?: LinkDirection
   }): Promise<readonly ObjectLinkRow[]> {
+    return this.listLinksFromSource(params)
+  }
+
+  private listLinksFromSource(
+    params: {
+      projectId: string
+      objectTypeId: string
+      objectId: string
+      linkId?: string
+      direction?: LinkDirection
+    },
+    source?: SqliteObjectQuerySource
+  ): readonly ObjectLinkRow[] {
     const direction = params.direction ?? "outgoing"
     const directionWhere =
       direction === "incoming"
@@ -213,7 +403,7 @@ export class SqliteObjectStorage implements ObjectStorage {
         : direction === "both"
           ? "((source_type_id = ? AND source_id = ?) OR (target_type_id = ? AND target_id = ?))"
           : "source_type_id = ? AND source_id = ?"
-    let query = `SELECT * FROM links WHERE project_id = ? AND ${directionWhere}`
+    let query = `SELECT * FROM ${source?.linksTable ?? "links"} WHERE project_id = ? AND ${directionWhere}`
     const args: (string | number)[] =
       direction === "both"
         ? [
@@ -230,7 +420,8 @@ export class SqliteObjectStorage implements ObjectStorage {
       args.push(params.linkId)
     }
 
-    const rows = this.db.query(query).all(...args) as LinkDatabaseRow[]
+    const statement = wrapSourceStatement(source, query, args)
+    const rows = this.db.query(statement.sql).all(...statement.args) as LinkDatabaseRow[]
 
     return rows.map((row) => this.rowToLink(row))
   }
@@ -239,23 +430,39 @@ export class SqliteObjectStorage implements ObjectStorage {
     projectId: string
     items: readonly { objectTypeId: string; primaryId: string }[]
   }): Promise<Map<ObjectBatchKey, ObjectRow>> {
+    return this.getByPrimaryIdBatchFromSource(params)
+  }
+
+  private getByPrimaryIdBatchFromSource(
+    params: {
+      projectId: string
+      items: readonly { objectTypeId: string; primaryId: string }[]
+    },
+    source?: SqliteObjectQuerySource
+  ): Map<ObjectBatchKey, ObjectRow> {
     const result = new Map<ObjectBatchKey, ObjectRow>()
     if (params.items.length === 0) return result
 
-    const rows = this.db
-      .query(
-        `
-          SELECT object.*
-          FROM json_each(?) AS requested
-          JOIN objects AS object
-            ON object.project_id = ?
-           AND object.object_type_id = json_extract(requested.value, '$.objectTypeId')
-           AND object.primary_id = json_extract(requested.value, '$.primaryId')
-        `
-      )
-      .all(JSON.stringify(params.items), params.projectId) as DatabaseRow[]
-    for (const row of rows) {
-      result.set(objectBatchKey(row.object_type_id, row.primary_id), this.rowToObject(row))
+    const items = params.items.map((item, batchIndex) => ({ ...item, batchIndex }))
+    const statement = wrapSourceStatement(
+      source,
+      `
+        SELECT
+          object.*,
+          CAST(json_extract(requested.value, '$.batchIndex') AS INTEGER) AS _batch_index
+        FROM json_each(?) AS requested
+        JOIN ${source?.objectsTable ?? "objects"} AS object
+          ON object.project_id = ?
+         AND object.object_type_id = json_extract(requested.value, '$.objectTypeId')
+         AND object.primary_id = json_extract(requested.value, '$.primaryId')
+      `,
+      [JSON.stringify(items), params.projectId]
+    )
+    const rows = this.db.query(statement.sql).all(...statement.args) as ObjectBatchDatabaseRow[]
+    const rowsByIndex = new Map(rows.map((row) => [row._batch_index, row]))
+    for (const [index, item] of params.items.entries()) {
+      const row = rowsByIndex.get(index)
+      if (row) result.set(objectBatchKey(item.objectTypeId, item.primaryId), this.rowToObject(row))
     }
     return result
   }
@@ -265,19 +472,58 @@ export class SqliteObjectStorage implements ObjectStorage {
     direction?: LinkDirection
     items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
   }): Promise<Map<LinkBatchKey, ObjectLinkRow[]>> {
+    return this.listLinksBatchFromSource(params)
+  }
+
+  private listLinksBatchFromSource(
+    params: {
+      projectId: string
+      direction?: LinkDirection
+      items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
+    },
+    source?: SqliteObjectQuerySource
+  ): Map<LinkBatchKey, ObjectLinkRow[]> {
     const result = new Map<LinkBatchKey, ObjectLinkRow[]>()
     if (params.items.length === 0) return result
 
-    for (const item of params.items) {
-      const rows = await this.listLinks({
-        projectId: params.projectId,
-        objectTypeId: item.objectTypeId,
-        objectId: item.objectId,
-        linkId: item.linkId,
-        ...(params.direction === undefined ? {} : { direction: params.direction }),
-      })
-      if (rows.length > 0) {
-        result.set(linkBatchKey(item.objectTypeId, item.objectId, item.linkId), [...rows])
+    const direction = params.direction ?? "outgoing"
+    const requestedType = "CAST(json_extract(requested.value, '$.objectTypeId') AS TEXT)"
+    const requestedId = "CAST(json_extract(requested.value, '$.objectId') AS TEXT)"
+    const requestedLink = "CAST(json_extract(requested.value, '$.linkId') AS TEXT)"
+    const outgoing = `stored.source_type_id = ${requestedType} AND stored.source_id = ${requestedId}`
+    const incoming = `stored.target_type_id = ${requestedType} AND stored.target_id = ${requestedId}`
+    const directionJoin =
+      direction === "both"
+        ? `((${outgoing}) OR (${incoming}))`
+        : direction === "incoming"
+          ? incoming
+          : outgoing
+    const items = params.items.map((item, batchIndex) => ({ ...item, batchIndex }))
+    const statement = wrapSourceStatement(
+      source,
+      `
+        SELECT
+          stored.*,
+          CAST(json_extract(requested.value, '$.batchIndex') AS INTEGER) AS _batch_index
+        FROM ${source?.linksTable ?? "links"} AS stored
+        JOIN json_each(?) AS requested
+          ON ${directionJoin}
+         AND stored.link_id = ${requestedLink}
+        WHERE stored.project_id = ?
+        ORDER BY _batch_index, source_type_id, source_id, link_id, target_type_id, target_id
+      `,
+      [JSON.stringify(items), params.projectId]
+    )
+    const rows = this.db.query(statement.sql).all(...statement.args) as LinkBatchDatabaseRow[]
+    const rowsByIndex = params.items.map(() => new Map<string, ObjectLinkRow>())
+    for (const row of rows) {
+      const link = this.rowToLink(row)
+      rowsByIndex[row._batch_index]?.set(fullLinkIdentity(link), link)
+    }
+    for (const [index, item] of params.items.entries()) {
+      const links = [...(rowsByIndex[index]?.values() ?? [])]
+      if (links.length > 0) {
+        result.set(linkBatchKey(item.objectTypeId, item.objectId, item.linkId), links)
       }
     }
     return result
@@ -285,22 +531,36 @@ export class SqliteObjectStorage implements ObjectStorage {
 
   async queryLinks(params: QueryObjectLinksInput): Promise<QueryObjectLinksResult> {
     assertLinkQueryLimit(params.limit)
+    return this.queryLinksFromSource(params)
+  }
+
+  private queryLinksFromSource(
+    params: QueryObjectLinksInput,
+    source?: SqliteObjectQuerySource
+  ): QueryObjectLinksResult {
     if (params.objectRefs.length === 0 || params.endpointObjectTypeIds?.length === 0) {
       return { links: [], hasMore: false }
     }
 
+    const requested = `
+      SELECT DISTINCT
+        json_extract(value, '$.objectTypeId') AS object_type_id,
+        json_extract(value, '$.primaryId') AS object_id
+      FROM json_each(?)
+    `
+    const linksTable = source?.linksTable ?? "links"
     const sourceJoin = `
       SELECT link.*
-      FROM links AS link
-      JOIN requested
+      FROM ${linksTable} AS link
+      JOIN (${requested}) AS requested
         ON requested.object_type_id = link.source_type_id
        AND requested.object_id = link.source_id
       WHERE link.project_id = ?
     `
     const targetJoin = `
       SELECT link.*
-      FROM links AS link
-      JOIN requested
+      FROM ${linksTable} AS link
+      JOIN (${requested}) AS requested
         ON requested.object_type_id = link.target_type_id
        AND requested.object_id = link.target_id
       WHERE link.project_id = ?
@@ -311,8 +571,11 @@ export class SqliteObjectStorage implements ObjectStorage {
         : params.direction === "incoming"
           ? targetJoin
           : `${sourceJoin} UNION ${targetJoin}`
-    const args: (string | number)[] = [JSON.stringify(params.objectRefs), params.projectId]
-    if (params.direction === "both") args.push(params.projectId)
+    const requestedJson = JSON.stringify(params.objectRefs)
+    const args: (string | number)[] =
+      params.direction === "both"
+        ? [requestedJson, params.projectId, requestedJson, params.projectId]
+        : [requestedJson, params.projectId]
 
     const predicates: string[] = []
     if (params.linkId !== undefined) {
@@ -336,23 +599,18 @@ export class SqliteObjectStorage implements ObjectStorage {
     args.push(params.limit + 1)
 
     const whereSql = predicates.length > 0 ? `WHERE ${predicates.join(" AND ")}` : ""
-    const rows = this.db
-      .query(
-        `
-          WITH requested AS (
-            SELECT DISTINCT
-              json_extract(value, '$.objectTypeId') AS object_type_id,
-              json_extract(value, '$.primaryId') AS object_id
-            FROM json_each(?)
-          ), incident AS (${incidentSql})
-          SELECT *
-          FROM incident
-          ${whereSql}
-          ORDER BY source_type_id, source_id, link_id, target_type_id, target_id
-          LIMIT ?
-        `
-      )
-      .all(...args) as LinkDatabaseRow[]
+    const statement = wrapSourceStatement(
+      source,
+      `
+        SELECT *
+        FROM (${incidentSql}) AS incident
+        ${whereSql}
+        ORDER BY source_type_id, source_id, link_id, target_type_id, target_id
+        LIMIT ?
+      `,
+      args
+    )
+    const rows = this.db.query(statement.sql).all(...statement.args) as LinkDatabaseRow[]
 
     return {
       links: rows.slice(0, params.limit).map((row) => this.rowToLink(row)),
@@ -442,7 +700,14 @@ export class SqliteObjectStorage implements ObjectStorage {
     orderBy?: "createdAt" | "updatedAt" | "primaryId"
     order?: "asc" | "desc"
   }): Promise<{ objects: readonly ObjectRow[]; hasMore: boolean; total: number }> {
-    let query = "SELECT * FROM objects WHERE project_id = ?"
+    return this.listFromSource(params)
+  }
+
+  private listFromSource(
+    params: Parameters<ObjectReadStorage["list"]>[0],
+    source?: SqliteObjectQuerySource
+  ): { objects: readonly ObjectRow[]; hasMore: boolean; total: number } {
+    let query = `SELECT * FROM ${source?.objectsTable ?? "objects"} WHERE project_id = ?`
     const args: (string | number | null)[] = [params.projectId]
 
     if (params.objectTypeId) {
@@ -486,7 +751,12 @@ export class SqliteObjectStorage implements ObjectStorage {
     }
 
     // Get total count
-    const countResult = this.db.query(`SELECT COUNT(*) as total FROM (${query})`).get(...args) as {
+    const countStatement = wrapSourceStatement(
+      source,
+      `SELECT COUNT(*) as total FROM (${query}) AS filtered_objects`,
+      args
+    )
+    const countResult = this.db.query(countStatement.sql).get(...countStatement.args) as {
       total: number
     }
     const total = countResult.total
@@ -506,7 +776,8 @@ export class SqliteObjectStorage implements ObjectStorage {
     query += " LIMIT ? OFFSET ?"
     args.push(limit + 1, offset) // +1 to check for hasMore
 
-    const rows = this.db.query(query).all(...args) as DatabaseRow[]
+    const rowsStatement = wrapSourceStatement(source, query, args)
+    const rows = this.db.query(rowsStatement.sql).all(...rowsStatement.args) as DatabaseRow[]
     const hasMore = rows.length > limit
     const objects = rows.slice(0, limit).map((row) => this.rowToObject(row))
 
@@ -543,7 +814,7 @@ export class SqliteObjectStorage implements ObjectStorage {
       linkId: row.link_id,
       targetTypeId: row.target_type_id,
       targetId: row.target_id,
-      properties: row.properties ? JSON.parse(row.properties) : undefined,
+      ...(row.properties === null ? {} : { properties: JSON.parse(row.properties) }),
       createdAt: new Date(row.created_at),
       updatedAt: new Date(row.updated_at),
       lastCommitId: row.last_commit_id,
@@ -556,6 +827,37 @@ export class SqliteObjectStorage implements ObjectStorage {
   close(): void {
     closeSqliteStoreConnection(this.connection)
   }
+}
+
+function wrapSourceStatement(
+  source: SqliteObjectQuerySource | undefined,
+  sql: string,
+  args: readonly SqliteValue[] = []
+): { readonly sql: string; readonly args: readonly SqliteValue[] } {
+  return source?.wrapStatement(sql, args) ?? { sql, args }
+}
+
+function assertTraversalBudget(
+  db: Database,
+  source: SqliteSelectedObjectReadSource,
+  maxTraversalFacts: number
+): void {
+  const row = db.query(source.traversalProbe.sql).get(...source.traversalProbe.args) as {
+    total: number | bigint
+  }
+  if (BigInt(row.total) > BigInt(maxTraversalFacts)) {
+    throw new ObjectReadLimitExceededError("traversalFacts", maxTraversalFacts)
+  }
+}
+
+function fullLinkIdentity(link: ObjectLinkRow): string {
+  return JSON.stringify([
+    link.sourceTypeId,
+    link.sourceId,
+    link.linkId,
+    link.targetTypeId,
+    link.targetId,
+  ])
 }
 
 function assertReconciliationPageLimit(limit: number): void {
@@ -698,6 +1000,14 @@ interface ObjectQueryDatabaseRow extends DatabaseRow {
   _expand?: string | null
 }
 
+interface ObjectBatchDatabaseRow extends DatabaseRow {
+  _batch_index: number
+}
+
+interface PropertyPermissionBatchDatabaseRow {
+  _batch_index: number
+}
+
 interface FacetDatabaseRow {
   value_type: string | null
   value: unknown
@@ -715,4 +1025,8 @@ interface LinkDatabaseRow {
   created_at: string
   updated_at: string
   last_commit_id: string
+}
+
+interface LinkBatchDatabaseRow extends LinkDatabaseRow {
+  _batch_index: number
 }

--- a/storage/sqlite/src/transactions.ts
+++ b/storage/sqlite/src/transactions.ts
@@ -45,6 +45,7 @@ export function closeSqliteStoreConnection(connection: SqliteStoreConnection): v
 }
 
 const activeImmediateTransactions = new WeakSet<Database>()
+const activeDeferredReadTransactions = new WeakSet<Database>()
 
 export function runImmediateTransaction<T>(db: Database, run: () => T): T {
   if (activeImmediateTransactions.has(db)) {
@@ -91,6 +92,37 @@ export async function runImmediateTransactionAsync<T>(
     throw error
   } finally {
     activeImmediateTransactions.delete(db)
+  }
+}
+
+/**
+ * Run a multi-statement read against one proven SQLite snapshot.
+ *
+ * A provider-owned immediate transaction already has a stable snapshot and may be reused. Any
+ * other pre-existing transaction is rejected because this provider cannot prove who owns it or
+ * which lifecycle will close it.
+ */
+export function runDeferredReadTransaction<T>(db: Database, run: () => T): T {
+  if (activeImmediateTransactions.has(db) || activeDeferredReadTransactions.has(db)) {
+    return run()
+  }
+  if (db.inTransaction) {
+    throw new Error(
+      "[SixbSqlite] Selected object reads cannot join an unverified SQLite transaction."
+    )
+  }
+
+  db.run("BEGIN DEFERRED")
+  activeDeferredReadTransactions.add(db)
+  try {
+    const result = run()
+    db.run("COMMIT")
+    return result
+  } catch (error) {
+    rollbackQuietly(db)
+    throw error
+  } finally {
+    activeDeferredReadTransactions.delete(db)
   }
 }
 

--- a/storage/sqlite/tests/sqlite-object-read-scope-provider.test.ts
+++ b/storage/sqlite/tests/sqlite-object-read-scope-provider.test.ts
@@ -1,0 +1,505 @@
+import { Database, type SQLQueryBindings } from "bun:sqlite"
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { migrateStorage } from "@sixb/core"
+import {
+  compileSelectedObjectReadScope,
+  linkBatchKey,
+  type ObjectReadExecutionLimits,
+  type ObjectReadScopeFactory,
+  type ObjectReadStorage,
+  type ObjectStorage,
+  objectBatchKey,
+  type SelectedObjectReadScope,
+} from "@sixb/core/storage"
+import { SqliteStorage } from "../src"
+import { installFreshSqliteSchema, sqliteStoragePath } from "../src/migrations"
+import { compileSqliteSelectedObjectReadSource } from "../src/object-read-scope"
+import { SqliteObjectStorage } from "../src/object-storage"
+import { runImmediateTransactionAsync } from "../src/transactions"
+
+const projectId = "sqlite-selected-reader"
+const RootType = "SqliteScopeRoot"
+const TargetType = "SqliteScopeTarget"
+const timestamp = "2026-08-31T00:00:00.000Z"
+const generousLimits: ObjectReadExecutionLimits = {
+  maxTraversalFacts: 100,
+  maxOutputJsonBytes: 1_000_000,
+}
+
+describe("SqliteObjectStorage selected reader invariants", () => {
+  test("counts live path facts exactly and preserves redacted JSON values", async () => {
+    const storage = new SqliteObjectStorage()
+    try {
+      const db = databaseOf(storage)
+      insertObject(db, RootType, "root-1", {
+        id: "root-1",
+        nested: { key: "value" },
+        values: [1, true, null],
+        enabled: true,
+        disabled: false,
+        nullable: null,
+        amount: 2.5,
+        hidden: "root-secret",
+      })
+      insertObject(db, TargetType, "target-1", {
+        id: "target-1",
+        label: "visible",
+        hidden: "target-secret",
+      })
+      insertLink(db, "root-1", "items", "target-1", {
+        nested: { edge: true },
+        values: [false, null, 3],
+        enabled: true,
+        disabled: false,
+        nullable: null,
+        amount: 7.5,
+        hidden: "edge-secret",
+      })
+      // A stored edge whose target is absent is not a live traversal fact.
+      insertLink(db, "root-1", "items", "target-missing", { enabled: true })
+      const otherProjectId = `${projectId}-other`
+      insertObject(db, RootType, "root-1", { id: "other-root" }, otherProjectId)
+      insertObject(db, TargetType, "target-1", { id: "other-target" }, otherProjectId)
+      insertLink(db, "root-1", "items", "target-1", { enabled: false }, otherProjectId)
+
+      const scope = repeatedPathScope()
+      const exact = createReader(storage, scope, { ...generousLimits, maxTraversalFacts: 3 })
+      expect((await exact.list({ projectId })).objects.map((row) => row.primaryId).sort()).toEqual([
+        "root-1",
+        "target-1",
+      ])
+      expect(
+        (await exact.list({ projectId })).objects.every((row) => row.projectId === projectId)
+      ).toBe(true)
+      expect(
+        await exact.getByPrimaryId({
+          projectId,
+          objectTypeId: RootType,
+          primaryId: "root-1",
+        })
+      ).toMatchObject({
+        properties: {
+          id: "root-1",
+          nested: { key: "value" },
+          values: [1, true, null],
+          enabled: true,
+          disabled: false,
+          nullable: null,
+          amount: 2.5,
+        },
+      })
+      const links = await exact.listLinks({
+        projectId,
+        objectTypeId: RootType,
+        objectId: "root-1",
+        linkId: "items",
+      })
+      expect(links).toHaveLength(1)
+      expect(links[0]?.properties).toEqual({
+        nested: { edge: true },
+        values: [false, null, 3],
+        enabled: true,
+        disabled: false,
+        nullable: null,
+        amount: 7.5,
+      })
+
+      const batch = await exact.getByPrimaryIdBatch({
+        projectId,
+        items: [
+          { objectTypeId: TargetType, primaryId: "target-1" },
+          { objectTypeId: RootType, primaryId: "root-1" },
+          { objectTypeId: TargetType, primaryId: "target-1" },
+        ],
+      })
+      expect([...batch.keys()]).toEqual([
+        objectBatchKey(TargetType, "target-1"),
+        objectBatchKey(RootType, "root-1"),
+      ])
+      const linkBatch = await exact.listLinksBatch({
+        projectId,
+        items: [
+          { objectTypeId: TargetType, objectId: "target-1", linkId: "items" },
+          { objectTypeId: RootType, objectId: "root-1", linkId: "items" },
+        ],
+        direction: "both",
+      })
+      expect([...linkBatch.keys()]).toEqual([
+        linkBatchKey(TargetType, "target-1", "items"),
+        linkBatchKey(RootType, "root-1", "items"),
+      ])
+
+      const overBudget = createReader(storage, scope, {
+        ...generousLimits,
+        maxTraversalFacts: 2,
+      })
+      await expect(overBudget.list({ projectId })).rejects.toMatchObject({
+        code: "object_read_limit_exceeded",
+        metric: "traversalFacts",
+        limit: 2,
+      })
+      await expect(
+        overBudget.queryLinks({
+          projectId,
+          objectRefs: [{ objectTypeId: RootType, primaryId: "root-1" }],
+          direction: "outgoing",
+          limit: 0,
+        })
+      ).rejects.toThrow("positive safe integer")
+    } finally {
+      storage.close()
+    }
+  })
+
+  test("wraps main, total, and has-more statements in the selected source", async () => {
+    const storage = new SqliteObjectStorage()
+    try {
+      const db = databaseOf(storage)
+      insertObject(db, RootType, "root-1", { id: "root-1" })
+      insertObject(db, TargetType, "target-a", { id: "target-a", enabled: true, hidden: "a" })
+      insertObject(db, TargetType, "target-b", { id: "target-b", enabled: false, hidden: "b" })
+      insertObject(db, TargetType, "target-hidden", { id: "target-hidden" })
+      insertLink(db, "root-1", "items", "target-a")
+      insertLink(db, "root-1", "items", "target-b")
+      const reader = createReader(storage, singlePathScope())
+
+      const withTotal = await reader.queryObjects?.({
+        projectId,
+        query: { kind: "start", objectTypeId: TargetType },
+      })
+      expect(withTotal).toMatchObject({
+        total: 2,
+        hasMore: false,
+        objects: [{ primaryId: "target-a" }, { primaryId: "target-b" }],
+      })
+      expect(withTotal?.objects[0]?.properties).toEqual({ id: "target-a", enabled: true })
+
+      const withoutTotal = await reader.queryObjects?.({
+        projectId,
+        includeTotal: false,
+        query: {
+          kind: "sort",
+          fields: [{ kind: "property", propertyId: "id", direction: "asc" }],
+          input: {
+            kind: "limit",
+            limit: 1,
+            input: { kind: "start", objectTypeId: TargetType },
+          },
+        },
+      })
+      expect(withoutTotal).toMatchObject({
+        hasMore: true,
+        objects: [{ primaryId: "target-a" }],
+      })
+      expect(withoutTotal).not.toHaveProperty("total")
+
+      const projected = await reader.queryObjects?.({
+        projectId,
+        query: {
+          kind: "project",
+          properties: ["id", "enabled"],
+          input: { kind: "start", objectTypeId: TargetType },
+        },
+      })
+      expect(projected?.objects.map((object) => object.properties)).toEqual([
+        { id: "target-a", enabled: true },
+        { id: "target-b", enabled: false },
+      ])
+
+      const propertylessLinks = await reader.listLinks({
+        projectId,
+        objectTypeId: RootType,
+        objectId: "root-1",
+        linkId: "items",
+      })
+      expect(propertylessLinks).toHaveLength(2)
+      expect(propertylessLinks.every((link) => !Object.hasOwn(link, "properties"))).toBe(true)
+    } finally {
+      storage.close()
+    }
+  })
+
+  test("serializes a large compiled scope into one bounded statement parameter", () => {
+    const scope = compileSelectedObjectReadScope({
+      kind: "selected",
+      roots: Array.from({ length: 400 }, (_, index) => ({
+        anchor: { objectTypeId: RootType, primaryId: `root-${index}` },
+        node: {
+          objects: [{ objectTypeId: RootType, propertyIds: ["id"] }],
+          links: [],
+        },
+      })),
+    })
+    const source = compileSqliteSelectedObjectReadSource(projectId, scope, 1_000)
+    const statement = source.wrapStatement("SELECT ? AS terminal", ["value"])
+
+    expect(statement.args).toHaveLength(3)
+    expect(statement.args[0]).toBeString()
+    expect(statement.args[1]).toBe(projectId)
+    expect(statement.args[2]).toBe("value")
+    expect(statement.sql.match(/json\(\?\)/g)).toHaveLength(1)
+  })
+
+  test("reuses provider-owned transactions and rejects unverified ones", async () => {
+    const storage = new SqliteObjectStorage()
+    try {
+      const db = databaseOf(storage)
+      insertObject(db, RootType, "root-1", { id: "root-1" })
+      const reader = createReader(storage, rootOnlyScope())
+
+      const row = await runImmediateTransactionAsync(db, () =>
+        reader.getByPrimaryId({
+          projectId,
+          objectTypeId: RootType,
+          primaryId: "root-1",
+        })
+      )
+      expect(row?.primaryId).toBe("root-1")
+
+      db.run("BEGIN DEFERRED")
+      try {
+        await expect(reader.list({ projectId })).rejects.toThrow("unverified SQLite transaction")
+      } finally {
+        db.run("ROLLBACK")
+      }
+    } finally {
+      storage.close()
+    }
+  })
+
+  test("runs selected reads through the file-backed readonly production connection", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "sixb-sqlite-selected-readonly-"))
+    const storage = new SqliteStorage({ path: directory })
+    let writer: Database | undefined
+    try {
+      await migrateStorage(storage)
+      writer = new Database(sqliteStoragePath(directory))
+      insertObject(writer, RootType, "root-1", { id: "root-1", hidden: "secret" })
+
+      const factory = storage.objects as ObjectStorage & ObjectReadScopeFactory
+      const reader = factory.createSelectedReadScope({
+        projectId,
+        scope: compileSelectedObjectReadScope(rootOnlyScope()),
+        limits: generousLimits,
+      })
+      expect(
+        await reader.getByPrimaryId({
+          projectId,
+          objectTypeId: RootType,
+          primaryId: "root-1",
+        })
+      ).toMatchObject({ properties: { id: "root-1" } })
+    } finally {
+      writer?.close()
+      storage.close()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  test("keeps the traversal probe and every terminal statement on one WAL snapshot", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "sixb-sqlite-selected-snapshot-"))
+    const databasePath = join(directory, "scope.sqlite")
+    const setup = new Database(databasePath)
+    installFreshSqliteSchema(setup)
+    setup.run("PRAGMA journal_mode = WAL")
+    setup.close()
+
+    const storage = new SqliteObjectStorage({ path: databasePath })
+    const writer = new Database(databasePath)
+    writer.run("PRAGMA journal_mode = WAL")
+    writer.run("PRAGMA busy_timeout = 5000")
+    const holder = storage as unknown as { db: Database }
+    const originalDb = holder.db
+
+    try {
+      insertObject(originalDb, RootType, "root-1", { id: "root-1" })
+      insertObject(originalDb, TargetType, "target-1", { id: "target-1" })
+      const reader = createReader(storage, singlePathScope(), {
+        ...generousLimits,
+        maxTraversalFacts: 1,
+      })
+      let writerCommitted = false
+
+      holder.db = {
+        get inTransaction() {
+          return originalDb.inTransaction
+        },
+        run: originalDb.run.bind(originalDb),
+        query: (sql: string) => {
+          const statement = originalDb.query(sql)
+          return {
+            all: (...args: SQLQueryBindings[]) => statement.all(...args),
+            get: (...args: SQLQueryBindings[]) => {
+              const result = statement.get(...args)
+              if (!writerCommitted && sql.includes("bounded_traversal_facts")) {
+                writerCommitted = true
+                insertLink(writer, "root-1", "items", "target-1")
+              }
+              return result
+            },
+          }
+        },
+      } as unknown as Database
+
+      expect(await reader.list({ projectId })).toEqual({
+        objects: [expect.objectContaining({ primaryId: "root-1" })],
+        hasMore: false,
+        total: 1,
+      })
+      expect(writerCommitted).toBe(true)
+
+      holder.db = originalDb
+      await expect(reader.list({ projectId })).rejects.toMatchObject({
+        code: "object_read_limit_exceeded",
+        metric: "traversalFacts",
+        limit: 1,
+      })
+    } finally {
+      holder.db = originalDb
+      writer.close()
+      storage.close()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})
+
+function createReader(
+  storage: SqliteObjectStorage,
+  scope: SelectedObjectReadScope,
+  limits: ObjectReadExecutionLimits = generousLimits
+): ObjectReadStorage {
+  return storage.createSelectedReadScope({
+    projectId,
+    scope: compileSelectedObjectReadScope(scope),
+    limits,
+  })
+}
+
+function rootOnlyScope(): SelectedObjectReadScope {
+  return {
+    kind: "selected",
+    roots: [rootSelection("root-1")],
+  }
+}
+
+function singlePathScope(): SelectedObjectReadScope {
+  return {
+    kind: "selected",
+    roots: [
+      {
+        ...rootSelection("root-1"),
+        node: {
+          objects: [{ objectTypeId: RootType, propertyIds: ["id"] }],
+          links: [targetPath()],
+        },
+      },
+    ],
+  }
+}
+
+function repeatedPathScope(): SelectedObjectReadScope {
+  return {
+    kind: "selected",
+    roots: [
+      {
+        ...rootSelection("root-1"),
+        node: {
+          objects: [
+            {
+              objectTypeId: RootType,
+              propertyIds: ["id", "nested", "values", "enabled", "disabled", "nullable", "amount"],
+            },
+          ],
+          links: [targetPath(true), targetPath(true)],
+        },
+      },
+      rootSelection("root-missing"),
+    ],
+  }
+}
+
+function rootSelection(primaryId: string) {
+  return {
+    anchor: { objectTypeId: RootType, primaryId },
+    node: {
+      objects: [{ objectTypeId: RootType, propertyIds: ["id"] }],
+      links: [],
+    },
+  }
+}
+
+function targetPath(selectLinkValues = false) {
+  return {
+    definitions: [
+      {
+        sourceObjectTypeId: RootType,
+        linkId: "items",
+        targetObjectTypeIds: [TargetType],
+        propertyIds: selectLinkValues
+          ? ["nested", "values", "enabled", "disabled", "nullable", "amount"]
+          : [],
+      },
+    ],
+    target: {
+      objects: [{ objectTypeId: TargetType, propertyIds: ["id", "label", "enabled"] }],
+      links: [],
+    },
+  }
+}
+
+function databaseOf(storage: SqliteObjectStorage): Database {
+  return (storage as unknown as { db: Database }).db
+}
+
+function insertObject(
+  db: Database,
+  objectTypeId: string,
+  primaryId: string,
+  properties: Readonly<Record<string, unknown>>,
+  rowProjectId = projectId
+): void {
+  db.query(`
+    INSERT INTO objects (
+      project_id, object_type_id, primary_id, properties,
+      created_at, updated_at, version, last_commit_id
+    ) VALUES (?, ?, ?, json(?), ?, ?, 1, ?)
+  `).run(
+    rowProjectId,
+    objectTypeId,
+    primaryId,
+    JSON.stringify(properties),
+    timestamp,
+    timestamp,
+    "scope-test"
+  )
+}
+
+function insertLink(
+  db: Database,
+  sourceId: string,
+  linkId: string,
+  targetId: string,
+  properties?: Readonly<Record<string, unknown>>,
+  rowProjectId = projectId
+): void {
+  db.query(`
+    INSERT INTO links (
+      project_id, source_type_id, source_id, link_id, target_type_id, target_id,
+      properties, created_at, updated_at, last_commit_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    rowProjectId,
+    RootType,
+    sourceId,
+    linkId,
+    TargetType,
+    targetId,
+    properties === undefined ? null : JSON.stringify(properties),
+    timestamp,
+    timestamp,
+    "scope-test"
+  )
+}

--- a/storage/sqlite/tests/sqlite-object-read-scope-provider.test.ts
+++ b/storage/sqlite/tests/sqlite-object-read-scope-provider.test.ts
@@ -8,9 +8,7 @@ import {
   compileSelectedObjectReadScope,
   linkBatchKey,
   type ObjectReadExecutionLimits,
-  type ObjectReadScopeFactory,
   type ObjectReadStorage,
-  type ObjectStorage,
   objectBatchKey,
   type SelectedObjectReadScope,
 } from "@sixb/core/storage"
@@ -279,8 +277,7 @@ describe("SqliteObjectStorage selected reader invariants", () => {
       writer = new Database(sqliteStoragePath(directory))
       insertObject(writer, RootType, "root-1", { id: "root-1", hidden: "secret" })
 
-      const factory = storage.objects as ObjectStorage & ObjectReadScopeFactory
-      const reader = factory.createSelectedReadScope({
+      const reader = storage.objects.createSelectedReadScope({
         projectId,
         scope: compileSelectedObjectReadScope(rootOnlyScope()),
         limits: generousLimits,
@@ -296,6 +293,38 @@ describe("SqliteObjectStorage selected reader invariants", () => {
       writer?.close()
       storage.close()
       await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  test("preserves selected readers through a storage transaction and expires escaped readers", async () => {
+    const storage = new SqliteStorage()
+    let escapedReader: ObjectReadStorage | undefined
+    let escapedList: ObjectReadStorage["list"] | undefined
+    try {
+      await storage.transaction(async (tx) => {
+        const reader = tx.objects.createSelectedReadScope({
+          projectId,
+          scope: compileSelectedObjectReadScope(rootOnlyScope()),
+          limits: generousLimits,
+        })
+        await expect(reader.list({ projectId })).resolves.toEqual({
+          objects: [],
+          hasMore: false,
+          total: 0,
+        })
+        escapedReader = reader
+        escapedList = reader.list
+      })
+
+      if (!escapedReader || !escapedList) throw new Error("expected escaped selected reader")
+      const reader = escapedReader
+      const list = escapedList
+      expect(() => reader.queryCapabilities()).toThrow("after transaction completion")
+      await expect(Promise.resolve().then(() => list({ projectId }))).rejects.toMatchObject({
+        code: "transaction_inactive",
+      })
+    } finally {
+      storage.close()
     }
   })
 

--- a/storage/sqlite/tests/sqlite-object-read-scope.test.ts
+++ b/storage/sqlite/tests/sqlite-object-read-scope.test.ts
@@ -1,0 +1,16 @@
+import type { ObjectReadScopeFactory, ObjectStorage } from "@sixb/core/storage"
+import { runObjectReadScopeContractSuite } from "@sixb/core/testing"
+import { SqliteStorage } from "../src"
+
+runObjectReadScopeContractSuite("SqliteStorage selected object-read scope contract", {
+  createHarness: () => {
+    const storage = new SqliteStorage()
+    return {
+      storage,
+      // Storage activation is a later slice. The provider facade already preserves the concrete
+      // factory method, so this contract can validate SQLite independently in the meantime.
+      objectReadScopeFactory: storage.objects as ObjectStorage & ObjectReadScopeFactory,
+    }
+  },
+  teardown: ({ storage }) => storage.close(),
+})

--- a/storage/sqlite/tests/sqlite-object-read-scope.test.ts
+++ b/storage/sqlite/tests/sqlite-object-read-scope.test.ts
@@ -1,4 +1,3 @@
-import type { ObjectReadScopeFactory, ObjectStorage } from "@sixb/core/storage"
 import { runObjectReadScopeContractSuite } from "@sixb/core/testing"
 import { SqliteStorage } from "../src"
 
@@ -7,9 +6,7 @@ runObjectReadScopeContractSuite("SqliteStorage selected object-read scope contra
     const storage = new SqliteStorage()
     return {
       storage,
-      // Storage activation is a later slice. The provider facade already preserves the concrete
-      // factory method, so this contract can validate SQLite independently in the meantime.
-      objectReadScopeFactory: storage.objects as ObjectStorage & ObjectReadScopeFactory,
+      objectReadScopeFactory: storage.objects,
     }
   },
   teardown: ({ storage }) => storage.close(),


### PR DESCRIPTION
## Why

- #498 adds path-sensitive Query admission, but delegated readers still reject every Query terminal.
- Shared pages need the normal Query API without route-specific resource loading.

## What

```text
request snapshot
  → ordinary validation
  → selected-path admission
  → canonical executor
  → selected storage
```

- Activates `executeQuery`, `count`, `exists`, `facet`, and `queryLinks`.
- Builds admission and selected storage once from the same compiled scope.
- Executes the exact admitted snapshot; no forgeable executor flag or second AST walker.
- Reuses terminal preflights for facets and physical links.
- Bounds facet fan-out to 16 before reading caller-owned elements.

## Security contract

| Case | Result |
| --- | --- |
| Unselected property or link path | denied before storage |
| Known ID of an unselected sibling | empty result |
| Low-level executor + delegated token | denied |
| Principal / unrestricted reader | unchanged |

## Validation

- Core typecheck
- Biome
- 108 focused tests / 529 assertions
- InMemory end-to-end sibling-ID coverage

## Stack

- Base: #498
- Next: #500
