### PR TITLE
tiktok: add Login Kit Display API support

### DIFF
--- a/connectors/tiktok/README.md
+++ b/connectors/tiktok/README.md
@@ -1,14 +1,23 @@
 # @sixb/connector-tiktok
 
-Read-only TikTok API for Business v1.3 connector for organic account data and Ads reporting.
-TikTok uses separate Organic API and Marketing API OAuth grants, so register one connector
-definition per API.
+Read-only connector for TikTok Display API, Business Account organic data, and Ads reporting.
+Each API has its own OAuth grant and app credentials, so register one connector definition per API.
 
 ## Register
 
 ```ts
 import { defineConnector } from "@sixb/core"
 import { tiktok } from "@sixb/connector-tiktok"
+
+export const tiktokDisplay = defineConnector(
+  "tiktok-display",
+  tiktok({
+    api: "display",
+    clientKey: process.env.TIKTOK_CLIENT_KEY!,
+    clientSecret: process.env.TIKTOK_CLIENT_SECRET!,
+    scopes: ["user.info.basic", "user.info.profile", "user.info.stats", "video.list"],
+  })
+)
 
 export const tiktokOrganic = defineConnector(
   "tiktok-organic",
@@ -30,17 +39,35 @@ export const tiktokAds = defineConnector(
 )
 ```
 
-For the organic grant, copy the complete account-holder authorization URL from the TikTok app
-portal. Register Sixb's callback URL with a trailing slash; TikTok requires an exact HTTPS redirect
-URI ending in `/`. The Marketing API grant uses a long-lived, non-refreshable access token.
+| `api` | TikTok product | Credentials | Data |
+| --- | --- | --- | --- |
+| `display` | Login Kit + Display API | Client key / secret | Authorized user profile, public videos, public counters |
+| `organic` | Business Accounts API | Client ID / secret + portal authorization URL | Business profile insights, posts, comments |
+| `marketing` | Marketing API | App ID / secret | Advertisers, campaigns, ad groups, ads, reports |
 
-TikTok does not document PKCE for either flow. Sixb still sends its required `code_challenge` on
-the authorization request, but the connector does not send an undocumented `code_verifier` to the
-token endpoints. Sixb's one-use state and callback browser binding remain enforced.
+Display defaults to `user.info.basic` and `video.list`. Request `user.info.profile` and
+`user.info.stats` only after TikTok approves those scopes for the app. Display exposes video
+`comment_count`, but not comment contents.
+
+For Business Organic, copy the complete account-holder authorization URL from the TikTok app
+portal. Register Sixb's callback URL with a trailing slash; this flow requires an exact HTTPS
+redirect URI ending in `/`. Marketing uses a long-lived, non-refreshable access token.
+
+Login Kit Web does not use PKCE; TikTok documents it only for mobile and desktop. The two Business
+flows retain Sixb's framework challenge on the authorization request without sending an
+undocumented verifier. Sixb's one-use state and callback browser binding remain enforced.
 
 ## Client API
 
-Organic account:
+Display account:
+
+| Client method | Endpoint |
+| --- | --- |
+| `client.profile.get(...)` | `GET /v2/user/info/` |
+| `client.videos.list(...)` / `.listAll(...)` | `POST /v2/video/list/` |
+| `client.videos.query(...)` | `POST /v2/video/query/` |
+
+Business Organic account:
 
 | Client method | Endpoint |
 | --- | --- |
