### PR TITLE
server: accept matching OAuth code aliases

### DIFF
--- a/packages/server/src/schemas/connectors.ts
+++ b/packages/server/src/schemas/connectors.ts
@@ -168,9 +168,19 @@ export const ConnectorOAuthCallbackQuerySchema = z
     auth_code: z.string().min(1).optional(),
     error: z.string().min(1).optional(),
   })
-  .refine((query) => [query.code, query.auth_code, query.error].filter(Boolean).length === 1, {
-    message: "OAuth callback must contain exactly one of code, auth_code, or error.",
-  })
+  .refine(
+    (query) => {
+      const hasAuthorizationCode = query.code !== undefined || query.auth_code !== undefined
+      const hasProviderError = query.error !== undefined
+      return hasAuthorizationCode !== hasProviderError
+    },
+    { message: "OAuth callback must contain exactly one of an authorization code or error." }
+  )
+  .refine(
+    (query) =>
+      query.code === undefined || query.auth_code === undefined || query.code === query.auth_code,
+    { message: "OAuth callback code and auth_code must match when both are present." }
+  )
   .transform(({ auth_code, ...query }) => ({ ...query, code: query.code ?? auth_code }))
 
 function connectorRouteErrorResponseSchema<

--- a/packages/server/tests/connector-connections-routes.test.ts
+++ b/packages/server/tests/connector-connections-routes.test.ts
@@ -262,6 +262,46 @@ describe("connector connection Headless API", () => {
     expect(harness.exchangeCount()).toBe(1)
   })
 
+  test("accepts matching OAuth authorization code aliases from one callback", async () => {
+    // Regression guard: restoring the three-way exact-one count in the callback schema makes this
+    // return 400 before the provider code reaches the connector.
+    const harness = await createHarness()
+    const started = await startRun(harness)
+    const callbackUrl = new URL("http://localhost/auth/connectors/callback")
+    callbackUrl.searchParams.set("state", started.state)
+    callbackUrl.searchParams.set("code", "authorization-code")
+    callbackUrl.searchParams.set("auth_code", "authorization-code")
+
+    const callback = await harness.app.handle(
+      new Request(callbackUrl, {
+        redirect: "manual",
+        headers: { cookie: started.callbackCookie },
+      })
+    )
+
+    expect(callback.status, await callback.clone().text()).toBe(302)
+    expect(harness.exchangeCount()).toBe(1)
+  })
+
+  test("rejects conflicting OAuth authorization code aliases", async () => {
+    const harness = await createHarness()
+    const started = await startRun(harness)
+    const callbackUrl = new URL("http://localhost/auth/connectors/callback")
+    callbackUrl.searchParams.set("state", started.state)
+    callbackUrl.searchParams.set("code", "standard-code")
+    callbackUrl.searchParams.set("auth_code", "provider-code")
+
+    const callback = await harness.app.handle(
+      new Request(callbackUrl, {
+        redirect: "manual",
+        headers: { cookie: started.callbackCookie },
+      })
+    )
+
+    expect(callback.status).toBe(400)
+    expect(harness.exchangeCount()).toBe(0)
+  })
+
   test("returns coded boundaries when a connector cannot have managed connections", async () => {
     const harness = await createStaticHarness()
 


### PR DESCRIPTION
## Problem

TikTok can return the same authorization code as both `code` and `auth_code`. The callback schema counted parameter names, interpreted this as two outcomes, and returned HTTP 400 before token exchange.

## Change

| Callback outcome | Result |
| --- | --- |
| `code` only | Accepted |
| `auth_code` only | Accepted and normalized to `code` |
| Matching `code` + `auth_code` | Accepted and exchanged once |
| Conflicting aliases | Rejected before token exchange |
| Authorization code + provider error | Rejected |

- Treat aliases as one semantic OAuth result.
- Keep provider errors mutually exclusive with successful authorization.
- Add integration regressions for matching and conflicting aliases.

## Validation

- Regression reproduced before the fix: HTTP 400
- Connector connection route tests: **20 passed**
- Server suite: **310 passed**
- Server typecheck and build: passed
- Biome: passed
