### PR TITLE
core: scope and bound delegated telemetry reads

### DIFF
--- a/packages/core/src/execution/authorized-object-reader.ts
+++ b/packages/core/src/execution/authorized-object-reader.ts
@@ -31,6 +31,11 @@ import {
   validateObjectQuery,
   validateObjectQueryWithAdmission,
 } from "../objects/query/validate"
+import {
+  admitTelemetryHistoryReadWorkload,
+  type TelemetryHistoryReadAdmission,
+  type TelemetryHistoryReadWorkloadInput,
+} from "../objects/telemetry/workload"
 import type { OntologyRegistry } from "../ontology"
 import type {
   CompiledObjectReadStep,
@@ -419,6 +424,13 @@ class AuthorizedObjectReaderImpl {
   assertVisibleOutputWithinLimit(value: unknown): void {
     if (this.#authority.type !== "delegated") return
     assertObjectReadOutputWithinLimit(value, this.#authority.objectRead.limits)
+  }
+
+  /** Admit adjacent telemetry work without exposing which authority policy was selected. */
+  admitTelemetryHistoryRead(
+    input: TelemetryHistoryReadWorkloadInput
+  ): TelemetryHistoryReadAdmission {
+    return admitTelemetryHistoryReadWorkload(input, this.#authority.type === "delegated")
   }
 
   #queryExecutorOptions() {

--- a/packages/core/src/execution/authorized-object-reader.ts
+++ b/packages/core/src/execution/authorized-object-reader.ts
@@ -40,7 +40,7 @@ import type {
   ObjectReadStorage,
   ObjectStorage,
 } from "../storage"
-import { MAX_OBJECT_READ_FACETS } from "../storage"
+import { assertObjectReadOutputWithinLimit, MAX_OBJECT_READ_FACETS } from "../storage"
 import { captureExecutionScope, resolveExecutionScopeAuthorization } from "./authorization"
 import type { ExecutionScope, RuntimeAuthorization } from "./types"
 
@@ -169,6 +169,7 @@ class AuthorizedObjectReaderImpl {
       propertyId: input.propertyId,
     })
     this.#assertObjectTypesViewable([request.objectTypeId])
+    if (this.#authority.type !== "delegated") return true
     const [readable] = await this.#storage.selectsObjectProperties({
       projectId: this.#runtime.projectId,
       items: [request],
@@ -187,6 +188,7 @@ class AuthorizedObjectReaderImpl {
       })),
     })
     this.#assertObjectTypesViewable(request.items.map((item) => item.objectTypeId))
+    if (this.#authority.type !== "delegated") return request.items.map(() => true)
     return detachReadResult(
       await this.#storage.selectsObjectProperties({
         ...request,
@@ -411,6 +413,12 @@ class AuthorizedObjectReaderImpl {
         this.#queryExecutorOptions()
       )
     )
+  }
+
+  /** Enforce the delegated response budget without exposing or recombining its limits. */
+  assertVisibleOutputWithinLimit(value: unknown): void {
+    if (this.#authority.type !== "delegated") return
+    assertObjectReadOutputWithinLimit(value, this.#authority.objectRead.limits)
   }
 
   #queryExecutorOptions() {

--- a/packages/core/src/objects/execution.ts
+++ b/packages/core/src/objects/execution.ts
@@ -36,7 +36,7 @@ import type {
 import { createObjectSet } from "./sdk"
 import type { ListObjectsParams } from "./service"
 import * as objectService from "./service"
-import { getTelemetryHistoryBatch } from "./telemetry"
+import { getLatestTelemetryPoint, getTelemetryHistoryBatch } from "./telemetry"
 
 export interface ExecutionObjectOperations {
   listTypes(): readonly ObjectTypeWithPropertyTokens[]
@@ -225,16 +225,12 @@ export function createObjectsRuntime<TOntologySources extends readonly OntologyS
       }) => {
         return runtime.objectReader.listLinks(input)
       },
-      getTelemetryHistoryBatch: (input: Omit<TimeseriesHistoryBatchInput, "projectId">) =>
-        getTelemetryHistoryBatch(
-          { projectId: runtime.projectId, ...input },
-          {
-            storage: runtime.storage.timeseries,
-            runtimeAuthorization: runtime.runtimeAuthorization,
-            authorization: runtime.authorization,
-          }
-        ),
-      getTelemetryHistory: (input: {
+      getTelemetryHistoryBatch: (input: Omit<TimeseriesHistoryBatchInput, "projectId">) => {
+        const objectReader = runtime.objectReader
+        const timeseries = runtime.storage.timeseries
+        return getTelemetryHistoryBatch(input, { storage: timeseries, objectReader })
+      },
+      getTelemetryHistory: async (input: {
         objectTypeId: string
         objectId: string
         propertyId: string
@@ -243,22 +239,41 @@ export function createObjectsRuntime<TOntologySources extends readonly OntologyS
         limit?: number
         order?: "asc" | "desc"
       }) => {
-        assertAuthorized(runtime, { kind: "object.view", objectTypeId: input.objectTypeId })
-        return runtime.storage.timeseries.getHistory({
-          projectId: runtime.projectId,
-          ...input,
-        })
+        const objectReader = runtime.objectReader
+        const timeseries = runtime.storage.timeseries
+        const objectTypeId = input.objectTypeId
+        const objectId = input.objectId
+        const propertyId = input.propertyId
+        const from = input.from
+        const to = input.to
+        const limit = input.limit
+        const order = input.order
+        const [result] = await getTelemetryHistoryBatch(
+          {
+            series: [{ objectTypeId, objectId, propertyId }],
+            ...(from === undefined ? {} : { from }),
+            ...(to === undefined ? {} : { to }),
+            ...(limit === undefined ? {} : { limitPerSeries: limit }),
+            ...(order === undefined ? {} : { order }),
+          },
+          { storage: timeseries, objectReader }
+        )
+        return result?.points ?? []
       },
-      getLatestTelemetry: (input: {
+      getLatestTelemetry: async (input: {
         objectTypeId: string
         objectId: string
         propertyId: string
       }) => {
-        assertAuthorized(runtime, { kind: "object.view", objectTypeId: input.objectTypeId })
-        return runtime.storage.timeseries.getLatest({
-          projectId: runtime.projectId,
-          ...input,
-        })
+        const objectReader = runtime.objectReader
+        const timeseries = runtime.storage.timeseries
+        const objectTypeId = input.objectTypeId
+        const objectId = input.objectId
+        const propertyId = input.propertyId
+        return getLatestTelemetryPoint(
+          { objectTypeId, objectId, propertyId },
+          { storage: timeseries, objectReader }
+        )
       },
       list: (params: ListObjectsParams) => objectService.listObjects(runtime, params),
       get: (objectTypeId: string, primaryId: string) =>

--- a/packages/core/src/objects/sdk/telemetry-channel.ts
+++ b/packages/core/src/objects/sdk/telemetry-channel.ts
@@ -51,23 +51,27 @@ export function createTelemetryChannel<
 
       history: async (input: TelemetryHistoryInput = {}) => {
         const timeseries = ctx.storage.timeseries
+        const objectReader = ctx.objectReader
         if (!timeseries) {
           throw new RuntimeError("[Sixb] Reading telemetry requires storage.timeseries support.")
         }
 
+        const from = input.from
+        const to = input.to
+        const limit = input.limit
+        const order = input.order
+
         const [result] = await getTelemetryHistoryBatch(
           {
-            projectId: ctx.projectId,
             series: [series],
-            ...(input.from !== undefined ? { from: input.from } : {}),
-            ...(input.to !== undefined ? { to: input.to } : {}),
-            ...(input.limit !== undefined ? { limitPerSeries: input.limit } : {}),
-            ...(input.order !== undefined ? { order: input.order } : {}),
+            ...(from !== undefined ? { from } : {}),
+            ...(to !== undefined ? { to } : {}),
+            ...(limit !== undefined ? { limitPerSeries: limit } : {}),
+            ...(order !== undefined ? { order } : {}),
           },
           {
             storage: timeseries,
-            runtimeAuthorization: ctx.runtimeAuthorization,
-            authorization: ctx.authorization,
+            objectReader,
           }
         )
 

--- a/packages/core/src/objects/telemetry/history.ts
+++ b/packages/core/src/objects/telemetry/history.ts
@@ -1,39 +1,277 @@
-import { type AuthorizationContext, assertAuthorized } from "../../authorization"
-import type { RuntimeAuthorization } from "../../execution"
+import { createSixbError } from "../../errors/internal"
+import type { AuthorizedObjectReader } from "../../execution/authorized-object-reader"
 import type {
   TimeseriesHistoryBatchInput,
   TimeseriesHistoryBatchResult,
   TimeseriesHistorySeriesInput,
+  TimeseriesPoint,
   TimeseriesStorage,
 } from "../../storage"
 
 export interface TelemetryHistoryOptions {
   readonly storage: TimeseriesStorage
-  readonly runtimeAuthorization?: RuntimeAuthorization
-  readonly authorization?: AuthorizationContext | null
+  readonly objectReader: AuthorizedObjectReader
 }
 
+export type TelemetryHistoryBatchInput = Omit<TimeseriesHistoryBatchInput, "projectId">
+
+/** Read only series selected for the exact object occurrence carried by the nominal reader. */
 export async function getTelemetryHistoryBatch(
-  input: TimeseriesHistoryBatchInput,
+  input: TelemetryHistoryBatchInput,
   options: TelemetryHistoryOptions
 ): Promise<readonly TimeseriesHistoryBatchResult[]> {
-  assertTelemetrySeriesViewable(input.projectId, input.series, options)
-  return options.storage.getHistoryBatch(input)
+  // Capture both provider capabilities before reading caller-owned request fields.
+  const objectReader = options.objectReader
+  const storage = options.storage
+  const projectId = objectReader.projectId
+  const request = snapshotTelemetryHistoryInput(input)
+
+  const uniqueSeries = new Map<string, TimeseriesHistorySeriesInput>()
+  for (const series of request.series) {
+    const key = seriesKey(series)
+    if (!uniqueSeries.has(key)) uniqueSeries.set(key, series)
+  }
+  const deduplicatedSeries = [...uniqueSeries.values()]
+  const readable = await objectReader.canReadObjectPropertiesBatch({
+    items: deduplicatedSeries.map(objectPropertySelection),
+  })
+  const visibility = new Map(
+    deduplicatedSeries.map(
+      (series, index) => [seriesKey(series), readable[index] === true] as const
+    )
+  )
+  const visibleSeries = deduplicatedSeries.filter(
+    (series) => visibility.get(seriesKey(series)) === true
+  )
+
+  // The provider receives its own detached request. It must never retain or mutate the canonical
+  // series snapshot that admission and the final release check rely on.
+  const providerRequest = structuredClone({
+    projectId,
+    series: visibleSeries,
+    ...(request.from === undefined ? {} : { from: request.from }),
+    ...(request.to === undefined ? {} : { to: request.to }),
+    ...(request.limitPerSeries === undefined ? {} : { limitPerSeries: request.limitPerSeries }),
+    ...(request.order === undefined ? {} : { order: request.order }),
+  })
+  const stored = visibleSeries.length === 0 ? [] : await storage.getHistoryBatch(providerRequest)
+
+  // Fully detach and validate provider-owned data before the final live check. A provider result
+  // may contain accessors or a custom iterator; none of that code may run after release admission.
+  if (!Array.isArray(stored)) throw invalidTimeseriesProviderResult()
+  const storedCount = stored.length
+  if (!Number.isSafeInteger(storedCount) || storedCount > visibleSeries.length) {
+    throw invalidTimeseriesProviderResult()
+  }
+  const visibleSeriesKeys = new Set(visibleSeries.map(seriesKey))
+  const providerResultBySeries = new Map<string, TimeseriesHistoryBatchResult>()
+  for (let index = 0; index < storedCount; index += 1) {
+    const providerResult = snapshotProviderResult(stored[index]!)
+    const key = seriesKey(providerResult)
+    if (providerResultBySeries.has(key) || !visibleSeriesKeys.has(key)) {
+      throw invalidTimeseriesProviderResult()
+    }
+    if (
+      request.limitPerSeries !== undefined &&
+      providerResult.points.length > request.limitPerSeries
+    ) {
+      throw invalidTimeseriesProviderResult()
+    }
+    for (const point of providerResult.points) {
+      assertTimeseriesPointMatchesSeries(projectId, providerResult, point)
+    }
+    providerResultBySeries.set(key, providerResult)
+  }
+
+  // Objects and telemetry do not yet share a portable read snapshot. This second exact check is
+  // the release point: a series revoked while the provider was reading is never returned.
+  const releaseReadable =
+    visibleSeries.length === 0
+      ? []
+      : await objectReader.canReadObjectPropertiesBatch({
+          items: visibleSeries.map(objectPropertySelection),
+        })
+  const releasableSeriesKeys = new Set(
+    visibleSeries.flatMap((series, index) =>
+      releaseReadable[index] === true ? [seriesKey(series)] : []
+    )
+  )
+
+  const result = request.series.map((series) => ({
+    ...series,
+    points: releasableSeriesKeys.has(seriesKey(series))
+      ? (providerResultBySeries
+          .get(seriesKey(series))
+          ?.points.map((point) => structuredClone(point)) ?? [])
+      : [],
+  }))
+  objectReader.assertVisibleOutputWithinLimit(result)
+  return result
 }
 
-function assertTelemetrySeriesViewable(
-  projectId: string,
-  series: readonly TimeseriesHistorySeriesInput[],
-  authorization: Pick<TelemetryHistoryOptions, "authorization" | "runtimeAuthorization">
-): void {
-  for (const objectTypeId of new Set(series.map((entry) => entry.objectTypeId))) {
-    assertAuthorized(
-      {
-        projectId,
-        runtimeAuthorization: authorization.runtimeAuthorization,
-        authorization: authorization.authorization ?? undefined,
-      },
-      { kind: "object.view", objectTypeId }
-    )
+/** Read the latest point only while its exact object property remains selected. */
+export async function getLatestTelemetryPoint(
+  input: TimeseriesHistorySeriesInput,
+  options: TelemetryHistoryOptions
+): Promise<TimeseriesPoint | null> {
+  const objectReader = options.objectReader
+  const storage = options.storage
+  const projectId = objectReader.projectId
+  const series = snapshotTelemetrySeries(input)
+  const readable = await objectReader.canReadObjectProperty(objectPropertySelection(series))
+  if (!readable) return visibleLatestResult(null, objectReader)
+
+  const rawResult = await storage.getLatest({ projectId, ...series })
+  const result = rawResult === null ? null : snapshotProviderPoint(rawResult)
+  if (result) assertTimeseriesPointMatchesSeries(projectId, series, result)
+
+  // See the batch release check above. Revocation during the timeseries read hides the result.
+  const releaseReadable = await objectReader.canReadObjectProperty(objectPropertySelection(series))
+  if (!releaseReadable) return visibleLatestResult(null, objectReader)
+
+  return visibleLatestResult(result, objectReader)
+}
+
+function snapshotTelemetrySeries(
+  series: TimeseriesHistorySeriesInput
+): TimeseriesHistorySeriesInput {
+  if (typeof series !== "object" || series === null || Array.isArray(series)) {
+    throw new Error("[Sixb] Telemetry history series must be an object.")
   }
+  const objectTypeId = telemetryIdentifier(series.objectTypeId, "objectTypeId")
+  const objectId = telemetryIdentifier(series.objectId, "objectId")
+  const propertyId = telemetryIdentifier(series.propertyId, "propertyId")
+  return structuredClone({ objectTypeId, objectId, propertyId })
+}
+
+function assertTimeseriesPointMatchesSeries(
+  projectId: string,
+  series: TimeseriesHistorySeriesInput,
+  point: TimeseriesPoint
+): void {
+  if (
+    typeof point !== "object" ||
+    point === null ||
+    point.projectId !== projectId ||
+    point.objectTypeId !== series.objectTypeId ||
+    point.objectId !== series.objectId ||
+    point.propertyId !== series.propertyId
+  ) {
+    throw invalidTimeseriesProviderResult()
+  }
+}
+
+function snapshotTelemetryHistoryInput(
+  input: TelemetryHistoryBatchInput
+): TelemetryHistoryBatchInput {
+  const authoredSeries = input.series
+  const from = input.from
+  const to = input.to
+  const limitPerSeries = input.limitPerSeries
+  const order = input.order
+  if (!Array.isArray(authoredSeries)) {
+    throw new Error("[Sixb] Telemetry history series must be an array.")
+  }
+  if (
+    limitPerSeries !== undefined &&
+    (!Number.isSafeInteger(limitPerSeries) || limitPerSeries < 0)
+  ) {
+    throw new Error("[Sixb] Telemetry history limit must be a non-negative safe integer.")
+  }
+  if (order !== undefined && order !== "asc" && order !== "desc") {
+    throw new Error("[Sixb] Telemetry history order must be 'asc' or 'desc'.")
+  }
+
+  // Capture length once and walk by index so proxies cannot change the iteration shape halfway.
+  const seriesCount = authoredSeries.length
+  if (!Number.isSafeInteger(seriesCount) || seriesCount < 0) {
+    throw new Error("[Sixb] Telemetry history series must have a safe integer length.")
+  }
+  const series: TimeseriesHistorySeriesInput[] = []
+  for (let index = 0; index < seriesCount; index += 1) {
+    series.push(snapshotTelemetrySeries(authoredSeries[index]!))
+  }
+  return structuredClone({
+    series,
+    ...(from === undefined ? {} : { from }),
+    ...(to === undefined ? {} : { to }),
+    ...(limitPerSeries === undefined ? {} : { limitPerSeries }),
+    ...(order === undefined ? {} : { order }),
+  })
+}
+
+function objectPropertySelection(series: TimeseriesHistorySeriesInput): {
+  readonly objectTypeId: string
+  readonly primaryId: string
+  readonly propertyId: string
+} {
+  return {
+    objectTypeId: series.objectTypeId,
+    primaryId: series.objectId,
+    propertyId: series.propertyId,
+  }
+}
+
+function visibleLatestResult<T extends TimeseriesPoint | null>(
+  result: T,
+  objectReader: AuthorizedObjectReader
+): T {
+  objectReader.assertVisibleOutputWithinLimit(result)
+  return result
+}
+
+function snapshotProviderResult(
+  result: TimeseriesHistoryBatchResult
+): TimeseriesHistoryBatchResult {
+  try {
+    const snapshot = structuredClone(result)
+    if (!snapshot || typeof snapshot !== "object" || !Array.isArray(snapshot.points)) {
+      throw invalidTimeseriesProviderResult()
+    }
+    return snapshot
+  } catch (error) {
+    if (isInvalidTimeseriesProviderResult(error)) throw error
+    throw invalidTimeseriesProviderResult(error)
+  }
+}
+
+function snapshotProviderPoint(point: TimeseriesPoint): TimeseriesPoint {
+  try {
+    const snapshot = structuredClone(point)
+    if (!snapshot || typeof snapshot !== "object") throw invalidTimeseriesProviderResult()
+    return snapshot
+  } catch (error) {
+    if (isInvalidTimeseriesProviderResult(error)) throw error
+    throw invalidTimeseriesProviderResult(error)
+  }
+}
+
+function invalidTimeseriesProviderResult(cause?: unknown): Error {
+  return createSixbError(
+    "internal.unexpected",
+    "[Sixb] Timeseries storage returned data outside the requested series.",
+    cause === undefined ? {} : { cause }
+  )
+}
+
+function isInvalidTimeseriesProviderResult(
+  error: unknown
+): error is Error & { readonly code: "internal.unexpected" } {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    error.code === "internal.unexpected" &&
+    error.message === "[Sixb] Timeseries storage returned data outside the requested series."
+  )
+}
+
+function telemetryIdentifier(value: unknown, field: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`[Sixb] Telemetry history ${field} must be a non-empty string.`)
+  }
+  return value
+}
+
+function seriesKey(series: TimeseriesHistorySeriesInput): string {
+  return JSON.stringify([series.objectTypeId, series.objectId, series.propertyId])
 }

--- a/packages/core/src/objects/telemetry/history.ts
+++ b/packages/core/src/objects/telemetry/history.ts
@@ -15,6 +15,10 @@ export interface TelemetryHistoryOptions {
 
 export type TelemetryHistoryBatchInput = Omit<TimeseriesHistoryBatchInput, "projectId">
 
+interface SnapshotTelemetryHistoryRequest extends TelemetryHistoryBatchInput {
+  readonly maxPointOccurrences?: number
+}
+
 /** Read only series selected for the exact object occurrence carried by the nominal reader. */
 export async function getTelemetryHistoryBatch(
   input: TelemetryHistoryBatchInput,
@@ -24,7 +28,7 @@ export async function getTelemetryHistoryBatch(
   const objectReader = options.objectReader
   const storage = options.storage
   const projectId = objectReader.projectId
-  const request = snapshotTelemetryHistoryInput(input)
+  const request = snapshotTelemetryHistoryInput(input, objectReader)
 
   const uniqueSeries = new Map<string, TimeseriesHistorySeriesInput>()
   for (const series of request.series) {
@@ -66,15 +70,9 @@ export async function getTelemetryHistoryBatch(
   const visibleSeriesKeys = new Set(visibleSeries.map(seriesKey))
   const providerResultBySeries = new Map<string, TimeseriesHistoryBatchResult>()
   for (let index = 0; index < storedCount; index += 1) {
-    const providerResult = snapshotProviderResult(stored[index]!)
+    const providerResult = snapshotProviderResult(stored[index]!, request.limitPerSeries)
     const key = seriesKey(providerResult)
     if (providerResultBySeries.has(key) || !visibleSeriesKeys.has(key)) {
-      throw invalidTimeseriesProviderResult()
-    }
-    if (
-      request.limitPerSeries !== undefined &&
-      providerResult.points.length > request.limitPerSeries
-    ) {
       throw invalidTimeseriesProviderResult()
     }
     for (const point of providerResult.points) {
@@ -97,13 +95,18 @@ export async function getTelemetryHistoryBatch(
     )
   )
 
-  const result = request.series.map((series) => ({
+  const releasedPoints = request.series.map((series) =>
+    releasableSeriesKeys.has(seriesKey(series))
+      ? (providerResultBySeries.get(seriesKey(series))?.points ?? [])
+      : []
+  )
+  const pointOccurrences = releasedPoints.reduce((total, points) => total + points.length, 0)
+  if (request.maxPointOccurrences !== undefined && pointOccurrences > request.maxPointOccurrences) {
+    throw invalidTimeseriesProviderResult()
+  }
+  const result = request.series.map((series, index) => ({
     ...series,
-    points: releasableSeriesKeys.has(seriesKey(series))
-      ? (providerResultBySeries
-          .get(seriesKey(series))
-          ?.points.map((point) => structuredClone(point)) ?? [])
-      : [],
+    points: releasedPoints[index]!.map((point) => structuredClone(point)),
   }))
   objectReader.assertVisibleOutputWithinLimit(result)
   return result
@@ -162,8 +165,9 @@ function assertTimeseriesPointMatchesSeries(
 }
 
 function snapshotTelemetryHistoryInput(
-  input: TelemetryHistoryBatchInput
-): TelemetryHistoryBatchInput {
+  input: TelemetryHistoryBatchInput,
+  objectReader: AuthorizedObjectReader
+): SnapshotTelemetryHistoryRequest {
   const authoredSeries = input.series
   const from = input.from
   const to = input.to
@@ -172,21 +176,16 @@ function snapshotTelemetryHistoryInput(
   if (!Array.isArray(authoredSeries)) {
     throw new Error("[Sixb] Telemetry history series must be an array.")
   }
-  if (
-    limitPerSeries !== undefined &&
-    (!Number.isSafeInteger(limitPerSeries) || limitPerSeries < 0)
-  ) {
-    throw new Error("[Sixb] Telemetry history limit must be a non-negative safe integer.")
-  }
   if (order !== undefined && order !== "asc" && order !== "desc") {
     throw new Error("[Sixb] Telemetry history order must be 'asc' or 'desc'.")
   }
 
   // Capture length once and walk by index so proxies cannot change the iteration shape halfway.
   const seriesCount = authoredSeries.length
-  if (!Number.isSafeInteger(seriesCount) || seriesCount < 0) {
-    throw new Error("[Sixb] Telemetry history series must have a safe integer length.")
-  }
+  const admission = objectReader.admitTelemetryHistoryRead({
+    seriesCount,
+    ...(limitPerSeries === undefined ? {} : { limitPerSeries }),
+  })
   const series: TimeseriesHistorySeriesInput[] = []
   for (let index = 0; index < seriesCount; index += 1) {
     series.push(snapshotTelemetrySeries(authoredSeries[index]!))
@@ -195,8 +194,11 @@ function snapshotTelemetryHistoryInput(
     series,
     ...(from === undefined ? {} : { from }),
     ...(to === undefined ? {} : { to }),
-    ...(limitPerSeries === undefined ? {} : { limitPerSeries }),
+    ...(admission.limitPerSeries === undefined ? {} : { limitPerSeries: admission.limitPerSeries }),
     ...(order === undefined ? {} : { order }),
+    ...(admission.maxPointOccurrences === undefined
+      ? {}
+      : { maxPointOccurrences: admission.maxPointOccurrences }),
   })
 }
 
@@ -221,14 +223,28 @@ function visibleLatestResult<T extends TimeseriesPoint | null>(
 }
 
 function snapshotProviderResult(
-  result: TimeseriesHistoryBatchResult
+  result: TimeseriesHistoryBatchResult,
+  maxPointsPerSeries: number | undefined
 ): TimeseriesHistoryBatchResult {
   try {
-    const snapshot = structuredClone(result)
-    if (!snapshot || typeof snapshot !== "object" || !Array.isArray(snapshot.points)) {
+    if (typeof result !== "object" || result === null || Array.isArray(result)) {
       throw invalidTimeseriesProviderResult()
     }
-    return snapshot
+    const series = snapshotTelemetrySeries(result)
+    const authoredPoints = result.points
+    if (!Array.isArray(authoredPoints)) throw invalidTimeseriesProviderResult()
+    const pointCount = authoredPoints.length
+    if (
+      !Number.isSafeInteger(pointCount) ||
+      (maxPointsPerSeries !== undefined && pointCount > maxPointsPerSeries)
+    ) {
+      throw invalidTimeseriesProviderResult()
+    }
+    const points: TimeseriesPoint[] = []
+    for (let index = 0; index < pointCount; index += 1) {
+      points.push(snapshotProviderPoint(authoredPoints[index]!))
+    }
+    return { ...series, points }
   } catch (error) {
     if (isInvalidTimeseriesProviderResult(error)) throw error
     throw invalidTimeseriesProviderResult(error)

--- a/packages/core/src/objects/telemetry/history.ts
+++ b/packages/core/src/objects/telemetry/history.ts
@@ -30,84 +30,20 @@ export async function getTelemetryHistoryBatch(
   const projectId = objectReader.projectId
   const request = snapshotTelemetryHistoryInput(input, objectReader)
 
-  const uniqueSeries = new Map<string, TimeseriesHistorySeriesInput>()
-  for (const series of request.series) {
-    const key = seriesKey(series)
-    if (!uniqueSeries.has(key)) uniqueSeries.set(key, series)
-  }
-  const deduplicatedSeries = [...uniqueSeries.values()]
-  const readable = await objectReader.canReadObjectPropertiesBatch({
-    items: deduplicatedSeries.map(objectPropertySelection),
-  })
-  const visibility = new Map(
-    deduplicatedSeries.map(
-      (series, index) => [seriesKey(series), readable[index] === true] as const
-    )
-  )
-  const visibleSeries = deduplicatedSeries.filter(
-    (series) => visibility.get(seriesKey(series)) === true
-  )
-
-  // The provider receives its own detached request. It must never retain or mutate the canonical
-  // series snapshot that admission and the final release check rely on.
-  const providerRequest = structuredClone({
+  const uniqueSeries = deduplicateSeries(request.series)
+  const readableSeries = await selectReadableSeries(uniqueSeries, objectReader)
+  const resultsBySeries = await readAndValidateHistory({
+    storage,
     projectId,
-    series: visibleSeries,
-    ...(request.from === undefined ? {} : { from: request.from }),
-    ...(request.to === undefined ? {} : { to: request.to }),
-    ...(request.limitPerSeries === undefined ? {} : { limitPerSeries: request.limitPerSeries }),
-    ...(request.order === undefined ? {} : { order: request.order }),
+    request,
+    series: readableSeries,
   })
-  const stored = visibleSeries.length === 0 ? [] : await storage.getHistoryBatch(providerRequest)
 
-  // Fully detach and validate provider-owned data before the final live check. A provider result
-  // may contain accessors or a custom iterator; none of that code may run after release admission.
-  if (!Array.isArray(stored)) throw invalidTimeseriesProviderResult()
-  const storedCount = stored.length
-  if (!Number.isSafeInteger(storedCount) || storedCount > visibleSeries.length) {
-    throw invalidTimeseriesProviderResult()
-  }
-  const visibleSeriesKeys = new Set(visibleSeries.map(seriesKey))
-  const providerResultBySeries = new Map<string, TimeseriesHistoryBatchResult>()
-  for (let index = 0; index < storedCount; index += 1) {
-    const providerResult = snapshotProviderResult(stored[index]!, request.limitPerSeries)
-    const key = seriesKey(providerResult)
-    if (providerResultBySeries.has(key) || !visibleSeriesKeys.has(key)) {
-      throw invalidTimeseriesProviderResult()
-    }
-    for (const point of providerResult.points) {
-      assertTimeseriesPointMatchesSeries(projectId, providerResult, point)
-    }
-    providerResultBySeries.set(key, providerResult)
-  }
-
-  // Objects and telemetry do not yet share a portable read snapshot. This second exact check is
-  // the release point: a series revoked while the provider was reading is never returned.
-  const releaseReadable =
-    visibleSeries.length === 0
-      ? []
-      : await objectReader.canReadObjectPropertiesBatch({
-          items: visibleSeries.map(objectPropertySelection),
-        })
-  const releasableSeriesKeys = new Set(
-    visibleSeries.flatMap((series, index) =>
-      releaseReadable[index] === true ? [seriesKey(series)] : []
-    )
-  )
-
-  const releasedPoints = request.series.map((series) =>
-    releasableSeriesKeys.has(seriesKey(series))
-      ? (providerResultBySeries.get(seriesKey(series))?.points ?? [])
-      : []
-  )
-  const pointOccurrences = releasedPoints.reduce((total, points) => total + points.length, 0)
-  if (request.maxPointOccurrences !== undefined && pointOccurrences > request.maxPointOccurrences) {
-    throw invalidTimeseriesProviderResult()
-  }
-  const result = request.series.map((series, index) => ({
-    ...series,
-    points: releasedPoints[index]!.map((point) => structuredClone(point)),
-  }))
+  // Objects and telemetry do not share a portable read snapshot. Recheck live selection after
+  // all provider-owned values have been detached, before deciding which points to return.
+  const releasableSeries =
+    readableSeries.length === 0 ? [] : await selectReadableSeries(readableSeries, objectReader)
+  const result = assembleHistoryResults({ request, resultsBySeries, releasableSeries })
   objectReader.assertVisibleOutputWithinLimit(result)
   return result
 }
@@ -133,6 +69,94 @@ export async function getLatestTelemetryPoint(
   if (!releaseReadable) return visibleLatestResult(null, objectReader)
 
   return visibleLatestResult(result, objectReader)
+}
+
+function deduplicateSeries(
+  series: readonly TimeseriesHistorySeriesInput[]
+): TimeseriesHistorySeriesInput[] {
+  const uniqueSeries = new Map<string, TimeseriesHistorySeriesInput>()
+  for (const item of series) {
+    const key = seriesKey(item)
+    if (!uniqueSeries.has(key)) uniqueSeries.set(key, item)
+  }
+  return [...uniqueSeries.values()]
+}
+
+async function selectReadableSeries(
+  series: readonly TimeseriesHistorySeriesInput[],
+  objectReader: AuthorizedObjectReader
+): Promise<readonly TimeseriesHistorySeriesInput[]> {
+  const readable = await objectReader.canReadObjectPropertiesBatch({
+    items: series.map(objectPropertySelection),
+  })
+  return series.filter((_, index) => readable[index] === true)
+}
+
+async function readAndValidateHistory(input: {
+  readonly storage: TimeseriesStorage
+  readonly projectId: string
+  readonly request: SnapshotTelemetryHistoryRequest
+  readonly series: readonly TimeseriesHistorySeriesInput[]
+}): Promise<ReadonlyMap<string, TimeseriesHistoryBatchResult>> {
+  const { storage, projectId, request, series } = input
+
+  // The provider receives its own detached request. It must never retain or mutate the canonical
+  // series snapshot that admission and the final release check rely on.
+  const providerRequest = structuredClone({
+    projectId,
+    series,
+    ...(request.from === undefined ? {} : { from: request.from }),
+    ...(request.to === undefined ? {} : { to: request.to }),
+    ...(request.limitPerSeries === undefined ? {} : { limitPerSeries: request.limitPerSeries }),
+    ...(request.order === undefined ? {} : { order: request.order }),
+  })
+  const stored = series.length === 0 ? [] : await storage.getHistoryBatch(providerRequest)
+
+  // Fully detach and validate provider-owned data before the final live check. A provider result
+  // may contain accessors or a custom iterator; none of that code may run after release admission.
+  if (!Array.isArray(stored)) throw invalidTimeseriesProviderResult()
+  const storedCount = stored.length
+  if (!Number.isSafeInteger(storedCount) || storedCount > series.length) {
+    throw invalidTimeseriesProviderResult()
+  }
+  const seriesKeys = new Set(series.map(seriesKey))
+  const providerResultBySeries = new Map<string, TimeseriesHistoryBatchResult>()
+  for (let index = 0; index < storedCount; index += 1) {
+    const providerResult = snapshotProviderResult(stored[index]!, request.limitPerSeries)
+    const key = seriesKey(providerResult)
+    if (providerResultBySeries.has(key) || !seriesKeys.has(key)) {
+      throw invalidTimeseriesProviderResult()
+    }
+    for (const point of providerResult.points) {
+      assertTimeseriesPointMatchesSeries(projectId, providerResult, point)
+    }
+    providerResultBySeries.set(key, providerResult)
+  }
+
+  return providerResultBySeries
+}
+
+/** Restore request order and duplicates, with independent point copies for every occurrence. */
+function assembleHistoryResults(input: {
+  readonly request: SnapshotTelemetryHistoryRequest
+  readonly resultsBySeries: ReadonlyMap<string, TimeseriesHistoryBatchResult>
+  readonly releasableSeries: readonly TimeseriesHistorySeriesInput[]
+}): readonly TimeseriesHistoryBatchResult[] {
+  const { request, resultsBySeries, releasableSeries } = input
+  const releasableSeriesKeys = new Set(releasableSeries.map(seriesKey))
+  const releasedPoints = request.series.map((series) =>
+    releasableSeriesKeys.has(seriesKey(series))
+      ? (resultsBySeries.get(seriesKey(series))?.points ?? [])
+      : []
+  )
+  const pointOccurrences = releasedPoints.reduce((total, points) => total + points.length, 0)
+  if (request.maxPointOccurrences !== undefined && pointOccurrences > request.maxPointOccurrences) {
+    throw invalidTimeseriesProviderResult()
+  }
+  return request.series.map((series, index) => ({
+    ...series,
+    points: releasedPoints[index]!.map((point) => structuredClone(point)),
+  }))
 }
 
 function snapshotTelemetrySeries(

--- a/packages/core/src/objects/telemetry/index.ts
+++ b/packages/core/src/objects/telemetry/index.ts
@@ -1,4 +1,4 @@
 export { appendTelemetryBatch } from "./append-batch"
-export type { TelemetryHistoryOptions } from "./history"
-export { getTelemetryHistoryBatch } from "./history"
+export type { TelemetryHistoryBatchInput, TelemetryHistoryOptions } from "./history"
+export { getLatestTelemetryPoint, getTelemetryHistoryBatch } from "./history"
 export { writeTelemetryBatch } from "./write-batch"

--- a/packages/core/src/objects/telemetry/workload.ts
+++ b/packages/core/src/objects/telemetry/workload.ts
@@ -1,0 +1,79 @@
+const MAX_DELEGATED_TELEMETRY_HISTORY_SERIES = 100
+const MAX_DELEGATED_TELEMETRY_HISTORY_POINTS = 10_000
+const DEFAULT_DELEGATED_TELEMETRY_HISTORY_LIMIT_PER_SERIES = 100
+
+export interface TelemetryHistoryReadWorkloadInput {
+  readonly seriesCount: number
+  readonly limitPerSeries?: number
+}
+
+export interface TelemetryHistoryReadAdmission {
+  readonly limitPerSeries?: number
+  readonly maxPointOccurrences?: number
+}
+
+type TelemetryHistoryWorkloadMetric = "series" | "points"
+
+class TelemetryHistoryWorkloadExceededError extends Error {
+  readonly name = "TelemetryHistoryWorkloadExceededError"
+  readonly code = "telemetry_history_workload_exceeded"
+
+  constructor(
+    readonly metric: TelemetryHistoryWorkloadMetric,
+    readonly limit: number
+  ) {
+    super(`[Sixb] Delegated telemetry history exceeded its ${metric} limit (${limit}).`)
+  }
+}
+
+/** Resolve one history request without exposing the authority that selected its policy. */
+export function admitTelemetryHistoryReadWorkload(
+  input: TelemetryHistoryReadWorkloadInput,
+  delegated: boolean
+): TelemetryHistoryReadAdmission {
+  const seriesCount = input.seriesCount
+  const limitPerSeries = input.limitPerSeries
+  if (!Number.isSafeInteger(seriesCount) || seriesCount < 0) {
+    throw new Error("[Sixb] Telemetry history series must have a non-negative safe integer length.")
+  }
+  if (
+    limitPerSeries !== undefined &&
+    (!Number.isSafeInteger(limitPerSeries) || limitPerSeries < 0)
+  ) {
+    throw new Error("[Sixb] Telemetry history limit must be a non-negative safe integer.")
+  }
+
+  if (!delegated) {
+    const admission: TelemetryHistoryReadAdmission =
+      limitPerSeries === undefined ? {} : { limitPerSeries }
+    return Object.freeze(admission)
+  }
+  if (seriesCount > MAX_DELEGATED_TELEMETRY_HISTORY_SERIES) {
+    throw new TelemetryHistoryWorkloadExceededError(
+      "series",
+      MAX_DELEGATED_TELEMETRY_HISTORY_SERIES
+    )
+  }
+  if (seriesCount === 0) {
+    return Object.freeze({
+      ...(limitPerSeries === undefined ? {} : { limitPerSeries }),
+      maxPointOccurrences: MAX_DELEGATED_TELEMETRY_HISTORY_POINTS,
+    })
+  }
+
+  const maxLimitPerSeries = Math.floor(MAX_DELEGATED_TELEMETRY_HISTORY_POINTS / seriesCount)
+  const effectiveLimitPerSeries =
+    limitPerSeries ??
+    Math.min(DEFAULT_DELEGATED_TELEMETRY_HISTORY_LIMIT_PER_SERIES, maxLimitPerSeries)
+  if (effectiveLimitPerSeries > maxLimitPerSeries) {
+    throw new TelemetryHistoryWorkloadExceededError(
+      "points",
+      MAX_DELEGATED_TELEMETRY_HISTORY_POINTS
+    )
+  }
+
+  return Object.freeze({
+    limitPerSeries: effectiveLimitPerSeries,
+    maxPointOccurrences: MAX_DELEGATED_TELEMETRY_HISTORY_POINTS,
+  })
+}

--- a/packages/core/tests/object-reader-binding.test.ts
+++ b/packages/core/tests/object-reader-binding.test.ts
@@ -331,6 +331,7 @@ describe("AuthorizedObjectReader", () => {
     })
 
     expect(backend.selectedScopeCalls).toBe(0)
+    expect(backend.calls.filter((call) => call.operation === "selectsObjectProperties")).toEqual([])
     for (const call of backend.calls) {
       if (call.operation === "queryCapabilities") continue
       expect(call.input).toMatchObject({ projectId })

--- a/packages/core/tests/object-reader-binding.test.ts
+++ b/packages/core/tests/object-reader-binding.test.ts
@@ -79,6 +79,7 @@ type PublicReaderMethod =
   | "count"
   | "exists"
   | "facet"
+  | "admitTelemetryHistoryRead"
 
 type InputsWithoutProjectId = {
   [Method in PublicReaderMethod]: "projectId" extends keyof Parameters<
@@ -101,6 +102,7 @@ const inputsWithoutProjectId: InputsWithoutProjectId = {
   count: true,
   exists: true,
   facet: true,
+  admitTelemetryHistoryRead: true,
 }
 
 type FacadeIsNominal =

--- a/packages/core/tests/sixb-runtime.test.ts
+++ b/packages/core/tests/sixb-runtime.test.ts
@@ -565,6 +565,20 @@ describe("SixbHost runtime", () => {
     expect((await temperature.history({ limit: 2 })).map((point) => point.value)).toEqual([
       21.5, 22,
     ])
+
+    const optionReads = new Map<string, number>()
+    const historyOptions = Object.defineProperties(
+      {},
+      {
+        from: { get: () => countRead(optionReads, "from", undefined) },
+        to: { get: () => countRead(optionReads, "to", undefined) },
+        limit: { get: () => countRead(optionReads, "limit", 1) },
+        order: { get: () => countRead(optionReads, "order", "desc" as const) },
+      }
+    ) as Parameters<typeof temperature.history>[0]
+    expect((await temperature.history(historyOptions)).map((point) => point.value)).toEqual([22.5])
+    expect(Object.fromEntries(optionReads)).toEqual({ from: 1, to: 1, limit: 1, order: 1 })
+
     expect(
       (
         await temperature.history({
@@ -581,6 +595,11 @@ describe("SixbHost runtime", () => {
     expect(
       await sixb.objects(Room).byId("room:102").telemetry(Room.p.currentTemperature).history()
     ).toEqual([])
+
+    // A principal grant authorizes the telemetry series by type. Historical data remains readable
+    // after the materialized object is deleted; only delegated reads depend on live selection.
+    await sixb.objects(Room).byId("room:101").delete()
+    expect((await temperature.history()).map((point) => point.value)).toEqual([21.5, 22, 22.5])
   })
 
   test("emits typed events and projects through the runtime dependencies", async () => {
@@ -1348,3 +1367,8 @@ describe("SixbHost runtime", () => {
     expect(events.length).toBeGreaterThanOrEqual(4)
   })
 })
+
+function countRead<T>(reads: Map<string, number>, field: string, value: T): T {
+  reads.set(field, (reads.get(field) ?? 0) + 1)
+  return value
+}

--- a/packages/core/tests/telemetry-history.test.ts
+++ b/packages/core/tests/telemetry-history.test.ts
@@ -458,6 +458,173 @@ describe("telemetry history admission", () => {
       limit: 32,
     })
   })
+
+  test("preserves principal history workload semantics", async () => {
+    const reader = createAuthorizedObjectReader({
+      scope: principalScope(),
+      ontology,
+      objectStorage: new InMemoryObjectStorage(),
+    })
+    const series = sensorSeries("sensor-1", "temperature")
+    const providerInputs: TimeseriesHistoryBatchInput[] = []
+    const storage = timeseriesStorage({
+      getHistoryBatch: async (input) => {
+        providerInputs.push(input)
+        return []
+      },
+    })
+
+    await getTelemetryHistoryBatch({ series: [series] }, { storage, objectReader: reader })
+    await getTelemetryHistoryBatch(
+      { series: Array.from({ length: 101 }, () => series), limitPerSeries: 10_001 },
+      { storage, objectReader: reader }
+    )
+
+    expect(providerInputs.map((input) => input.limitPerSeries)).toEqual([undefined, 10_001])
+    expect(providerInputs[1]?.series).toEqual([series])
+  })
+
+  test("bounds delegated authored series and point occurrences before provider work", async () => {
+    const reader = createAuthorizedObjectReader({
+      scope: delegatedScope({
+        roots: [selectedRoot("sensor-1", ["id", "temperature"])],
+        maxOutputJsonBytes: 10_000_000,
+      }),
+      ontology,
+      objectStorage: seededObjectStorage(["sensor-1"]),
+    })
+    const series = sensorSeries("sensor-1", "temperature")
+    const providerInputs: TimeseriesHistoryBatchInput[] = []
+    const providerPoints = Array.from({ length: 100 }, () => point(series))
+    const storage = timeseriesStorage({
+      getHistoryBatch: async (input) => {
+        providerInputs.push(input)
+        return input.series.map((requested) => ({ ...requested, points: providerPoints }))
+      },
+    })
+
+    await expect(
+      getTelemetryHistoryBatch({ series: [series, series] }, { storage, objectReader: reader })
+    ).resolves.toHaveLength(2)
+    await expect(
+      getTelemetryHistoryBatch(
+        { series: [series], limitPerSeries: 10_000 },
+        { storage, objectReader: reader }
+      )
+    ).resolves.toHaveLength(1)
+
+    const oneHundredDuplicates = Array.from({ length: 100 }, () => series)
+    const boundary = await getTelemetryHistoryBatch(
+      { series: oneHundredDuplicates, limitPerSeries: 100 },
+      { storage, objectReader: reader }
+    )
+    expect(boundary).toHaveLength(100)
+    expect(boundary.reduce((total, result) => total + result.points.length, 0)).toBe(10_000)
+    expect(providerInputs.map((input) => input.limitPerSeries)).toEqual([100, 10_000, 100])
+    expect(providerInputs.every((input) => input.series.length === 1)).toBe(true)
+
+    const hidden = sensorSeries("sensor-2", "temperature")
+    await expect(
+      getTelemetryHistoryBatch(
+        { series: [series, hidden], limitPerSeries: 5_001 },
+        { storage, objectReader: reader }
+      )
+    ).rejects.toMatchObject({
+      code: "telemetry_history_workload_exceeded",
+      metric: "points",
+      limit: 10_000,
+    })
+    await expect(
+      getTelemetryHistoryBatch(
+        { series: oneHundredDuplicates, limitPerSeries: 101 },
+        { storage, objectReader: reader }
+      )
+    ).rejects.toMatchObject({
+      code: "telemetry_history_workload_exceeded",
+      metric: "points",
+      limit: 10_000,
+    })
+    expect(providerInputs).toHaveLength(3)
+  })
+
+  test("rejects an oversized hostile series array before reading an element", async () => {
+    // Regression proof: raising the delegated series cap to 101 makes this test read proxy
+    // elements before rejecting the request.
+    let selectionCalls = 0
+    const selectedReader = {
+      selectsObjectProperties: async (
+        input: Parameters<ObjectReadStorage["selectsObjectProperties"]>[0]
+      ) => {
+        selectionCalls += 1
+        return input.items.map(() => true)
+      },
+    } as unknown as ObjectReadStorage
+    const reader = createAuthorizedObjectReader({
+      scope: delegatedScope({ roots: [selectedRoot("sensor-1", ["id", "temperature"])] }),
+      ontology,
+      objectStorage: selectedStorageFactory(selectedReader),
+    })
+    const series = sensorSeries("sensor-1", "temperature")
+    let elementReads = 0
+    const hostileSeries = new Proxy([] as TimeseriesHistorySeriesInput[], {
+      get: (target, property, receiver) => {
+        if (property === "length") return 101
+        if (typeof property === "string" && /^\d+$/.test(property)) {
+          elementReads += 1
+          return series
+        }
+        return Reflect.get(target, property, receiver)
+      },
+    })
+    let providerCalls = 0
+    const storage = timeseriesStorage({
+      getHistoryBatch: async () => {
+        providerCalls += 1
+        return []
+      },
+    })
+
+    await expect(
+      getTelemetryHistoryBatch({ series: hostileSeries }, { storage, objectReader: reader })
+    ).rejects.toMatchObject({
+      code: "telemetry_history_workload_exceeded",
+      metric: "series",
+      limit: 100,
+    })
+    expect(elementReads).toBe(0)
+    expect(selectionCalls).toBe(0)
+    expect(providerCalls).toBe(0)
+  })
+
+  test("rejects oversized provider points before cloning an element", async () => {
+    // Regression proof: removing the provider point-count guard makes this test traverse the
+    // hostile points array before rejecting the provider result.
+    const reader = createAuthorizedObjectReader({
+      scope: delegatedScope({ roots: [selectedRoot("sensor-1", ["id", "temperature"])] }),
+      ontology,
+      objectStorage: seededObjectStorage(["sensor-1"]),
+    })
+    const series = sensorSeries("sensor-1", "temperature")
+    let pointReads = 0
+    const hostilePoints = new Proxy([] as TimeseriesPoint[], {
+      get: (target, property, receiver) => {
+        if (property === "length") return 101
+        if (typeof property === "string" && /^\d+$/.test(property)) {
+          pointReads += 1
+          return point(series)
+        }
+        return Reflect.get(target, property, receiver)
+      },
+    })
+    const storage = timeseriesStorage({
+      getHistoryBatch: async () => [{ ...series, points: hostilePoints }],
+    })
+
+    await expect(
+      getTelemetryHistoryBatch({ series: [series] }, { storage, objectReader: reader })
+    ).rejects.toMatchObject({ code: "internal.unexpected" })
+    expect(pointReads).toBe(0)
+  })
 })
 
 function principalScope(): ExecutionScope {

--- a/packages/core/tests/telemetry-history.test.ts
+++ b/packages/core/tests/telemetry-history.test.ts
@@ -1,0 +1,557 @@
+import { describe, expect, test } from "bun:test"
+import { AuthorizationError, emptyGrantIndex } from "../src/authorization"
+import { createAuthorizedObjectReader } from "../src/execution/authorized-object-reader"
+import {
+  createDelegatedRequestScope,
+  createPrincipalRequestScope,
+  createTestingScope,
+} from "../src/execution/scopes"
+import type { ExecutionScope } from "../src/execution/types"
+import { getLatestTelemetryPoint, getTelemetryHistoryBatch } from "../src/objects/telemetry/history"
+import { defineObjectType, OntologyRegistry, prop } from "../src/ontology"
+import type {
+  ObjectReadStorage,
+  ObjectStorage,
+  TimeseriesHistoryBatchInput,
+  TimeseriesHistoryBatchResult,
+  TimeseriesHistorySeriesInput,
+  TimeseriesPoint,
+  TimeseriesStorage,
+} from "../src/storage"
+import {
+  getInMemoryObjectMaterializerAdapter,
+  InMemoryObjectStorage,
+} from "../src/storage/objects/in-memory"
+
+const projectId = "telemetry-history"
+const at = new Date("2026-01-01T00:00:00.000Z")
+
+const Sensor = defineObjectType({
+  id: "TelemetrySensor",
+  name: "Telemetry sensor",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("temperature", "double", { mode: "telemetry" }),
+    prop("humidity", "double", { mode: "telemetry" }),
+  ],
+})
+
+const Secret = defineObjectType({
+  id: "TelemetrySecret",
+  name: "Telemetry secret",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("reading", "double", { mode: "telemetry" }),
+  ],
+})
+
+const ontology = new OntologyRegistry({ sources: [Sensor, Secret] })
+
+describe("telemetry history admission", () => {
+  test("derives project identity from the reader and preserves principal historical reads", async () => {
+    const objectStorage = new InMemoryObjectStorage()
+    let objectSelectionCalls = 0
+    const originalSelection = objectStorage.selectsObjectProperties.bind(objectStorage)
+    objectStorage.selectsObjectProperties = async (input) => {
+      objectSelectionCalls += 1
+      return originalSelection(input)
+    }
+    const reader = createAuthorizedObjectReader({
+      scope: principalScope(),
+      ontology,
+      objectStorage,
+    })
+    const requestedProjects: string[] = []
+    const storage = timeseriesStorage({
+      getHistoryBatch: async (input) => {
+        requestedProjects.push(input.projectId)
+        return input.series.map((series) => ({ ...series, points: [point(series)] }))
+      },
+    })
+    const series = sensorSeries("deleted-sensor", "temperature")
+
+    await expect(
+      getTelemetryHistoryBatch(
+        { projectId: "forged-project", series: [series] } as TimeseriesHistoryBatchInput,
+        { storage, objectReader: reader }
+      )
+    ).resolves.toEqual([{ ...series, points: [point(series)] }])
+    expect(requestedProjects).toEqual([projectId])
+    expect(objectSelectionCalls).toBe(0)
+  })
+
+  test("reads only exact selected object properties and preserves duplicate alignment", async () => {
+    const objectStorage = seededObjectStorage(["sensor-1", "sensor-2"])
+    const reader = createAuthorizedObjectReader({
+      scope: delegatedScope({
+        roots: [selectedRoot("sensor-1", ["id", "temperature"]), selectedRoot("sensor-2", ["id"])],
+      }),
+      ontology,
+      objectStorage,
+    })
+    const providerSeries: TimeseriesHistorySeriesInput[][] = []
+    let latestCalls = 0
+    const storage = timeseriesStorage({
+      getHistoryBatch: async (input) => {
+        providerSeries.push([...input.series])
+        return input.series.map((series) => ({ ...series, points: [point(series)] }))
+      },
+      getLatest: async (input) => {
+        latestCalls += 1
+        return point(input)
+      },
+    })
+    const visible = sensorSeries("sensor-1", "temperature")
+    const hiddenProperty = sensorSeries("sensor-2", "temperature")
+    const hiddenSibling = sensorSeries("sensor-3", "temperature")
+
+    await expect(
+      getTelemetryHistoryBatch(
+        { series: [visible, visible, hiddenProperty, hiddenSibling], limitPerSeries: 1 },
+        { storage, objectReader: reader }
+      )
+    ).resolves.toEqual([
+      { ...visible, points: [point(visible)] },
+      { ...visible, points: [point(visible)] },
+      { ...hiddenProperty, points: [] },
+      { ...hiddenSibling, points: [] },
+    ])
+    expect(providerSeries).toEqual([[visible]])
+
+    await expect(
+      getLatestTelemetryPoint(hiddenSibling, { storage, objectReader: reader })
+    ).resolves.toBeNull()
+    expect(latestCalls).toBe(0)
+    await expect(
+      getLatestTelemetryPoint(visible, { storage, objectReader: reader })
+    ).resolves.toEqual(point(visible))
+    expect(latestCalls).toBe(1)
+  })
+
+  test("denies an unselected type before timeseries storage", async () => {
+    const reader = createAuthorizedObjectReader({
+      scope: delegatedScope({ roots: [selectedRoot("sensor-1", ["id", "temperature"])] }),
+      ontology,
+      objectStorage: seededObjectStorage(["sensor-1"]),
+    })
+    let historyCalls = 0
+    const storage = timeseriesStorage({
+      getHistoryBatch: async () => {
+        historyCalls += 1
+        return []
+      },
+    })
+
+    await expect(
+      getTelemetryHistoryBatch(
+        {
+          series: [{ objectTypeId: Secret.id, objectId: "secret-1", propertyId: "reading" }],
+        },
+        { storage, objectReader: reader }
+      )
+    ).rejects.toBeInstanceOf(AuthorizationError)
+    expect(historyCalls).toBe(0)
+  })
+
+  test("revalidates live selection after history and latest provider reads", async () => {
+    let selectionChecks = 0
+    const selectedReader = {
+      selectsObjectProperties: async (
+        input: Parameters<ObjectReadStorage["selectsObjectProperties"]>[0]
+      ) => {
+        selectionChecks += 1
+        return input.items.map(() => selectionChecks % 2 === 1)
+      },
+    } as unknown as ObjectReadStorage
+    const reader = createAuthorizedObjectReader({
+      scope: delegatedScope({ roots: [selectedRoot("sensor-1", ["id", "temperature"])] }),
+      ontology,
+      objectStorage: selectedStorageFactory(selectedReader),
+    })
+    const series = sensorSeries("sensor-1", "temperature")
+    let historyCalls = 0
+    let latestCalls = 0
+    const storage = timeseriesStorage({
+      getHistoryBatch: async () => {
+        historyCalls += 1
+        return [{ ...series, points: [point(series)] }]
+      },
+      getLatest: async () => {
+        latestCalls += 1
+        return point(series)
+      },
+    })
+
+    await expect(
+      getTelemetryHistoryBatch(
+        { series: [series], limitPerSeries: 1 },
+        { storage, objectReader: reader }
+      )
+    ).resolves.toEqual([{ ...series, points: [] }])
+    expect(historyCalls).toBe(1)
+
+    await expect(
+      getLatestTelemetryPoint(series, { storage, objectReader: reader })
+    ).resolves.toBeNull()
+    expect(latestCalls).toBe(1)
+    expect(selectionChecks).toBe(4)
+  })
+
+  test("normalizes provider-owned values before the final live selection check", async () => {
+    let selected = true
+    const selectedReader = {
+      selectsObjectProperties: async (
+        input: Parameters<ObjectReadStorage["selectsObjectProperties"]>[0]
+      ) => input.items.map(() => selected),
+    } as unknown as ObjectReadStorage
+    const reader = createAuthorizedObjectReader({
+      scope: delegatedScope({ roots: [selectedRoot("sensor-1", ["id", "temperature"])] }),
+      ontology,
+      objectStorage: selectedStorageFactory(selectedReader),
+    })
+    const series = sensorSeries("sensor-1", "temperature")
+    const revokeWhileSnapshotting = <T>(value: T): T => {
+      selected = false
+      return value
+    }
+    const historyResult = Object.defineProperties(
+      { ...series },
+      {
+        points: {
+          enumerable: true,
+          get: () => revokeWhileSnapshotting([point(series)]),
+        },
+      }
+    ) as TimeseriesHistoryBatchResult
+    const latestResult = Object.defineProperty(point(series), "value", {
+      enumerable: true,
+      get: () => revokeWhileSnapshotting(21),
+    })
+    const storage = timeseriesStorage({
+      getHistoryBatch: async () => [historyResult],
+      getLatest: async () => latestResult,
+    })
+
+    await expect(
+      getTelemetryHistoryBatch(
+        { series: [series], limitPerSeries: 1 },
+        { storage, objectReader: reader }
+      )
+    ).resolves.toEqual([{ ...series, points: [] }])
+
+    selected = true
+    await expect(
+      getLatestTelemetryPoint(series, { storage, objectReader: reader })
+    ).resolves.toBeNull()
+  })
+
+  test("never shares its canonical series snapshot with the provider", async () => {
+    const reader = createAuthorizedObjectReader({
+      scope: delegatedScope({ roots: [selectedRoot("sensor-1", ["id", "temperature"])] }),
+      ontology,
+      objectStorage: seededObjectStorage(["sensor-1"]),
+    })
+    const series = sensorSeries("sensor-1", "temperature")
+    const storage = timeseriesStorage({
+      getHistoryBatch: async (input) => {
+        Object.defineProperty(input.series[0]!, "objectId", { value: "sensor-2" })
+        return [{ ...series, points: [point(series)] }]
+      },
+    })
+
+    await expect(
+      getTelemetryHistoryBatch(
+        { series: [series], limitPerSeries: 1 },
+        { storage, objectReader: reader }
+      )
+    ).resolves.toEqual([{ ...series, points: [point(series)] }])
+  })
+
+  test("rejects provider results outside the requested project, series, or limit", async () => {
+    const reader = createAuthorizedObjectReader({
+      scope: createTestingScope({ projectId }),
+      ontology,
+      objectStorage: new InMemoryObjectStorage(),
+    })
+    const series = sensorSeries("sensor-1", "temperature")
+    const other = sensorSeries("sensor-2", "temperature")
+
+    const wrongPoint = timeseriesStorage({
+      getHistoryBatch: async () => [
+        { ...series, points: [{ ...point(series), projectId: "foreign-project" }] },
+      ],
+    })
+    await expect(
+      getTelemetryHistoryBatch(
+        { series: [series], limitPerSeries: 1 },
+        { storage: wrongPoint, objectReader: reader }
+      )
+    ).rejects.toMatchObject({ code: "internal.unexpected" })
+
+    const extraSeries = timeseriesStorage({
+      getHistoryBatch: async () => [{ ...other, points: [] }],
+    })
+    await expect(
+      getTelemetryHistoryBatch(
+        { series: [series], limitPerSeries: 1 },
+        { storage: extraSeries, objectReader: reader }
+      )
+    ).rejects.toMatchObject({ code: "internal.unexpected" })
+
+    const duplicateSeries = timeseriesStorage({
+      getHistoryBatch: async () => [
+        { ...series, points: [] },
+        { ...series, points: [] },
+      ],
+    })
+    await expect(
+      getTelemetryHistoryBatch(
+        { series: [series], limitPerSeries: 1 },
+        { storage: duplicateSeries, objectReader: reader }
+      )
+    ).rejects.toMatchObject({ code: "internal.unexpected" })
+
+    const tooManyPoints = timeseriesStorage({
+      getHistoryBatch: async () => [{ ...series, points: [point(series)] }],
+    })
+    await expect(
+      getTelemetryHistoryBatch(
+        { series: [series], limitPerSeries: 0 },
+        { storage: tooManyPoints, objectReader: reader }
+      )
+    ).rejects.toMatchObject({ code: "internal.unexpected" })
+
+    const wrongLatest = timeseriesStorage({
+      getLatest: async () => ({ ...point(series), objectId: "sensor-2" }),
+    })
+    await expect(
+      getLatestTelemetryPoint(series, { storage: wrongLatest, objectReader: reader })
+    ).rejects.toMatchObject({ code: "internal.unexpected" })
+  })
+
+  test("captures hostile capabilities and request fields once", async () => {
+    const reader = createAuthorizedObjectReader({
+      scope: createTestingScope({ projectId }),
+      ontology,
+      objectStorage: new InMemoryObjectStorage(),
+    })
+    const foreignReader = createAuthorizedObjectReader({
+      scope: createTestingScope({ projectId: "foreign-project" }),
+      ontology,
+      objectStorage: new InMemoryObjectStorage(),
+    })
+    const requestedProjects: string[] = []
+    const storage = timeseriesStorage({
+      getHistoryBatch: async (input) => {
+        requestedProjects.push(input.projectId)
+        return []
+      },
+    })
+    let readerReads = 0
+    let storageReads = 0
+    const options = Object.defineProperties(
+      {},
+      {
+        objectReader: {
+          enumerable: true,
+          get: () => {
+            readerReads += 1
+            return readerReads === 1 ? reader : foreignReader
+          },
+        },
+        storage: {
+          enumerable: true,
+          get: () => {
+            storageReads += 1
+            return storage
+          },
+        },
+      }
+    ) as Parameters<typeof getTelemetryHistoryBatch>[1]
+    const reads = new Map<string, number>()
+    const read = <T>(field: string, value: T): T => {
+      reads.set(field, (reads.get(field) ?? 0) + 1)
+      return value
+    }
+    const authoredSeries = Object.defineProperties(
+      {},
+      {
+        objectTypeId: { enumerable: true, get: () => read("objectTypeId", Sensor.id) },
+        objectId: { enumerable: true, get: () => read("objectId", "sensor-1") },
+        propertyId: { enumerable: true, get: () => read("propertyId", "temperature") },
+      }
+    ) as TimeseriesHistorySeriesInput
+    const series = new Proxy([authoredSeries], {
+      get: (target, property, receiver) => {
+        if (property === "length") read("length", undefined)
+        if (property === "0") read("series[0]", undefined)
+        return Reflect.get(target, property, receiver)
+      },
+    })
+    const input = Object.defineProperties(
+      {},
+      {
+        series: { enumerable: true, get: () => read("series", series) },
+        from: { enumerable: true, get: () => read("from", undefined) },
+        to: { enumerable: true, get: () => read("to", undefined) },
+        limitPerSeries: { enumerable: true, get: () => read("limitPerSeries", 1) },
+        order: { enumerable: true, get: () => read("order", "asc" as const) },
+        projectId: {
+          enumerable: true,
+          get: () => {
+            throw new Error("forged projectId must not be read")
+          },
+        },
+      }
+    ) as unknown as Parameters<typeof getTelemetryHistoryBatch>[0]
+
+    await expect(getTelemetryHistoryBatch(input, options)).resolves.toEqual([
+      { ...sensorSeries("sensor-1", "temperature"), points: [] },
+    ])
+    expect(readerReads).toBe(1)
+    expect(storageReads).toBe(1)
+    expect(Object.fromEntries(reads)).toEqual({
+      series: 1,
+      from: 1,
+      to: 1,
+      limitPerSeries: 1,
+      order: 1,
+      length: 1,
+      "series[0]": 1,
+      objectTypeId: 1,
+      objectId: 1,
+      propertyId: 1,
+    })
+    expect(requestedProjects).toEqual([projectId])
+  })
+
+  test("applies the delegated JSON release budget to history and latest", async () => {
+    const reader = createAuthorizedObjectReader({
+      scope: delegatedScope({
+        roots: [selectedRoot("sensor-1", ["id", "temperature"])],
+        maxOutputJsonBytes: 32,
+      }),
+      ontology,
+      objectStorage: seededObjectStorage(["sensor-1"]),
+    })
+    const series = sensorSeries("sensor-1", "temperature")
+    const storage = timeseriesStorage({
+      getHistoryBatch: async () => [{ ...series, points: [point(series)] }],
+      getLatest: async () => point(series),
+    })
+
+    await expect(
+      getTelemetryHistoryBatch(
+        { series: [series], limitPerSeries: 1 },
+        { storage, objectReader: reader }
+      )
+    ).rejects.toMatchObject({
+      code: "object_read_limit_exceeded",
+      metric: "outputJsonBytes",
+      limit: 32,
+    })
+    await expect(
+      getLatestTelemetryPoint(series, { storage, objectReader: reader })
+    ).rejects.toMatchObject({
+      code: "object_read_limit_exceeded",
+      metric: "outputJsonBytes",
+      limit: 32,
+    })
+  })
+})
+
+function principalScope(): ExecutionScope {
+  return createPrincipalRequestScope({
+    projectId,
+    requestId: "telemetry-principal",
+    correlationId: "telemetry-principal-correlation",
+    context: {
+      principal: { type: "user", id: "telemetry-user" },
+      groupIds: [],
+      roleIds: [],
+      grants: {
+        ...emptyGrantIndex(),
+        "view:object": new Set([Sensor.id]),
+      },
+    },
+  })
+}
+
+function delegatedScope(input: {
+  readonly roots: Parameters<
+    typeof createDelegatedRequestScope
+  >[0]["objectRead"]["selection"]["roots"]
+  readonly maxOutputJsonBytes?: number
+}): ExecutionScope {
+  return createDelegatedRequestScope({
+    projectId,
+    requestId: "telemetry-delegated",
+    correlationId: "telemetry-delegated-correlation",
+    objectRead: {
+      selection: { kind: "selected", roots: input.roots },
+      limits: {
+        maxTraversalFacts: 100,
+        maxOutputJsonBytes: input.maxOutputJsonBytes ?? 100_000,
+      },
+    },
+  })
+}
+
+function selectedRoot(primaryId: string, propertyIds: readonly string[]) {
+  return {
+    anchor: { objectTypeId: Sensor.id, primaryId },
+    node: {
+      objects: [{ objectTypeId: Sensor.id, propertyIds }],
+      links: [],
+    },
+  }
+}
+
+function seededObjectStorage(primaryIds: readonly string[]): InMemoryObjectStorage {
+  const storage = new InMemoryObjectStorage()
+  const adapter = getInMemoryObjectMaterializerAdapter(storage)
+  for (const primaryId of primaryIds) {
+    adapter.applyExactObject(
+      {
+        ref: { objectTypeId: Sensor.id, primaryId },
+        properties: { id: primaryId },
+        version: 1,
+        createdAt: at.toISOString(),
+        updatedAt: at.toISOString(),
+        lastCommitId: `commit:${primaryId}`,
+      },
+      projectId
+    )
+  }
+  return storage
+}
+
+function selectedStorageFactory(reader: ObjectReadStorage): ObjectStorage {
+  return { createSelectedReadScope: () => reader } as unknown as ObjectStorage
+}
+
+function sensorSeries(
+  objectId: string,
+  propertyId: "temperature" | "humidity"
+): TimeseriesHistorySeriesInput {
+  return { objectTypeId: Sensor.id, objectId, propertyId }
+}
+
+function point(series: TimeseriesHistorySeriesInput): TimeseriesPoint {
+  return {
+    projectId,
+    ...series,
+    value: 21,
+    at,
+    lastCommitId: `commit:${series.objectId}:${series.propertyId}`,
+  }
+}
+
+function timeseriesStorage(overrides: Partial<TimeseriesStorage> = {}): TimeseriesStorage {
+  return {
+    getHistory: async () => [],
+    getHistoryBatch: async () => [],
+    getLatest: async () => null,
+    ...overrides,
+  }
+}


### PR DESCRIPTION
Part of #269 · Stack #547 · Parent: #500 · Next: #506

## What this adds

**Telemetry reads now respect the exact object/property selection carried by `AuthorizedObjectReader`.** Selecting `Sensor/sensor-1/temperature` does not grant access to another sensor or property.

```mermaid
flowchart TD
  A["History or latest-point request"] --> B["Capture request<br/>Check history workload limits"]
  B --> C["AuthorizedObjectReader<br/>Select readable object properties"]
  C --> D["TimeseriesStorage<br/>Read only selected series"]
  D --> E["Copy and validate results"]
  E --> F["Recheck live selection"]
  F --> G["Prepare points or empty result"]
  G --> H["Check output budget<br/>Return"]
```

The second check catches access lost during the read: objects and telemetry do not share an atomic snapshot.

Batch, single-series, latest and typed history use this boundary.

| Situation | Behavior |
| --- | --- |
| Selected object/property | Return its points |
| Unselected object/property within an allowed type | No fetch; empty history or `null` |
| Access lost during the read | Empty history or `null` |
| Duplicate series | Read once; preserve order and independent copies |
| Unexpected provider data | Reject the result |

## Delegated history limits

| Limit | Value |
| --- | ---: |
| Requested series, including duplicates | 100 |
| Default points per series | 100 |
| Requested / returned point occurrences | 10,000 |

The reader's JSON output budget also applies. Ordinary read limits remain unchanged.

**Validation:** 31 targeted tests, Core typecheck and Biome pass. Incorporates #503.