@@ -63,7 +90,14 @@ Every resource is scoped to the account selected during the Sixb connection flow
 retain TikTok's field names and values; list helpers only normalize pagination envelopes.
 
 ```ts
-for await (const post of organic.posts.listAll({
+for await (const video of display.videos.listAll({
+  fields: ["id", "create_time", "view_count", "like_count", "comment_count", "share_count"],
+  maxCount: 20,
+})) {
+  // persist or transform the TikTok wire object
+}
+
+for await (const post of businessOrganic.posts.listAll({
   fields: ["item_id", "caption", "create_time", "video_views", "likes"],
   maxCount: 20,
 })) {
@@ -86,10 +120,10 @@ for await (const row of ads.reports.runAll({
 
 ## Operational notes
 
-- Organic access tokens expire after one day and are refreshed automatically. TikTok refresh
-  tokens expire after one year, after which the account must be reauthorized. Sixb's current OAuth
-  credential contract does not store a separate refresh-token expiry timestamp, so expiry is
-  detected from TikTok's terminal refresh response rather than scheduled in advance.
+- Display and Business Organic access tokens expire after one day and are refreshed automatically.
+  Their refresh tokens expire after one year, after which the account must be reauthorized. Sixb's
+  current OAuth credential contract does not store a separate refresh-token expiry timestamp, so
+  expiry is detected from TikTok's terminal refresh response rather than scheduled in advance.
 - Marketing API access tokens are long-lived and have no refresh endpoint. A rejected token
   therefore produces a terminal reauthorization error.
 - Profile insight windows are limited to 60 days; post statistics stop updating after 365 days.

--- a/connectors/tiktok/package.json
+++ b/connectors/tiktok/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sixb/connector-tiktok",
   "version": "0.1.0",
-  "description": "TikTok organic account and Ads reporting connector for Sixb",
+  "description": "TikTok Display, business organic, and Ads reporting connector for Sixb",
   "keywords": [
     "sixb",
     "bun",

--- a/connectors/tiktok/src/display/client.ts
+++ b/connectors/tiktok/src/display/client.ts
@@ -1,0 +1,15 @@
+import type { TiktokDisplayClient } from "../types/client"
+import type { TiktokConnectedAccount } from "../types/common"
+import type { TiktokDisplayHttp } from "./http"
+import { createDisplayProfileApi, createDisplayVideosApi } from "./resources"
+
+export function createDisplayClient(
+  http: TiktokDisplayHttp,
+  account: TiktokConnectedAccount<"tiktok-account">
+): TiktokDisplayClient {
+  return {
+    account,
+    profile: createDisplayProfileApi(http),
+    videos: createDisplayVideosApi(http),
+  }
+}

--- a/connectors/tiktok/src/display/http.ts
+++ b/connectors/tiktok/src/display/http.ts
@@ -1,0 +1,172 @@
+import { type RestClient, rest } from "@sixb/connector-rest"
+import type { ConnectorContext, ConnectorTokenSource } from "@sixb/core"
+import { assertNonEmpty, assertNonNegativeInteger, TiktokApiError } from "../http"
+import type { TiktokResponseMetadata } from "../types/common"
+import type { TiktokDisplayConnectorOptions } from "../types/options"
+
+export const TIKTOK_DISPLAY_API_BASE_URL = "https://open.tiktokapis.com/v2/"
+
+export interface TiktokDisplayApiResult<T> {
+  readonly data: T
+  readonly logId?: string
+}
+
+interface TiktokDisplayEnvelope<T> {
+  readonly data: T
+  readonly error: {
+    readonly code: string
+    readonly message: string
+    readonly log_id?: string
+  }
+}
+
+export class TiktokDisplayHttp {
+  constructor(
+    private readonly http: RestClient,
+    private readonly tokenSource: ConnectorTokenSource,
+    private readonly onResponse?: (metadata: TiktokResponseMetadata) => Promise<void> | void
+  ) {}
+
+  get<T>(path: string, fields: readonly string[]): Promise<TiktokDisplayApiResult<T>> {
+    return this.request<T>("GET", withFields(path, fields))
+  }
+
+  post<T>(
+    path: string,
+    fields: readonly string[],
+    body: unknown
+  ): Promise<TiktokDisplayApiResult<T>> {
+    return this.request<T>("POST", withFields(path, fields), body)
+  }
+
+  private async request<T>(
+    method: "GET" | "POST",
+    path: string,
+    body?: unknown
+  ): Promise<TiktokDisplayApiResult<T>> {
+    for (let authorizationAttempt = 0; ; authorizationAttempt += 1) {
+      const token = await this.tokenSource.get()
+      const headers = { Authorization: `Bearer ${token.accessToken}` }
+      const response =
+        method === "GET"
+          ? await this.http.get(path, { headers })
+          : await this.http.post(path, body, { headers }, { idempotent: true })
+
+      const parsed = await readDisplayResponse<T>(response)
+      await this.onResponse?.(responseMetadata(response, path, method, parsed.logId))
+
+      if (parsed.error && authorizationAttempt === 0 && isTokenFailure(parsed.error)) {
+        token.invalidate()
+        continue
+      }
+      if (parsed.error) throw parsed.error
+      return { data: parsed.data as T, logId: parsed.logId }
+    }
+  }
+}
+
+export async function createTiktokDisplayHttp(
+  context: ConnectorContext,
+  options: TiktokDisplayConnectorOptions,
+  tokenSource: ConnectorTokenSource
+): Promise<TiktokDisplayHttp> {
+  const maxRetries = options.retry?.maxRetries ?? 2
+  assertNonNegativeInteger(maxRetries, "retry.maxRetries")
+
+  const connector = rest({
+    baseUrl: normalizeBaseUrl(options.baseUrl ?? TIKTOK_DISPLAY_API_BASE_URL),
+    headers: { Accept: "application/json" },
+    retry: { maxRetries },
+    timeoutMs: options.timeoutMs,
+  })
+
+  return new TiktokDisplayHttp(await connector.connect(context), tokenSource, options.onResponse)
+}
+
+function withFields(path: string, fields: readonly string[]): string {
+  if (fields.length === 0) {
+    throw new Error("[SixbTikTok] fields must contain at least one field.")
+  }
+  const url = new URL(path, "https://sixb.invalid/")
+  url.searchParams.set("fields", fields.join(","))
+  return `${url.pathname.replace(/^\//, "")}${url.search}`
+}
+
+async function readDisplayResponse<T>(response: Response): Promise<{
+  readonly data?: T
+  readonly logId?: string
+  readonly error?: TiktokApiError
+}> {
+  const rawBody = response.status === 204 ? "" : await response.text()
+  const envelope = parseEnvelope<T>(rawBody)
+  const logId = envelope?.error.log_id
+
+  if (!response.ok || !envelope || envelope.error.code !== "ok") {
+    return {
+      logId,
+      error: new TiktokApiError(
+        response.status,
+        envelope?.error.code,
+        envelope?.error.message,
+        logId,
+        rawBody,
+        response.headers
+      ),
+    }
+  }
+
+  return { data: envelope.data, logId }
+}
+
+function parseEnvelope<T>(rawBody: string): TiktokDisplayEnvelope<T> | undefined {
+  let value: unknown
+  try {
+    value = JSON.parse(rawBody)
+  } catch {
+    return undefined
+  }
+  if (!isRecord(value) || !("data" in value) || !isRecord(value.error)) return undefined
+  if (typeof value.error.code !== "string" || typeof value.error.message !== "string") {
+    return undefined
+  }
+  return {
+    data: value.data as T,
+    error: {
+      code: value.error.code,
+      message: value.error.message,
+      log_id: typeof value.error.log_id === "string" ? value.error.log_id : undefined,
+    },
+  }
+}
+
+function responseMetadata(
+  response: Response,
+  path: string,
+  method: "GET" | "POST",
+  logId: string | undefined
+): TiktokResponseMetadata {
+  return {
+    path: new URL(path, "https://sixb.invalid/").pathname,
+    method,
+    status: response.status,
+    logId: logId ?? response.headers.get("x-tt-logid") ?? undefined,
+  }
+}
+
+function isTokenFailure(error: TiktokApiError): boolean {
+  return (
+    error.status === 401 ||
+    /access[ _-]?token.*(?:invalid|expired)|(?:invalid|expired).*access[ _-]?token/i.test(
+      `${error.code ?? ""} ${error.providerMessage ?? ""}`
+    )
+  )
+}
+
+function normalizeBaseUrl(value: string): string {
+  assertNonEmpty(value, "baseUrl")
+  return value.endsWith("/") ? value : `${value}/`
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/connectors/tiktok/src/display/oauth.ts
+++ b/connectors/tiktok/src/display/oauth.ts
@@ -1,0 +1,239 @@
+import {
+  type ConnectorContext,
+  type ConnectorOAuth2Authentication,
+  type ConnectorOAuthCredentials,
+  ConnectorOAuthError,
+} from "@sixb/core"
+import { assertNonEmpty } from "../http"
+import type { TiktokDisplayConnectorOptions } from "../types/options"
+import { TIKTOK_DISPLAY_API_BASE_URL } from "./http"
+
+const DISPLAY_AUTHORIZATION_URL = "https://www.tiktok.com/v2/auth/authorize/"
+const DISPLAY_DEFAULT_SCOPES = ["user.info.basic", "video.list"] as const
+
+type OAuthOperation = "exchange" | "refresh" | "revoke"
+
+export function createDisplayAuthentication(
+  options: TiktokDisplayConnectorOptions
+): ConnectorOAuth2Authentication {
+  return {
+    type: "oauth2",
+    authorizationUrl(context, input) {
+      const url = new URL(DISPLAY_AUTHORIZATION_URL)
+      url.searchParams.set("client_key", options.clientKey)
+      url.searchParams.set("response_type", "code")
+      url.searchParams.set("scope", (options.scopes ?? DISPLAY_DEFAULT_SCOPES).join(","))
+      url.searchParams.set("redirect_uri", displayRedirectUri(context.redirectUri))
+      url.searchParams.set("state", input.state)
+      if (options.disableAutoAuth) url.searchParams.set("disable_auto_auth", "1")
+      // Login Kit Web relies on state for CSRF protection. TikTok only documents PKCE for its
+      // mobile and desktop flows, so Sixb's framework challenge is intentionally not forwarded.
+      return url
+    },
+    async exchangeCode(context, input) {
+      const data = await displayOAuthRequest(
+        context,
+        options,
+        "oauth/token/",
+        {
+          client_key: options.clientKey,
+          client_secret: options.clientSecret,
+          code: input.code,
+          grant_type: "authorization_code",
+          redirect_uri: displayRedirectUri(context.redirectUri),
+        },
+        "exchange"
+      )
+      return displayCredentials(data)
+    },
+    async refresh(context, credentials) {
+      if (!credentials.refreshToken) {
+        throw new ConnectorOAuthError(
+          "terminal",
+          "[SixbTikTok] The TikTok Display grant has no refresh token; reauthorization is required."
+        )
+      }
+      const data = await displayOAuthRequest(
+        context,
+        options,
+        "oauth/token/",
+        {
+          client_key: options.clientKey,
+          client_secret: options.clientSecret,
+          grant_type: "refresh_token",
+          refresh_token: credentials.refreshToken,
+        },
+        "refresh"
+      )
+      return displayCredentials(data)
+    },
+    async revoke(context, credentials) {
+      try {
+        await displayOAuthRequest(
+          context,
+          options,
+          "oauth/revoke/",
+          {
+            client_key: options.clientKey,
+            client_secret: options.clientSecret,
+            token: credentials.accessToken,
+          },
+          "revoke",
+          true
+        )
+      } catch (error) {
+        if (error instanceof ConnectorOAuthError && isAlreadyRevoked(error.message)) return
+        throw error
+      }
+    },
+  }
+}
+
+function displayRedirectUri(redirectUri: string): string {
+  const url = new URL(redirectUri)
+  if (url.protocol !== "https:" || url.search || url.hash) {
+    throw new Error(
+      "[SixbTikTok] The Display redirect URI must use HTTPS without a query or fragment."
+    )
+  }
+  const normalized = url.toString()
+  if (normalized.length >= 512) {
+    throw new Error("[SixbTikTok] The Display redirect URI must be shorter than 512 characters.")
+  }
+  return normalized
+}
+
+function displayCredentials(data: unknown): ConnectorOAuthCredentials {
+  if (!isRecord(data)) throw malformedTokenResponse("response")
+  requiredString(data.open_id, "open_id")
+  const accessToken = requiredString(data.access_token, "access_token")
+  const refreshToken = requiredString(data.refresh_token, "refresh_token")
+  const expiresIn = requiredPositiveNumber(data.expires_in, "expires_in")
+  requiredPositiveNumber(data.refresh_expires_in, "refresh_expires_in")
+  const scope = requiredString(data.scope, "scope")
+  const tokenType = requiredString(data.token_type, "token_type")
+  return {
+    accessToken,
+    refreshToken,
+    tokenType,
+    scopes: splitScopes(scope),
+    expiresAt: new Date(Date.now() + expiresIn * 1000),
+  }
+}
+
+async function displayOAuthRequest(
+  context: ConnectorContext,
+  options: TiktokDisplayConnectorOptions,
+  path: string,
+  body: Readonly<Record<string, string>>,
+  operation: OAuthOperation,
+  allowEmptySuccess = false
+): Promise<unknown> {
+  let response: Response
+  try {
+    const signal = options.timeoutMs
+      ? AbortSignal.any([context.signal, AbortSignal.timeout(options.timeoutMs)])
+      : context.signal
+    response = await fetch(new URL(path, normalizedBaseUrl(options.baseUrl)), {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams(body),
+      signal,
+    })
+  } catch (error) {
+    throw new ConnectorOAuthError(
+      "ambiguous",
+      `[SixbTikTok] TikTok Display OAuth ${operation} ended without a provider response.`,
+      { cause: error }
+    )
+  }
+
+  let rawBody: string
+  try {
+    rawBody = await response.text()
+  } catch (error) {
+    throw new ConnectorOAuthError(
+      "ambiguous",
+      `[SixbTikTok] TikTok Display OAuth ${operation} response could not be read.`,
+      { cause: error }
+    )
+  }
+
+  const parsed = parseJsonRecord(rawBody)
+  const providerError =
+    (typeof parsed?.error_description === "string" && parsed.error_description) ||
+    (typeof parsed?.error === "string" && parsed.error)
+  if (!response.ok || providerError) {
+    const detail = providerError || `HTTP ${response.status}`
+    const logId = typeof parsed?.log_id === "string" ? ` (log ${parsed.log_id})` : ""
+    throw new ConnectorOAuthError(
+      response.status === 429 || response.status >= 500 ? "retryable" : "terminal",
+      `[SixbTikTok] TikTok Display OAuth ${operation} failed: ${detail}${logId}.`
+    )
+  }
+
+  if (!rawBody.trim() && allowEmptySuccess) return {}
+  if (!parsed) {
+    throw new ConnectorOAuthError(
+      "ambiguous",
+      `[SixbTikTok] TikTok Display OAuth ${operation} returned a malformed success response.`
+    )
+  }
+  return parsed
+}
+
+function normalizedBaseUrl(baseUrl: string | undefined): string {
+  const value = baseUrl ?? TIKTOK_DISPLAY_API_BASE_URL
+  assertNonEmpty(value, "baseUrl")
+  return value.endsWith("/") ? value : `${value}/`
+}
+
+function parseJsonRecord(rawBody: string): Record<string, unknown> | undefined {
+  if (!rawBody) return undefined
+  try {
+    const value: unknown = JSON.parse(rawBody)
+    return isRecord(value) ? value : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || !value.trim()) throw malformedTokenResponse(field)
+  return value
+}
+
+function requiredPositiveNumber(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw malformedTokenResponse(field)
+  }
+  return value
+}
+
+function malformedTokenResponse(field: string): ConnectorOAuthError {
+  return new ConnectorOAuthError(
+    "ambiguous",
+    `[SixbTikTok] TikTok returned an invalid OAuth token field '${field}'.`
+  )
+}
+
+function splitScopes(value: string): readonly string[] | undefined {
+  const scopes = value
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter(Boolean)
+  return scopes.length ? scopes : undefined
+}
+
+function isAlreadyRevoked(message: string): boolean {
+  return /(?:already revoked|invalid|expired|not exist).*token|token.*(?:already revoked|invalid|expired|not exist)/i.test(
+    message
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/connectors/tiktok/src/display/resources.ts
+++ b/connectors/tiktok/src/display/resources.ts
@@ -1,0 +1,116 @@
+import { assertNonEmpty, assertPositiveIntegerInRange } from "../http"
+import { paginateCursor } from "../pagination"
+import type { TiktokCursorPage } from "../types/common"
+import type {
+  TiktokDisplayProfileApi,
+  TiktokDisplayUser,
+  TiktokDisplayUserField,
+  TiktokDisplayVideo,
+  TiktokDisplayVideoField,
+  TiktokDisplayVideosApi,
+  TiktokDisplayVideosListQuery,
+  TiktokDisplayVideosQuery,
+} from "../types/display"
+import type { TiktokDisplayHttp } from "./http"
+
+const DEFAULT_USER_FIELDS = ["open_id", "display_name", "avatar_url"] as const
+const DEFAULT_VIDEO_FIELDS = [
+  "id",
+  "create_time",
+  "cover_image_url",
+  "share_url",
+  "video_description",
+  "duration",
+  "height",
+  "width",
+  "title",
+  "embed_html",
+  "embed_link",
+  "like_count",
+  "comment_count",
+  "share_count",
+  "view_count",
+] as const satisfies readonly TiktokDisplayVideoField[]
+
+interface UserInfoData {
+  readonly user: TiktokDisplayUser
+}
+
+interface VideoListData {
+  readonly videos?: readonly TiktokDisplayVideo[]
+  readonly cursor?: number
+  readonly has_more?: boolean
+}
+
+interface VideoQueryData {
+  readonly videos?: readonly TiktokDisplayVideo[]
+}
+
+export function createDisplayProfileApi(http: TiktokDisplayHttp): TiktokDisplayProfileApi {
+  return {
+    async get(query) {
+      return getDisplayProfile(http, query?.fields)
+    },
+  }
+}
+
+export async function getDisplayProfile(
+  http: TiktokDisplayHttp,
+  fields: readonly TiktokDisplayUserField[] = DEFAULT_USER_FIELDS
+): Promise<TiktokDisplayUser> {
+  const result = await http.get<UserInfoData>("user/info/", fields)
+  return result.data.user
+}
+
+export function createDisplayVideosApi(http: TiktokDisplayHttp): TiktokDisplayVideosApi {
+  const list = (
+    query: TiktokDisplayVideosListQuery | undefined,
+    cursor = query?.cursor
+  ): Promise<TiktokCursorPage<TiktokDisplayVideo>> => listVideos(http, query, cursor)
+
+  return {
+    list,
+    listAll(query) {
+      return paginateCursor((cursor) => list(query, cursor), query?.cursor)
+    },
+    async query(query) {
+      validateVideoQuery(query)
+      const result = await http.post<VideoQueryData>(
+        "video/query/",
+        query.fields ?? DEFAULT_VIDEO_FIELDS,
+        { filters: { video_ids: query.videoIds } }
+      )
+      return result.data.videos ?? []
+    },
+  }
+}
+
+async function listVideos(
+  http: TiktokDisplayHttp,
+  query: TiktokDisplayVideosListQuery | undefined,
+  cursor: number | undefined
+): Promise<TiktokCursorPage<TiktokDisplayVideo>> {
+  assertPositiveIntegerInRange(query?.maxCount, "maxCount", 20)
+  const result = await http.post<VideoListData>(
+    "video/list/",
+    query?.fields ?? DEFAULT_VIDEO_FIELDS,
+    compactBody({ cursor, max_count: query?.maxCount })
+  )
+  return {
+    items: result.data.videos ?? [],
+    hasMore: result.data.has_more ?? false,
+    nextCursor: result.data.cursor,
+    requestId: result.logId,
+  }
+}
+
+function validateVideoQuery(query: TiktokDisplayVideosQuery): void {
+  if (query.videoIds.length === 0 || query.videoIds.length > 20) {
+    throw new Error("[SixbTikTok] videoIds must contain between one and 20 IDs.")
+  }
+  for (const videoId of query.videoIds) assertNonEmpty(videoId, "videoIds")
+}
+
+function compactBody(value: Readonly<Record<string, unknown>>): Readonly<Record<string, unknown>> {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined))
+}

--- a/connectors/tiktok/src/http.ts
+++ b/connectors/tiktok/src/http.ts
@@ -23,7 +23,7 @@ export class TiktokApiError extends Error {
 
   constructor(
     readonly status: number,
-    readonly code: number | undefined,
+    readonly code: number | string | undefined,
     readonly providerMessage: string | undefined,
     readonly requestId: string | undefined,
     readonly rawBody: string,
@@ -129,7 +129,10 @@ export function withTiktokQuery(path: string, query: TiktokQuery): string {
   return search ? `${path}?${search}` : path
 }
 
-export function assertNonEmpty(value: string, field: string): void {
+export function assertNonEmpty(
+  value: string | null | undefined,
+  field: string
+): asserts value is string {
   if (!value?.trim()) {
     throw new Error(`[SixbTikTok] ${field} must not be empty.`)
   }
@@ -246,7 +249,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function formatApiError(
   status: number,
-  code: number | undefined,
+  code: number | string | undefined,
   providerMessage: string | undefined,
   requestId: string | undefined
 ): string {

--- a/connectors/tiktok/src/index.ts
+++ b/connectors/tiktok/src/index.ts
@@ -2,6 +2,7 @@ export { TiktokApiError } from "./http"
 export type {
   TiktokAdsConnector,
   TiktokConnector,
+  TiktokDisplayConnector,
   TiktokOrganicConnector,
 } from "./tiktok"
 export { tiktok } from "./tiktok"

--- a/connectors/tiktok/src/oauth.ts
+++ b/connectors/tiktok/src/oauth.ts
@@ -4,6 +4,7 @@ import {
   type ConnectorOAuthCredentials,
   ConnectorOAuthError,
 } from "@sixb/core"
+import { createDisplayAuthentication } from "./display/oauth"
 import { assertNonEmpty, TIKTOK_API_BASE_URL } from "./http"
 import type {
   TiktokAdsConnectorOptions,
@@ -25,9 +26,9 @@ type OAuthOperation = "exchange" | "refresh" | "revoke"
 export function createTiktokAuthentication(
   options: TiktokConnectorOptions
 ): ConnectorOAuth2Authentication {
-  return options.api === "organic"
-    ? createOrganicAuthentication(options)
-    : createMarketingAuthentication(options)
+  if (options.api === "display") return createDisplayAuthentication(options)
+  if (options.api === "organic") return createOrganicAuthentication(options)
+  return createMarketingAuthentication(options)
 }
 
 export function organicRedirectUri(redirectUri: string): string {

--- a/connectors/tiktok/src/tiktok.ts
+++ b/connectors/tiktok/src/tiktok.ts
@@ -5,20 +5,26 @@ import type {
   OAuthConnectorAdapter,
 } from "@sixb/core"
 import { createAdsClient } from "./ads/client"
+import { createDisplayClient } from "./display/client"
+import { createTiktokDisplayHttp } from "./display/http"
+import { getDisplayProfile } from "./display/resources"
 import { assertNonEmpty, createTiktokHttp, fixedTokenSource } from "./http"
 import { createTiktokAuthentication } from "./oauth"
 import { createOrganicClient } from "./organic/client"
-import type { TiktokAdsClient, TiktokOrganicClient } from "./types/client"
+import type { TiktokAdsClient, TiktokDisplayClient, TiktokOrganicClient } from "./types/client"
+import type { TiktokDisplayUser } from "./types/display"
 import type {
   TiktokAdsConnectorOptions,
   TiktokConnectorOptions,
+  TiktokDisplayConnectorOptions,
   TiktokOrganicConnectorOptions,
 } from "./types/options"
 import type { TiktokOrganicProfile } from "./types/organic"
 
 export type TiktokOrganicConnector = OAuthConnectorAdapter<"tiktok", TiktokOrganicClient>
+export type TiktokDisplayConnector = OAuthConnectorAdapter<"tiktok", TiktokDisplayClient>
 export type TiktokAdsConnector = OAuthConnectorAdapter<"tiktok", TiktokAdsClient>
-export type TiktokConnector = TiktokOrganicConnector | TiktokAdsConnector
+export type TiktokConnector = TiktokDisplayConnector | TiktokOrganicConnector | TiktokAdsConnector
 
 interface OrganicTokenInfo {
   readonly app_id?: string
@@ -33,12 +39,29 @@ interface AdvertiserListData {
   }[]
 }
 
-/** Create a managed TikTok connector for one of TikTok's two distinct OAuth grants. */
+/** Create a managed TikTok connector for one of TikTok's three distinct OAuth grants. */
+export function tiktok(options: TiktokDisplayConnectorOptions): TiktokDisplayConnector
 export function tiktok(options: TiktokOrganicConnectorOptions): TiktokOrganicConnector
 export function tiktok(options: TiktokAdsConnectorOptions): TiktokAdsConnector
 export function tiktok(options: TiktokConnectorOptions): TiktokConnector {
   validateOptions(options)
   const authentication = createTiktokAuthentication(options)
+
+  if (options.api === "display") {
+    return {
+      type: "tiktok",
+      authentication,
+      discoverAccounts: (context, credentials) =>
+        discoverDisplayAccount(context, options, credentials),
+      async connect(context) {
+        const http = await createTiktokDisplayHttp(context, options, context.tokenSource)
+        return createDisplayClient(http, {
+          type: "tiktok-account",
+          ...context.account,
+        })
+      },
+    }
+  }
 
   if (options.api === "organic") {
     return {
@@ -68,6 +91,29 @@ export function tiktok(options: TiktokConnectorOptions): TiktokConnector {
       })
     },
   }
+}
+
+async function discoverDisplayAccount(
+  context: ConnectorContext,
+  options: TiktokDisplayConnectorOptions,
+  credentials: ConnectorOAuthCredentials
+): Promise<readonly ConnectorAccountCandidate[]> {
+  const http = await createTiktokDisplayHttp(
+    context,
+    options,
+    fixedTokenSource(credentials.accessToken)
+  )
+  const profile: TiktokDisplayUser = await getDisplayProfile(http)
+  const id = profile.open_id
+  assertNonEmpty(id, "open_id")
+  return [
+    {
+      id,
+      label: profile.display_name || profile.username || id,
+      description: profile.username ? `@${profile.username}` : profile.bio_description,
+      avatarUrl: profile.avatar_url,
+    },
+  ]
 }
 
 async function discoverOrganicAccount(
@@ -128,6 +174,17 @@ function validateOptions(options: TiktokConnectorOptions): void {
     assertNonEmpty(options.clientId, "clientId")
     assertNonEmpty(options.clientSecret, "clientSecret")
     assertNonEmpty(options.authorizationUrl, "authorizationUrl")
+    return
+  }
+
+  if (options.api === "display") {
+    assertNonEmpty(options.clientKey, "clientKey")
+    assertNonEmpty(options.clientSecret, "clientSecret")
+    const scopes = options.scopes
+    if (scopes?.length === 0) {
+      throw new Error("[SixbTikTok] scopes must contain at least one scope.")
+    }
+    for (const scope of scopes ?? []) assertNonEmpty(scope, "scopes")
     return
   }
 

--- a/connectors/tiktok/src/types/client.ts
+++ b/connectors/tiktok/src/types/client.ts
@@ -6,6 +6,7 @@ import type {
   TiktokReportsApi,
 } from "./ads"
 import type { TiktokConnectedAccount } from "./common"
+import type { TiktokDisplayProfileApi, TiktokDisplayVideosApi } from "./display"
 import type {
   TiktokOrganicCommentsApi,
   TiktokOrganicPostsApi,
@@ -19,6 +20,12 @@ export interface TiktokOrganicClient {
   readonly comments: TiktokOrganicCommentsApi
 }
 
+export interface TiktokDisplayClient {
+  readonly account: TiktokConnectedAccount<"tiktok-account">
+  readonly profile: TiktokDisplayProfileApi
+  readonly videos: TiktokDisplayVideosApi
+}
+
 export interface TiktokAdsClient {
   readonly account: TiktokConnectedAccount<"ad-account">
   readonly adAccount: TiktokAdAccountApi
@@ -28,4 +35,4 @@ export interface TiktokAdsClient {
   readonly reports: TiktokReportsApi
 }
 
-export type TiktokClient = TiktokOrganicClient | TiktokAdsClient
+export type TiktokClient = TiktokDisplayClient | TiktokOrganicClient | TiktokAdsClient

--- a/connectors/tiktok/src/types/common.ts
+++ b/connectors/tiktok/src/types/common.ts
@@ -1,4 +1,4 @@
-export type TiktokApi = "organic" | "marketing"
+export type TiktokApi = "display" | "organic" | "marketing"
 
 export type TiktokAccountType = "tiktok-account" | "ad-account"
 

--- a/connectors/tiktok/src/types/display.ts
+++ b/connectors/tiktok/src/types/display.ts
@@ -1,0 +1,107 @@
+import type { TiktokCursorPage, TiktokExtensible } from "./common"
+
+export type TiktokDisplayScope = TiktokExtensible<
+  "user.info.basic" | "user.info.profile" | "user.info.stats" | "video.list"
+>
+
+export type TiktokDisplayUserField =
+  | "open_id"
+  | "union_id"
+  | "avatar_url"
+  | "avatar_url_100"
+  | "avatar_large_url"
+  | "display_name"
+  | "bio_description"
+  | "profile_deep_link"
+  | "is_verified"
+  | "username"
+  | "follower_count"
+  | "following_count"
+  | "likes_count"
+  | "video_count"
+
+export interface TiktokDisplayUser {
+  readonly open_id?: string
+  readonly union_id?: string
+  readonly avatar_url?: string
+  readonly avatar_url_100?: string
+  readonly avatar_large_url?: string
+  readonly display_name?: string
+  readonly bio_description?: string
+  readonly profile_deep_link?: string
+  readonly is_verified?: boolean
+  readonly username?: string
+  readonly follower_count?: number
+  readonly following_count?: number
+  readonly likes_count?: number
+  readonly video_count?: number
+  readonly [field: string]: unknown
+}
+
+export interface TiktokDisplayProfileQuery {
+  /** Defaults to fields covered by `user.info.basic`. */
+  readonly fields?: readonly TiktokDisplayUserField[]
+}
+
+export type TiktokDisplayVideoField =
+  | "id"
+  | "create_time"
+  | "cover_image_url"
+  | "share_url"
+  | "video_description"
+  | "duration"
+  | "height"
+  | "width"
+  | "title"
+  | "embed_html"
+  | "embed_link"
+  | "like_count"
+  | "comment_count"
+  | "share_count"
+  | "view_count"
+
+export interface TiktokDisplayVideo {
+  readonly id: string
+  /** UTC Unix timestamp in seconds. */
+  readonly create_time?: number
+  readonly cover_image_url?: string
+  readonly share_url?: string
+  readonly video_description?: string
+  readonly duration?: number
+  readonly height?: number
+  readonly width?: number
+  readonly title?: string
+  readonly embed_html?: string
+  readonly embed_link?: string
+  readonly like_count?: number
+  readonly comment_count?: number
+  readonly share_count?: number
+  readonly view_count?: number
+  readonly [field: string]: unknown
+}
+
+export interface TiktokDisplayVideosListQuery {
+  /** Defaults to all currently documented video fields. */
+  readonly fields?: readonly TiktokDisplayVideoField[]
+  /** Cursor from `nextCursor`, expressed as Unix time in milliseconds. */
+  readonly cursor?: number
+  /** 1-20. Defaults to TikTok's page size. */
+  readonly maxCount?: number
+}
+
+export interface TiktokDisplayVideosQuery {
+  /** One to 20 video IDs owned by the authorized user. */
+  readonly videoIds: readonly string[]
+  /** Defaults to all currently documented video fields. */
+  readonly fields?: readonly TiktokDisplayVideoField[]
+}
+
+export interface TiktokDisplayProfileApi {
+  get(query?: TiktokDisplayProfileQuery): Promise<TiktokDisplayUser>
+}
+
+export interface TiktokDisplayVideosApi {
+  list(query?: TiktokDisplayVideosListQuery): Promise<TiktokCursorPage<TiktokDisplayVideo>>
+  listAll(query?: TiktokDisplayVideosListQuery): AsyncIterable<TiktokDisplayVideo>
+  query(query: TiktokDisplayVideosQuery): Promise<readonly TiktokDisplayVideo[]>
+}

--- a/connectors/tiktok/src/types/index.ts
+++ b/connectors/tiktok/src/types/index.ts
@@ -1,5 +1,6 @@
 export type * from "./ads"
 export type * from "./client"
 export type * from "./common"
+export type * from "./display"
 export type * from "./options"
 export type * from "./organic"

--- a/connectors/tiktok/src/types/options.ts
+++ b/connectors/tiktok/src/types/options.ts
@@ -1,11 +1,23 @@
 import type { TiktokResponseMetadata, TiktokRetryOptions } from "./common"
+import type { TiktokDisplayScope } from "./display"
 
 interface TiktokConnectorOptionsBase {
-  /** TikTok Business API base URL. Override only for compatible proxies and tests. */
+  /** API base URL for the selected TikTok API. Override only for compatible proxies and tests. */
   readonly baseUrl?: string
   readonly timeoutMs?: number
   readonly retry?: TiktokRetryOptions
   readonly onResponse?: (metadata: TiktokResponseMetadata) => Promise<void> | void
+}
+
+export interface TiktokDisplayConnectorOptions extends TiktokConnectorOptionsBase {
+  readonly api: "display"
+  /** Client key from the TikTok for Developers app. */
+  readonly clientKey: string
+  readonly clientSecret: string
+  /** Defaults to `user.info.basic` and `video.list`. */
+  readonly scopes?: readonly TiktokDisplayScope[]
+  /** Add `disable_auto_auth=1` to always show the Login Kit authorization page. */
+  readonly disableAutoAuth?: boolean
 }
 
 export interface TiktokOrganicConnectorOptions extends TiktokConnectorOptionsBase {
@@ -27,4 +39,7 @@ export interface TiktokAdsConnectorOptions extends TiktokConnectorOptionsBase {
   readonly scope?: string
 }
 
-export type TiktokConnectorOptions = TiktokOrganicConnectorOptions | TiktokAdsConnectorOptions
+export type TiktokConnectorOptions =
+  | TiktokDisplayConnectorOptions
+  | TiktokOrganicConnectorOptions
+  | TiktokAdsConnectorOptions

--- a/connectors/tiktok/tests/display.test.ts
+++ b/connectors/tiktok/tests/display.test.ts
@@ -1,0 +1,301 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { ConnectorOAuthError } from "@sixb/core"
+import { TiktokApiError, tiktok } from "../src"
+
+const originalFetch = globalThis.fetch
+const signal = new AbortController().signal
+const context = { projectId: "demo", connectorId: "tiktok-display", signal }
+const authorizationContext = {
+  ...context,
+  redirectUri: "https://api.example.com/auth/connectors/callback",
+}
+const authorizationInput = {
+  state: "signed-state",
+  codeChallenge: "framework-challenge",
+  codeChallengeMethod: "S256" as const,
+}
+
+beforeEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("TikTok Display OAuth", () => {
+  test("builds the documented Login Kit Web authorization URL", async () => {
+    const url = new URL(
+      await displayAdapter().authentication.authorizationUrl(
+        authorizationContext,
+        authorizationInput
+      )
+    )
+
+    expect(url.origin).toBe("https://www.tiktok.com")
+    expect(url.pathname).toBe("/v2/auth/authorize/")
+    expect(url.searchParams.get("client_key")).toBe("client-key")
+    expect(url.searchParams.get("response_type")).toBe("code")
+    expect(url.searchParams.get("scope")).toBe(
+      "user.info.basic,user.info.profile,user.info.stats,video.list"
+    )
+    expect(url.searchParams.get("redirect_uri")).toBe(authorizationContext.redirectUri)
+    expect(url.searchParams.get("state")).toBe("signed-state")
+    expect(url.searchParams.get("disable_auto_auth")).toBe("1")
+    expect(url.searchParams.has("code_challenge")).toBeFalse()
+  })
+
+  test("exchanges, rotates, and revokes tokens with form-encoded requests", async () => {
+    const requests: CapturedRequest[] = []
+    mockFetch(async (input, init) => {
+      requests.push({ input, init })
+      const url = new URL(String(input))
+      if (url.pathname.endsWith("/revoke/")) return new Response("")
+      const grantType = formBody(init).get("grant_type")
+      return json(
+        displayToken(
+          grantType === "refresh_token" ? "access-2" : "access-1",
+          grantType === "refresh_token" ? "refresh-2" : "refresh-1"
+        )
+      )
+    })
+
+    const authentication = displayAdapter().authentication
+    const exchanged = await authentication.exchangeCode(authorizationContext, {
+      code: "provider-code",
+      codeVerifier: "must-not-leave-sixb",
+    })
+    const refreshed = await authentication.refresh(context, exchanged)
+    await authentication.revoke?.(context, refreshed)
+
+    expect(exchanged.accessToken).toBe("access-1")
+    expect(exchanged.refreshToken).toBe("refresh-1")
+    expect(refreshed.accessToken).toBe("access-2")
+    expect(refreshed.refreshToken).toBe("refresh-2")
+    expect(exchanged.scopes).toEqual(["user.info.basic", "video.list"])
+    expect(new Headers(requests[0]?.init?.headers).get("content-type")).toBe(
+      "application/x-www-form-urlencoded"
+    )
+    expect(Object.fromEntries(formBody(requests[0]?.init))).toEqual({
+      client_key: "client-key",
+      client_secret: "client-secret",
+      code: "provider-code",
+      grant_type: "authorization_code",
+      redirect_uri: authorizationContext.redirectUri,
+    })
+    expect(formBody(requests[0]?.init).has("code_verifier")).toBeFalse()
+    expect(Object.fromEntries(formBody(requests[1]?.init))).toEqual({
+      client_key: "client-key",
+      client_secret: "client-secret",
+      grant_type: "refresh_token",
+      refresh_token: "refresh-1",
+    })
+    expect(Object.fromEntries(formBody(requests[2]?.init))).toEqual({
+      client_key: "client-key",
+      client_secret: "client-secret",
+      token: "access-2",
+    })
+  })
+
+  test("classifies provider token errors without hiding their log ID", async () => {
+    mockFetch(async () =>
+      json(
+        {
+          error: "invalid_request",
+          error_description: "Redirect URI does not match",
+          log_id: "log-oauth",
+        },
+        { status: 400 }
+      )
+    )
+
+    try {
+      await displayAdapter().authentication.exchangeCode(authorizationContext, {
+        code: "bad-code",
+        codeVerifier: "verifier",
+      })
+      throw new Error("expected exchange to fail")
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConnectorOAuthError)
+      expect((error as ConnectorOAuthError).kind).toBe("terminal")
+      expect((error as Error).message).toContain("log-oauth")
+    }
+  })
+})
+
+describe("TikTok Display resources", () => {
+  test("discovers the authorized user from basic profile fields", async () => {
+    let requested = ""
+    mockFetch(async (input, init) => {
+      requested = String(input)
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer display-token")
+      return displayJson({
+        user: {
+          open_id: "user-1",
+          display_name: "Acme Creator",
+          avatar_url: "https://cdn.example.com/avatar.jpg",
+        },
+      })
+    })
+
+    const accounts = await displayAdapter().discoverAccounts(context, {
+      accessToken: "display-token",
+    })
+
+    expect(accounts).toEqual([
+      {
+        id: "user-1",
+        label: "Acme Creator",
+        description: undefined,
+        avatarUrl: "https://cdn.example.com/avatar.jpg",
+      },
+    ])
+    expect(new URL(requested).searchParams.get("fields")).toBe("open_id,display_name,avatar_url")
+  })
+
+  test("reads profile statistics and paginates public videos", async () => {
+    const requests: CapturedRequest[] = []
+    mockFetch(async (input, init) => {
+      requests.push({ input, init })
+      const url = new URL(String(input))
+      if (url.pathname.endsWith("/user/info/")) {
+        return displayJson({ user: { open_id: "user-1", follower_count: 42 } })
+      }
+      const cursor = jsonBody(init).cursor
+      return displayJson(
+        cursor
+          ? { videos: [{ id: "video-2", view_count: 20 }], cursor: 200, has_more: false }
+          : { videos: [{ id: "video-1", view_count: 10 }], cursor: 100, has_more: true },
+        `log-${cursor ?? "first"}`
+      )
+    })
+
+    const client = await displayClient()
+    const profile = await client.profile.get({ fields: ["open_id", "follower_count"] })
+    const videos = await collect(
+      client.videos.listAll({ fields: ["id", "view_count"], maxCount: 20 })
+    )
+
+    expect(profile.follower_count).toBe(42)
+    expect(videos.map((video) => video.id)).toEqual(["video-1", "video-2"])
+    expect(new URL(String(requests[0]?.input)).searchParams.get("fields")).toBe(
+      "open_id,follower_count"
+    )
+    expect(new URL(String(requests[1]?.input)).searchParams.get("fields")).toBe("id,view_count")
+    expect(jsonBody(requests[1]?.init)).toEqual({ max_count: 20 })
+    expect(jsonBody(requests[2]?.init)).toEqual({ cursor: 100, max_count: 20 })
+  })
+
+  test("queries up to 20 owned videos by ID", async () => {
+    let request: CapturedRequest | undefined
+    mockFetch(async (input, init) => {
+      request = { input, init }
+      return displayJson({ videos: [{ id: "video-1", comment_count: 3 }] })
+    })
+
+    const videos = await (await displayClient()).videos.query({
+      videoIds: ["video-1"],
+      fields: ["id", "comment_count"],
+    })
+
+    expect(videos[0]?.comment_count).toBe(3)
+    expect(new URL(String(request?.input)).pathname).toEndWith("/video/query/")
+    expect(new URL(String(request?.input)).searchParams.get("fields")).toBe("id,comment_count")
+    expect(jsonBody(request?.init)).toEqual({ filters: { video_ids: ["video-1"] } })
+  })
+
+  test("preserves Display API envelope failures", async () => {
+    mockFetch(async () =>
+      json({
+        data: {},
+        error: { code: "scope_not_authorized", message: "Missing scope", log_id: "log-api" },
+      })
+    )
+
+    try {
+      await (await displayClient()).profile.get()
+      throw new Error("expected request to fail")
+    } catch (error) {
+      expect(error).toBeInstanceOf(TiktokApiError)
+      expect((error as TiktokApiError).code).toBe("scope_not_authorized")
+      expect((error as TiktokApiError).requestId).toBe("log-api")
+    }
+  })
+})
+
+function displayAdapter() {
+  return tiktok({
+    api: "display",
+    clientKey: "client-key",
+    clientSecret: "client-secret",
+    scopes: ["user.info.basic", "user.info.profile", "user.info.stats", "video.list"],
+    disableAutoAuth: true,
+    baseUrl: "https://open-api.example.com/v2/",
+    retry: { maxRetries: 0 },
+  })
+}
+
+async function displayClient() {
+  return displayAdapter().connect({
+    ...context,
+    connectionId: "connection-1",
+    account: { id: "user-1", label: "Acme Creator" },
+    tokenSource: staticToken("display-token"),
+  })
+}
+
+function staticToken(accessToken: string) {
+  return {
+    async get() {
+      return { accessToken, invalidate() {} }
+    },
+  }
+}
+
+function displayToken(accessToken: string, refreshToken: string) {
+  return {
+    access_token: accessToken,
+    expires_in: 86_400,
+    open_id: "user-1",
+    refresh_expires_in: 31_536_000,
+    refresh_token: refreshToken,
+    scope: "user.info.basic,video.list",
+    token_type: "Bearer",
+  }
+}
+
+type CapturedRequest = {
+  readonly input: RequestInfo | URL
+  readonly init?: RequestInit
+}
+
+function mockFetch(
+  implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+): void {
+  globalThis.fetch = implementation as typeof fetch
+}
+
+function json(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  })
+}
+
+function displayJson(data: unknown, logId = "log-api"): Response {
+  return json({ data, error: { code: "ok", message: "", log_id: logId } })
+}
+
+function formBody(init: RequestInit | undefined): URLSearchParams {
+  return new URLSearchParams(String(init?.body))
+}
+
+function jsonBody(init: RequestInit | undefined): Record<string, unknown> {
+  return JSON.parse(String(init?.body)) as Record<string, unknown>
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const items: T[] = []
+  for await (const item of iterable) items.push(item)
+  return items
+}

--- a/docs/data/connectors.md
+++ b/docs/data/connectors.md
@@ -411,7 +411,7 @@ to `defineConnector`, and most ship a matching webhook helper for the [Webhooks]
 | `@sixb/connector-pipedrive` | `pipedrive(...)` | Pipedrive CRM | `pipedriveEventsWebhook` |
 | `@sixb/connector-stripe` | `stripe(...)` | Stripe customers, subscriptions, invoices, refunds, events | `stripeEventsWebhook` |
 | `@sixb/connector-teamleader` | `teamleader(...)` | Teamleader CRM, invoicing, quotations | `defineTeamleaderWebhook` |
-| `@sixb/connector-tiktok` | `tiktok(...)` | TikTok organic accounts and Ads reporting | — |
+| `@sixb/connector-tiktok` | `tiktok(...)` | TikTok Display, Business Organic, and Ads reporting | — |
 | `@sixb/connector-pandadoc` | `pandadoc(...)` | PandaDoc documents and e-signatures | `pandaDocEventsWebhook` |
 | `@sixb/connector-companycam` | `companycam(...)` | CompanyCam jobsite photos | `companyCamEventsWebhook` |
 | `@sixb/connector-pennylane` | `pennylane(...)` | Pennylane quotes, products, customers | — |


### PR DESCRIPTION
## Summary

| API | OAuth | Resources |
| --- | --- | --- |
| `display` | Login Kit Web | User profile, public videos, public counters |
| `organic` | Business Accounts | Existing behavior unchanged |
| `marketing` | Marketing API | Existing behavior unchanged |

- Adds the explicit `api: "display"` connector variant.
- Implements form-encoded token exchange, refresh-token rotation, and revocation.
- Adds typed profile, video list, pagination, and video query clients.
- Preserves Display API errors and request log IDs.
- Updates connector documentation and exports.

## Why

- Login Kit tokens target `open.tiktokapis.com` and cannot call the Business Accounts API.
- Separating the variants prevents credentials from being used against incompatible endpoints.

## Choices

- Defaults to `user.info.basic` and `video.list`; profile and stats scopes stay opt-in.
- Does not send PKCE for Login Kit Web because TikTok documents it only for mobile and desktop.
- Exposes `comment_count`; Display API does not expose comment contents.

## Validation

- 23 TikTok tests
- TikTok package build and typecheck
- Repository lint and typecheck