### PR TITLE
core: admit exact delegated Actions

### DIFF
--- a/packages/core/src/actions/delegated-admission.ts
+++ b/packages/core/src/actions/delegated-admission.ts
@@ -1,0 +1,72 @@
+import { AuthorizationError } from "../authorization"
+import type { ResolvedRuntimeAuthorization } from "../execution/authorization"
+import {
+  type AuthorizedObjectReader,
+  assertAuthorizedObjectReaderBinding,
+} from "../execution/authorized-object-reader"
+import type { ExecutionContext, RuntimeAuthorization } from "../execution/types"
+import type { ActionDefinition, ActionObjectSubject, ActionSubject } from "./types"
+
+type DelegatedAuthorization = Extract<ResolvedRuntimeAuthorization, { readonly type: "delegated" }>
+
+/** Reject ungranted tuples before Action lookup can become a metadata oracle. */
+export function assertDelegatedActionTarget(input: {
+  readonly authorization: DelegatedAuthorization
+  readonly actionId: string
+  readonly subject: ActionSubject
+}): ActionObjectSubject {
+  const { actionId, authorization, subject } = input
+  if (
+    subject.kind !== "object" ||
+    !authorization.actionApply.some(
+      (target) =>
+        target.actionId === actionId &&
+        target.subject.objectTypeId === subject.objectTypeId &&
+        target.subject.primaryId === subject.primaryId
+    )
+  ) {
+    throw denied(actionId, subject)
+  }
+  return subject
+}
+
+/** Admit an exact tuple against its definition and current selected-read visibility. */
+export async function admitDelegatedObjectAction(input: {
+  readonly objectReader: AuthorizedObjectReader
+  readonly runtimeAuthorization: RuntimeAuthorization
+  readonly execution: ExecutionContext
+  readonly authorization: DelegatedAuthorization
+  readonly action: ActionDefinition
+  readonly subject: ActionObjectSubject
+}): Promise<void> {
+  const { action, authorization, execution, objectReader, runtimeAuthorization, subject } = input
+  assertDelegatedActionTarget({ authorization, actionId: action.id, subject })
+  if (action.binding.kind !== "object" || action.binding.objectType.id !== subject.objectTypeId) {
+    throw denied(action.id, subject)
+  }
+
+  assertAuthorizedObjectReaderBinding({
+    reader: objectReader,
+    scope: { execution, authorization: runtimeAuthorization },
+  })
+
+  try {
+    const visible = await objectReader.getByPrimaryId({
+      objectTypeId: subject.objectTypeId,
+      primaryId: subject.primaryId,
+    })
+    if (!visible) throw denied(action.id, subject)
+  } catch (error) {
+    if (error instanceof AuthorizationError) throw denied(action.id, subject)
+    throw error
+  }
+}
+
+function denied(actionId: string, subject: ActionSubject): AuthorizationError {
+  const target =
+    subject.kind === "object" ? `${subject.objectTypeId}:${subject.primaryId}` : "global"
+  return new AuthorizationError(
+    `apply:action:${actionId}:${target}`,
+    `[Sixb] Delegated authority cannot apply Action '${actionId}' to '${target}'.`
+  )
+}

--- a/packages/core/src/actions/execution.ts
+++ b/packages/core/src/actions/execution.ts
@@ -1,5 +1,6 @@
 import { canViewActionRun, isAllowed } from "../authorization"
 import type { ExecutionContext } from "../execution"
