### PR TITLE
core: expose authority-scoped ontology and Action metadata

### DIFF
--- a/packages/core/src/actions/descriptor.ts
+++ b/packages/core/src/actions/descriptor.ts
@@ -1,0 +1,58 @@
+import type { ActionDefinition, ActionParamsConfig } from "./types"
+
+type DeepReadonly<T> = T extends object ? { readonly [TKey in keyof T]: DeepReadonly<T[TKey]> } : T
+
+export type ActionDescriptorBinding =
+  | { readonly kind: "global" }
+  | { readonly kind: "object"; readonly objectTypeId: string }
+
+export type ActionParamDescriptor = DeepReadonly<ActionParamsConfig[string]>
+
+export interface ActionPhaseDescriptor {
+  readonly validate: boolean
+  readonly writeback: boolean
+  readonly edits: boolean
+  readonly effects: boolean
+}
+
+/** Immutable metadata exposed by the execution-bound Actions catalog. */
+export interface ActionDescriptor<TId extends string = string> {
+  readonly id: TId
+  readonly description?: string
+  readonly binding: ActionDescriptorBinding
+  readonly params: Readonly<Record<string, ActionParamDescriptor>>
+  readonly phases: ActionPhaseDescriptor
+}
+
+/** Project an executable definition into inert, detached public metadata. */
+export function snapshotActionDescriptor(action: ActionDefinition): ActionDescriptor {
+  const params = Object.fromEntries(
+    Object.entries(action.params).map(([id, config]) => [id, structuredClone(config)])
+  ) as Record<string, ActionParamDescriptor>
+
+  return deepFreeze({
+    id: action.id,
+    ...(action.description === undefined ? {} : { description: action.description }),
+    binding:
+      action.binding.kind === "global"
+        ? { kind: "global" as const }
+        : { kind: "object" as const, objectTypeId: action.binding.objectType.id },
+    params,
+    phases: {
+      validate: action.phases.validate.length > 0,
+      writeback: action.phases.writeback !== undefined,
+      edits: action.phases.edits !== undefined,
+      effects: action.phases.effects !== undefined,
+    },
+  })
+}
+
+function deepFreeze<T>(value: T, seen: Set<object> = new Set()): T {
+  if (typeof value !== "object" || value === null || seen.has(value)) return value
+  seen.add(value)
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (descriptor && "value" in descriptor) deepFreeze(descriptor.value, seen)
+  }
+  return Object.freeze(value)
+}

--- a/packages/core/src/actions/execution.ts
+++ b/packages/core/src/actions/execution.ts
@@ -1,6 +1,10 @@
 import { canViewActionRun, isAllowed } from "../authorization"
 import type { ExecutionContext } from "../execution"
 import { resolveRuntimeAuthorizationForProject } from "../execution/authorization"