+import { resolveRuntimeAuthorizationForProject } from "../execution/authorization"
 import type { ObjectType } from "../ontology"
 import type { SixbRuntimeContext } from "../runtime/types"
 import type {
@@ -37,13 +38,24 @@ export function createActionsRuntime(
   runtime: SixbRuntimeContext,
   execution: ExecutionContext
 ): ActionsRuntime {
-  const canList = (action: ActionDefinition) =>
-    isAllowed(runtime.authorization, { kind: "action.apply", actionId: action.id }) &&
-    (action.binding.kind === "global" ||
-      isAllowed(runtime.authorization, {
-        kind: "object.view",
-        objectTypeId: action.binding.objectType.id,
-      }))
+  const projectId = runtime.projectId
+  const runtimeAuthorization = runtime.runtimeAuthorization
+  const authorization = resolveRuntimeAuthorizationForProject({
+    projectId,
+    runtimeAuthorization,
+  })
+  const canList = (action: ActionDefinition) => {
+    if (authorization.type === "denied" || authorization.type === "delegated") return false
+    if (authorization.type === "unrestricted") return true
+    return (
+      isAllowed(authorization.context, { kind: "action.apply", actionId: action.id }) &&
+      (action.binding.kind === "global" ||
+        isAllowed(authorization.context, {
+          kind: "object.view",
+          objectTypeId: action.binding.objectType.id,
+        }))
+    )
+  }
 
   return {
     list: () => runtime.actionRegistry.list().filter(canList),
@@ -57,25 +69,34 @@ export function createActionsRuntime(
     requestAndWait: (input) => requestActionAndWait(runtime, execution, input),
     runs: {
       getById: async (runId) => {
+        if (authorization.type === "denied" || authorization.type === "delegated") return null
         const run =
           (await runtime.storage.actionRuns?.getById({
-            projectId: runtime.projectId,
+            projectId,
             id: runId,
           })) ?? null
-        return run && canViewActionRun(runtime.authorization, run) ? run : null
+        return run &&
+          (authorization.type === "unrestricted" || canViewActionRun(authorization.context, run))
+          ? run
+          : null
       },
       list: (input = {}) => {
+        if (authorization.type === "denied" || authorization.type === "delegated") {
+          return Promise.resolve({ runs: [], hasMore: false, total: 0 })
+        }
         const storage = runtime.storage.actionRuns
         if (!storage) return Promise.resolve({ runs: [], hasMore: false, total: 0 })
         return storage.list({
-          projectId: runtime.projectId,
           ...input,
-          actionIds: runtime.authorization
-            ? [...runtime.authorization.grants["apply:action"]]
-            : undefined,
-          objectTypeIds: runtime.authorization
-            ? [...runtime.authorization.grants["view:object"]]
-            : undefined,
+          projectId,
+          actionIds:
+            authorization.type === "principal"
+              ? [...authorization.context.grants["apply:action"]]
+              : undefined,
+          objectTypeIds:
+            authorization.type === "principal"
+              ? [...authorization.context.grants["view:object"]]
+              : undefined,
         })
       },
     },

--- a/packages/core/src/actions/request.ts
+++ b/packages/core/src/actions/request.ts
@@ -1,5 +1,9 @@
-import { assertAuthorized } from "../authorization"
-import { resolveExecutionScopeAuthorization } from "../execution/authorization"
+import { AuthorizationError, assertAuthorized, canViewActionRun } from "../authorization"
+import {
+  getAuthorizationRef,
+  resolveExecutionScopeAuthorization,
+  resolveRuntimeAuthorizationForProject,
+} from "../execution/authorization"
 import {
   createPrimitiveExecutionRecord,
   ensureExecutionRecord,
@@ -16,6 +20,7 @@ import {
   type ActionRunStorage,
   isTerminalActionRun,
 } from "../storage"
+import { admitDelegatedObjectAction, assertDelegatedActionTarget } from "./delegated-admission"
 import { dispatchActionRun } from "./run-dispatch"
 import { createActionRunId } from "./run-id"
 import type { ActionDefinition, ActionSubject } from "./types"
@@ -84,20 +89,46 @@ export async function requestAction(
   execution: ExecutionContext,
   input: RequestActionInput
 ): Promise<RequestActionResult> {
-  resolveExecutionScopeAuthorization(runtime.projectId, {
+  // Capture the three process-local capabilities before caller-owned request getters can run.
+  const projectId = runtime.projectId
+  const runtimeAuthorization = runtime.runtimeAuthorization
+  const objectReader = runtime.objectReader
+  const request = snapshotActionRequest(input)
+  const authorization = resolveExecutionScopeAuthorization(projectId, {
     execution,
-    authorization: runtime.runtimeAuthorization,
+    authorization: runtimeAuthorization,
   })
-  requireActionRunStorage(runtime)
-  const action = getActionDefinition(runtime, input.actionId)
+  const subject = request.subject
+  const delegatedSubject =
+    authorization.type === "delegated"
+      ? assertDelegatedActionTarget({
+          authorization,
+          actionId: request.actionId,
+          subject,
+        })
+      : undefined
+  const action = getActionDefinition(runtime, request.actionId)
   const actionId = action.id
-  const rawParams: Record<string, unknown> = input.params ?? {}
-  const subject: ActionSubject = input.subject ?? { kind: "none" }
+  const rawParams = request.params
 
-  assertAuthorized(runtime, { kind: "action.apply", actionId })
-  if (action.binding.kind === "object") {
+  if (authorization.type === "delegated") {
+    await admitDelegatedObjectAction({
+      objectReader,
+      runtimeAuthorization,
+      execution,
+      authorization,
+      action,
+      subject: delegatedSubject!,
+    })
+  } else {
+    assertAuthorized({ projectId, runtimeAuthorization }, { kind: "action.apply", actionId })
+  }
+  if (authorization.type !== "delegated" && action.binding.kind === "object") {
     // Object actions also require visibility of the subject's object type.
-    assertAuthorized(runtime, { kind: "object.view", objectTypeId: action.binding.objectType.id })
+    assertAuthorized(
+      { projectId, runtimeAuthorization },
+      { kind: "object.view", objectTypeId: action.binding.objectType.id }
+    )
   }
 
   validateActionSubject(action, subject)
@@ -112,22 +143,26 @@ export async function requestAction(
 
   const actionParams = normalizeActionParams(runtime, action.params, rawParams, pathPrefix)
 
+  // `dispatchActionRun` checks an existing run id before creating its durable execution. Keep
+  // process-local delegation outside that oracle until durable grant provenance is implemented.
+  void getAuthorizationRef(runtimeAuthorization)
+
   return dispatchActionRun({
     errorReporterHost: runtime,
-    projectId: runtime.projectId,
+    projectId,
     storage: runtime.storage,
     queue: runtime.queues.actions,
     events: runtime.events,
     actionId,
     subject,
     params: actionParams,
-    runId: input.runId,
+    runId: request.runId,
     createExecution: async (executionId, runId) => {
       const caller = await ensureExecutionRecord(
         runtime.storage.executions,
         executionRecordInputFromRuntime({
           execution,
-          runtimeAuthorization: runtime.runtimeAuthorization,
+          runtimeAuthorization,
         })
       )
       return createPrimitiveExecutionRecord({
@@ -136,6 +171,24 @@ export async function requestAction(
         origin: { type: "execution", parent: caller },
       })
     },
+  })
+}
+
+function snapshotActionRequest(input: RequestActionInput): {
+  readonly actionId: string
+  readonly subject: ActionSubject
+  readonly params: Record<string, unknown>
+  readonly runId?: string
+} {
+  const actionId = input.actionId
+  const subject = input.subject
+  const params = input.params
+  const runId = input.runId
+  return structuredClone({
+    actionId,
+    subject: subject ?? { kind: "none" },
+    params: params ?? {},
+    ...(runId === undefined ? {} : { runId }),
   })
 }
 
@@ -163,9 +216,28 @@ export async function waitForActionRun(
   runtime: SixbRuntimeContext,
   input: WaitForActionRunInput
 ): Promise<ActionRunRecord> {
+  const projectId = runtime.projectId
+  const runtimeAuthorization = runtime.runtimeAuthorization
+  const request = {
+    runId: input.runId,
+    timeoutMs: input.timeoutMs,
+    signal: input.signal,
+  }
+  const authorization = resolveRuntimeAuthorizationForProject({
+    projectId,
+    runtimeAuthorization,
+  })
+  if (authorization.type === "denied") {
+    throw new AuthorizationError(
+      "runtime:unbound",
+      "[Sixb] Protected operations require registered runtime authorization for this project."
+    )
+  }
+  // Polling cannot be delegated safely until durable runs carry their originating grant.
+  if (authorization.type === "delegated") void getAuthorizationRef(runtimeAuthorization)
   const actionRuns = requireActionRunStorage(runtime)
-  const timeoutMs = input.timeoutMs ?? DEFAULT_ACTION_WAIT_TIMEOUT_MS
-  const signal = input.signal
+  const timeoutMs = request.timeoutMs ?? DEFAULT_ACTION_WAIT_TIMEOUT_MS
+  const signal = request.signal
   const startedAt = Date.now()
 
   if (signal?.aborted) {
@@ -218,10 +290,14 @@ export async function waitForActionRun(
       checking = true
       try {
         const record = await actionRuns.getById({
-          projectId: runtime.projectId,
-          id: input.runId,
+          projectId,
+          id: request.runId,
         })
-        if (record && isTerminalActionRun(record)) {
+        const visible =
+          record &&
+          (authorization.type === "unrestricted" ||
+            (authorization.type === "principal" && canViewActionRun(authorization.context, record)))
+        if (visible && isTerminalActionRun(record)) {
           cleanup()
           resolve(record)
           return
@@ -240,7 +316,7 @@ export async function waitForActionRun(
 
     timer = setTimeout(
       () => {
-        rejectWith(new ActionRunTimeoutError({ runId: input.runId, timeoutMs }))
+        rejectWith(new ActionRunTimeoutError({ runId: request.runId, timeoutMs }))
       },
       Math.max(0, timeoutMs - (Date.now() - startedAt))
     )
@@ -255,7 +331,7 @@ export async function waitForActionRun(
           events.some(
             (event) =>
               (event.type === "action.completed" || event.type === "action.failed") &&
-              event.payload.runId === input.runId
+              event.payload.runId === request.runId
           )
         ) {
           void check()

--- a/packages/core/src/execution/authorization.ts
+++ b/packages/core/src/execution/authorization.ts
@@ -4,6 +4,7 @@ import type { Principal } from "../auth"
 import { TARGETED_GRANT_KIND_KEYS, type TargetedGrantKind } from "../authorization/grant-kinds"
 import type { AuthorizationContext, GrantIndex } from "../authorization/types"
 import { createSixbError } from "../errors/internal"
+import type { ObjectRef } from "../ontology"
 import {
   type ObjectReadExecutionLimits,
   snapshotObjectReadExecutionLimits,
@@ -42,6 +43,7 @@ export type ResolvedRuntimeAuthorization =
       readonly type: "delegated"
       readonly projectId: string
       readonly objectRead: DelegatedObjectReadAuthorization
+      readonly actionApply: readonly DelegatedActionApplyTarget[]
     }
   | { readonly type: "denied" }
 
@@ -49,6 +51,12 @@ export type ResolvedRuntimeAuthorization =
 export interface DelegatedObjectReadAuthorization {
   readonly scope: CompiledSelectedObjectReadScope
   readonly limits: ObjectReadExecutionLimits
+}
+
+/** One exact object-bound Action target carried by process-local delegated authority. */
+export interface DelegatedActionApplyTarget {
+  readonly actionId: string
+  readonly subject: ObjectRef
 }
 
 type RegisteredRuntimeAuthorization = Exclude<
@@ -69,6 +77,9 @@ const registeredAuthorizations = new WeakMap<
   RuntimeAuthorization,
   RuntimeAuthorizationRegistration
 >()
+
+const MAX_DELEGATED_ACTION_APPLY_TARGETS = 4_096
+const MAX_DELEGATED_ACTION_IDENTIFIER_CHARACTERS = 1_000_000
 
 export function createPrincipalRuntimeAuthorization(input: {
   readonly execution: ExecutionContext
@@ -154,9 +165,11 @@ export function createDelegatedRuntimeAuthorization(input: {
     readonly selection: SelectedObjectReadScope
     readonly limits: ObjectReadExecutionLimits
   }
+  readonly actionApply?: readonly DelegatedActionApplyTarget[]
 }): RuntimeAuthorization {
   const execution = input.execution
   const objectReadInput = input.objectRead
+  const actionApplyInput = input.actionApply
   if (execution.executor.type !== "request" || execution.requestedBy !== undefined) {
     throw new Error(
       "[Sixb] Delegated runtime authorization requires a request execution without a principal."
@@ -171,6 +184,7 @@ export function createDelegatedRuntimeAuthorization(input: {
     type: "delegated",
     projectId: execution.projectId,
     objectRead,
+    actionApply: snapshotDelegatedActionApply(actionApplyInput ?? []),
   })
 }
 
@@ -674,6 +688,76 @@ function snapshotKernelOperation(operation: KernelOperation): KernelOperation {
   }
   assertNonEmpty(operation.recoveryId, "Kernel recovery id")
   return Object.freeze({ type: operation.type, recoveryId: operation.recoveryId })
+}
+
+/** Validate, bound, and detach exact delegated Action targets before registering authority. */
+function snapshotDelegatedActionApply(
+  input: readonly DelegatedActionApplyTarget[]
+): readonly DelegatedActionApplyTarget[] {
+  if (!Array.isArray(input)) {
+    throw new Error("[Sixb] Delegated Action targets must be an array.")
+  }
+
+  const targetCount = input.length
+  if (targetCount > MAX_DELEGATED_ACTION_APPLY_TARGETS) {
+    throw new Error(
+      `[Sixb] Delegated authority exceeds the maximum of ${MAX_DELEGATED_ACTION_APPLY_TARGETS} Action targets.`
+    )
+  }
+
+  let identifierCharacters = 0
+  const targets: DelegatedActionApplyTarget[] = []
+  for (let index = 0; index < targetCount; index += 1) {
+    const authoredTarget = input[index]
+    if (!isRecord(authoredTarget)) {
+      throw new Error(`[Sixb] Delegated Action target ${index} must be an object.`)
+    }
+
+    const authoredActionId = authoredTarget.actionId
+    const authoredSubject = authoredTarget.subject
+    if (!isRecord(authoredSubject)) {
+      throw new Error(`[Sixb] Delegated Action target ${index} subject must be an ObjectRef.`)
+    }
+
+    const actionId = delegatedActionIdentifier(
+      authoredActionId,
+      `Delegated Action target ${index} action id`
+    )
+    const objectTypeId = delegatedActionIdentifier(
+      authoredSubject.objectTypeId,
+      `Delegated Action target ${index} subject object type id`
+    )
+    const primaryId = delegatedActionIdentifier(
+      authoredSubject.primaryId,
+      `Delegated Action target ${index} subject primary id`
+    )
+    identifierCharacters += actionId.length + objectTypeId.length + primaryId.length
+    if (identifierCharacters > MAX_DELEGATED_ACTION_IDENTIFIER_CHARACTERS) {
+      throw new Error(
+        `[Sixb] Delegated authority exceeds the maximum of ${MAX_DELEGATED_ACTION_IDENTIFIER_CHARACTERS} Action identifier characters.`
+      )
+    }
+
+    targets.push(
+      Object.freeze({
+        actionId,
+        subject: Object.freeze({ objectTypeId, primaryId }),
+      })
+    )
+  }
+
+  return Object.freeze(targets)
+}
+
+function delegatedActionIdentifier(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`[Sixb] ${label} must not be empty.`)
+  }
+  return value
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 function cloneAuthorizationRef(ref: AuthorizationRef): AuthorizationRef {

--- a/packages/core/src/execution/scopes.ts
+++ b/packages/core/src/execution/scopes.ts
@@ -6,6 +6,7 @@ import {
   createDisabledRuntimeAuthorization,
   createKernelRuntimeAuthorization,
   createPrincipalRuntimeAuthorization,
+  type DelegatedActionApplyTarget,
 } from "./authorization"
 import type {
   AuthorizablePrincipal,
@@ -61,13 +62,16 @@ export function createDelegatedRequestScope(input: {
     readonly selection: SelectedObjectReadScope
     readonly limits: ObjectReadExecutionLimits
   }
+  readonly actionApply?: readonly DelegatedActionApplyTarget[]
 }): ExecutionScope {
   const execution = createRequestExecution(input)
+  const actionApply = input.actionApply
   return Object.freeze({
     execution,
     authorization: createDelegatedRuntimeAuthorization({
       execution,
       objectRead: input.objectRead,
+      ...(actionApply === undefined ? {} : { actionApply }),
     }),
   })
 }

--- a/packages/core/tests/action-wait.test.ts
+++ b/packages/core/tests/action-wait.test.ts
@@ -1,11 +1,18 @@
 import { expect, spyOn, test } from "bun:test"
 import { waitForActionRun } from "../src/actions/request"
+import { AuthorizationError, emptyGrantIndex } from "../src/authorization"
+import { createDisabledRuntimeAuthorization } from "../src/execution/authorization"
+import { createDelegatedRequestScope, createTestingScope } from "../src/execution/scopes"
+import type { ExecutionScope } from "../src/execution/types"
 import { ActionRunTimeoutError } from "../src/objects/action/errors"
 import type { SixbRuntimeContext } from "../src/runtime/types"
+import type { ActionRunRecord } from "../src/storage"
 
 function runtimeWithSubscription(subscribe: () => Promise<() => void>): SixbRuntimeContext {
+  const scope = createTestingScope({ projectId: "test" })
   return {
     projectId: "test",
+    runtimeAuthorization: scope.authorization,
     storage: {
       actionRuns: {
         getById: async () => null,
@@ -14,6 +21,136 @@ function runtimeWithSubscription(subscribe: () => Promise<() => void>): SixbRunt
     events: { subscribe },
   } as unknown as SixbRuntimeContext
 }
+
+function runtimeWithRecord(scope: ExecutionScope, record: ActionRunRecord): SixbRuntimeContext {
+  return {
+    projectId: "test",
+    runtimeAuthorization: scope.authorization,
+    storage: { actionRuns: { getById: async () => record } },
+    events: { subscribe: async () => () => undefined },
+  } as unknown as SixbRuntimeContext
+}
+
+const terminalRun: ActionRunRecord = {
+  id: "secret-run",
+  projectId: "test",
+  executionId: "secret-execution",
+  actionId: "secret-action",
+  subject: { kind: "object", objectTypeId: "Secret", primaryId: "secret-1" },
+  status: "succeeded",
+  phase: "effects",
+  queuedAt: new Date("2026-01-01T00:00:00.000Z"),
+  finishedAt: new Date("2026-01-01T00:00:01.000Z"),
+  params: { secret: "classified" },
+  idempotencyKey: "action:test:secret-run",
+}
+
+test("a wait rejects cross-project authority before storage or broker access", async () => {
+  const scope = createTestingScope({ projectId: "project-a" })
+  let storageReads = 0
+  let subscriptions = 0
+  const runtime = {
+    projectId: "project-b",
+    runtimeAuthorization: scope.authorization,
+    storage: {
+      actionRuns: {
+        getById: async () => {
+          storageReads += 1
+          return null
+        },
+      },
+    },
+    events: {
+      subscribe: async () => {
+        subscriptions += 1
+        return () => undefined
+      },
+    },
+  } as unknown as SixbRuntimeContext
+
+  await expect(waitForActionRun(runtime, { runId: "guessed-run" })).rejects.toBeInstanceOf(
+    AuthorizationError
+  )
+  expect(storageReads).toBe(0)
+  expect(subscriptions).toBe(0)
+})
+
+test("a wait captures delegated authority once before its durable boundary", async () => {
+  const scope = createDelegatedRequestScope({
+    projectId: "test",
+    requestId: "delegated-wait",
+    correlationId: "delegated-wait-correlation",
+    objectRead: {
+      selection: { kind: "selected", roots: [] },
+      limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+    },
+  })
+  const disabledAuthorization = createDisabledRuntimeAuthorization(scope.execution)
+  let authorizationReads = 0
+  let storageReads = 0
+  let subscriptions = 0
+  const runtime = Object.defineProperties(
+    {
+      projectId: "test",
+      storage: {
+        actionRuns: {
+          getById: async () => {
+            storageReads += 1
+            return terminalRun
+          },
+        },
+      },
+      events: {
+        subscribe: async () => {
+          subscriptions += 1
+          return () => undefined
+        },
+      },
+    },
+    {
+      runtimeAuthorization: {
+        enumerable: true,
+        get: () => {
+          authorizationReads += 1
+          return authorizationReads === 1 ? scope.authorization : disabledAuthorization
+        },
+      },
+    }
+  ) as unknown as SixbRuntimeContext
+
+  await expect(waitForActionRun(runtime, { runId: terminalRun.id })).rejects.toThrow(
+    "cannot cross a durable execution boundary"
+  )
+  expect(authorizationReads).toBe(1)
+  expect(storageReads).toBe(0)
+  expect(subscriptions).toBe(0)
+})
+
+test("a wait never returns a terminal run hidden from its principal", async () => {
+  const principalScope = createTestingScope({
+    projectId: "test",
+    context: {
+      principal: { type: "user", id: "user-1" },
+      groupIds: [],
+      roleIds: [],
+      grants: emptyGrantIndex(),
+    },
+  })
+  const hidden = await waitForActionRun(runtimeWithRecord(principalScope, terminalRun), {
+    runId: terminalRun.id,
+    timeoutMs: 5,
+  }).catch((error: unknown) => error)
+
+  expect(hidden).toBeInstanceOf(ActionRunTimeoutError)
+
+  const unrestrictedScope = createTestingScope({ projectId: "test" })
+  await expect(
+    waitForActionRun(runtimeWithRecord(unrestrictedScope, terminalRun), {
+      runId: terminalRun.id,
+      timeoutMs: 25,
+    })
+  ).resolves.toBe(terminalRun)
+})
 
 /**
  * `waitForActionRun` subscribes asynchronously but releases the subscription from `cleanup()`,

--- a/packages/core/tests/authorization-decision.test.ts
+++ b/packages/core/tests/authorization-decision.test.ts
@@ -90,6 +90,12 @@ const delegatedScope = createDelegatedRequestScope({
     },
     limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
   },
+  actionApply: [
+    {
+      actionId: "approve",
+      subject: { objectTypeId: "quote", primaryId: "quote-1" },
+    },
+  ],
 })
 const delegatedRuntime = {
   projectId: "decision-test",

--- a/packages/core/tests/delegated-action-admission.test.ts
+++ b/packages/core/tests/delegated-action-admission.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect, test } from "bun:test"
+import {
+  type ActionDefinition,
+  defineAction,
+  defineObjectType,
+  type OntologyRegistry,
+  prop,
+  SixbHost,
+} from "../src"
+import { createActionsRuntime } from "../src/actions/execution"
+import { requestAction, waitForActionRun } from "../src/actions/request"
+import { AuthorizationError } from "../src/authorization"
+import { createDisabledRuntimeAuthorization } from "../src/execution/authorization"
+import { createAuthorizedObjectReader } from "../src/execution/authorized-object-reader"
+import { createDelegatedRequestScope, createTestingScope } from "../src/execution/scopes"
+import type { ExecutionScope } from "../src/execution/types"
+import type { SixbRuntimeContext } from "../src/runtime/types"
+import type { SelectedObjectReadScope } from "../src/storage"
+import { decorateOperationScopedMethodForTesting } from "../src/storage/operation-scope"
+import { createTestSixb } from "../src/testing"
+import { createTestRuntimeDeps } from "./test-runtime-deps"
+
+const Proposal = defineObjectType({
+  id: "DelegatedActionProposal",
+  name: "Delegated Action Proposal",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+const ArchivedProposal = defineObjectType({
+  id: "DelegatedActionArchivedProposal",
+  name: "Delegated Action Archived Proposal",
+  extends: Proposal,
+  properties: [prop("archived", "boolean", { required: true })],
+})
+
+const approve = defineAction("delegated-action-approve")
+  .on(Proposal)
+  .params({})
+  .writeback(async () => {})
+
+const reject = defineAction("delegated-action-reject")
+  .on(Proposal)
+  .params({})
+  .writeback(async () => {})
+
+const refresh = defineAction("delegated-action-refresh")
+  .params({})
+  .writeback(async () => {})
+
+type ActionTarget = {
+  readonly actionId: string
+  readonly subject: { readonly objectTypeId: string; readonly primaryId: string }
+}
+
+type RuntimeHost = Omit<
+  SixbRuntimeContext,
+  "authorization" | "objectReader" | "runtimeAuthorization"
+>
+
+function actionDefinition(action: unknown): ActionDefinition {
+  return action as ActionDefinition
+}
+
+async function createFixture() {
+  const runtimeDeps = createTestRuntimeDeps()
+  const host = new SixbHost({
+    id: "delegated-action-admission",
+    ontology: [Proposal, ArchivedProposal],
+    actions: [actionDefinition(approve), actionDefinition(reject), actionDefinition(refresh)],
+    ...runtimeDeps,
+  })
+  const sixb = createTestSixb(host)
+  await sixb.objects(Proposal).upsert({ properties: { id: "proposal-1" } })
+  await sixb.objects(Proposal).upsert({ properties: { id: "proposal-2" } })
+  await sixb.objects(ArchivedProposal).upsert({
+    properties: { id: "archived-1", archived: true },
+  })
+  const runtimeHost: RuntimeHost = {
+    projectId: host.id,
+    broker: host.broker,
+    ontology: host.definitions.ontology as OntologyRegistry,
+    actionRegistry: host.definitions.actions,
+    events: host.events,
+    storage: host.storage,
+    queues: host.queues,
+  }
+  return { runtimeHost, runtimeDeps }
+}
+
+function createDelegatedRuntime(
+  host: RuntimeHost,
+  input: {
+    readonly selected: readonly { readonly objectTypeId: string; readonly primaryId: string }[]
+    readonly actionApply?: readonly ActionTarget[]
+    readonly requestId: string
+  }
+): { readonly runtime: SixbRuntimeContext; readonly scope: ExecutionScope } {
+  const scope = createDelegatedRequestScope({
+    projectId: host.projectId,
+    requestId: input.requestId,
+    correlationId: `${input.requestId}-correlation`,
+    objectRead: {
+      selection: selectedObjects(input.selected),
+      limits: { maxTraversalFacts: 100, maxOutputJsonBytes: 100_000 },
+    },
+    actionApply: input.actionApply,
+  })
+  const runtime: SixbRuntimeContext = {
+    projectId: host.projectId,
+    broker: host.broker,
+    ontology: host.ontology,
+    actionRegistry: host.actionRegistry,
+    events: host.events,
+    storage: host.storage,
+    queues: host.queues,
+    runtimeAuthorization: scope.authorization,
+    objectReader: createAuthorizedObjectReader({
+      scope,
+      ontology: host.ontology,
+      objectStorage: host.storage.objects,
+    }),
+  }
+  return { runtime, scope }
+}
+
+function selectedObjects(
+  refs: readonly { readonly objectTypeId: string; readonly primaryId: string }[]
+): SelectedObjectReadScope {
+  return {
+    kind: "selected",
+    roots: refs.map((ref) => ({
+      anchor: ref,
+      node: {
+        objects: [
+          {
+            objectTypeId: ref.objectTypeId,
+            propertyIds: ref.objectTypeId === ArchivedProposal.id ? ["id", "archived"] : ["id"],
+          },
+        ],
+        links: [],
+      },
+    })),
+  }
+}
+
+function target(actionId: string, objectTypeId: string, primaryId: string): ActionTarget {
+  return { actionId, subject: { objectTypeId, primaryId } }
+}
+
+async function rejectedMessage(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise
+  } catch (error) {
+    expect(error).toBeInstanceOf(AuthorizationError)
+    return (error as Error).message
+  }
+  throw new Error("expected delegated Action request to be denied")
+}
+
+describe("delegated Action admission", () => {
+  test("preserves exact Action and ObjectRef pairs without a type-wide fallback", async () => {
+    const { runtimeHost } = await createFixture()
+    const { runtime, scope } = createDelegatedRuntime(runtimeHost, {
+      requestId: "cross-pairs",
+      selected: [
+        { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+        { objectTypeId: Proposal.id, primaryId: "proposal-2" },
+      ],
+      actionApply: [
+        target(approve.id, Proposal.id, "proposal-1"),
+        target(reject.id, Proposal.id, "proposal-2"),
+      ],
+    })
+
+    await expect(
+      requestAction(runtime, scope.execution, {
+        actionId: approve.id,
+        subject: { kind: "object", objectTypeId: Proposal.id, primaryId: "proposal-2" },
+      })
+    ).rejects.toBeInstanceOf(AuthorizationError)
+    await expect(
+      requestAction(runtime, scope.execution, {
+        actionId: reject.id,
+        subject: { kind: "object", objectTypeId: Proposal.id, primaryId: "proposal-1" },
+      })
+    ).rejects.toBeInstanceOf(AuthorizationError)
+    await expect(
+      requestAction(runtime, scope.execution, {
+        actionId: "unknown-action",
+        subject: { kind: "object", objectTypeId: Proposal.id, primaryId: "proposal-1" },
+      })
+    ).rejects.toMatchObject({
+      name: "AuthorizationError",
+      message: expect.not.stringContaining("Unknown action"),
+    })
+  })
+
+  test("makes an unselected exact target indistinguishable from a missing pair", async () => {
+    const { runtimeHost } = await createFixture()
+    const selected = [{ objectTypeId: Proposal.id, primaryId: "proposal-1" }]
+    const missingPair = createDelegatedRuntime(runtimeHost, {
+      requestId: "missing-pair",
+      selected,
+      actionApply: [],
+    })
+    const unselectedTarget = createDelegatedRuntime(runtimeHost, {
+      requestId: "unselected-target",
+      selected,
+      actionApply: [target(approve.id, Proposal.id, "proposal-2")],
+    })
+    const request = {
+      actionId: approve.id,
+      subject: { kind: "object" as const, objectTypeId: Proposal.id, primaryId: "proposal-2" },
+    }
+
+    const missingPairMessage = await rejectedMessage(
+      requestAction(missingPair.runtime, missingPair.scope.execution, request)
+    )
+    const unselectedTargetMessage = await rejectedMessage(
+      requestAction(unselectedTarget.runtime, unselectedTarget.scope.execution, request)
+    )
+    expect(unselectedTargetMessage).toBe(missingPairMessage)
+  })
+
+  test("rejects global Actions and inherited parent Actions in delegated V1", async () => {
+    const { runtimeHost } = await createFixture()
+    const global = createDelegatedRuntime(runtimeHost, {
+      requestId: "global-action",
+      selected: [],
+    })
+    await expect(
+      requestAction(global.runtime, global.scope.execution, { actionId: refresh.id })
+    ).rejects.toBeInstanceOf(AuthorizationError)
+    await expect(
+      requestAction(global.runtime, global.scope.execution, { actionId: approve.id })
+    ).rejects.toBeInstanceOf(AuthorizationError)
+
+    const inherited = createDelegatedRuntime(runtimeHost, {
+      requestId: "inherited-action",
+      selected: [{ objectTypeId: ArchivedProposal.id, primaryId: "archived-1" }],
+      actionApply: [target(approve.id, ArchivedProposal.id, "archived-1")],
+    })
+    await expect(
+      requestAction(inherited.runtime, inherited.scope.execution, {
+        actionId: approve.id,
+        subject: {
+          kind: "object",
+          objectTypeId: ArchivedProposal.id,
+          primaryId: "archived-1",
+        },
+      })
+    ).rejects.toBeInstanceOf(AuthorizationError)
+  })
+
+  test("captures one request and stops an admitted pair before durable run lookup", async () => {
+    const { runtimeHost, runtimeDeps } = await createFixture()
+    const { runtime, scope } = createDelegatedRuntime(runtimeHost, {
+      requestId: "admitted-pair",
+      selected: [{ objectTypeId: Proposal.id, primaryId: "proposal-1" }],
+      actionApply: [target(approve.id, Proposal.id, "proposal-1")],
+    })
+    const delegatedReader = runtime.objectReader
+    const disabledAuthorization = createDisabledRuntimeAuthorization(scope.execution)
+    const disabledReader = createAuthorizedObjectReader({
+      scope: { execution: scope.execution, authorization: disabledAuthorization },
+      ontology: runtimeHost.ontology,
+      objectStorage: runtimeHost.storage.objects,
+    })
+    let authorizationReads = 0
+    let readerReads = 0
+    const hostileRuntime = Object.defineProperties(
+      { ...runtime },
+      {
+        runtimeAuthorization: {
+          enumerable: true,
+          get: () => {
+            authorizationReads += 1
+            return authorizationReads === 1 ? scope.authorization : disabledAuthorization
+          },
+        },
+        objectReader: {
+          enumerable: true,
+          get: () => {
+            readerReads += 1
+            return readerReads === 1 ? delegatedReader : disabledReader
+          },
+        },
+      }
+    ) as SixbRuntimeContext
+    const actionRuns = runtimeDeps.storage.actionRuns
+    if (!actionRuns) throw new Error("test storage requires Action runs")
+    let runReads = 0
+    const restore = decorateOperationScopedMethodForTesting(actionRuns, "getById", (getById) => {
+      return async (input) => {
+        runReads += 1
+        return getById(input)
+      }
+    })
+    let actionIdReads = 0
+    let subjectReads = 0
+    let objectTypeIdReads = 0
+    let primaryIdReads = 0
+    let paramsReads = 0
+    let runIdReads = 0
+    const subject = Object.defineProperties(
+      { kind: "object" },
+      {
+        objectTypeId: {
+          enumerable: true,
+          get: () => {
+            objectTypeIdReads += 1
+            return Proposal.id
+          },
+        },
+        primaryId: {
+          enumerable: true,
+          get: () => {
+            primaryIdReads += 1
+            return "proposal-1"
+          },
+        },
+      }
+    )
+    const request = Object.defineProperties(
+      {},
+      {
+        actionId: {
+          enumerable: true,
+          get: () => {
+            actionIdReads += 1
+            return actionIdReads === 1 ? approve.id : reject.id
+          },
+        },
+        subject: {
+          enumerable: true,
+          get: () => {
+            subjectReads += 1
+            return subject
+          },
+        },
+        params: {
+          enumerable: true,
+          get: () => {
+            paramsReads += 1
+            return {}
+          },
+        },
+        runId: {
+          enumerable: true,
+          get: () => {
+            runIdReads += 1
+            return "delegated-action-existing-or-guessed-run"
+          },
+        },
+      }
+    ) as Parameters<typeof requestAction>[2]
+
+    try {
+      await expect(requestAction(hostileRuntime, scope.execution, request)).rejects.toThrow(
+        "cannot cross a durable execution boundary"
+      )
+      expect(authorizationReads).toBe(1)
+      expect(readerReads).toBe(1)
+      expect(actionIdReads).toBe(1)
+      expect(subjectReads).toBe(1)
+      expect(objectTypeIdReads).toBe(1)
+      expect(primaryIdReads).toBe(1)
+      expect(paramsReads).toBe(1)
+      expect(runIdReads).toBe(1)
+      expect(runReads).toBe(0)
+    } finally {
+      restore()
+    }
+  })
+
+  test("keeps delegated Action metadata, runs, and polling closed before activation", async () => {
+    const { runtimeHost, runtimeDeps } = await createFixture()
+    const { runtime, scope } = createDelegatedRuntime(runtimeHost, {
+      requestId: "closed-action-surfaces",
+      selected: [{ objectTypeId: Proposal.id, primaryId: "proposal-1" }],
+      actionApply: [target(approve.id, Proposal.id, "proposal-1")],
+    })
+    const actionRuns = runtimeDeps.storage.actionRuns
+    if (!actionRuns) throw new Error("test storage requires Action runs")
+    let getReads = 0
+    let listReads = 0
+    const restoreGet = decorateOperationScopedMethodForTesting(actionRuns, "getById", (getById) => {
+      return async (input) => {
+        getReads += 1
+        return getById(input)
+      }
+    })
+    const restoreList = decorateOperationScopedMethodForTesting(actionRuns, "list", (list) => {
+      return async (input) => {
+        listReads += 1
+        return list(input)
+      }
+    })
+
+    try {
+      const actions = createActionsRuntime(runtime, scope.execution)
+      expect(actions.list()).toEqual([])
+      expect(actions.getById(approve.id)).toBeNull()
+      expect(actions.listGlobal()).toEqual([])
+      expect(actions.listForType(Proposal)).toEqual([])
+      await expect(actions.runs.getById("guessed-run")).resolves.toBeNull()
+      await expect(actions.runs.list()).resolves.toEqual({ runs: [], hasMore: false, total: 0 })
+      await expect(waitForActionRun(runtime, { runId: "guessed-run" })).rejects.toThrow(
+        "cannot cross a durable execution boundary"
+      )
+      expect(getReads).toBe(0)
+      expect(listReads).toBe(0)
+    } finally {
+      restoreList()
+      restoreGet()
+    }
+  })
+
+  test("pins Action run storage to the runtime capabilities captured at construction", async () => {
+    const { runtimeHost, runtimeDeps } = await createFixture()
+    const scope = createTestingScope({ projectId: runtimeHost.projectId })
+    const foreignScope = createTestingScope({ projectId: "foreign-project" })
+    const reader = createAuthorizedObjectReader({
+      scope,
+      ontology: runtimeHost.ontology,
+      objectStorage: runtimeHost.storage.objects,
+    })
+    let projectIdReads = 0
+    let authorizationReads = 0
+    const runtime = Object.defineProperties(
+      { ...runtimeHost, objectReader: reader },
+      {
+        projectId: {
+          enumerable: true,
+          get: () => {
+            projectIdReads += 1
+            return projectIdReads === 1 ? runtimeHost.projectId : "foreign-project"
+          },
+        },
+        runtimeAuthorization: {
+          enumerable: true,
+          get: () => {
+            authorizationReads += 1
+            return authorizationReads === 1 ? scope.authorization : foreignScope.authorization
+          },
+        },
+      }
+    ) as SixbRuntimeContext
+    const actionRuns = runtimeDeps.storage.actionRuns
+    if (!actionRuns) throw new Error("test storage requires Action runs")
+    const providerProjects: string[] = []
+    const restoreGet = decorateOperationScopedMethodForTesting(actionRuns, "getById", (getById) => {
+      return async (input) => {
+        providerProjects.push(input.projectId)
+        return getById(input)
+      }
+    })
+    const restoreList = decorateOperationScopedMethodForTesting(actionRuns, "list", (list) => {
+      return async (input) => {
+        providerProjects.push(input.projectId)
+        return list(input)
+      }
+    })
+
+    try {
+      const actions = createActionsRuntime(runtime, scope.execution)
+      await expect(actions.runs.getById("missing-run")).resolves.toBeNull()
+      await expect(actions.runs.list({ projectId: "foreign-project" } as never)).resolves.toEqual({
+        runs: [],
+        hasMore: false,
+        total: 0,
+      })
+      expect(projectIdReads).toBe(1)
+      expect(authorizationReads).toBe(1)
+      expect(providerProjects).toEqual([runtimeHost.projectId, runtimeHost.projectId])
+    } finally {
+      restoreList()
+      restoreGet()
+    }
+  })
+})

--- a/packages/core/tests/execution-authorization.test.ts
+++ b/packages/core/tests/execution-authorization.test.ts
@@ -13,6 +13,7 @@ import {
   createDelegatedRuntimeAuthorization,
   createPrincipalRuntimeAuthorization,
   createTrustedPrimitiveRuntimeAuthorization,
+  type DelegatedActionApplyTarget,
   getAuthorizationRef,
   resolveExecutionScopeAuthorization,
   resolveRuntimeAuthorization,
@@ -282,6 +283,117 @@ describe("execution scopes", () => {
         runtimeAuthorization: scope.authorization,
       })
     ).toThrow("cannot cross a durable execution boundary")
+  })
+
+  test("snapshots and bounds exact delegated Action targets once", () => {
+    let actionIdReads = 0
+    let subjectReads = 0
+    let objectTypeIdReads = 0
+    let primaryIdReads = 0
+    const subject = Object.defineProperties(
+      {},
+      {
+        objectTypeId: {
+          enumerable: true,
+          get: () => {
+            objectTypeIdReads += 1
+            return "Proposal"
+          },
+        },
+        primaryId: {
+          enumerable: true,
+          get: () => {
+            primaryIdReads += 1
+            return "proposal-1"
+          },
+        },
+      }
+    )
+    const authoredTarget = Object.defineProperties(
+      {},
+      {
+        actionId: {
+          enumerable: true,
+          get: () => {
+            actionIdReads += 1
+            return "approve"
+          },
+        },
+        subject: {
+          enumerable: true,
+          get: () => {
+            subjectReads += 1
+            return subject
+          },
+        },
+      }
+    ) as DelegatedActionApplyTarget
+    const targets: DelegatedActionApplyTarget[] = [authoredTarget]
+    const scope = createDelegatedRequestScope({
+      projectId: "project-1",
+      requestId: "delegated-action-request",
+      correlationId: "delegated-action-correlation",
+      objectRead: {
+        selection: delegatedSelection(),
+        limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+      },
+      actionApply: targets,
+    })
+
+    targets.push({
+      actionId: "late-action",
+      subject: { objectTypeId: "Proposal", primaryId: "proposal-late" },
+    })
+
+    const resolved = resolveRuntimeAuthorization(scope.authorization)
+    expect(resolved.type).toBe("delegated")
+    if (resolved.type !== "delegated") throw new Error("expected delegated authorization")
+    expect(resolved.actionApply).toEqual([
+      {
+        actionId: "approve",
+        subject: { objectTypeId: "Proposal", primaryId: "proposal-1" },
+      },
+    ])
+    expect(actionIdReads).toBe(1)
+    expect(subjectReads).toBe(1)
+    expect(objectTypeIdReads).toBe(1)
+    expect(primaryIdReads).toBe(1)
+    expect(Object.isFrozen(resolved.actionApply)).toBe(true)
+    expect(Object.isFrozen(resolved.actionApply[0])).toBe(true)
+    expect(Object.isFrozen(resolved.actionApply[0]?.subject)).toBe(true)
+
+    expect(() =>
+      createDelegatedRequestScope({
+        projectId: "project-1",
+        requestId: "too-many-action-targets",
+        correlationId: "too-many-action-targets",
+        objectRead: {
+          selection: delegatedSelection(),
+          limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+        },
+        actionApply: Array.from({ length: 4_097 }, () => ({
+          actionId: "approve",
+          subject: { objectTypeId: "Proposal", primaryId: "proposal-1" },
+        })),
+      })
+    ).toThrow("maximum of 4096 Action targets")
+    expect(() =>
+      createDelegatedRequestScope({
+        projectId: "project-1",
+        requestId: "oversized-action-target",
+        correlationId: "oversized-action-target",
+        objectRead: {
+          selection: delegatedSelection(),
+          limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+        },
+        actionApply: [
+          {
+            actionId: "a".repeat(1_000_001),
+            subject: { objectTypeId: "Proposal", primaryId: "proposal-1" },
+          },
+        ],
+      })
+    ).toThrow("maximum of 1000000 Action identifier characters")
   })
 
   test("binds delegated authority only to its exact principal-free request", () => {


### PR DESCRIPTION
Part of #269 · Stack #547 · Parent: #498 · Next: #501

## Why

- #498 activates normal Query terminals for delegated pages.
- Actions need the same authority without widening one grant to every object of a type.

## What

```text
request snapshot
  → exact (Action, ObjectRef) admission
  → exact Action binding
  → live AuthorizedObjectReader proof
  → durable boundary
```

- Adds finite, immutable exact Action targets to process-local delegated authority.
- Denies global Actions and parent-to-subtype inheritance in delegated V1.
- Keeps Action metadata, run history, polling, and dispatch closed until durable grant attribution lands.
- Captures runtime capabilities once and pins every run lookup to the runtime project.

Diff shape: 295 production insertions; 736 test insertions.

## Security contract

| Case | Result |
| --- | --- |
| Allowed Action on allowed visible object | admitted, then stopped at the durable boundary |
| Allowed Action on known sibling ID | denied before run storage |
| Unknown or different Action | same denial; no Action lookup oracle |
| Global or inherited Action | denied in delegated V1 |
| Guessed run ID | no delegated metadata or polling access |

## Validation

- Root typecheck
- Biome
- 139 focused tests / 442 assertions
- Full suite: 4,666 passed / 0 failed

## Stack

- Base: #498
- Next: #501