+import {
+  assertAuthorizedObjectReaderBinding,
+  getAuthorizedOntologyView,
+} from "../execution/authorized-object-reader"
 import type { ObjectType } from "../ontology"
 import type { SixbRuntimeContext } from "../runtime/types"
 import type {
@@ -8,6 +12,8 @@ import type {
   ListActionRunsInput,
   ListActionRunsResult,
 } from "../storage/action-runs"
+import { assertObjectReadOutputWithinLimit } from "../storage/objects/execution-limits"
+import { type ActionDescriptor, snapshotActionDescriptor } from "./descriptor"
 import {
   type RequestActionAndWaitInput,
   type RequestActionInput,
@@ -25,10 +31,10 @@ export interface ActionRunsRuntime {
 }
 
 export interface ActionsRuntime {
-  list(): readonly ActionDefinition[]
-  getById(actionId: string): ActionDefinition | null
-  listGlobal(): readonly ActionDefinition[]
-  listForType(objectType: ObjectType): readonly ActionDefinition[]
+  list(): readonly ActionDescriptor[]
+  getById(actionId: string): ActionDescriptor | null
+  listGlobal(): readonly ActionDescriptor[]
+  listForType(objectType: ObjectType): readonly ActionDescriptor[]
   request(input: RequestActionInput): Promise<RequestActionResult>
   requestAndWait(input: RequestActionAndWaitInput): Promise<ActionRunRecord>
   readonly runs: ActionRunsRuntime
@@ -40,12 +46,28 @@ export function createActionsRuntime(
 ): ActionsRuntime {
   const projectId = runtime.projectId
   const runtimeAuthorization = runtime.runtimeAuthorization
+  const objectReader = runtime.objectReader
+  assertAuthorizedObjectReaderBinding({
+    reader: objectReader,
+    scope: { execution, authorization: runtimeAuthorization },
+  })
   const authorization = resolveRuntimeAuthorizationForProject({
     projectId,
     runtimeAuthorization,
   })
   const canList = (action: ActionDefinition) => {
-    if (authorization.type === "denied" || authorization.type === "delegated") return false
+    if (authorization.type === "denied") return false
+    if (authorization.type === "delegated") {
+      const binding = action.binding
+      return (
+        binding.kind === "object" &&
+        authorization.actionApply.some(
+          (target) =>
+            target.actionId === action.id && target.subject.objectTypeId === binding.objectType.id
+        ) &&
+        getAuthorizedOntologyView(objectReader).getObjectTypeById(binding.objectType.id) !== null
+      )
+    }
     if (authorization.type === "unrestricted") return true
     return (
       isAllowed(authorization.context, { kind: "action.apply", actionId: action.id }) &&
@@ -57,14 +79,32 @@ export function createActionsRuntime(
     )
   }
 
+  const release = <T>(value: T): T => {
+    if (authorization.type === "delegated") {
+      assertObjectReadOutputWithinLimit(value, authorization.objectRead.limits)
+    }
+    return value
+  }
+  const describeAll = (actions: readonly ActionDefinition[]) =>
+    release(actions.filter(canList).map(snapshotActionDescriptor))
+
   return {
-    list: () => runtime.actionRegistry.list().filter(canList),
+    list: () => describeAll(runtime.actionRegistry.list()),
     getById: (actionId) => {
       const action = runtime.actionRegistry.getById(actionId)
-      return action && canList(action) ? action : null
+      return release(action && canList(action) ? snapshotActionDescriptor(action) : null)
     },
-    listGlobal: () => runtime.actionRegistry.listGlobal().filter(canList),
-    listForType: (objectType) => runtime.actionRegistry.listForType(objectType).filter(canList),
+    listGlobal: () => describeAll(runtime.actionRegistry.listGlobal()),
+    listForType: (objectType) =>
+      describeAll(
+        runtime.actionRegistry
+          .listForType(objectType)
+          .filter(
+            (action) =>
+              authorization.type !== "delegated" ||
+              (action.binding.kind === "object" && action.binding.objectType.id === objectType.id)
+          )
+      ),
     request: (input) => requestAction(runtime, execution, input),
     requestAndWait: (input) => requestActionAndWait(runtime, execution, input),
     runs: {

--- a/packages/core/src/execution/authorized-object-reader.ts
+++ b/packages/core/src/execution/authorized-object-reader.ts
@@ -2,6 +2,11 @@ import { assertAuthorized, isAllowed } from "../authorization"
 import { AuthorizationError } from "../authorization/errors"
 import type { AuthorizationContext } from "../authorization/types"
 import {
+  type AuthorizedOntologySelection,
+  type AuthorizedOntologyView,
+  createAuthorizedOntologyView,
+} from "../objects/authorized-ontology-view"
+import {
   countObjects,
   type ExecuteObjectCountInput,
   type ExecuteObjectCountResult,
@@ -79,6 +84,7 @@ class AuthorizedObjectReaderImpl {
   readonly #authority: ResolvedExecutionAuthority
   readonly #runtime: RuntimeReadAuthorization
   readonly #ontology: OntologyRegistry
+  #ontologyView?: AuthorizedOntologyView
   readonly #storage: ObjectReadStorage
   readonly #delegatedObjectTypeIds?: ReadonlySet<string>
   readonly #delegatedLinkDefinitions?: ReadonlySet<string>
@@ -128,6 +134,21 @@ class AuthorizedObjectReaderImpl {
         "[Sixb] AuthorizedObjectReader is not bound to this exact execution authority."
       )
     }
+  }
+
+  static ontologyView(reader: AuthorizedObjectReaderImpl): AuthorizedOntologyView {
+    const authority = reader.#authority
+    reader.#ontologyView ??= createAuthorizedOntologyView({
+      ontology: reader.#ontology,
+      selection: ontologySelectionForAuthority(authority, reader.#ontology),
+      ...(authority.type === "delegated"
+        ? {
+            assertOutputWithinLimit: (value: unknown) =>
+              assertObjectReadOutputWithinLimit(value, authority.objectRead.limits),
+          }
+        : {}),
+    })
+    return reader.#ontologyView
   }
 
   /** Project identity carried by this nominal reader capability. */
@@ -549,6 +570,11 @@ export function assertAuthorizedObjectReaderBinding(input: {
   AuthorizedObjectReaderImpl.assertBound(input.reader, input.scope)
 }
 
+/** Return inert metadata projected from the exact authority already owned by the reader. */
+export function getAuthorizedOntologyView(reader: AuthorizedObjectReader): AuthorizedOntologyView {
+  return AuthorizedObjectReaderImpl.ontologyView(reader)
+}
+
 function objectStorageForAuthority(
   authority: ResolvedExecutionAuthority,
   objectStorage: ObjectStorage
@@ -572,6 +598,31 @@ function assertNever(value: never): never {
   throw new Error(
     `[Sixb] Unsupported object reader authority '${String((value as { type?: unknown }).type)}'.`
   )
+}
+
+function ontologySelectionForAuthority(
+  authority: ResolvedExecutionAuthority,
+  ontology: OntologyRegistry
+): AuthorizedOntologySelection {
+  switch (authority.type) {
+    case "unrestricted":
+      return { kind: "all" }
+    case "principal":
+      return {
+        kind: "types",
+        objectTypeIds: ontology
+          .listObjectTypes()
+          .filter((objectType) =>
+            isAllowed(authority.context, {
+              kind: "object.view",
+              objectTypeId: objectType.id,
+            })
+          )
+          .map((objectType) => objectType.id),
+      }
+    case "delegated":
+      return { kind: "selected", scope: authority.objectRead.scope }
+  }
 }
 
 function delegatedLinkDefinitionKey(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1054,6 +1054,12 @@ export { CronValidationError } from "./schedules"
 // ── Projections ─────────────────────────────────────────────
 
 export type {
+  ActionDescriptor,
+  ActionDescriptorBinding,
+  ActionParamDescriptor,
+  ActionPhaseDescriptor,
+} from "./actions/descriptor"
+export type {
   ForeignKeyDescriptor,
   LinkProjectionDefinition,
   LinkProjectionTarget,
@@ -1070,7 +1076,6 @@ export type {
   TelemetryProjectionDefinition,
   TelemetryProjectionPropertyMapping,
 } from "./projections"
-
 export {
   defineProjection,
   fromForeignKey,

--- a/packages/core/src/objects/authorized-ontology-view.ts
+++ b/packages/core/src/objects/authorized-ontology-view.ts
@@ -1,0 +1,512 @@
+import {
+  formatUnknownObjectTypeMessage,
+  OntologyNotFoundError,
+  OntologyValidationError,
+} from "../ontology/errors"
+import type { OntologyDefinitionCatalog } from "../ontology/registry"
+import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
+import { createLinkTokenMap, createPropertyTokenMap } from "../ontology/tokens"
+import type {
+  ObjectLink,
+  ObjectType,
+  ObjectTypeSearchMetadata,
+  Property,
+  PropertyQueryMetadata,
+  Schema,
+  ValueType,
+} from "../ontology/types"
+import type { CompiledSelectedObjectReadScope } from "../storage/objects/types"
+
+/** Public ontology operations that may cross an execution-bound authorization boundary. */
+export type AuthorizedOntologyView = Pick<
+  OntologyDefinitionCatalog,
+  | "listObjectTypes"
+  | "getObjectTypeById"
+  | "resolveObjectType"
+  | "getValueTypesById"
+  | "getPrimaryPropertyId"
+  | "listSubTypes"
+  | "isValidLinkTarget"
+>
+
+export type AuthorizedOntologySelection =
+  | { readonly kind: "all" }
+  | { readonly kind: "types"; readonly objectTypeIds: readonly string[] }
+  | { readonly kind: "selected"; readonly scope: CompiledSelectedObjectReadScope }
+
+interface LinkSelection {
+  readonly targetObjectTypeIds: Set<string>
+  readonly propertyIds: Set<string>
+}
+
+interface SelectedSchema {
+  readonly propertyIdsByObjectType: ReadonlyMap<string, ReadonlySet<string>>
+  readonly linksBySourceType: ReadonlyMap<string, ReadonlyMap<string, LinkSelection>>
+}
+
+/**
+ * Project inert ontology metadata from one already-captured authority.
+ *
+ * Query validation intentionally keeps using the complete internal registry. This view is only
+ * the discovery surface returned to application code and HTTP serializers.
+ */
+export function createAuthorizedOntologyView(input: {
+  readonly ontology: OntologyDefinitionCatalog
+  readonly selection: AuthorizedOntologySelection
+  readonly assertOutputWithinLimit?: (value: unknown) => void
+}): AuthorizedOntologyView {
+  const allObjectTypes = input.ontology.listObjectTypes()
+  const registeredObjectTypeIds = new Set(allObjectTypes.map((objectType) => objectType.id))
+  const requestedObjectTypeIds = selectedObjectTypeIds(input.selection, allObjectTypes)
+  const visibleObjectTypeIds = new Set(
+    [...requestedObjectTypeIds].filter((objectTypeId) => registeredObjectTypeIds.has(objectTypeId))
+  )
+  const selectedSchema =
+    input.selection.kind === "selected" ? collectSelectedSchema(input.selection.scope) : undefined
+  const projectedObjectTypes: ObjectTypeWithPropertyTokens[] = []
+
+  for (const objectType of allObjectTypes) {
+    if (!visibleObjectTypeIds.has(objectType.id)) continue
+    const propertyIds =
+      selectedSchema?.propertyIdsByObjectType.get(objectType.id) ??
+      new Set(objectType.properties.map((property) => property.id))
+    const links = selectedSchema
+      ? (selectedSchema.linksBySourceType.get(objectType.id) ?? new Map())
+      : input.selection.kind === "all"
+        ? allDeclaredLinks(objectType)
+        : allVisibleLinks(input.ontology, objectType, visibleObjectTypeIds)
+    projectedObjectTypes.push(
+      projectObjectType({
+        objectType,
+        propertyIds,
+        links,
+        visibleObjectTypeIds,
+        ontology: input.ontology,
+        targetMode:
+          input.selection.kind === "all"
+            ? "original"
+            : input.selection.kind === "types"
+              ? "principal"
+              : "exact",
+        exposeContracts: input.selection.kind !== "selected",
+      })
+    )
+  }
+
+  const objectTypes = projectedObjectTypes
+  const objectTypesById = new Map(objectTypes.map((objectType) => [objectType.id, objectType]))
+  const valueTypesById =
+    input.selection.kind === "selected"
+      ? collectVisibleValueTypes(input.ontology.getValueTypesById(), objectTypes)
+      : snapshotAllValueTypes(input.ontology.getValueTypesById())
+  const release = <T>(value: T, budgetValue: unknown = value): T => {
+    input.assertOutputWithinLimit?.(budgetValue)
+    return value
+  }
+  const cloneObjectType = (objectType: ObjectTypeWithPropertyTokens) => structuredClone(objectType)
+  const cloneValueTypes = () =>
+    new Map(
+      [...valueTypesById].map(([valueTypeId, valueType]) => [
+        valueTypeId,
+        structuredClone(valueType),
+      ])
+    )
+
+  return Object.freeze({
+    listObjectTypes: () => release(objectTypes.map(cloneObjectType)),
+    getObjectTypeById: (objectTypeId: string) => {
+      const objectType = objectTypesById.get(objectTypeId)
+      return release(objectType ? cloneObjectType(objectType) : null)
+    },
+    resolveObjectType: (objectTypeId: string) => {
+      const objectType = objectTypesById.get(objectTypeId)
+      return objectType ? release(cloneObjectType(objectType)) : unknownObjectType(objectTypeId)
+    },
+    getValueTypesById: () => {
+      const valueTypes = cloneValueTypes()
+      return release(valueTypes, [...valueTypes.entries()])
+    },
+    getPrimaryPropertyId: (objectTypeId: string) => {
+      const objectType = objectTypesById.get(objectTypeId)
+      if (!objectType) return unknownObjectType(objectTypeId)
+      const primary = objectType.properties.find((property) => property.primary)
+      if (!primary) {
+        throw new OntologyValidationError(
+          `[Sixb] Object type '${objectTypeId}' does not expose its primary property in this execution scope.`
+        )
+      }
+      return release(primary.id)
+    },
+    listSubTypes: (objectTypeId: string) => {
+      const subTypes = visibleObjectTypeIds.has(objectTypeId)
+        ? input.ontology
+            .listSubTypes(objectTypeId)
+            .filter((subTypeId) => visibleObjectTypeIds.has(subTypeId))
+        : []
+      return release(subTypes)
+    },
+    isValidLinkTarget: (expected: string | string[], actual: string) => {
+      if (input.selection.kind === "all") {
+        return release(input.ontology.isValidLinkTarget(expected, actual))
+      }
+      if (!visibleObjectTypeIds.has(actual)) return release(false)
+      const expectedTypes = Array.isArray(expected) ? expected : [expected]
+      if (input.selection.kind === "selected") {
+        return release(
+          expectedTypes.some((expectedType) => expectedType === "*" || expectedType === actual)
+        )
+      }
+      return release(
+        expectedTypes.some(
+          (expectedType) =>
+            expectedType === "*" ||
+            (visibleObjectTypeIds.has(expectedType) &&
+              input.ontology.isValidLinkTarget(expectedType, actual))
+        )
+      )
+    },
+  })
+}
+
+function selectedObjectTypeIds(
+  selection: AuthorizedOntologySelection,
+  allObjectTypes: readonly ObjectTypeWithPropertyTokens[]
+): ReadonlySet<string> {
+  switch (selection.kind) {
+    case "all":
+      return new Set(allObjectTypes.map((objectType) => objectType.id))
+    case "types":
+      return new Set(selection.objectTypeIds)
+    case "selected":
+      return new Set(selection.scope.objects.map((object) => object.objectTypeId))
+  }
+}
+
+function collectSelectedSchema(scope: CompiledSelectedObjectReadScope): SelectedSchema {
+  const propertyIdsByObjectType = new Map<string, Set<string>>()
+  for (const object of scope.objects) {
+    const properties = propertyIdsByObjectType.get(object.objectTypeId) ?? new Set<string>()
+    for (const propertyId of object.propertyIds) properties.add(propertyId)
+    propertyIdsByObjectType.set(object.objectTypeId, properties)
+  }
+
+  const linksBySourceType = new Map<string, Map<string, LinkSelection>>()
+  for (const step of scope.steps) {
+    const links = linksBySourceType.get(step.sourceObjectTypeId) ?? new Map()
+    const selected = links.get(step.linkId) ?? {
+      targetObjectTypeIds: new Set<string>(),
+      propertyIds: new Set<string>(),
+    }
+    selected.targetObjectTypeIds.add(step.targetObjectTypeId)
+    for (const propertyId of step.propertyIds) selected.propertyIds.add(propertyId)
+    links.set(step.linkId, selected)
+    linksBySourceType.set(step.sourceObjectTypeId, links)
+  }
+
+  return { propertyIdsByObjectType, linksBySourceType }
+}
+
+function allDeclaredLinks(
+  objectType: ObjectTypeWithPropertyTokens
+): ReadonlyMap<string, LinkSelection> {
+  return new Map(
+    objectType.links.map((link) => [
+      link.id,
+      {
+        targetObjectTypeIds: new Set(
+          typeof link.targetObjectTypeId === "string"
+            ? [link.targetObjectTypeId]
+            : link.targetObjectTypeId
+        ),
+        propertyIds: new Set(link.properties?.map((property) => property.id) ?? []),
+      },
+    ])
+  )
+}
+
+function allVisibleLinks(
+  ontology: OntologyDefinitionCatalog,
+  objectType: ObjectTypeWithPropertyTokens,
+  visibleObjectTypeIds: ReadonlySet<string>
+): ReadonlyMap<string, LinkSelection> {
+  const links = new Map<string, LinkSelection>()
+  for (const link of objectType.links) {
+    const targetObjectTypeIds = new Set(
+      [...visibleObjectTypeIds].filter((targetObjectTypeId) =>
+        ontology.isValidLinkTarget(link.targetObjectTypeId, targetObjectTypeId)
+      )
+    )
+    if (targetObjectTypeIds.size === 0) continue
+    links.set(link.id, {
+      targetObjectTypeIds,
+      propertyIds: new Set(link.properties?.map((property) => property.id) ?? []),
+    })
+  }
+  return links
+}
+
+function projectObjectType(input: {
+  readonly ontology: OntologyDefinitionCatalog
+  readonly objectType: ObjectTypeWithPropertyTokens
+  readonly propertyIds: ReadonlySet<string>
+  readonly links: ReadonlyMap<string, LinkSelection>
+  readonly visibleObjectTypeIds: ReadonlySet<string>
+  readonly targetMode: "original" | "principal" | "exact"
+  readonly exposeContracts: boolean
+}): ObjectTypeWithPropertyTokens {
+  const properties = input.objectType.properties
+    .filter((property) => input.propertyIds.has(property.id))
+    .map(snapshotProperty)
+  const visiblePropertyIds = new Set(properties.map((property) => property.id))
+  const links = input.objectType.links.flatMap((link): ObjectLink[] => {
+    const selected = input.links.get(link.id)
+    if (!selected) return []
+    if (input.targetMode === "original") {
+      return [snapshotLink(link, snapshotLinkTarget(link.targetObjectTypeId), selected.propertyIds)]
+    }
+    const targetObjectTypeIds = new Set(
+      [...selected.targetObjectTypeIds].filter(
+        (targetObjectTypeId) =>
+          input.visibleObjectTypeIds.has(targetObjectTypeId) &&
+          input.ontology.isValidLinkTarget(link.targetObjectTypeId, targetObjectTypeId)
+      )
+    )
+    if (targetObjectTypeIds.size === 0) return []
+    const target =
+      input.targetMode === "principal"
+        ? principalLinkTargets(link, targetObjectTypeIds, input.visibleObjectTypeIds)
+        : exactLinkTargets(targetObjectTypeIds)
+    return [snapshotLink(link, target, selected.propertyIds, { omitEmptyProperties: true })]
+  })
+
+  // Whitelist top-level metadata so future cross-ontology fields remain closed until reviewed.
+  const projected: ObjectType = {
+    id: input.objectType.id,
+    name: input.objectType.name,
+    description: input.objectType.description,
+    quantityKind: input.objectType.quantityKind,
+    seeAlso: input.objectType.seeAlso ? [...input.objectType.seeAlso] : undefined,
+    extends:
+      input.objectType.extends && input.visibleObjectTypeIds.has(input.objectType.extends)
+        ? input.objectType.extends
+        : undefined,
+    parents: projectOptionalIds(
+      input.objectType.parents,
+      input.visibleObjectTypeIds,
+      input.targetMode === "original"
+    ),
+    implements:
+      input.exposeContracts && input.objectType.implements
+        ? [...input.objectType.implements]
+        : undefined,
+    properties,
+    links,
+    search: projectSearch(input.objectType.search, visiblePropertyIds, {
+      preserveEmpty: input.targetMode !== "exact",
+    }),
+  }
+  const withTokens = {
+    ...projected,
+    p: createPropertyTokenMap(projected),
+    l: createLinkTokenMap(projected),
+  }
+  return deepFreeze(withTokens) as ObjectTypeWithPropertyTokens
+}
+
+function principalLinkTargets(
+  link: ObjectLink,
+  allowedTargetObjectTypeIds: ReadonlySet<string>,
+  visibleObjectTypeIds: ReadonlySet<string>
+): string | string[] {
+  if (link.targetObjectTypeId === "*") return exactLinkTargets(allowedTargetObjectTypeIds)
+  const declared = Array.isArray(link.targetObjectTypeId)
+    ? link.targetObjectTypeId
+    : [link.targetObjectTypeId]
+  if (declared.every((objectTypeId) => visibleObjectTypeIds.has(objectTypeId))) {
+    return snapshotLinkTarget(link.targetObjectTypeId)
+  }
+  return exactLinkTargets(allowedTargetObjectTypeIds)
+}
+
+function exactLinkTargets(targetObjectTypeIds: ReadonlySet<string>): string | string[] {
+  const targets = [...targetObjectTypeIds].sort()
+  return targets.length === 1 ? targets[0]! : targets
+}
+
+function projectOptionalIds(
+  ids: readonly string[] | undefined,
+  visibleObjectTypeIds: ReadonlySet<string>,
+  preserveOriginal: boolean
+): string[] | undefined {
+  if (!ids) return undefined
+  if (preserveOriginal) return [...ids]
+  const visible = ids.filter((id) => visibleObjectTypeIds.has(id))
+  return visible.length > 0 ? visible : undefined
+}
+
+function snapshotLink(
+  link: ObjectLink,
+  targetObjectTypeId: string | string[],
+  propertyIds: ReadonlySet<string>,
+  options: { readonly omitEmptyProperties?: boolean } = {}
+): ObjectLink {
+  const properties = link.properties
+    ?.filter((property) => propertyIds.has(property.id))
+    .map(snapshotProperty)
+  return {
+    id: link.id,
+    name: link.name,
+    description: link.description,
+    targetObjectTypeId,
+    cardinality: link.cardinality,
+    properties: options.omitEmptyProperties && properties?.length === 0 ? undefined : properties,
+  }
+}
+
+function snapshotLinkTarget(target: string | readonly string[]): string | string[] {
+  return typeof target === "string" ? target : [...target]
+}
+
+function snapshotProperty(property: Property): Property {
+  return {
+    id: property.id,
+    name: property.name,
+    schema: snapshotSchema(property.schema),
+    description: property.description,
+    required: property.required,
+    nullable: property.nullable,
+    primary: property.primary,
+    mode: property.mode,
+    semanticType: property.semanticType,
+    query: snapshotPropertyQuery(property.query),
+  }
+}
+
+function snapshotPropertyQuery(
+  query: PropertyQueryMetadata | undefined
+): PropertyQueryMetadata | undefined {
+  if (!query) return undefined
+  return {
+    searchable: query.searchable,
+    filterable: query.filterable,
+    sortable: query.sortable,
+    text: query.text,
+    exact: query.exact,
+    facet: query.facet,
+    vector: query.vector,
+    weight: query.weight,
+  }
+}
+
+function projectSearch(
+  search: ObjectTypeSearchMetadata | undefined,
+  visiblePropertyIds: ReadonlySet<string>,
+  options: { readonly preserveEmpty: boolean }
+): ObjectTypeSearchMetadata | undefined {
+  if (!search) return undefined
+  const title = search.title && visiblePropertyIds.has(search.title) ? search.title : undefined
+  const selectedDefaultText = search.defaultText?.filter((propertyId) =>
+    visiblePropertyIds.has(propertyId)
+  )
+  const selectedExact = search.exact?.filter((propertyId) => visiblePropertyIds.has(propertyId))
+  const defaultText =
+    options.preserveEmpty || selectedDefaultText?.length ? selectedDefaultText : undefined
+  const exact = options.preserveEmpty || selectedExact?.length ? selectedExact : undefined
+  const vector =
+    search.vector &&
+    visiblePropertyIds.has(search.vector.property) &&
+    search.vector.source.every((propertyId) => visiblePropertyIds.has(propertyId))
+      ? { property: search.vector.property, source: [...search.vector.source] }
+      : undefined
+  const projected: ObjectTypeSearchMetadata = {
+    ...(title === undefined ? {} : { title }),
+    ...(defaultText === undefined ? {} : { defaultText }),
+    ...(exact === undefined ? {} : { exact }),
+    ...(vector === undefined ? {} : { vector }),
+  }
+  return Object.keys(projected).length > 0 || options.preserveEmpty ? projected : undefined
+}
+
+function snapshotAllValueTypes(
+  registered: ReadonlyMap<string, ValueType>
+): ReadonlyMap<string, ValueType> {
+  return new Map(
+    [...registered.values()].map((valueType) => {
+      const snapshot = snapshotValueType(valueType)
+      return [snapshot.id, snapshot] as const
+    })
+  )
+}
+
+function collectVisibleValueTypes(
+  registered: ReadonlyMap<string, ValueType>,
+  objectTypes: readonly ObjectTypeWithPropertyTokens[]
+): ReadonlyMap<string, ValueType> {
+  const referencedIds = new Set<string>()
+  const pendingSchemas: Schema[] = []
+  const visitedSchemas = new Set<object>()
+  for (const objectType of objectTypes) {
+    for (const property of objectType.properties) pendingSchemas.push(property.schema)
+    for (const link of objectType.links) {
+      for (const property of link.properties ?? []) pendingSchemas.push(property.schema)
+    }
+  }
+
+  while (pendingSchemas.length > 0) {
+    const schema = pendingSchemas.pop()!
+    if (typeof schema === "string" || visitedSchemas.has(schema)) continue
+    visitedSchemas.add(schema)
+    if (schema.type === "valueTypeRef") {
+      if (!referencedIds.has(schema.valueTypeId)) {
+        referencedIds.add(schema.valueTypeId)
+        const valueType = registered.get(schema.valueTypeId)
+        if (valueType) pendingSchemas.push(valueType.schema)
+      }
+      if (schema._resolved) pendingSchemas.push(schema._resolved)
+    } else if (schema.type === "object") {
+      for (const field of Object.values(schema.properties)) pendingSchemas.push(field.schema)
+    } else if (schema.type === "array") {
+      pendingSchemas.push(schema.items)
+    } else if (schema.type === "map") {
+      pendingSchemas.push(schema.valueSchema)
+    }
+  }
+
+  return new Map(
+    [...referencedIds]
+      .map((valueTypeId) => registered.get(valueTypeId))
+      .filter((valueType): valueType is ValueType => valueType !== undefined)
+      .map((valueType) => {
+        const snapshot = snapshotValueType(valueType)
+        return [snapshot.id, snapshot] as const
+      })
+  )
+}
+
+function snapshotValueType(valueType: ValueType): ValueType {
+  return deepFreeze({
+    id: valueType.id,
+    name: valueType.name,
+    description: valueType.description,
+    schema: snapshotSchema(valueType.schema),
+    semanticType: valueType.semanticType,
+  })
+}
+
+function snapshotSchema(schema: Schema): Schema {
+  return deepFreeze(structuredClone(schema))
+}
+
+function deepFreeze<T>(value: T, seen: Set<object> = new Set()): T {
+  if (typeof value !== "object" || value === null || seen.has(value)) return value
+  seen.add(value)
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (descriptor && "value" in descriptor) deepFreeze(descriptor.value, seen)
+  }
+  return Object.freeze(value)
+}
+
+function unknownObjectType(objectTypeId: string): never {
+  throw new OntologyNotFoundError(formatUnknownObjectTypeMessage(objectTypeId))
+}

--- a/packages/core/src/objects/execution.ts
+++ b/packages/core/src/objects/execution.ts
@@ -1,9 +1,13 @@
-import { assertAuthorized, isAllowed } from "../authorization"
+import { shareSixbErrorReporter } from "../error-reporting/capability"
 import type { ExecutionContext } from "../execution"
-import { assertAuthorizedObjectReaderBinding } from "../execution/authorized-object-reader"
+import {
+  assertAuthorizedObjectReaderBinding,
+  getAuthorizedOntologyView,
+} from "../execution/authorized-object-reader"
 import type { ValueType } from "../ontology"
 import { assertObjectTypeRegistered } from "../ontology"
 import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
+import { shareOntologyMutationRuntime } from "../runtime/ontology-mutations"
 import type {
   ListResult,
   ObjectByIdHandle,
@@ -169,65 +173,66 @@ export function createObjectsRuntime<TOntologySources extends readonly OntologyS
   runtime: SixbRuntimeContext,
   execution: ExecutionContext
 ): ObjectsRuntime<TOntologySources> {
+  const runtimeAuthorization = runtime.runtimeAuthorization
+  const objectReader = runtime.objectReader
   assertAuthorizedObjectReaderBinding({
-    reader: runtime.objectReader,
-    scope: { execution, authorization: runtime.runtimeAuthorization },
+    reader: objectReader,
+    scope: { execution, authorization: runtimeAuthorization },
   })
+  const authorization = runtime.authorization
+  const capturedRuntime: SixbRuntimeContext = {
+    projectId: runtime.projectId,
+    broker: runtime.broker,
+    ontology: runtime.ontology,
+    actionRegistry: runtime.actionRegistry,
+    events: runtime.events,
+    storage: runtime.storage,
+    queues: runtime.queues,
+    runtimeAuthorization,
+    objectReader,
+    ...(authorization === undefined ? {} : { authorization }),
+  }
+  shareOntologyMutationRuntime(runtime, capturedRuntime)
+  shareSixbErrorReporter(runtime, capturedRuntime)
+  Object.freeze(capturedRuntime)
+  const ontologyView = () => getAuthorizedOntologyView(objectReader)
   const objects = Object.assign(
     <TObjectType extends RegisteredObjectType<TOntologySources>>(objectType: TObjectType) => {
-      assertObjectTypeRegistered(runtime.ontology.getObjectTypesById(), objectType)
+      assertObjectTypeRegistered(capturedRuntime.ontology.getObjectTypesById(), objectType)
       return createObjectSet<
         TObjectType,
         RegisteredObjectType<TOntologySources>,
         RegisteredValueTypes<TOntologySources>
-      >({ ...runtime, execution, objectType }) as ExecutionObjectSet<
+      >({ ...capturedRuntime, execution, objectType }) as ExecutionObjectSet<
         TObjectType,
         RegisteredValueTypes<TOntologySources>,
         RegisteredObjectType<TOntologySources>
       >
     },
     {
-      listTypes: () =>
-        runtime.ontology.listObjectTypes().filter((objectType) =>
-          isAllowed(runtime.authorization, {
-            kind: "object.view",
-            objectTypeId: objectType.id,
-          })
-        ),
-      getTypeById: (objectTypeId: string) => {
-        const objectType = runtime.ontology.getObjectTypeById(objectTypeId)
-        return objectType && isAllowed(runtime.authorization, { kind: "object.view", objectTypeId })
-          ? objectType
-          : null
-      },
-      resolveType: (objectTypeId: string) => {
-        assertAuthorized(runtime, { kind: "object.view", objectTypeId })
-        return runtime.ontology.resolveObjectType(objectTypeId)
-      },
-      getValueTypesById: () => runtime.ontology.getValueTypesById(),
-      listSubTypes: (objectTypeId: string) => runtime.ontology.listSubTypes(objectTypeId),
+      listTypes: () => ontologyView().listObjectTypes(),
+      getTypeById: (objectTypeId: string) => ontologyView().getObjectTypeById(objectTypeId),
+      resolveType: (objectTypeId: string) => ontologyView().resolveObjectType(objectTypeId),
+      getValueTypesById: () => ontologyView().getValueTypesById(),
+      listSubTypes: (objectTypeId: string) => ontologyView().listSubTypes(objectTypeId),
       isValidLinkTarget: (expected: string | string[], actual: string) =>
-        runtime.ontology.isValidLinkTarget(expected, actual),
+        ontologyView().isValidLinkTarget(expected, actual),
       executeQuery: (input: Omit<ExecuteObjectQueryInput, "projectId">) =>
-        runtime.objectReader.executeQuery(input),
-      queryLinks: (input: ObjectQueryLinksInput) => runtime.objectReader.queryLinks(input),
-      count: (input: Omit<ExecuteObjectCountInput, "projectId">) =>
-        runtime.objectReader.count(input),
-      exists: (input: Omit<ExecuteObjectExistsInput, "projectId">) =>
-        runtime.objectReader.exists(input),
-      facet: (input: Omit<ExecuteObjectFacetsInput, "projectId">) =>
-        runtime.objectReader.facet(input),
+        objectReader.executeQuery(input),
+      queryLinks: (input: ObjectQueryLinksInput) => objectReader.queryLinks(input),
+      count: (input: Omit<ExecuteObjectCountInput, "projectId">) => objectReader.count(input),
+      exists: (input: Omit<ExecuteObjectExistsInput, "projectId">) => objectReader.exists(input),
+      facet: (input: Omit<ExecuteObjectFacetsInput, "projectId">) => objectReader.facet(input),
       listLinks: async (input: {
         objectTypeId: string
         objectId: string
         linkId?: string
         direction?: LinkDirection
       }) => {
-        return runtime.objectReader.listLinks(input)
+        return objectReader.listLinks(input)
       },
       getTelemetryHistoryBatch: (input: Omit<TimeseriesHistoryBatchInput, "projectId">) => {
-        const objectReader = runtime.objectReader
-        const timeseries = runtime.storage.timeseries
+        const timeseries = capturedRuntime.storage.timeseries
         return getTelemetryHistoryBatch(input, { storage: timeseries, objectReader })
       },
       getTelemetryHistory: async (input: {
@@ -239,8 +244,7 @@ export function createObjectsRuntime<TOntologySources extends readonly OntologyS
         limit?: number
         order?: "asc" | "desc"
       }) => {
-        const objectReader = runtime.objectReader
-        const timeseries = runtime.storage.timeseries
+        const timeseries = capturedRuntime.storage.timeseries
         const objectTypeId = input.objectTypeId
         const objectId = input.objectId
         const propertyId = input.propertyId
@@ -265,8 +269,7 @@ export function createObjectsRuntime<TOntologySources extends readonly OntologyS
         objectId: string
         propertyId: string
       }) => {
-        const objectReader = runtime.objectReader
-        const timeseries = runtime.storage.timeseries
+        const timeseries = capturedRuntime.storage.timeseries
         const objectTypeId = input.objectTypeId
         const objectId = input.objectId
         const propertyId = input.propertyId
@@ -275,25 +278,24 @@ export function createObjectsRuntime<TOntologySources extends readonly OntologyS
           { storage: timeseries, objectReader }
         )
       },
-      list: (params: ListObjectsParams) => objectService.listObjects(runtime, params),
+      list: (params: ListObjectsParams) => objectService.listObjects(capturedRuntime, params),
       get: (objectTypeId: string, primaryId: string) =>
-        runtime.objectReader.getByPrimaryId({ objectTypeId, primaryId }),
+        objectReader.getByPrimaryId({ objectTypeId, primaryId }),
       getPrimaryPropertyId: (objectTypeId: string) => {
-        assertAuthorized(runtime, { kind: "object.view", objectTypeId })
-        return runtime.ontology.getPrimaryPropertyId(objectTypeId)
+        return ontologyView().getPrimaryPropertyId(objectTypeId)
       },
       upsert: (objectTypeId: string, properties: Record<string, unknown>) =>
-        objectService.upsertObject(runtime, objectTypeId, properties),
+        objectService.upsertObject(capturedRuntime, objectTypeId, properties),
       upsertBatch: (
         objectTypeId: string,
         items: readonly { properties: Record<string, unknown> }[]
-      ) => objectService.upsertObjectBatch(runtime, objectTypeId, items),
+      ) => objectService.upsertObjectBatch(capturedRuntime, objectTypeId, items),
       upsertLink: (
         objectTypeId: string,
         sourceId: string,
         linkId: string,
         target: { targetTypeId: string; targetId: string; properties?: Record<string, unknown> }
-      ) => objectService.upsertLink(runtime, objectTypeId, sourceId, linkId, target),
+      ) => objectService.upsertLink(capturedRuntime, objectTypeId, sourceId, linkId, target),
       upsertLinkBatch: (
         items: readonly {
           objectTypeId: string
@@ -301,17 +303,17 @@ export function createObjectsRuntime<TOntologySources extends readonly OntologyS
           linkId: string
           target: { targetTypeId: string; targetId: string; properties?: Record<string, unknown> }
         }[]
-      ) => objectService.upsertLinkBatch(runtime, items),
+      ) => objectService.upsertLinkBatch(capturedRuntime, items),
       removeLink: (
         objectTypeId: string,
         sourceId: string,
         linkId: string,
         target: { targetTypeId: string; targetId: string }
-      ) => objectService.removeLink(runtime, objectTypeId, sourceId, linkId, target),
+      ) => objectService.removeLink(capturedRuntime, objectTypeId, sourceId, linkId, target),
       appendTelemetry: (
         objectTypeId: string,
         items: readonly { id: string; properties: Record<string, unknown>; at?: Date }[]
-      ) => objectService.appendTelemetry(runtime, objectTypeId, items),
+      ) => objectService.appendTelemetry(capturedRuntime, objectTypeId, items),
     }
   )
 

--- a/packages/core/src/ontology/json-schema.ts
+++ b/packages/core/src/ontology/json-schema.ts
@@ -1,17 +1,19 @@
 import type { JsonObject } from "../json"
 import { OntologyValidationError } from "./errors"
-import { isObjectRefSchema, type SchemaOrRef } from "./refs"
+import type { SchemaOrRef } from "./refs"
 import type { Schema, ValueType } from "./types"
 
+type DeepReadonly<T> = T extends object ? { readonly [K in keyof T]: DeepReadonly<T[K]> } : T
+
 export interface SchemaJsonField {
-  readonly schema: SchemaOrRef
+  readonly schema: DeepReadonly<SchemaOrRef>
   readonly required?: boolean
   readonly nullable?: boolean
 }
 
 /** Convert a record of Sixb schemas into the strict JSON object schema used by model outputs. */
 export function schemaRecordToJsonSchema(input: {
-  readonly shape: Readonly<Record<string, SchemaOrRef>>
+  readonly shape: Readonly<Record<string, DeepReadonly<SchemaOrRef>>>
   readonly valueTypesById: ReadonlyMap<string, ValueType>
 }): JsonObject {
   return schemaFieldsToJsonSchema({
@@ -44,11 +46,11 @@ export function schemaFieldsToJsonSchema(input: {
 }
 
 function schemaOrRefJsonSchema(
-  schema: SchemaOrRef,
+  schema: DeepReadonly<SchemaOrRef>,
   valueTypesById: ReadonlyMap<string, ValueType>,
   resolving: ReadonlySet<string>
 ): JsonObject {
-  if (isObjectRefSchema(schema)) {
+  if (typeof schema !== "string" && schema.type === "objectRef") {
     return {
       type: "object",
       properties: {
@@ -63,7 +65,7 @@ function schemaOrRefJsonSchema(
 }
 
 function schemaJsonSchema(
-  schema: Schema,
+  schema: DeepReadonly<Schema>,
   valueTypesById: ReadonlyMap<string, ValueType>,
   resolving: ReadonlySet<string>
 ): JsonObject {

--- a/packages/core/tests/action-descriptor.test.ts
+++ b/packages/core/tests/action-descriptor.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import { defineAction, defineObjectType, prop } from "../src"
+import { snapshotActionDescriptor } from "../src/actions/descriptor"
+import { schemaFieldsToJsonSchema } from "../src/ontology/json-schema"
+
+test("Action metadata contains no executable handlers or live ontology definitions", () => {
+  const Proposal = defineObjectType({
+    id: "proposal",
+    name: "Proposal",
+    properties: [prop("id", "string", { primary: true })],
+  })
+  const approve = defineAction("approve")
+    .on(Proposal)
+    .params({
+      reason: { schema: { type: "enum", valueType: "string", values: ["accepted", "rejected"] } },
+    })
+    .validate(() => {})
+    .edits(() => {})
+  // Returning the live definition instead of snapshotActionDescriptor makes this fail:
+  // structuredClone rejects phase functions, and the binding leaks the complete ObjectType.
+  const descriptor = snapshotActionDescriptor(approve)
+  expect(structuredClone(descriptor)).toEqual(descriptor)
+  expect(descriptor.binding).toEqual({ kind: "object", objectTypeId: "proposal" })
+  expect(descriptor.phases).toEqual({
+    validate: true,
+    writeback: false,
+    edits: true,
+    effects: false,
+  })
+  expect(descriptor.params).not.toBe(approve.params)
+  expect(Object.isFrozen(descriptor.params.reason.schema)).toBe(true)
+  expect(descriptor).not.toHaveProperty("edits")
+  // Requiring mutable SchemaOrRef fields in the converter makes this fail typecheck.
+  // HTTP action details must still render the exact input schema from frozen metadata.
+  expect(
+    schemaFieldsToJsonSchema({ fields: descriptor.params, valueTypesById: new Map() })
+  ).toEqual({
+    type: "object",
+    properties: { reason: { enum: ["accepted", "rejected"] } },
+    additionalProperties: false,
+  })
+})

--- a/packages/core/tests/authorized-ontology-view.test.ts
+++ b/packages/core/tests/authorized-ontology-view.test.ts
@@ -1,0 +1,642 @@
+import { describe, expect, test } from "bun:test"
+import {
+  can,
+  defineGroup,
+  defineObjectType,
+  defineOntology,
+  defineRole,
+  defineValueType,
+  every,
+  link,
+  type ObjectTypeWithPropertyTokens,
+  prop,
+  resolveAuthorizationContext,
+  SixbHost,
+  valueTypeRef,
+} from "../src"
+import {
+  createAuthorizedObjectReader,
+  getAuthorizedOntologyView,
+} from "../src/execution/authorized-object-reader"
+import { createDelegatedRequestScope } from "../src/execution/scopes"
+import { createAuthorizedOntologyView } from "../src/objects/authorized-ontology-view"
+import { createObjectsRuntime } from "../src/objects/execution"
+import { OntologyRegistry } from "../src/ontology"
+import { registerOntologyMutationRuntime } from "../src/runtime/ontology-mutations"
+import type { SixbRuntimeContext } from "../src/runtime/types"
+import { InMemoryObjectStorage } from "../src/storage/objects/in-memory"
+import type { CompiledSelectedObjectReadScope } from "../src/storage/objects/types"
+import { createTestSixb } from "../src/testing"
+import { createTestRuntimeDeps } from "./test-runtime-deps"
+
+const Address = defineValueType({
+  id: "catalog:Address",
+  name: "Address",
+  schema: {
+    type: "object",
+    properties: { city: { required: true, schema: "string" } },
+  },
+})
+
+const CustomerProfile = defineValueType({
+  id: "catalog:CustomerProfile",
+  name: "Customer profile",
+  schema: {
+    type: "object",
+    properties: { address: { required: true, schema: valueTypeRef(Address) } },
+  },
+})
+
+const PrivateProfile = defineValueType({
+  id: "catalog:PrivateProfile",
+  name: "Private profile",
+  schema: "string",
+})
+
+const EdgeNote = defineValueType({
+  id: "catalog:EdgeNote",
+  name: "Edge note",
+  schema: "string",
+})
+
+const PrivateEdgeNote = defineValueType({
+  id: "catalog:PrivateEdgeNote",
+  name: "Private edge note",
+  schema: "string",
+})
+
+const UnusedValue = defineValueType({
+  id: "catalog:Unused",
+  name: "Unused",
+  schema: "string",
+})
+
+const HiddenOnlyValue = defineValueType({
+  id: "catalog:HiddenOnly",
+  name: "Hidden only",
+  schema: "string",
+})
+
+const Customer = defineObjectType({
+  id: "CatalogCustomer",
+  name: "Customer",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("label", "string"),
+    prop("privateProfile", valueTypeRef(PrivateProfile)),
+  ],
+})
+
+const PremiumCustomer = defineObjectType({
+  id: "CatalogPremiumCustomer",
+  name: "Premium customer",
+  extends: Customer,
+  properties: [prop("tier", "string")],
+})
+
+const HiddenRecord = defineObjectType({
+  id: "CatalogHiddenRecord",
+  name: "Hidden record",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("hiddenOnly", valueTypeRef(HiddenOnlyValue)),
+  ],
+})
+
+const Proposal = defineObjectType({
+  id: "CatalogProposal",
+  name: "Proposal",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("title", "string", { query: { searchable: true, text: true } }),
+    prop("customerProfile", valueTypeRef(CustomerProfile)),
+    prop("secret", valueTypeRef(PrivateProfile), {
+      query: { searchable: true, exact: true, text: true },
+    }),
+  ],
+  search: {
+    title: "title",
+    defaultText: ["title", "secret"],
+    exact: ["secret"],
+  },
+  links: [
+    link("customer", Customer, {
+      properties: [
+        prop("note", valueTypeRef(EdgeNote)),
+        prop("privateNote", valueTypeRef(PrivateEdgeNote)),
+      ],
+    }),
+    link("addedAfterIssuance", Customer),
+    link("hiddenRecord", HiddenRecord),
+    link.any("mixedTarget", {
+      properties: [prop("note", valueTypeRef(EdgeNote))],
+    }),
+  ],
+})
+
+const CatalogOntology = defineOntology({
+  id: "catalog-tests",
+  version: "1.0.0",
+  objectTypes: [Proposal, Customer, PremiumCustomer, HiddenRecord],
+  valueTypes: [
+    Address,
+    CustomerProfile,
+    PrivateProfile,
+    EdgeNote,
+    PrivateEdgeNote,
+    UnusedValue,
+    HiddenOnlyValue,
+  ],
+})
+
+const catalogReaders = defineGroup("catalog-readers")
+const catalogViewer = defineRole("catalog.viewer", {
+  grantedTo: [catalogReaders],
+  grants: [can.view(every.object().except([HiddenRecord]))],
+})
+
+function createHost() {
+  return new SixbHost({
+    id: "authorized-ontology-view",
+    ontology: [CatalogOntology],
+    groups: [catalogReaders],
+    roles: [catalogViewer],
+    ...createTestRuntimeDeps(),
+  })
+}
+
+function createDelegatedCatalogScope(
+  maxOutputJsonBytes = 1_000_000,
+  options: { readonly includePremiumRoot?: boolean } = {}
+) {
+  return createDelegatedRequestScope({
+    projectId: "delegated-catalog",
+    requestId: "delegated-catalog-request",
+    correlationId: "delegated-catalog-correlation",
+    objectRead: {
+      selection: {
+        kind: "selected",
+        roots: [
+          {
+            anchor: { objectTypeId: Proposal.id, primaryId: "proposal-1" },
+            node: {
+              objects: [
+                {
+                  objectTypeId: Proposal.id,
+                  propertyIds: ["id", "title", "customerProfile"],
+                },
+              ],
+              links: [
+                {
+                  definitions: [
+                    {
+                      sourceObjectTypeId: Proposal.id,
+                      linkId: Proposal.l.customer.id,
+                      targetObjectTypeIds: [Customer.id],
+                      propertyIds: ["note"],
+                    },
+                    {
+                      sourceObjectTypeId: Proposal.id,
+                      linkId: Proposal.l.mixedTarget.id,
+                      targetObjectTypeIds: [Customer.id],
+                      propertyIds: [],
+                    },
+                  ],
+                  target: {
+                    objects: [{ objectTypeId: Customer.id, propertyIds: ["id", "label"] }],
+                    links: [],
+                  },
+                },
+              ],
+            },
+          },
+          ...(options.includePremiumRoot
+            ? [
+                {
+                  anchor: {
+                    objectTypeId: PremiumCustomer.id,
+                    primaryId: "premium-customer-1",
+                  },
+                  node: {
+                    objects: [{ objectTypeId: PremiumCustomer.id, propertyIds: ["tier"] }],
+                    links: [],
+                  },
+                },
+              ]
+            : []),
+        ],
+      },
+      limits: { maxTraversalFacts: 100, maxOutputJsonBytes },
+    },
+  })
+}
+
+function tokenKeys(objectType: ObjectTypeWithPropertyTokens, tokenMap: "p" | "l"): string[] {
+  const tokens = objectType as ObjectTypeWithPropertyTokens & {
+    readonly l: Readonly<Record<string, unknown>>
+  }
+  return Object.keys(tokens[tokenMap]).sort()
+}
+
+function createSelectedView(
+  ontology: OntologyRegistry,
+  objects: CompiledSelectedObjectReadScope["objects"],
+  steps: CompiledSelectedObjectReadScope["steps"] = []
+) {
+  return createAuthorizedOntologyView({
+    ontology,
+    selection: { kind: "selected", scope: { kind: "selected", roots: [], objects, steps } },
+  })
+}
+
+describe("authorized ontology view", () => {
+  test("projects principal types and endpoints while preserving the ValueType catalog", () => {
+    const host = createHost()
+    const authorization = resolveAuthorizationContext({
+      principal: { type: "user", id: "catalog-user" },
+      groupIds: [catalogReaders.id],
+      roles: host.definitions.security.listResolvedRoles(),
+    })
+    const sixb = createTestSixb(host, { authorization })
+
+    expect(sixb.objects.listTypes().map((objectType) => objectType.id)).toEqual([
+      Proposal.id,
+      Customer.id,
+      PremiumCustomer.id,
+    ])
+    expect(sixb.objects.getTypeById(HiddenRecord.id)).toBeNull()
+    expect(() => sixb.objects.resolveType(HiddenRecord.id)).toThrow("Unknown object type")
+    expect(sixb.objects.listSubTypes(Customer.id)).toEqual([PremiumCustomer.id])
+    expect(sixb.objects.listSubTypes(HiddenRecord.id)).toEqual([])
+    expect(sixb.objects.isValidLinkTarget(Customer.id, PremiumCustomer.id)).toBe(true)
+    expect(sixb.objects.isValidLinkTarget("*", HiddenRecord.id)).toBe(false)
+
+    const proposal = sixb.objects.resolveType(Proposal.id)
+    expect(proposal.links.map((candidate) => candidate.id)).toEqual([
+      "customer",
+      "addedAfterIssuance",
+      "mixedTarget",
+    ])
+    expect(proposal.links.find((candidate) => candidate.id === "hiddenRecord")).toBeUndefined()
+    expect(
+      proposal.links.find((candidate) => candidate.id === "mixedTarget")?.targetObjectTypeId
+    ).toEqual([Customer.id, PremiumCustomer.id, Proposal.id])
+    expect(tokenKeys(proposal, "l")).toEqual(["addedAfterIssuance", "customer", "mixedTarget"])
+
+    expect([...sixb.objects.getValueTypesById().keys()].sort()).toEqual(
+      [
+        Address,
+        CustomerProfile,
+        PrivateProfile,
+        EdgeNote,
+        PrivateEdgeNote,
+        UnusedValue,
+        HiddenOnlyValue,
+      ]
+        .map((valueType) => valueType.id)
+        .sort()
+    )
+  })
+
+  test("derives delegated metadata only from the captured selected scope", () => {
+    const ontology = new OntologyRegistry({ sources: [CatalogOntology] })
+    const reader = createAuthorizedObjectReader({
+      scope: createDelegatedCatalogScope(),
+      ontology,
+      objectStorage: new InMemoryObjectStorage(),
+    })
+    const view = getAuthorizedOntologyView(reader)
+
+    // Regression proof: projecting the complete registry for delegated authority makes this
+    // include PremiumCustomer and HiddenRecord before the field-level assertions run.
+    expect(view.listObjectTypes().map((objectType) => objectType.id)).toEqual([
+      Proposal.id,
+      Customer.id,
+    ])
+    expect(view.getObjectTypeById(HiddenRecord.id)).toBeNull()
+    expect(view.getObjectTypeById(PremiumCustomer.id)).toBeNull()
+
+    const proposal = view.resolveObjectType(Proposal.id)
+    expect(proposal.properties.map((property) => property.id)).toEqual([
+      "id",
+      "title",
+      "customerProfile",
+    ])
+    expect(proposal.search).toEqual({ title: "title", defaultText: ["title"] })
+    expect(proposal.links.map((candidate) => candidate.id)).toEqual(["customer", "mixedTarget"])
+    expect(proposal.links[0]?.targetObjectTypeId).toBe(Customer.id)
+    expect(proposal.links[0]?.properties?.map((property) => property.id)).toEqual(["note"])
+    expect(proposal.links[1]?.targetObjectTypeId).toBe(Customer.id)
+    expect(proposal.links[1]?.properties).toBeUndefined()
+    expect(tokenKeys(proposal, "p")).toEqual(["customerProfile", "id", "title"])
+    expect(tokenKeys(proposal, "l")).toEqual(["customer", "mixedTarget"])
+    expect(view.getPrimaryPropertyId(Proposal.id)).toBe("id")
+    const customerSubTypes = view.listSubTypes(Customer.id)
+    expect(customerSubTypes).toEqual([])
+    customerSubTypes.push(PremiumCustomer.id)
+    expect(view.listSubTypes(Customer.id)).toEqual([])
+    expect(view.isValidLinkTarget("*", HiddenRecord.id)).toBe(false)
+
+    expect([...view.getValueTypesById().keys()].sort()).toEqual(
+      [Address.id, CustomerProfile.id, EdgeNote.id].sort()
+    )
+    expect(view.getValueTypesById().has(PrivateProfile.id)).toBe(false)
+    expect(view.getValueTypesById().has(PrivateEdgeNote.id)).toBe(false)
+    expect(view.getValueTypesById().has(UnusedValue.id)).toBe(false)
+
+    const registeredProposal = ontology.resolveObjectType(Proposal.id)
+    const projectedValues = view.getValueTypesById()
+    const projectedAddress = projectedValues.get(Address.id)
+    if (!projectedAddress) throw new Error("Expected projected Address ValueType")
+    expect(proposal).not.toBe(registeredProposal)
+    expect(Object.isFrozen(view)).toBe(true)
+    expect(Object.isFrozen(proposal)).toBe(false)
+    proposal.properties[0]!.name = "tampered"
+    expect(view.resolveObjectType(Proposal.id).properties[0]?.name).toBe("id")
+    expect(projectedValues).toBeInstanceOf(Map)
+    expect(structuredClone(projectedValues)).toEqual(projectedValues)
+    ;(projectedValues as Map<string, typeof Address>).set("tampered", Address)
+    expect(view.getValueTypesById().has("tampered")).toBe(false)
+    ;(view.listObjectTypes() as ObjectTypeWithPropertyTokens[]).push(HiddenRecord)
+    expect(view.listObjectTypes().map((objectType) => objectType.id)).toEqual([
+      Proposal.id,
+      Customer.id,
+    ])
+    expect(ontology.resolveObjectType(Proposal.id).properties[0]?.name).toBe("id")
+  })
+
+  test("enforces the delegated output budget on every metadata terminal", () => {
+    const ontology = new OntologyRegistry({ sources: [CatalogOntology] })
+    const reader = createAuthorizedObjectReader({
+      scope: createDelegatedCatalogScope(1),
+      ontology,
+      objectStorage: new InMemoryObjectStorage(),
+    })
+    const view = getAuthorizedOntologyView(reader)
+    const expectBudgetExceeded = (read: () => unknown) => {
+      expect(read).toThrow(
+        expect.objectContaining({
+          code: "object_read_limit_exceeded",
+          metric: "outputJsonBytes",
+          limit: 1,
+        })
+      )
+    }
+
+    // Regression proof: removing the delegated release guard makes this metadata read succeed.
+    expectBudgetExceeded(() => view.listObjectTypes())
+    expectBudgetExceeded(() => view.getObjectTypeById(Proposal.id))
+    expectBudgetExceeded(() => view.resolveObjectType(Proposal.id))
+    expectBudgetExceeded(() => view.getValueTypesById())
+    expectBudgetExceeded(() => view.getPrimaryPropertyId(Proposal.id))
+    expectBudgetExceeded(() => view.listSubTypes(Customer.id))
+    expectBudgetExceeded(() => view.isValidLinkTarget(Customer.id, Customer.id))
+
+    const mapReader = createAuthorizedObjectReader({
+      scope: createDelegatedCatalogScope(16),
+      ontology,
+      objectStorage: new InMemoryObjectStorage(),
+    })
+    // Regression proof: budgeting the native Map itself serializes `{}` and bypasses this bound;
+    // the released representation must include its entries.
+    expect(() => getAuthorizedOntologyView(mapReader).getValueTypesById()).toThrow(
+      expect.objectContaining({
+        code: "object_read_limit_exceeded",
+        metric: "outputJsonBytes",
+        limit: 16,
+      })
+    )
+  })
+
+  test("keeps selected link targets exact even when a subtype is visible elsewhere", () => {
+    const ontology = new OntologyRegistry({ sources: [CatalogOntology] })
+    const reader = createAuthorizedObjectReader({
+      scope: createDelegatedCatalogScope(1_000_000, { includePremiumRoot: true }),
+      ontology,
+      objectStorage: new InMemoryObjectStorage(),
+    })
+    const view = getAuthorizedOntologyView(reader)
+
+    expect(view.getObjectTypeById(PremiumCustomer.id)).not.toBeNull()
+    expect(view.isValidLinkTarget(Customer.id, PremiumCustomer.id)).toBe(false)
+    expect(view.isValidLinkTarget([Customer.id, PremiumCustomer.id], PremiumCustomer.id)).toBe(true)
+  })
+
+  test("unions repeated selected definitions in deterministic ontology order", () => {
+    const ontology = new OntologyRegistry({ sources: [CatalogOntology] })
+    const view = createSelectedView(
+      ontology,
+      [
+        { nodeId: 2, objectTypeId: Proposal.id, propertyIds: ["title"] },
+        { nodeId: 1, objectTypeId: Proposal.id, propertyIds: ["id"] },
+        { nodeId: 4, objectTypeId: PremiumCustomer.id, propertyIds: ["tier"] },
+        { nodeId: 3, objectTypeId: Customer.id, propertyIds: ["id"] },
+      ],
+      [
+        {
+          nodeId: 4,
+          parentNodeId: 1,
+          sourceObjectTypeId: Proposal.id,
+          linkId: Proposal.l.customer.id,
+          targetObjectTypeId: PremiumCustomer.id,
+          propertyIds: ["privateNote"],
+        },
+        {
+          nodeId: 3,
+          parentNodeId: 1,
+          sourceObjectTypeId: Proposal.id,
+          linkId: Proposal.l.customer.id,
+          targetObjectTypeId: Customer.id,
+          propertyIds: ["note"],
+        },
+      ]
+    )
+
+    expect(view.listObjectTypes().map((objectType) => objectType.id)).toEqual([
+      Proposal.id,
+      Customer.id,
+      PremiumCustomer.id,
+    ])
+    const proposal = view.resolveObjectType(Proposal.id)
+    expect(proposal.properties.map((property) => property.id)).toEqual(["id", "title"])
+    expect(proposal.links[0]?.targetObjectTypeId).toEqual([Customer.id, PremiumCustomer.id])
+    expect(proposal.links[0]?.properties?.map((property) => property.id)).toEqual([
+      "note",
+      "privateNote",
+    ])
+  })
+
+  test("intersects stale selections with the current ontology and keeps writes closed", () => {
+    const ontology = new OntologyRegistry({ sources: [CatalogOntology] })
+    const view = createSelectedView(
+      ontology,
+      [
+        {
+          nodeId: 1,
+          objectTypeId: Proposal.id,
+          propertyIds: ["title", "removedProperty"],
+        },
+        { nodeId: 2, objectTypeId: Customer.id, propertyIds: ["id"] },
+        { nodeId: 3, objectTypeId: "RemovedType", propertyIds: ["id"] },
+      ],
+      [
+        {
+          nodeId: 2,
+          parentNodeId: 1,
+          sourceObjectTypeId: Proposal.id,
+          linkId: Proposal.l.customer.id,
+          targetObjectTypeId: Customer.id,
+          propertyIds: ["removedEdgeProperty"],
+        },
+        {
+          nodeId: 2,
+          parentNodeId: 1,
+          sourceObjectTypeId: Proposal.id,
+          linkId: "removedLink",
+          targetObjectTypeId: Customer.id,
+          propertyIds: [],
+        },
+      ]
+    )
+
+    const proposal = view.resolveObjectType(Proposal.id)
+    expect(proposal.properties.map((property) => property.id)).toEqual(["title"])
+    expect(proposal.links).toEqual([
+      expect.objectContaining({
+        id: "customer",
+        targetObjectTypeId: Customer.id,
+        properties: undefined,
+      }),
+    ])
+    expect(view.getObjectTypeById("RemovedType")).toBeNull()
+    expect(() => view.resolveObjectType("RemovedType")).toThrow("Unknown object type")
+    expect(() => view.getPrimaryPropertyId(Proposal.id)).toThrow(
+      "does not expose its primary property"
+    )
+  })
+
+  test("hides parent classification and incomplete vector search metadata", () => {
+    const SearchDocument = defineObjectType({
+      id: "SearchDocument",
+      name: "Search document",
+      properties: [
+        prop("id", "string", { required: true, primary: true }),
+        prop("title", "string", { query: { searchable: true, text: true } }),
+        prop("secret", "string", { query: { searchable: true, text: true } }),
+        prop(
+          "embedding",
+          { type: "array", items: "double" },
+          {
+            query: { searchable: true, vector: true },
+          }
+        ),
+      ],
+      search: {
+        title: "title",
+        vector: { property: "embedding", source: ["title", "secret"] },
+      },
+    })
+    const ontology = new OntologyRegistry({ sources: [CatalogOntology, SearchDocument] })
+    const view = createSelectedView(ontology, [
+      { nodeId: 1, objectTypeId: PremiumCustomer.id, propertyIds: ["tier"] },
+      {
+        nodeId: 2,
+        objectTypeId: SearchDocument.id,
+        propertyIds: ["id", "title", "embedding"],
+      },
+    ])
+
+    const premium = view.resolveObjectType(PremiumCustomer.id)
+    expect(premium.extends).toBeUndefined()
+    expect(premium.parents).toBeUndefined()
+    expect(view.listSubTypes(Customer.id)).toEqual([])
+    expect(view.isValidLinkTarget(Customer.id, PremiumCustomer.id)).toBe(false)
+    expect(view.resolveObjectType(SearchDocument.id).search).toEqual({ title: "title" })
+  })
+
+  test("pins one authorized reader across every object facade terminal", async () => {
+    const host = createHost()
+    const ontology = new OntologyRegistry({ sources: [CatalogOntology] })
+    const scope = createDelegatedCatalogScope()
+    const reader = createAuthorizedObjectReader({
+      scope,
+      ontology,
+      objectStorage: host.storage.objects,
+    })
+    let objectReaderReads = 0
+    const runtime = {
+      projectId: scope.execution.projectId,
+      broker: host.broker,
+      ontology,
+      actionRegistry: host.definitions.actions,
+      events: host.events,
+      storage: host.storage,
+      queues: host.queues,
+      runtimeAuthorization: scope.authorization,
+      get objectReader() {
+        objectReaderReads += 1
+        if (objectReaderReads > 1) {
+          throw new Error("Object facade re-read its authority after binding.")
+        }
+        return reader
+      },
+    } satisfies SixbRuntimeContext
+    const unavailableMutation = async (): Promise<never> => {
+      throw new Error("Mutation is unavailable in this read-only test.")
+    }
+    registerOntologyMutationRuntime(runtime, {
+      commitEdits: unavailableMutation,
+      replaceProjection: unavailableMutation,
+      finishProjection: unavailableMutation,
+      appendTelemetry: unavailableMutation,
+    })
+
+    // Regression proof: reconstructing the runtime with `{ ...runtime }` after binding reads the
+    // accessor a second time before any terminal runs and fails this test.
+    const objects = createObjectsRuntime<readonly [typeof CatalogOntology]>(
+      runtime,
+      scope.execution
+    )
+    const proposals = objects(Proposal)
+
+    expect(await proposals.get("proposal-1")).toBeNull()
+    expect((await proposals.list()).objects).toEqual([])
+    expect((await proposals.query().list()).objects).toEqual([])
+    expect((await objects.list({ objectTypeIds: [Proposal.id] })).objects).toEqual([])
+    expect(objects.listTypes().map((objectType) => objectType.id)).toEqual([
+      Proposal.id,
+      Customer.id,
+    ])
+    expect(objectReaderReads).toBe(1)
+  })
+
+  test("detaches the unrestricted catalog while preserving complete metadata", () => {
+    const host = createHost()
+    const sixb = createTestSixb(host)
+    const projected = sixb.objects.resolveType(Proposal.id)
+    const registered = host.definitions.ontology.resolveObjectType(Proposal.id)
+
+    expect(sixb.objects.listTypes()).toHaveLength(4)
+    expect(sixb.objects.getValueTypesById().has(UnusedValue.id)).toBe(true)
+    expect(projected).not.toBe(registered)
+    projected.name = "tampered"
+    expect(sixb.objects.resolveType(Proposal.id).name).toBe("Proposal")
+    expect(registered.name).toBe("Proposal")
+  })
+
+  test("preserves unresolved link references for unrestricted execution", () => {
+    const ExternalOwner = defineObjectType({
+      id: "ExternalOwner",
+      name: "External owner",
+      properties: [prop("id", "string", { required: true, primary: true })],
+      links: [link.ref("external", "External")],
+    })
+    const ontology = new OntologyRegistry({ sources: [ExternalOwner] })
+    const view = createAuthorizedOntologyView({ ontology, selection: { kind: "all" } })
+
+    expect(view.resolveObjectType(ExternalOwner.id).links).toEqual([
+      expect.objectContaining({ id: "external", targetObjectTypeId: "External" }),
+    ])
+    expect(view.isValidLinkTarget("External", "External")).toBe(true)
+  })
+})

--- a/packages/core/tests/delegated-action-admission.test.ts
+++ b/packages/core/tests/delegated-action-admission.test.ts
@@ -373,7 +373,7 @@ describe("delegated Action admission", () => {
     }
   })
 
-  test("keeps delegated Action metadata, runs, and polling closed before activation", async () => {
+  test("exposes inert delegated Action metadata while keeping runs and polling closed", async () => {
     const { runtimeHost, runtimeDeps } = await createFixture()
     const { runtime, scope } = createDelegatedRuntime(runtimeHost, {
       requestId: "closed-action-surfaces",
@@ -399,10 +399,16 @@ describe("delegated Action admission", () => {
 
     try {
       const actions = createActionsRuntime(runtime, scope.execution)
-      expect(actions.list()).toEqual([])
-      expect(actions.getById(approve.id)).toBeNull()
+      expect(actions.list().map((action) => action.id)).toEqual([approve.id])
+      expect(actions.getById(approve.id)?.phases.writeback).toBe(true)
+      expect(actions.getById(approve.id)?.binding).toEqual({
+        kind: "object",
+        objectTypeId: Proposal.id,
+      })
+      expect(actions.getById(reject.id)).toBeNull()
       expect(actions.listGlobal()).toEqual([])
-      expect(actions.listForType(Proposal)).toEqual([])
+      expect(actions.listForType(Proposal).map((action) => action.id)).toEqual([approve.id])
+      expect(actions.listForType(ArchivedProposal)).toEqual([])
       await expect(actions.runs.getById("guessed-run")).resolves.toBeNull()
       await expect(actions.runs.list()).resolves.toEqual({ runs: [], hasMore: false, total: 0 })
       await expect(waitForActionRun(runtime, { runId: "guessed-run" })).rejects.toThrow(

--- a/packages/server/src/routes/actions.ts
+++ b/packages/server/src/routes/actions.ts
@@ -1,4 +1,4 @@
-import type { ActionDefinition, SixbHostView } from "@sixb/core"
+import type { ActionDescriptor, SixbHostView } from "@sixb/core"
 import { schemaFieldsToJsonSchema } from "@sixb/core/internal/ontology"
 import type { Elysia } from "elysia"
 import { bearerSecurityRequirement } from "../auth/access-token-boundary"
@@ -15,13 +15,13 @@ import { ErrorResponseSchema } from "../schemas/common"
 import { handleRouteError } from "../utils/http"
 
 function serializeAction(
-  action: ActionDefinition
+  action: ActionDescriptor
 ): ReturnType<typeof ActionCatalogItemSchema.parse> {
   return ActionCatalogItemSchema.parse({
     id: action.id,
     name: action.id,
     description: action.description,
-    ...(action.binding.kind === "object" ? { objectTypeId: action.binding.objectType.id } : {}),
+    ...(action.binding.kind === "object" ? { objectTypeId: action.binding.objectTypeId } : {}),
     params: Object.entries(action.params).map(([id, config]) => ({
       id,
       name: id,
@@ -31,17 +31,12 @@ function serializeAction(
       description: config.description,
       semanticType: config.semanticType,
     })),
-    phases: {
-      validate: action.phases.validate.length > 0,
-      writeback: action.phases.writeback !== undefined,
-      edits: action.phases.edits !== undefined,
-      effects: action.phases.effects !== undefined,
-    },
+    phases: action.phases,
   })
 }
 
 function serializeActionDetail(
-  action: ActionDefinition,
+  action: ActionDescriptor,
   host: SixbHostView
 ): ReturnType<typeof ActionDetailSchema.parse> {
   return ActionDetailSchema.parse({

--- a/packages/server/tests/auth-guard.test.ts
+++ b/packages/server/tests/auth-guard.test.ts
@@ -323,7 +323,9 @@ describe("server auth guard", () => {
     expect(acceptedTelemetryRead.status).toBe(404)
     expect(acceptedActionRunDetail.status).toBe(404)
     expect(rejectedAuthManagement.status).toBe(403)
-    expect(rejectedRawWrite.status).toBe(403)
+    // The token crosses the bearer-capable route boundary, then the authority-scoped ontology
+    // deliberately makes an ObjectType without object.view indistinguishable from an unknown one.
+    expect(rejectedRawWrite.status).toBe(404)
   })
 
   test("returns a safe session shape", async () => {

--- a/packages/server/tests/authorization-routes.test.ts
+++ b/packages/server/tests/authorization-routes.test.ts
@@ -691,11 +691,10 @@ describe("authorized object routes", () => {
       })
     )
 
-    // `listObjectTypes` shows this principal nothing, so the write route must not answer 403 for a
-    // type that exists and 404 for one that does not — that difference is the type universe. The
-    // Primary-property lookup runs on the bound SDK for exactly this reason; point it back at
-    // the privileged `sixb` in the route and the second status returns to 404.
-    expect([registered.status, unregistered.status]).toEqual([403, 403])
+    // `listObjectTypes` shows this principal nothing. The authorized catalog therefore treats a
+    // hidden type exactly like an unknown type before the write runs, so neither status reveals
+    // whether the requested id belongs to the registered type universe.
+    expect([registered.status, unregistered.status]).toEqual([404, 404])
 
     const listed = await app.fetch(
       new Request("http://localhost/api/object-types", { headers: outsider.headers })


### PR DESCRIPTION
Part of #269 · Stack #547 · Parent: #501 · Next: #542

## Why

Shared pages need discoverable metadata without access to the host registry or executable Action definitions.

## What

- Project ObjectTypes, properties, links, link properties and referenced ValueTypes through the authorized reader.
- Intersect captured selections with current ontology; prune incomplete search/inheritance metadata.
- Return detached ontology metadata and inert Action descriptors: binding IDs, parameters and phase availability, never handlers.
- Require exact allowed Action/type pairs for delegated Action discovery.
- Enforce delegated metadata output budgets.

## Compatibility

- Preserve principal/trusted visibility rules and HTTP/OpenAPI response shapes.
- Keep Action dispatch separately authorized.
- Static metadata embedded in application bundles is non-confidential in V1.
- The delegated SDK remains closed until #542.

## Review order

1. Authorized ontology view and projection tests.
2. Action descriptors and execution-bound discovery.
3. Detachment, output-budget and HTTP compatibility regressions.

Preserves two focused commits; incorporates #541.
