### PR TITLE
atlas: refine workspace navigation and collections

### DIFF
--- a/packages/atlas/src/components/CollectionPageHeader.tsx
+++ b/packages/atlas/src/components/CollectionPageHeader.tsx
@@ -1,0 +1,90 @@
+import { Input } from "@sixb/ui/components"
+import { Search } from "lucide-react"
+import type { ReactNode } from "react"
+
+export function CollectionPageHeader({
+  title,
+  count,
+  singularLabel,
+  search,
+  actions,
+}: {
+  title: string
+  count: number
+  singularLabel: string
+  search?: {
+    value: string
+    placeholder: string
+    onChange: (value: string) => void
+  }
+  actions?: ReactNode
+}) {
+  return (
+    <>
+      <CollectionPageTitle title={title} count={count} singularLabel={singularLabel} />
+
+      {search || actions ? (
+        <div className="sticky top-0 z-30 mt-3 bg-background/92 py-2 backdrop-blur-xl supports-[backdrop-filter]:bg-background/82">
+          <div className="flex flex-col gap-1.5 sm:flex-row sm:items-center">
+            {search ? <CollectionSearchInput {...search} /> : null}
+            {actions ? (
+              <div className="flex shrink-0 items-center gap-2 [&_[data-slot=toggle-group]]:h-9">
+                {actions}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </>
+  )
+}
+
+export function CollectionPageTitle({
+  title,
+  count,
+  singularLabel,
+}: {
+  title: string
+  count: number
+  singularLabel: string
+}) {
+  return (
+    <header className="flex flex-col gap-3 pb-2 sm:flex-row sm:items-center sm:justify-between">
+      <h1 className="text-2xl font-semibold tracking-[-0.04em] text-foreground sm:text-[2rem]">
+        {title}
+      </h1>
+      <p className="text-xs text-muted-foreground">
+        {count.toLocaleString()} {singularLabel}
+        {count === 1 ? "" : "s"}
+      </p>
+    </header>
+  )
+}
+
+export function CollectionSearchInput({
+  value,
+  placeholder,
+  disabled,
+  onChange,
+}: {
+  value: string
+  placeholder: string
+  disabled?: boolean
+  onChange: (value: string) => void
+}) {
+  return (
+    <div className="relative min-w-0 flex-1">
+      <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+      <Input
+        type="search"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        disabled={disabled}
+        className="h-9 bg-white pl-9 shadow-none focus-visible:bg-white dark:bg-card dark:focus-visible:bg-card"
+        autoComplete="off"
+      />
+    </div>
+  )
+}

--- a/packages/atlas/src/components/common.tsx
+++ b/packages/atlas/src/components/common.tsx
@@ -81,36 +81,24 @@ export function PageFrame({
   eyebrow,
   title,
   description,
-  headerVariant = "standard",
   headerDivider = true,
   backTo,
   backLabel,
   actions,
-  contentClassName,
   children,
 }: {
   eyebrow?: string
   title: ReactNode
   description?: ReactNode
-  headerVariant?: "standard" | "collection"
   headerDivider?: boolean
   backTo?: string
   backLabel?: string
   actions?: ReactNode
-  contentClassName?: string
   children: ReactNode
 }) {
-  const collectionHeader = headerVariant === "collection"
-
   return (
-    <div className="mx-auto flex w-full max-w-7xl flex-col p-3 sm:p-4 lg:p-6">
-      <div
-        className={cn(
-          "mx-auto flex w-full max-w-5xl flex-col",
-          collectionHeader ? "gap-2" : "gap-4",
-          contentClassName
-        )}
-      >
+    <div className="mx-auto flex w-full flex-col p-3 sm:p-5 lg:p-8">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-4">
         {backTo && backLabel ? (
           <Button
             variant="ghost"
@@ -123,36 +111,25 @@ export function PageFrame({
         ) : null}
         <header
           className={cn(
-            "flex gap-3 sm:flex-row sm:justify-between",
-            collectionHeader
-              ? "items-center"
-              : cn("flex-col sm:items-start", headerDivider && "atlas-page-header")
+            "flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between",
+            headerDivider && "atlas-page-header"
           )}
         >
-          <div className={cn("min-w-0", !collectionHeader && "space-y-1")}>
+          <div className="min-w-0 space-y-1">
             {eyebrow ? (
               <p className="atlas-eyebrow text-[11px] font-semibold uppercase">
                 <span aria-hidden="true" className="atlas-signal-dot" />
                 {eyebrow}
               </p>
             ) : null}
-            <h1
-              className={cn(
-                "break-words",
-                collectionHeader
-                  ? "text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
-                  : "text-2xl font-medium tracking-[-0.025em] text-foreground sm:text-3xl"
-              )}
-            >
+            <h1 className="break-words text-2xl font-semibold tracking-[-0.035em] text-foreground sm:text-[2rem]">
               {title}
             </h1>
             {description ? (
               <div className="max-w-3xl text-sm text-muted-foreground">{description}</div>
             ) : null}
           </div>
-          {actions ? (
-            <div className={cn("shrink-0", !collectionHeader && "sm:pt-1")}>{actions}</div>
-          ) : null}
+          {actions ? <div className="shrink-0 sm:pt-1">{actions}</div> : null}
         </header>
         {children}
       </div>

--- a/packages/atlas/src/components/layout/AppLayout.tsx
+++ b/packages/atlas/src/components/layout/AppLayout.tsx
@@ -8,11 +8,13 @@ import { AppShell } from "./AppShell"
 import { Sidebar, type ViewMode } from "./Sidebar"
 import { type ProjectSidebarData, SidebarDataContext } from "./sidebarData"
 import { getViewModeFromPath } from "./viewMode"
+import { WorkspaceCommandMenu } from "./WorkspaceCommandMenu"
 
 export function AppLayout() {
   const navigate = useNavigate()
   const location = useLocation()
   const [sidebarData, setSidebarData] = useState<ProjectSidebarData | null>(null)
+  const [commandMenuOpen, setCommandMenuOpen] = useState(false)
 
   const { data: projectInfo } = useQuery({
     ...getProjectInfoOptions(),
@@ -40,17 +42,10 @@ export function AppLayout() {
       viewMode={viewMode}
       onViewChange={handleViewChange}
       onViewIntent={preloadWorkspaceView}
+      onOpenCommand={() => setCommandMenuOpen(true)}
       objectCount={sidebarData?.objectCount}
-      connectorCount={sidebarData?.connectorCount}
-      datasetCount={sidebarData?.datasetCount}
-      syncCount={sidebarData?.syncCount}
-      pipelineCount={sidebarData?.pipelineCount}
-      projectionCount={sidebarData?.projectionCount}
       workflowCount={sidebarData?.workflowCount}
       actionCount={sidebarData?.actionCount}
-      agentCount={sidebarData?.agentCount}
-      ruleCount={sidebarData?.ruleCount}
-      ontologyCount={sidebarData?.ontologyCount}
     />
   )
 
@@ -59,6 +54,7 @@ export function AppLayout() {
       <AppShell sidebar={sidebar} currentProjectName={selectedProject?.name ?? null}>
         <Outlet />
       </AppShell>
+      <WorkspaceCommandMenu open={commandMenuOpen} onOpenChange={setCommandMenuOpen} />
       <Toaster position="bottom-right" />
     </SidebarDataContext.Provider>
   )

--- a/packages/atlas/src/components/layout/Sidebar.tsx
+++ b/packages/atlas/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuBadge,
@@ -18,17 +19,19 @@ import {
 import { useMutation, useQuery } from "@tanstack/react-query"
 import {
   Bolt,
-  Bot,
   Box,
   Cable,
   ChartNoAxesCombined,
+  ChevronRight,
   Database,
   GitBranch,
   Layers,
   LayoutGrid,
   ListChecks,
+  MessageCircle,
   RefreshCw,
   ScrollText,
+  Search,
   Settings,
   Workflow,
 } from "lucide-react"
@@ -55,21 +58,41 @@ interface NavItem {
   Icon: React.ComponentType<{ className?: string }>
 }
 
-const projectNavItems: NavItem[] = [
-  { id: "connectors", label: "Connectors", Icon: Cable },
-  { id: "datasets", label: "Datasets", Icon: Database },
-  { id: "syncs", label: "Syncs", Icon: RefreshCw },
-  { id: "pipelines", label: "Pipelines", Icon: Workflow },
-  { id: "projections", label: "Projections", Icon: Layers },
-  { id: "ontology", label: "Ontology", Icon: LayoutGrid },
-  { id: "home", label: "Objects", Icon: Box },
-  { id: "actions", label: "Actions", Icon: Bolt },
-  { id: "workflows", label: "Workflows", Icon: GitBranch },
-  { id: "agents", label: "Agents", Icon: Bot },
-  { id: "ai-usage", label: "AI usage", Icon: ChartNoAxesCombined },
-  { id: "logs", label: "Logs", Icon: ScrollText },
-  { id: "rules", label: "Rules", Icon: ListChecks },
-  { id: "settings", label: "Settings", Icon: Settings },
+const projectNavGroups: { label: string; items: NavItem[] }[] = [
+  {
+    label: "Data",
+    items: [
+      { id: "connectors", label: "Connectors", Icon: Cable },
+      { id: "datasets", label: "Datasets", Icon: Database },
+      { id: "syncs", label: "Syncs", Icon: RefreshCw },
+      { id: "pipelines", label: "Pipelines", Icon: Workflow },
+      { id: "projections", label: "Projections", Icon: Layers },
+    ],
+  },
+  {
+    label: "Model",
+    items: [
+      { id: "ontology", label: "Ontology", Icon: LayoutGrid },
+      { id: "home", label: "Objects", Icon: Box },
+    ],
+  },
+  {
+    label: "Automate",
+    items: [
+      { id: "actions", label: "Actions", Icon: Bolt },
+      { id: "workflows", label: "Workflows", Icon: GitBranch },
+      { id: "agents", label: "Chat", Icon: MessageCircle },
+    ],
+  },
+  {
+    label: "Operate",
+    items: [
+      { id: "ai-usage", label: "AI usage", Icon: ChartNoAxesCombined },
+      { id: "logs", label: "Logs", Icon: ScrollText },
+      { id: "rules", label: "Rules", Icon: ListChecks },
+      { id: "settings", label: "Settings", Icon: Settings },
+    ],
+  },
 ]
 
 function SixbMark({ className }: { className?: string }) {
@@ -98,16 +121,9 @@ interface SidebarProps {
   viewMode: ViewMode
   onViewChange: (mode: ViewMode) => void
   onViewIntent?: (mode: ViewMode) => void
-  datasetCount?: number
-  connectorCount?: number
-  syncCount?: number
-  pipelineCount?: number
-  projectionCount?: number
+  onOpenCommand: () => void
   workflowCount?: number
   actionCount?: number
-  agentCount?: number
-  ruleCount?: number
-  ontologyCount?: number
   objectCount?: number
 }
 
@@ -116,30 +132,15 @@ export function Sidebar({
   viewMode,
   onViewChange,
   onViewIntent,
-  datasetCount,
-  connectorCount,
-  syncCount,
-  pipelineCount,
-  projectionCount,
+  onOpenCommand,
   workflowCount,
   actionCount,
-  agentCount,
-  ruleCount,
-  ontologyCount,
   objectCount,
 }: SidebarProps) {
   const getCount = (id: ViewMode): number | undefined => {
     if (id === "home") return objectCount
-    if (id === "datasets") return datasetCount
-    if (id === "connectors") return connectorCount
-    if (id === "syncs") return syncCount
-    if (id === "projections") return projectionCount
-    if (id === "pipelines") return pipelineCount
     if (id === "workflows") return workflowCount
     if (id === "actions") return actionCount
-    if (id === "agents") return agentCount
-    if (id === "rules") return ruleCount
-    if (id === "ontology") return ontologyCount
     return undefined
   }
 
@@ -148,34 +149,63 @@ export function Sidebar({
       <AtlasSidebarHeader selectedProject={selectedProject} />
 
       <SidebarContent>
-        <SidebarGroup>
+        <SidebarGroup className="pt-1.5 pb-1">
           <SidebarGroupContent>
             <SidebarMenu>
-              {projectNavItems.map((item) => {
-                const count = getCount(item.id)
-                const isActive = viewMode === item.id
-                return (
-                  <SidebarMenuItem key={item.id}>
-                    <SidebarMenuButton
-                      isActive={isActive}
-                      tooltip={item.label}
-                      onPointerEnter={() => onViewIntent?.(item.id)}
-                      onPointerDown={() => onViewIntent?.(item.id)}
-                      onFocus={() => onViewIntent?.(item.id)}
-                      onClick={() => onViewChange(item.id)}
-                    >
-                      <item.Icon />
-                      <span>{item.label}</span>
-                    </SidebarMenuButton>
-                    {count !== undefined && count > 0 ? (
-                      <SidebarMenuBadge>{count}</SidebarMenuBadge>
-                    ) : null}
-                  </SidebarMenuItem>
-                )
-              })}
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  tooltip="Search"
+                  onClick={onOpenCommand}
+                  className="border border-sidebar-border bg-sidebar text-sidebar-foreground hover:border-foreground/15"
+                >
+                  <Search />
+                  <span>Search</span>
+                  <kbd className="ml-auto text-[10px] text-sidebar-foreground/60 group-data-[collapsible=icon]:hidden">
+                    ⌘K
+                  </kbd>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
+
+        {projectNavGroups.map((group) => (
+          <SidebarGroup key={group.label} className="py-1">
+            <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {group.items.map((item) => {
+                  const count = getCount(item.id)
+                  const isActive = viewMode === item.id
+                  return (
+                    <SidebarMenuItem key={item.id}>
+                      <SidebarMenuButton
+                        isActive={isActive}
+                        tooltip={item.label}
+                        onPointerEnter={() => onViewIntent?.(item.id)}
+                        onPointerDown={() => onViewIntent?.(item.id)}
+                        onFocus={() => onViewIntent?.(item.id)}
+                        onClick={() => onViewChange(item.id)}
+                      >
+                        <item.Icon />
+                        <span className="min-w-0 flex-1 truncate">{item.label}</span>
+                        {item.id === "agents" ? (
+                          <ChevronRight
+                            aria-hidden="true"
+                            className="ml-auto text-sidebar-foreground/55 group-data-[collapsible=icon]:hidden"
+                          />
+                        ) : null}
+                      </SidebarMenuButton>
+                      {count !== undefined && count > 0 ? (
+                        <SidebarMenuBadge>{count}</SidebarMenuBadge>
+                      ) : null}
+                    </SidebarMenuItem>
+                  )
+                })}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ))}
 
         <SidebarGroup className="mt-auto">
           <SidebarGroupContent>
@@ -197,17 +227,17 @@ export function Sidebar({
 
 export function AtlasSidebarHeader({ selectedProject }: { selectedProject: ProjectInfo | null }) {
   return (
-    <SidebarHeader className="h-[54px] justify-center border-b border-sidebar-border">
-      <div className="flex items-center gap-3 px-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
+    <SidebarHeader className="h-[50px] justify-center">
+      <div className="flex items-center gap-2 px-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
         {/* Sixb's orbit mark anchors Atlas to the website identity. */}
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center text-sidebar-accent-foreground">
-          <SixbMark className="h-[18px] w-[22px]" />
+        <div className="flex h-8 w-4 shrink-0 items-center justify-center text-sidebar-accent-foreground">
+          <SixbMark className="h-[18px] w-[22px] max-w-none shrink-0" />
         </div>
         <div className="min-w-0 flex-1 group-data-[collapsible=icon]:hidden">
-          <p className="truncate text-[14px] font-semibold tracking-[-0.02em] text-sidebar-accent-foreground">
+          <p className="truncate text-[14px] font-semibold leading-4 tracking-[-0.02em] text-sidebar-accent-foreground">
             Sixb Atlas
           </p>
-          <p className="truncate text-[11px] text-sidebar-foreground">
+          <p className="mt-0.5 truncate text-[11px] leading-4 text-sidebar-foreground/65">
             {selectedProject ? selectedProject.name : "Loading project"}
           </p>
         </div>

--- a/packages/atlas/src/components/layout/WorkspaceCommandMenu.tsx
+++ b/packages/atlas/src/components/layout/WorkspaceCommandMenu.tsx
@@ -1,0 +1,141 @@
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@sixb/ui/components"
+import {
+  Bolt,
+  Bot,
+  Box,
+  Cable,
+  ChartNoAxesCombined,
+  Database,
+  GitBranch,
+  Layers,
+  LayoutGrid,
+  ListChecks,
+  RefreshCw,
+  ScrollText,
+  Settings,
+  Workflow,
+} from "lucide-react"
+import { useEffect } from "react"
+import { useNavigate } from "react-router-dom"
+
+const commandGroups = [
+  {
+    label: "Explore",
+    commands: [
+      { label: "Objects", description: "Browse the operational graph", path: "/", Icon: Box },
+      {
+        label: "Ontology",
+        description: "Inspect types and relationships",
+        path: "/ontology",
+        Icon: LayoutGrid,
+      },
+    ],
+  },
+  {
+    label: "Automate",
+    commands: [
+      { label: "Actions", description: "Request typed operations", path: "/actions", Icon: Bolt },
+      {
+        label: "Workflows",
+        description: "Run and supervise processes",
+        path: "/workflows",
+        Icon: GitBranch,
+      },
+      { label: "Agents", description: "Inspect registered agents", path: "/agents", Icon: Bot },
+    ],
+  },
+  {
+    label: "Data",
+    commands: [
+      { label: "Connectors", path: "/connectors", Icon: Cable },
+      { label: "Datasets", path: "/datasets", Icon: Database },
+      { label: "Syncs", path: "/syncs", Icon: RefreshCw },
+      { label: "Pipelines", path: "/pipelines", Icon: Workflow },
+      { label: "Projections", path: "/projections", Icon: Layers },
+    ],
+  },
+  {
+    label: "Operate",
+    commands: [
+      { label: "AI usage", path: "/ai-usage", Icon: ChartNoAxesCombined },
+      { label: "Logs", path: "/logs", Icon: ScrollText },
+      { label: "Rules", path: "/rules", Icon: ListChecks },
+      { label: "Settings", path: "/settings/members", Icon: Settings },
+    ],
+  },
+] as const
+
+export function WorkspaceCommandMenu({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() === "k" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault()
+        onOpenChange(!open)
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [onOpenChange, open])
+
+  const selectPath = (path: string) => {
+    onOpenChange(false)
+    navigate(path)
+  }
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Search Atlas"
+      description="Navigate to an Atlas workspace"
+      className="max-w-xl rounded-xl"
+    >
+      <CommandInput placeholder="Search…" />
+      <CommandList className="max-h-[min(28rem,70vh)] p-1">
+        <CommandEmpty>No matching workspace.</CommandEmpty>
+        {commandGroups.map((group, groupIndex) => (
+          <div key={group.label}>
+            {groupIndex > 0 ? <CommandSeparator className="my-1" /> : null}
+            <CommandGroup heading={group.label}>
+              {group.commands.map((command) => (
+                <CommandItem
+                  key={command.path}
+                  value={`${command.label} ${"description" in command ? command.description : ""}`}
+                  onSelect={() => selectPath(command.path)}
+                  className="min-h-11 rounded-lg px-3"
+                >
+                  <command.Icon className="size-4" />
+                  <div className="min-w-0 flex-1">
+                    <p className="font-medium text-foreground">{command.label}</p>
+                    {"description" in command ? (
+                      <p className="truncate text-xs text-muted-foreground">
+                        {command.description}
+                      </p>
+                    ) : null}
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </div>
+        ))}
+      </CommandList>
+    </CommandDialog>
+  )
+}

--- a/packages/atlas/src/components/layout/sidebarData.ts
+++ b/packages/atlas/src/components/layout/sidebarData.ts
@@ -2,16 +2,8 @@ import { createContext } from "react"
 
 export interface ProjectSidebarData {
   objectCount?: number
-  datasetCount: number
-  connectorCount: number
-  syncCount: number
-  pipelineCount: number
-  projectionCount: number
   workflowCount: number
   actionCount: number
-  agentCount: number
-  ruleCount: number
-  ontologyCount: number
 }
 
 export const SidebarDataContext = createContext<{

--- a/packages/atlas/src/components/objects/ObjectFilterPopover.tsx
+++ b/packages/atlas/src/components/objects/ObjectFilterPopover.tsx
@@ -39,15 +39,11 @@ export function ObjectFilterPopover({
   properties,
   filters,
   facetResults,
-  label = "Filter",
-  prominent = false,
   onAddFilter,
 }: {
   properties: QueryProperty[]
   filters: QueryFilter[]
   facetResults: ObjectQueryFacetResult[]
-  label?: string
-  prominent?: boolean
   onAddFilter: (filter: QueryFilter) => void
 }) {
   const [open, setOpen] = useState(false)
@@ -120,13 +116,13 @@ export function ObjectFilterPopover({
       <PopoverTrigger asChild>
         <Button
           type="button"
-          variant={prominent ? "default" : "outline"}
+          variant="outline"
           size="sm"
-          className="h-10 rounded-xl"
+          className="h-9 rounded-md"
           disabled={properties.length === 0}
         >
           <Plus />
-          {label}
+          Filter
         </Button>
       </PopoverTrigger>
       <PopoverContent align="end" className="w-80 space-y-3">

--- a/packages/atlas/src/components/objects/ObjectQueryBar.tsx
+++ b/packages/atlas/src/components/objects/ObjectQueryBar.tsx
@@ -1,11 +1,9 @@
 import type { ObjectQueryFacetResult } from "@sixb/client"
-import { Alert, AlertDescription, Badge, Button, Input } from "@sixb/ui/components"
+import { Alert, AlertDescription, Badge, Button } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
-import { AlertCircle, Search, X } from "lucide-react"
+import { AlertCircle, X } from "lucide-react"
 import { formatCount, formatValue } from "../../lib/formatValue"
-import { humanizeIdentifier } from "../../lib/labels"
 import {
-  type AtlasObjectType,
   createFilterId,
   describeFilter,
   filterHasValue,
@@ -15,90 +13,30 @@ import {
   type QueryMatchMode,
   type QueryProperty,
 } from "../../lib/objects/objectQuery"
-import { ObjectFilterPopover } from "./ObjectFilterPopover"
 
 export function ObjectQueryBar({
-  objectType,
-  searchQuery,
-  textSearchEnabled,
   filters,
   matchMode,
-  filterableProperties,
   propertiesById,
   facetResults,
   facetsLoading,
   queryError,
-  onSearchQueryChange,
   onAddFilter,
   onRemoveFilter,
-  onClear,
   onMatchModeChange,
 }: {
-  objectType: AtlasObjectType
-  searchQuery: string
-  textSearchEnabled: boolean
   filters: QueryFilter[]
   matchMode: QueryMatchMode
-  filterableProperties: QueryProperty[]
   propertiesById: ReadonlyMap<string, QueryProperty>
   facetResults: ObjectQueryFacetResult[]
   facetsLoading: boolean
   queryError: unknown
-  onSearchQueryChange: (value: string) => void
   onAddFilter: (filter: QueryFilter) => void
   onRemoveFilter: (filterId: string) => void
-  onClear: () => void
   onMatchModeChange: (mode: QueryMatchMode) => void
 }) {
-  const active = searchQuery.trim().length > 0 || filters.length > 0
-  const objectTypeLabel = humanizeIdentifier(objectType.name || objectType.id)
-  const addFilterLabel = textSearchEnabled || active ? "Filter" : `Filter ${objectTypeLabel}`
-
   return (
     <div className="mt-3 space-y-3">
-      {textSearchEnabled ? (
-        <div className="flex flex-col gap-2 sm:flex-row">
-          <div className="relative min-w-0 flex-1">
-            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              type="text"
-              value={searchQuery}
-              onChange={(event) => onSearchQueryChange(event.target.value)}
-              placeholder={`Search ${objectTypeLabel}...`}
-              className="h-10 rounded-xl bg-card pl-9 shadow-none"
-            />
-          </div>
-          <QueryToolbarActions
-            active={active}
-            filters={filters}
-            facetResults={facetResults}
-            filterLabel={addFilterLabel}
-            filterableProperties={filterableProperties}
-            onAddFilter={onAddFilter}
-            onClear={onClear}
-          />
-        </div>
-      ) : (
-        <div className="flex flex-col gap-2 rounded-xl bg-muted/35 px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between">
-          <div className="min-w-0 space-y-0.5">
-            <p className="text-sm font-medium text-foreground">Filter {objectTypeLabel}</p>
-            <p className="text-xs text-muted-foreground">
-              Text search is not configured for this type. Use fields to narrow the set.
-            </p>
-          </div>
-          <QueryToolbarActions
-            active={active}
-            filters={filters}
-            facetResults={facetResults}
-            filterLabel={addFilterLabel}
-            filterableProperties={filterableProperties}
-            prominent={!active}
-            onAddFilter={onAddFilter}
-            onClear={onClear}
-          />
-        </div>
-      )}
-
       {filters.length > 0 ? (
         <div className="flex flex-wrap items-center gap-1.5">
           <span className="mr-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
@@ -158,45 +96,6 @@ export function ObjectQueryBar({
       />
 
       <ObjectQueryErrorAlert error={queryError} />
-    </div>
-  )
-}
-
-function QueryToolbarActions({
-  active,
-  filters,
-  facetResults,
-  filterLabel,
-  filterableProperties,
-  prominent = false,
-  onAddFilter,
-  onClear,
-}: {
-  active: boolean
-  filters: QueryFilter[]
-  facetResults: ObjectQueryFacetResult[]
-  filterLabel: string
-  filterableProperties: QueryProperty[]
-  prominent?: boolean
-  onAddFilter: (filter: QueryFilter) => void
-  onClear: () => void
-}) {
-  return (
-    <div className="flex shrink-0 items-center gap-2">
-      <ObjectFilterPopover
-        properties={filterableProperties}
-        filters={filters}
-        facetResults={facetResults}
-        label={filterLabel}
-        prominent={prominent}
-        onAddFilter={onAddFilter}
-      />
-      {active ? (
-        <Button type="button" variant="ghost" size="sm" className="h-10 px-2.5" onClick={onClear}>
-          <X />
-          Clear
-        </Button>
-      ) : null}
     </div>
   )
 }

--- a/packages/atlas/src/features/workflows/components/workflows/WorkflowCard.tsx
+++ b/packages/atlas/src/features/workflows/components/workflows/WorkflowCard.tsx
@@ -1,37 +1,35 @@
 import { Card } from "@sixb/ui/components"
-import { ArrowRight, GitBranch } from "lucide-react"
+import { GitBranch } from "lucide-react"
 import { Link } from "react-router-dom"
+import { humanizeIdentifier } from "../../../../lib/labels"
 import { runTimeLabel, type WorkflowSummary } from "../../utils/workflows"
 import { StatusBadge } from "../runs/StatusBadge"
 
 export function WorkflowCard({ workflow }: { workflow: WorkflowSummary }) {
-  const inputFieldCount = Object.keys(workflow.input ?? {}).length
-
+  const inputCount = Object.keys(workflow.input ?? {}).length
   return (
     <Link
       to={`/workflows/${workflow.id}`}
       className="group block rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
     >
-      <Card className="gap-0 overflow-hidden py-0 transition-colors group-hover:border-foreground/20 group-hover:bg-muted/20">
-        <div className="flex min-w-0 items-start justify-between gap-4 p-5">
-          <div className="flex min-w-0 items-start gap-3">
-            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-              <GitBranch className="h-4 w-4" />
-            </span>
-            <div className="min-w-0">
-              <h3 className="truncate font-medium text-foreground">{workflow.id}</h3>
-              <p className="mt-1 text-sm text-muted-foreground">
-                {workflow.nodes.length} node{workflow.nodes.length === 1 ? "" : "s"} ·{" "}
-                {workflow.triggers.length} trigger
-                {workflow.triggers.length === 1 ? "" : "s"} · {inputFieldCount} input{" "}
-                {inputFieldCount === 1 ? "field" : "fields"}
-              </p>
-            </div>
+      <Card className="h-full gap-0 overflow-hidden p-0 transition-colors group-hover:border-[var(--atlas-border-hover)] group-hover:bg-[var(--atlas-surface-hover)]">
+        <div className="flex min-w-0 items-center gap-3 p-4">
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-[var(--atlas-panel-subtle)] text-muted-foreground">
+            <GitBranch className="size-4" />
+          </span>
+          <div className="min-w-0">
+            <h3 className="truncate text-sm font-medium text-foreground">
+              {humanizeIdentifier(workflow.id)}
+            </h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {workflow.nodes.length} node{workflow.nodes.length === 1 ? "" : "s"} ·{" "}
+              {workflow.triggers.length} trigger{workflow.triggers.length === 1 ? "" : "s"} ·{" "}
+              {inputCount} input {inputCount === 1 ? "field" : "fields"}
+            </p>
           </div>
-          <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-[opacity,transform] group-hover:translate-x-0.5 sm:opacity-0 sm:group-hover:opacity-100" />
         </div>
 
-        <div className="flex min-h-14 items-center justify-between gap-4 border-t border-border/60 bg-muted/20 px-5 py-3">
+        <div className="flex min-h-14 items-center justify-between gap-3 border-t border-border px-4 py-3">
           {workflow.latestRun ? (
             <>
               <p className="min-w-0 truncate text-sm text-muted-foreground">

--- a/packages/atlas/src/index.css
+++ b/packages/atlas/src/index.css
@@ -9,22 +9,23 @@
 
 :root {
   /* Atlas follows the Sixb website's paper, ink, ledger-line, and signal-blue palette. */
-  --background: #fafafa;
-  --foreground: #17181c;
+  color-scheme: light;
+  --background: #f8f8f7;
+  --foreground: #18191c;
   --card: #ffffff;
-  --card-foreground: #17181c;
+  --card-foreground: #18191c;
   --popover: #ffffff;
   --popover-foreground: #17181c;
-  --primary: #17181c;
+  --primary: #18191c;
   --primary-foreground: #ffffff;
-  --secondary: #f3f3f3;
-  --secondary-foreground: #17181c;
-  --accent: #f3f3f3;
-  --accent-foreground: #17181c;
-  --muted: #f5f5f5;
-  --muted-foreground: #63666d;
-  --border: #e1e1e1;
-  --input: #d6d6d6;
+  --secondary: #f0f1f2;
+  --secondary-foreground: #18191c;
+  --accent: #eef4ff;
+  --accent-foreground: #18191c;
+  --muted: #f1f2f3;
+  --muted-foreground: #666970;
+  --border: #dedfe2;
+  --input: #d4d6da;
   --ring: #007aff;
   --info: #007aff;
   --chart-1: #007aff;
@@ -32,17 +33,17 @@
   --chart-3: #5799df;
   --chart-4: #9ec3ee;
   --chart-5: #d4e6ff;
-  --sidebar: #ffffff;
+  --sidebar: #fbfbfa;
   --sidebar-foreground: #63666d;
   --sidebar-primary: #17181c;
   --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #f3f3f3;
-  --sidebar-accent-foreground: #17181c;
-  --sidebar-border: #e1e1e1;
+  --sidebar-accent: #f0f1f2;
+  --sidebar-accent-foreground: #18191c;
+  --sidebar-border: #dedfe2;
   --sidebar-ring: #007aff;
   --font-sans: "ABC Diatype", "SF Pro Text", "SF Pro Display", "Segoe UI Variable Text",
     "Segoe UI", system-ui, sans-serif;
-  --radius: 0.25rem;
+  --radius: 0.5rem;
   --shadow-2xs: none;
   --shadow-xs: none;
   --shadow-sm: none;
@@ -56,13 +57,15 @@
   --atlas-blue-soft: #9ec3ee;
   --atlas-blue-line: #d4e6ff;
   --atlas-blue-fill: #eef4ff;
-  --atlas-rail: #ffffff;
-  --atlas-sidebar-active: #17181c;
-  --atlas-sidebar-active-foreground: #ffffff;
-  --atlas-sidebar-count: #f1f1f1;
-  --atlas-surface-hover: #fafafa;
-  --atlas-row-hover: #f7f7f7;
-  --atlas-border-hover: #c6c6c6;
+  --atlas-rail: #fbfbfa;
+  --atlas-sidebar-active: #dfeaff;
+  --atlas-sidebar-active-foreground: #18191c;
+  --atlas-sidebar-count: #e9eaec;
+  --atlas-surface-hover: #f7f8f9;
+  --atlas-row-hover: #f3f5f7;
+  --atlas-border-hover: #c2c5ca;
+  --atlas-panel-subtle: #f4f5f6;
+  --atlas-shadow-float: 0 16px 48px rgb(23 24 28 / 10%), 0 2px 8px rgb(23 24 28 / 6%);
 
   font-family: var(--font-sans);
   line-height: 1.5;
@@ -73,22 +76,23 @@
 }
 
 .dark {
-  --background: #0b0b0b;
-  --foreground: #f5f5f5;
-  --card: #101010;
+  color-scheme: dark;
+  --background: #101112;
+  --foreground: #f1f2f3;
+  --card: #151617;
   --card-foreground: #f5f5f5;
-  --popover: #151515;
+  --popover: #191a1c;
   --popover-foreground: #f5f5f5;
   --primary: #f5f5f5;
-  --primary-foreground: #0b0b0b;
-  --secondary: #1a1a1a;
+  --primary-foreground: #101112;
+  --secondary: #202225;
   --secondary-foreground: #f5f5f5;
-  --accent: #202020;
+  --accent: #1b2a3e;
   --accent-foreground: #f5f5f5;
-  --muted: #181818;
-  --muted-foreground: #a1a1a1;
-  --border: #2b2b2b;
-  --input: #363636;
+  --muted: #202225;
+  --muted-foreground: #9a9da3;
+  --border: #2b2d31;
+  --input: #3a3d42;
   --ring: #007aff;
   --info: #007aff;
   --chart-1: #007aff;
@@ -96,26 +100,28 @@
   --chart-3: #68aef8;
   --chart-4: #3f7fbd;
   --chart-5: #23527f;
-  --sidebar: #0f0f0f;
-  --sidebar-foreground: #a1a1a1;
+  --sidebar: #131415;
+  --sidebar-foreground: #9a9da3;
   --sidebar-primary: #f5f5f5;
-  --sidebar-primary-foreground: #0b0b0b;
-  --sidebar-accent: #202020;
+  --sidebar-primary-foreground: #101112;
+  --sidebar-accent: #202225;
   --sidebar-accent-foreground: #f5f5f5;
-  --sidebar-border: #2b2b2b;
+  --sidebar-border: #2b2d31;
   --sidebar-ring: #007aff;
   --atlas-blue: #007aff;
   --atlas-blue-deep: #68aef8;
   --atlas-blue-soft: #3f7fbd;
   --atlas-blue-line: #23527f;
-  --atlas-blue-fill: #151515;
-  --atlas-rail: #0f0f0f;
-  --atlas-sidebar-active: #f5f5f5;
-  --atlas-sidebar-active-foreground: #0b0b0b;
-  --atlas-sidebar-count: #1c1c1c;
-  --atlas-surface-hover: #171717;
-  --atlas-row-hover: #151515;
-  --atlas-border-hover: #484848;
+  --atlas-blue-fill: #16243a;
+  --atlas-rail: #131415;
+  --atlas-sidebar-active: #19283b;
+  --atlas-sidebar-active-foreground: #f1f2f3;
+  --atlas-sidebar-count: #292b2f;
+  --atlas-surface-hover: #1b1c1f;
+  --atlas-row-hover: #1c1e21;
+  --atlas-border-hover: #4b4e54;
+  --atlas-panel-subtle: #191a1c;
+  --atlas-shadow-float: 0 18px 56px rgb(0 0 0 / 38%), 0 2px 10px rgb(0 0 0 / 28%);
   --shadow-2xs: none;
   --shadow-xs: none;
   --shadow-sm: none;
@@ -136,6 +142,11 @@ body {
 
 body {
   margin: 0;
+}
+
+::selection {
+  background: var(--atlas-blue-line);
+  color: var(--foreground);
 }
 
 h1,
@@ -182,13 +193,24 @@ a:focus-visible {
 
 [data-sidebar="menu-button"] {
   position: relative;
-  border-radius: 2px;
+  border-radius: calc(var(--radius) - 2px);
   font-weight: 500;
 }
 
 [data-sidebar="menu-button"][data-active="true"] {
   background: var(--atlas-sidebar-active);
   color: var(--atlas-sidebar-active-foreground);
+}
+
+[data-sidebar="menu-button"][data-active="true"]::before {
+  position: absolute;
+  top: 0.45rem;
+  bottom: 0.45rem;
+  left: -0.5rem;
+  width: 2px;
+  border-radius: 999px;
+  background: var(--atlas-blue);
+  content: "";
 }
 
 [data-sidebar="menu-button"][data-active="true"]:hover {
@@ -198,13 +220,13 @@ a:focus-visible {
 
 [data-sidebar="menu-badge"] {
   min-width: 1.25rem;
-  border-radius: 2px;
-  background: var(--atlas-sidebar-count);
+  border-radius: 999px;
+  background: transparent;
   font-size: 0.6875rem;
 }
 
 [data-sidebar="menu-button"][data-active="true"] + [data-sidebar="menu-badge"] {
-  background: rgb(255 255 255 / 14%);
+  background: color-mix(in srgb, var(--atlas-blue) 12%, transparent);
   color: var(--atlas-sidebar-active-foreground);
 }
 
@@ -246,9 +268,17 @@ a:focus-visible {
   box-shadow: none;
 }
 
+[data-slot="dialog-content"],
+[data-slot="popover-content"],
+[data-slot="dropdown-menu-content"],
+[data-slot="select-content"] {
+  border-color: color-mix(in srgb, var(--border) 80%, var(--foreground));
+  box-shadow: var(--atlas-shadow-float);
+}
+
 .atlas-page-header {
   border-bottom: 1px solid var(--border);
-  padding-bottom: 1.25rem;
+  padding-bottom: 1.5rem;
 }
 
 .atlas-eyebrow {

--- a/packages/atlas/src/lib/userPreferences.ts
+++ b/packages/atlas/src/lib/userPreferences.ts
@@ -58,7 +58,7 @@ function writeViewStyle(key: string, style: string) {
 }
 
 export function getObjectViewStyle(): "cards" | "table" {
-  return readViewStyle(viewStyleKey, ["cards", "table"], "cards")
+  return readViewStyle(viewStyleKey, ["cards", "table"], "table")
 }
 
 export function setObjectViewStyle(style: "cards" | "table") {

--- a/packages/atlas/src/pages/ActionsPage.tsx
+++ b/packages/atlas/src/pages/ActionsPage.tsx
@@ -44,10 +44,27 @@ import {
 } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
-import { AlertCircle, CheckCircle2, Loader2, Play, SquareActivity } from "lucide-react"
-import { type SyntheticEvent, useCallback, useMemo, useState } from "react"
+import {
+  AlertCircle,
+  CheckCircle2,
+  GitCommitHorizontal,
+  Loader2,
+  Play,
+  Search,
+  SquareActivity,
+  X,
+} from "lucide-react"
+import {
+  type ReactElement,
+  type ReactNode,
+  type SyntheticEvent,
+  useCallback,
+  useMemo,
+  useState,
+} from "react"
 import { Link, useNavigate, useSearchParams } from "react-router-dom"
 import { ActionParamNullControl } from "../components/ActionParamNullControl"
+import { CollectionSearchInput } from "../components/CollectionPageHeader"
 import { ErrorPage, LoadingPage, PageFrame } from "../components/common"
 import {
   FileRefUploadField,
@@ -63,6 +80,7 @@ import {
   buildActionParams,
   describeActionParamInput,
 } from "../lib/actions/params"
+import { humanizeIdentifier } from "../lib/labels"
 
 type ActionCatalogItem = ListActionsResponse[number]
 type ActionRunSummary = ListActionRunsResponse["runs"][number]
@@ -94,7 +112,7 @@ const actionRunStatusClasses: Record<ActionRunStatus, string> = {
 export function ActionsPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const activeTab: ActionsPageTab = searchParams.get("tab") === "runs" ? "runs" : "actions"
-  useActionLiveUpdates({ enabled: activeTab === "runs" })
+  useActionLiveUpdates()
 
   const handleTabChange = (value: string) => {
     const nextTab: ActionsPageTab = value === "runs" ? "runs" : "actions"
@@ -108,7 +126,7 @@ export function ActionsPage() {
   return (
     <PageFrame title="Actions" headerDivider={false}>
       <Tabs value={activeTab} onValueChange={handleTabChange} className="gap-4">
-        <TabsList variant="line" className="border-b border-border">
+        <TabsList variant="line">
           <TabsTrigger value="actions">Actions</TabsTrigger>
           <TabsTrigger value="runs">Runs</TabsTrigger>
         </TabsList>
@@ -125,7 +143,74 @@ export function ActionsPage() {
 
 function ActionDefinitionsTab() {
   const actionsQuery = useQuery(listActionsOptions())
+  const runsQuery = useQuery({
+    ...listActionRunsOptions({ query: { limit: "50", order: "desc" } }),
+  })
   const actions = actionsQuery.data ?? []
+  const [searchParams, setSearchParams] = useSearchParams()
+  const query = searchParams.get("q") ?? ""
+  const scope =
+    searchParams.get("scope") === "global"
+      ? "global"
+      : searchParams.get("scope") === "object"
+        ? "object"
+        : "all"
+  const requestedType = searchParams.get("type") ?? "all"
+
+  const objectTypes = useMemo(
+    () =>
+      Array.from(
+        new Set(actions.flatMap((action) => (action.objectTypeId ? [action.objectTypeId] : [])))
+      ).sort((left, right) => humanizeIdentifier(left).localeCompare(humanizeIdentifier(right))),
+    [actions]
+  )
+  const objectType =
+    scope !== "global" && objectTypes.includes(requestedType) ? requestedType : "all"
+  const latestRunByAction = useMemo(() => {
+    const latest = new Map<string, ActionRunSummary>()
+    for (const run of runsQuery.data?.runs ?? []) {
+      if (!latest.has(run.actionId)) latest.set(run.actionId, run)
+    }
+    return latest
+  }, [runsQuery.data])
+  const filteredActions = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase()
+    return actions.filter((action) => {
+      if (scope === "global" && action.objectTypeId) return false
+      if (scope === "object" && !action.objectTypeId) return false
+      if (objectType !== "all" && action.objectTypeId !== objectType) return false
+      if (!normalizedQuery) return true
+      return [action.id, humanizeIdentifier(action.id), action.description, action.objectTypeId]
+        .filter((value): value is string => typeof value === "string")
+        .some((value) => value.toLowerCase().includes(normalizedQuery))
+    })
+  }, [actions, objectType, query, scope])
+  const filtersActive = query.trim().length > 0 || scope !== "all" || objectType !== "all"
+
+  const updateFilterParam = (key: "q" | "type", value: string) => {
+    setSearchParams(
+      (previous) => {
+        const next = new URLSearchParams(previous)
+        if (!value || value === "all") next.delete(key)
+        else next.set(key, value)
+        return next
+      },
+      { replace: key === "q" }
+    )
+  }
+
+  const updateScope = (value: string) => {
+    setSearchParams(
+      (previous) => {
+        const next = new URLSearchParams(previous)
+        if (value === "all") next.delete("scope")
+        else next.set("scope", value)
+        if (value === "global") next.delete("type")
+        return next
+      },
+      { replace: false }
+    )
+  }
 
   if (actionsQuery.isLoading) {
     return <LoadingPage label="Loading actions..." />
@@ -136,7 +221,7 @@ function ActionDefinitionsTab() {
   }
 
   return (
-    <section className="space-y-3">
+    <section className="space-y-4">
       {actions.length === 0 ? (
         <Card>
           <EmptyState
@@ -146,58 +231,147 @@ function ActionDefinitionsTab() {
           />
         </Card>
       ) : (
-        <div className="grid gap-3 lg:grid-cols-2">
-          {actions.map((action) => (
-            <ActionDefinitionCard key={action.id} action={action} />
-          ))}
-        </div>
+        <>
+          <div className="sticky top-0 z-20 flex flex-col gap-1.5 bg-background/92 py-2 backdrop-blur-xl supports-[backdrop-filter]:bg-background/82 lg:flex-row lg:items-center">
+            <CollectionSearchInput
+              value={query}
+              onChange={(value) => updateFilterParam("q", value)}
+              placeholder="Search actions…"
+            />
+            <Select value={scope} onValueChange={updateScope}>
+              <SelectTrigger className="h-9 w-full bg-white lg:w-36" aria-label="Action scope">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All scopes</SelectItem>
+                <SelectItem value="object">Object actions</SelectItem>
+                <SelectItem value="global">Global actions</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select
+              value={scope === "global" ? "all" : objectType}
+              disabled={scope === "global"}
+              onValueChange={(value) => updateFilterParam("type", value)}
+            >
+              <SelectTrigger
+                className="h-9 w-full bg-white lg:w-48"
+                aria-label="Target object type"
+              >
+                <SelectValue placeholder="All object types" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All object types</SelectItem>
+                {objectTypes.map((type) => (
+                  <SelectItem key={type} value={type}>
+                    {humanizeIdentifier(type)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {filtersActive ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-sm"
+                className="size-9 shrink-0 bg-white"
+                aria-label="Clear action filters"
+                title="Clear action filters"
+                onClick={() => {
+                  setSearchParams((previous) => {
+                    const next = new URLSearchParams(previous)
+                    next.delete("q")
+                    next.delete("scope")
+                    next.delete("type")
+                    return next
+                  })
+                }}
+              >
+                <X className="size-4" />
+              </Button>
+            ) : null}
+          </div>
+
+          {filtersActive ? (
+            <p className="text-xs text-muted-foreground">
+              Showing <span className="font-medium text-foreground">{filteredActions.length}</span>{" "}
+              of {actions.length} actions
+            </p>
+          ) : null}
+
+          {filteredActions.length > 0 ? (
+            <div className="grid gap-3 lg:grid-cols-2">
+              {filteredActions.map((action) => (
+                <ActionCard
+                  key={action.id}
+                  action={action}
+                  latestRun={latestRunByAction.get(action.id)}
+                />
+              ))}
+            </div>
+          ) : (
+            <Card>
+              <EmptyState
+                icon={<Search className="size-10 stroke-1" />}
+                title="No matching actions"
+                description="Try another name, scope, or object type."
+              />
+            </Card>
+          )}
+        </>
       )}
     </section>
   )
 }
 
-function ActionDefinitionCard({ action }: { action: ActionCatalogItem }) {
+function ActionCard({
+  action,
+  latestRun,
+}: {
+  action: ActionCatalogItem
+  latestRun?: ActionRunSummary
+}) {
   const paramCount = action.params.length
+  const scopeLabel = action.objectTypeId
+    ? `${humanizeIdentifier(action.objectTypeId)} action`
+    : "Global action"
 
   return (
-    <Card className="overflow-hidden p-0">
-      <CardContent className="flex h-full flex-col gap-3 p-5">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 space-y-1">
-            <h3 className="truncate font-medium text-foreground">{action.id}</h3>
-            <p className="text-sm text-muted-foreground">
-              {action.objectTypeId ? `Object action on ${action.objectTypeId}` : "Global action"} ·{" "}
-              {paramCount} {paramCount === 1 ? "param" : "params"}
-            </p>
-          </div>
-          <ActionRequestDialog action={action} />
-        </div>
+    <ActionRequestDialog
+      action={action}
+      trigger={
+        <button
+          type="button"
+          className="group flex h-full w-full flex-col overflow-hidden rounded-lg border bg-card text-left text-card-foreground outline-none transition-colors hover:border-[var(--atlas-border-hover)] hover:bg-[var(--atlas-surface-hover)] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          <span className="flex min-w-0 items-center gap-3 p-4">
+            <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-[var(--atlas-panel-subtle)] text-muted-foreground">
+              <GitCommitHorizontal className="size-4" />
+            </span>
+            <span className="min-w-0">
+              <span className="block truncate text-sm font-medium text-foreground">
+                {humanizeIdentifier(action.id)}
+              </span>
+              <span className="mt-1 block text-sm text-muted-foreground">
+                {scopeLabel} · {paramCount} input {paramCount === 1 ? "field" : "fields"}
+              </span>
+            </span>
+          </span>
 
-        {action.description ? (
-          <p className="line-clamp-2 text-sm text-muted-foreground">{action.description}</p>
-        ) : null}
-
-        <div className="mt-auto flex flex-wrap gap-2">
-          <PhaseBadge active={action.phases.writeback}>writeback</PhaseBadge>
-          <PhaseBadge active={action.phases.edits}>edits</PhaseBadge>
-          <PhaseBadge active={action.phases.effects}>effects</PhaseBadge>
-        </div>
-      </CardContent>
-    </Card>
-  )
-}
-
-function PhaseBadge({ active, children }: { active: boolean; children: string }) {
-  return (
-    <Badge
-      variant="outline"
-      className={cn(
-        "rounded-md font-mono text-[10px]",
-        active ? "border-border bg-muted text-foreground" : "text-muted-foreground opacity-60"
-      )}
-    >
-      {children}
-    </Badge>
+          <span className="flex min-h-14 w-full items-center justify-between gap-3 border-t border-border px-4 py-3">
+            {latestRun ? (
+              <>
+                <span className="min-w-0 truncate text-sm text-muted-foreground">
+                  Latest run {formatRelativeTime(latestRun.queuedAt)}
+                </span>
+                <ActionRunStatusBadge status={latestRun.status} />
+              </>
+            ) : (
+              <span className="text-sm text-muted-foreground">No runs recorded</span>
+            )}
+          </span>
+        </button>
+      }
+    />
   )
 }
 
@@ -234,7 +408,7 @@ function ActionRunHistoryTab() {
 
 export function ActionRunTable({ runs }: { runs: readonly ActionRunSummary[] }) {
   return (
-    <Card className="overflow-hidden p-0">
+    <Card className="gap-0 overflow-hidden p-0">
       <Table>
         <TableHeader>
           <TableRow>
@@ -286,9 +460,11 @@ export function ActionRunStatusBadge({ status }: { status: ActionRunStatus }) {
 function ActionRequestDialog({
   action,
   subject,
+  trigger,
 }: {
   action: ActionCatalogItem
   subject?: { kind: "object"; objectTypeId: string; primaryId: string }
+  trigger?: ReactElement
 }) {
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
@@ -380,10 +556,12 @@ function ActionRequestDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button type="button" size="sm">
-          <Play className="h-4 w-4" />
-          Request
-        </Button>
+        {trigger ?? (
+          <Button type="button" size="sm">
+            <Play className="h-4 w-4" />
+            Request
+          </Button>
+        )}
       </DialogTrigger>
       <DialogContent className="max-h-[min(48rem,calc(100vh-2rem))] sm:max-w-3xl">
         <DialogHeader>
@@ -684,7 +862,7 @@ export function ActionRunMetaGrid({ run }: { run: ActionRunSummary }) {
   )
 }
 
-function Metric({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
+function Metric({ label, value, mono }: { label: string; value: ReactNode; mono?: boolean }) {
   return (
     <Card className="p-0">
       <CardContent className="space-y-1.5 p-4">

--- a/packages/atlas/src/pages/ConnectorsPage.tsx
+++ b/packages/atlas/src/pages/ConnectorsPage.tsx
@@ -14,10 +14,8 @@ import {
   Card,
   CollectionCardButton,
   CollectionCardGrid,
-  CollectionHeader,
   CollectionViewToggle,
   EmptyState,
-  Input,
   Table,
   TableBody,
   TableCell,
@@ -41,6 +39,7 @@ import {
 } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { CollectionPageHeader } from "../components/CollectionPageHeader"
 import { SixbFailureSummary } from "../components/SixbFailureSummary"
 import {
   isUnconfiguredStorageError,
@@ -654,10 +653,20 @@ export function ConnectorsPage() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl">
-      <CollectionHeader
+    <div className="mx-auto w-full max-w-6xl">
+      <CollectionPageHeader
         title="Connectors"
-        count={filteredConnectors.length}
+        count={connectors.length}
+        singularLabel="connector"
+        search={
+          connectors.length > 0
+            ? {
+                value: searchQuery,
+                placeholder: "Search connectors, syncs, or webhooks…",
+                onChange: setSearchQuery,
+              }
+            : undefined
+        }
         actions={
           connectors.length > 0 ? (
             <CollectionViewToggle
@@ -671,19 +680,6 @@ export function ConnectorsPage() {
           ) : null
         }
       />
-
-      {connectors.length > 0 && (
-        <div className="relative mt-2">
-          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="text"
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder="Search connectors, syncs, or webhooks..."
-            className="pl-9"
-          />
-        </div>
-      )}
 
       <div className="mt-4">
         {connectors.length === 0 ? (

--- a/packages/atlas/src/pages/DatasetsPage.tsx
+++ b/packages/atlas/src/pages/DatasetsPage.tsx
@@ -11,7 +11,6 @@ import {
   Card,
   CollectionCardButton,
   CollectionCardGrid,
-  CollectionHeader,
   CollectionViewToggle,
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -50,6 +49,7 @@ import {
 } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { CollectionPageHeader } from "../components/CollectionPageHeader"
 import { DatasetDetails } from "../features/datasets/DatasetDetails"
 import { type DatasetGridColumnMeta, DatasetTableGrid } from "../features/datasets/DatasetTableGrid"
 import { useDatasetLiveUpdates } from "../features/datasets/hooks/useDatasetLiveUpdates"
@@ -225,10 +225,20 @@ export function DatasetsPage() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl">
-      <CollectionHeader
+    <div className="mx-auto w-full max-w-6xl">
+      <CollectionPageHeader
         title="Datasets"
-        count={filteredDatasets.length}
+        count={datasets.length}
+        singularLabel="dataset"
+        search={
+          datasets.length > 0
+            ? {
+                value: searchQuery,
+                placeholder: "Search datasets, columns, syncs, or pipelines…",
+                onChange: setSearchQuery,
+              }
+            : undefined
+        }
         actions={
           datasets.length > 0 ? (
             <CollectionViewToggle
@@ -242,19 +252,6 @@ export function DatasetsPage() {
           ) : null
         }
       />
-
-      {datasets.length > 0 && (
-        <div className="relative mt-2">
-          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="text"
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder="Search datasets, columns, syncs, or pipelines..."
-            className="pl-9"
-          />
-        </div>
-      )}
 
       <div className="mt-4">
         {datasets.length === 0 ? (

--- a/packages/atlas/src/pages/LogsPage.tsx
+++ b/packages/atlas/src/pages/LogsPage.tsx
@@ -67,7 +67,7 @@ export function LogsPage() {
   }, [kind, level])
 
   return (
-    <PageFrame title="Logs" headerVariant="collection" contentClassName="max-w-6xl">
+    <PageFrame title="Logs" headerDivider={false}>
       <LogConsole
         builder={builder}
         showKind

--- a/packages/atlas/src/pages/ObjectsWorkbench.tsx
+++ b/packages/atlas/src/pages/ObjectsWorkbench.tsx
@@ -4,10 +4,8 @@ import {
   Card,
   CollectionCardButton,
   CollectionCardGrid,
-  CollectionHeader,
   CollectionViewToggle,
   EmptyState,
-  Input,
   Select,
   SelectContent,
   SelectItem,
@@ -22,10 +20,12 @@ import {
 } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
-import { Box, ChevronRight, Search } from "lucide-react"
+import { ArrowRight, Box, ChevronRight, X } from "lucide-react"
 import { type ReactNode, useDeferredValue, useEffect, useMemo, useState } from "react"
+import { CollectionPageTitle, CollectionSearchInput } from "../components/CollectionPageHeader"
 import { LetterAvatar, LoadingState } from "../components/common"
 import { ObjectIcon } from "../components/ObjectIcon"
+import { ObjectFilterPopover } from "../components/objects/ObjectFilterPopover"
 import { ObjectQueryBar, ObjectsQueryPagination } from "../components/objects/ObjectQueryBar"
 import { useObjectLiveUpdates } from "../features/objects/hooks/useObjectLiveUpdates"
 import { useProjectTelemetryUpdates } from "../features/objects/hooks/useObjectTelemetryUpdates"
@@ -62,7 +62,6 @@ export interface ObjectTypePreviewSection {
 interface ObjectsWorkbenchProps {
   projectName: string
   objectPageSize: number
-  allObjectsTotal: number
   objectTypeCounts: ReadonlyMap<string, number>
   overviewSections: ObjectTypePreviewSection[]
   overviewLoading: boolean
@@ -81,6 +80,7 @@ const objectViewOptions = [
   { value: "cards", label: "Cards" },
   { value: "table", label: "Table" },
 ] as const
+const emptyTelemetryUpdates = new Map<string, TelemetryUpdate[]>()
 
 function formatCompactValue(value: number | string | boolean): string {
   if (typeof value === "number") {
@@ -114,7 +114,6 @@ function objectMatchesQuery(candidate: ObjectSummary, query: string): boolean {
 export function ObjectsWorkbench({
   projectName,
   objectPageSize,
-  allObjectsTotal,
   objectTypeCounts,
   overviewSections,
   overviewLoading,
@@ -295,6 +294,16 @@ export function ObjectsWorkbench({
     )
   }, [filteredObjects])
 
+  const recentObjects = useMemo(() => {
+    const unique = new Map<string, ObjectSummary>()
+    for (const section of overviewSections) {
+      for (const object of section.objects) unique.set(object.id, object)
+    }
+    return Array.from(unique.values())
+      .sort((left, right) => +new Date(right.updatedAt) - +new Date(left.updatedAt))
+      .slice(0, 8)
+  }, [overviewSections])
+
   const handleSelectObject = (objectId: string) => {
     trackRecentObject(projectName, objectId)
     onSelectObject(objectId)
@@ -303,16 +312,6 @@ export function ObjectsWorkbench({
   const searching = queryMode
     ? searchQuery.trim().length > 0 || queryFilters.length > 0
     : searchQuery.trim().length > 0
-  const visibleObjectCount = selectedTypeMode
-    ? filteredObjects.length
-    : filteredOverviewSections.reduce((total, section) => total + section.objects.length, 0)
-  const headerCount = queryMode
-    ? queryTotal
-    : searching
-      ? visibleObjectCount
-      : selectedTypeMode
-        ? 0
-        : allObjectsTotal
   const pageLoading = queryMode
     ? queriedObjects.isLoading
     : selectedTypeMode && !selectedObjectType
@@ -323,13 +322,65 @@ export function ObjectsWorkbench({
     : filteredOverviewSections.some((section) => section.objects.length > 0)
   const queryError = queriedObjects.error ?? facetsQuery.error
   const querySortValue = querySort ? `${querySort.propertyId}:${querySort.direction}` : "default"
+  const queryObjectTypeLabel = humanizeIdentifier(
+    selectedObjectType?.name || classFilter || "objects"
+  )
 
   return (
-    <div className="mx-auto w-full max-w-5xl">
-      <CollectionHeader
+    <div className="mx-auto w-full max-w-6xl">
+      <CollectionPageTitle
         title="Objects"
-        count={headerCount}
-        actions={
+        count={availableClasses.length}
+        singularLabel="object type"
+      />
+
+      <div className="sticky top-0 z-30 mt-3 bg-background/92 py-2 backdrop-blur-xl supports-[backdrop-filter]:bg-background/82">
+        <div className="flex flex-col gap-1.5 md:flex-row md:items-center">
+          <CollectionSearchInput
+            value={searchQuery}
+            onChange={setSearchQuery}
+            placeholder={
+              queryMode
+                ? textSearchEnabled
+                  ? `Search ${queryObjectTypeLabel}…`
+                  : "Text search unavailable"
+                : "Search objects…"
+            }
+            disabled={queryMode && !textSearchEnabled}
+          />
+
+          <div className="flex w-full items-center gap-1.5 md:w-auto">
+            <Select
+              value={classFilter ?? "all"}
+              onValueChange={(value) => onClassFilterChange(value === "all" ? null : value)}
+            >
+              <SelectTrigger className="h-9 w-full bg-white md:w-48" aria-label="Object type">
+                <SelectValue placeholder="All object types" />
+              </SelectTrigger>
+              <SelectContent align="start">
+                <SelectItem value="all">All objects</SelectItem>
+                {availableClasses.map((cls) => (
+                  <SelectItem key={cls} value={cls}>
+                    {humanizeIdentifier(cls)} · {formatCount(objectTypeCounts.get(cls) ?? 0)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {classFilter ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-sm"
+                onClick={() => onClassFilterChange(null)}
+                className="size-9 shrink-0 bg-white"
+                aria-label="Show all objects"
+                title="Show all objects"
+              >
+                <X className="size-4" />
+              </Button>
+            ) : null}
+          </div>
+
           <div className="flex items-center gap-2">
             {queryMode ? (
               <Select
@@ -348,7 +399,11 @@ export function ObjectsWorkbench({
                   }
                 }}
               >
-                <SelectTrigger size="sm" className="h-8 w-36 text-xs" aria-label="Sort objects">
+                <SelectTrigger
+                  size="sm"
+                  className="h-9 w-36 bg-white text-xs"
+                  aria-label="Sort objects"
+                >
                   <SelectValue placeholder="Sort" />
                 </SelectTrigger>
                 <SelectContent align="end">
@@ -374,7 +429,11 @@ export function ObjectsWorkbench({
                   }
                 }}
               >
-                <SelectTrigger size="sm" className="h-8 w-28 text-xs" aria-label="Sort objects">
+                <SelectTrigger
+                  size="sm"
+                  className="h-9 w-32 bg-white text-xs"
+                  aria-label="Sort objects"
+                >
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent align="end">
@@ -383,77 +442,62 @@ export function ObjectsWorkbench({
                 </SelectContent>
               </Select>
             )}
-            {selectedTypeMode ? (
-              <CollectionViewToggle
-                value={viewStyle}
-                options={objectViewOptions}
-                onChange={(style) => {
-                  setViewStyle(style)
-                  setObjectViewStyle(style)
-                }}
+            {queryMode ? (
+              <div className="[&_[data-slot=toggle-group]]:h-9">
+                <CollectionViewToggle
+                  value={viewStyle}
+                  options={objectViewOptions}
+                  onChange={(style) => {
+                    setViewStyle(style)
+                    setObjectViewStyle(style)
+                  }}
+                />
+              </div>
+            ) : null}
+            {queryMode && selectedObjectType ? (
+              <ObjectFilterPopover
+                properties={filterableProperties}
+                filters={queryFilters}
+                facetResults={facetsQuery.data ?? []}
+                onAddFilter={(filter) => setQueryFilters((current) => [...current, filter])}
               />
             ) : null}
+            {queryMode && searching ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-9 px-2.5"
+                onClick={() => {
+                  setSearchQuery("")
+                  setQueryFilters([])
+                }}
+              >
+                <X />
+                Clear
+              </Button>
+            ) : null}
           </div>
-        }
-      />
-
-      {availableClasses.length > 1 ? (
-        <div className="mt-3 flex flex-wrap items-center gap-1.5">
-          <ClassChip
-            label="All"
-            count={allObjectsTotal}
-            active={classFilter == null}
-            onClick={() => onClassFilterChange(null)}
-          />
-          {availableClasses.map((cls) => (
-            <ClassChip
-              key={cls}
-              label={humanizeIdentifier(cls)}
-              count={objectTypeCounts.get(cls) ?? 0}
-              active={classFilter === cls}
-              onClick={() => onClassFilterChange(cls)}
-            />
-          ))}
         </div>
-      ) : null}
+      </div>
 
       {queryMode && selectedObjectType ? (
         <ObjectQueryBar
-          objectType={selectedObjectType}
-          searchQuery={searchQuery}
-          textSearchEnabled={textSearchEnabled}
           filters={queryFilters}
           matchMode={queryMatchMode}
-          filterableProperties={filterableProperties}
           propertiesById={queryPropertiesById}
           facetResults={facetsQuery.data ?? []}
           facetsLoading={facetsQuery.isLoading}
           queryError={queryError}
-          onSearchQueryChange={setSearchQuery}
           onAddFilter={(filter) => setQueryFilters((current) => [...current, filter])}
           onRemoveFilter={(filterId) =>
             setQueryFilters((current) => current.filter((filter) => filter.id !== filterId))
           }
-          onClear={() => {
-            setSearchQuery("")
-            setQueryFilters([])
-          }}
           onMatchModeChange={setQueryMatchMode}
         />
-      ) : (
-        <div className="relative mt-3">
-          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="text"
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder="Search objects, location, or class..."
-            className="pl-9"
-          />
-        </div>
-      )}
+      ) : null}
 
-      <div className="mt-4 space-y-4">
+      <div className="mt-6 space-y-6">
         {pageLoading ? (
           <div className="flex min-h-72 items-center justify-center">
             <LoadingState label="Loading objects..." />
@@ -468,35 +512,26 @@ export function ObjectsWorkbench({
                 : "Try a broader search query."
             }
           />
+        ) : !selectedTypeMode && searching ? (
+          <section className="space-y-3">
+            <SectionHeading
+              title="Matching previews"
+              description={`${formatCount(filteredObjects.length)} loaded objects match this search.`}
+            />
+            <TableView
+              objects={filteredObjects}
+              updatesByObject={emptyTelemetryUpdates}
+              selectedObjectId={selectedObjectId ?? null}
+              onSelectObject={handleSelectObject}
+            />
+          </section>
         ) : !selectedTypeMode ? (
-          <div className="space-y-6">
-            {filteredOverviewSections.map((section) => (
-              <ObjectCardSection
-                key={section.objectTypeId}
-                objectTypeId={section.objectTypeId}
-                objects={section.objects}
-                count={formatLoadedCount(
-                  section.objects.length,
-                  searching ? undefined : section.total
-                )}
-                selectedObjectId={selectedObjectId}
-                onSelectObject={handleSelectObject}
-                action={
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="ml-auto h-7 px-2 text-xs"
-                    title={`View ${humanizeIdentifier(section.objectTypeId)} objects`}
-                    onClick={() => onClassFilterChange(section.objectTypeId)}
-                  >
-                    View all
-                    <ChevronRight />
-                  </Button>
-                }
-              />
-            ))}
-          </div>
+          <ObjectsOverview
+            sections={filteredOverviewSections}
+            recentObjects={recentObjects}
+            onSelectType={onClassFilterChange}
+            onSelectObject={handleSelectObject}
+          />
         ) : viewStyle === "table" ? (
           <TableView
             objects={filteredObjects}
@@ -541,6 +576,113 @@ export function ObjectsWorkbench({
   )
 }
 
+function SectionHeading({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+      <h2 className="text-base font-semibold tracking-[-0.02em] text-foreground">{title}</h2>
+      {description ? <p className="text-xs text-muted-foreground">{description}</p> : null}
+    </div>
+  )
+}
+
+function ObjectsOverview({
+  sections,
+  recentObjects,
+  onSelectType,
+  onSelectObject,
+}: {
+  sections: ObjectTypePreviewSection[]
+  recentObjects: ObjectSummary[]
+  onSelectType: (objectTypeId: string) => void
+  onSelectObject: (objectId: string) => void
+}) {
+  return (
+    <div className="space-y-8">
+      {recentObjects.length > 0 ? (
+        <section className="space-y-3">
+          <SectionHeading title="Recently updated" />
+          <div className="grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2 xl:grid-cols-4">
+            {recentObjects.map((object) => {
+              const label = object.name || humanizeIdentifier(object.id)
+              return (
+                <button
+                  key={object.id}
+                  type="button"
+                  onClick={() => onSelectObject(object.id)}
+                  className="group flex min-h-24 min-w-0 flex-col items-start bg-card p-4 text-left transition-colors hover:bg-[var(--atlas-surface-hover)] focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <div className="flex w-full min-w-0 items-center gap-2">
+                    <ObjectIcon
+                      type={object.class}
+                      className="size-3.5 shrink-0 text-muted-foreground"
+                    />
+                    <span className="truncate text-sm font-medium text-foreground">{label}</span>
+                    <ArrowRight className="ml-auto size-3.5 shrink-0 text-muted-foreground opacity-0 transition-[opacity,transform] group-hover:translate-x-0.5 group-hover:opacity-100" />
+                  </div>
+                  <p className="mt-auto pt-3 text-[11px] text-muted-foreground">
+                    {humanizeIdentifier(object.class)} · {formatRelativeTime(object.updatedAt)}
+                  </p>
+                </button>
+              )
+            })}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="space-y-3">
+        <SectionHeading
+          title="Browse by type"
+          description={`${formatCount(sections.length)} populated object types.`}
+        />
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {sections.map((section) => (
+            <ObjectTypeSummaryCard
+              key={section.objectTypeId}
+              section={section}
+              onClick={() => onSelectType(section.objectTypeId)}
+            />
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function ObjectTypeSummaryCard({
+  section,
+  onClick,
+}: {
+  section: ObjectTypePreviewSection
+  onClick: () => void
+}) {
+  const label = humanizeIdentifier(section.objectTypeId)
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex min-h-40 flex-col rounded-xl border border-border bg-card p-4 text-left transition-[border-color,background-color,transform] hover:-translate-y-0.5 hover:border-[var(--atlas-border-hover)] hover:bg-[var(--atlas-surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <div className="flex w-full items-start gap-3">
+        <LetterAvatar label={label} />
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate text-sm font-semibold text-foreground">{label}</h3>
+          <p className="mt-0.5 text-xs tabular-nums text-muted-foreground">
+            {formatCount(section.total)} object{section.total === 1 ? "" : "s"}
+          </p>
+        </div>
+        <ChevronRight className="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+      </div>
+      <div className="mt-4 w-full space-y-1.5 border-t border-border/70 pt-3">
+        {section.objects.slice(0, 3).map((object) => (
+          <p key={object.id} className="truncate text-xs text-muted-foreground">
+            {object.name || humanizeIdentifier(object.id)}
+          </p>
+        ))}
+      </div>
+    </button>
+  )
+}
+
 function ObjectCardSection({
   objectTypeId,
   objects,
@@ -579,36 +721,6 @@ function ObjectCardSection({
         ))}
       </CollectionCardGrid>
     </section>
-  )
-}
-
-function ClassChip({
-  label,
-  count,
-  active,
-  onClick,
-}: {
-  label: string
-  count: number
-  active: boolean
-  onClick: () => void
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "inline-flex h-7 items-center gap-1.5 rounded-full border px-3 text-xs transition-colors",
-        active
-          ? "border-foreground bg-foreground text-background"
-          : "border-border bg-card text-foreground hover:bg-muted"
-      )}
-    >
-      <span>{label}</span>
-      <span className={cn("tabular-nums", active ? "text-background/70" : "text-muted-foreground")}>
-        {formatCount(count)}
-      </span>
-    </button>
   )
 }
 

--- a/packages/atlas/src/pages/OntologyExplorer.tsx
+++ b/packages/atlas/src/pages/OntologyExplorer.tsx
@@ -17,6 +17,7 @@ import {
   type Node,
   type NodeProps,
   type NodeTypes,
+  Panel,
   Position,
   ReactFlow,
   ReactFlowProvider,
@@ -25,7 +26,7 @@ import {
   useReactFlow,
   type Edge as XYEdge,
 } from "@xyflow/react"
-import { CornerDownRight, Link2, Rows3, Search, X, Zap } from "lucide-react"
+import { CornerDownRight, Link2, Maximize2, Rows3, Search, X, Zap } from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { LetterAvatar } from "../components/common"
 import { humanizeIdentifier } from "../lib/labels"
@@ -199,7 +200,7 @@ export function OntologyExplorer({
                 if (detailsOpen && selectedType) onSelectedTypeChange(selectedType.id)
               }}
             />
-            {view !== "details" ? (
+            {view === "list" ? (
               <div className="relative min-w-0 flex-1 xl:w-64 xl:flex-none">
                 <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
                 <Input
@@ -224,6 +225,7 @@ export function OntologyExplorer({
                   objectTypes={objectTypes}
                   objectTypeCounts={objectTypeCounts}
                   search={search}
+                  onSearchChange={setSearch}
                   selectedTypeId={selectedTypeId}
                   onSelectType={onSelectedTypeChange}
                   savedViewport={graphViewport}
@@ -320,6 +322,7 @@ function OntologyGraph({
   objectTypes,
   objectTypeCounts,
   search,
+  onSearchChange,
   selectedTypeId,
   onSelectType,
   savedViewport,
@@ -328,6 +331,7 @@ function OntologyGraph({
   objectTypes: ObjectTypeSummary[]
   objectTypeCounts: ReadonlyMap<string, number>
   search: string
+  onSearchChange: (query: string) => void
   selectedTypeId: string | null
   onSelectType: (typeId: string | null) => void
   savedViewport: OntologyGraphViewport | null
@@ -514,6 +518,38 @@ function OntologyGraph({
       >
         <Background variant={BackgroundVariant.Dots} gap={22} size={1} />
         <Controls position="bottom-left" showInteractive={false} />
+        <Panel position="bottom-center" className="!m-3 w-[calc(100%-1.5rem)] max-w-[720px]">
+          <div className="flex items-center gap-1.5 rounded-2xl border border-border/80 bg-card/95 p-1.5 shadow-xl transition-colors focus-within:border-ring/50 backdrop-blur-xl supports-[backdrop-filter]:bg-card/88">
+            <div className="relative min-w-0 flex-1">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                type="search"
+                value={search}
+                onChange={(event) => onSearchChange(event.target.value)}
+                placeholder="Search graph..."
+                aria-label="Search ontology graph"
+                className="h-8 border-0 bg-transparent pl-8 text-xs shadow-none focus-visible:ring-0 dark:bg-transparent"
+              />
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Fit visible graph"
+              title="Fit visible graph"
+              onClick={() => {
+                const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+                void fitBounds(layout.bounds, {
+                  padding: 0.1,
+                  duration: reduceMotion ? 0 : GRAPH_LAYOUT_DURATION,
+                })
+              }}
+              className="shrink-0"
+            >
+              <Maximize2 />
+            </Button>
+          </div>
+        </Panel>
       </ReactFlow>
     </div>
   )

--- a/packages/atlas/src/pages/PipelinesPage.tsx
+++ b/packages/atlas/src/pages/PipelinesPage.tsx
@@ -20,10 +20,8 @@ import {
   Card,
   CollectionCardButton,
   CollectionCardGrid,
-  CollectionHeader,
   CollectionViewToggle,
   EmptyState,
-  Input,
   Table,
   TableBody,
   TableCell,
@@ -69,6 +67,7 @@ import {
 } from "lucide-react"
 import { type ReactNode, useEffect, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { CollectionPageHeader } from "../components/CollectionPageHeader"
 import { SixbFailureSummary } from "../components/SixbFailureSummary"
 import {
   isUnconfiguredStorageError,
@@ -357,10 +356,20 @@ export function PipelinesPage() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl">
-      <CollectionHeader
+    <div className="mx-auto w-full max-w-6xl">
+      <CollectionPageHeader
         title="Pipelines"
-        count={filteredPipelines.length}
+        count={pipelines.length}
+        singularLabel="pipeline"
+        search={
+          pipelines.length > 0
+            ? {
+                value: searchQuery,
+                placeholder: "Search pipelines, steps, or datasets…",
+                onChange: setSearchQuery,
+              }
+            : undefined
+        }
         actions={
           pipelines.length > 0 ? (
             <CollectionViewToggle
@@ -374,19 +383,6 @@ export function PipelinesPage() {
           ) : null
         }
       />
-
-      {pipelines.length > 0 && (
-        <div className="relative mt-2">
-          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="text"
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder="Search pipelines, steps, or datasets..."
-            className="pl-9"
-          />
-        </div>
-      )}
 
       <div className="mt-4">
         {pipelines.length === 0 ? (

--- a/packages/atlas/src/pages/ProjectWorkspace.tsx
+++ b/packages/atlas/src/pages/ProjectWorkspace.tsx
@@ -3,15 +3,8 @@ import {
   getProjectInfoOptions,
   getWorkflowRunOptions,
   listActionsOptions,
-  listAgentsOptions,
-  listConnectorsOptions,
-  listDatasetsOptions,
   listObjectsPageOptions,
   listObjectTypesOptions,
-  listPipelinesOptions,
-  listProjectionsOptions,
-  listRulesOptions,
-  listSyncsOptions,
   listWorkflowsOptions,
   objectCountOptions,
 } from "@sixb/client/hooks"
@@ -143,7 +136,7 @@ export function ProjectWorkspace() {
           params.delete("offset")
           return params
         },
-        { replace: options?.replace ?? true }
+        { replace: options?.replace ?? false }
       )
     },
     [setSearchParams]
@@ -246,42 +239,10 @@ export function ProjectWorkspace() {
     return total
   }, [objectTypes, objectTypeCounts])
 
-  const allObjectsTotal = globalObjectCountQuery.data ?? objectTypeTotal ?? 0
-
   const overviewLoading =
     !classFilter &&
     (objectTypesLoading ||
       (objectTypes.length > 0 && objectTypePreviewQueries.some((query) => query.isLoading)))
-
-  const { data: connectors = [] } = useQuery({
-    ...listConnectorsOptions(),
-    enabled: !!projectInfo,
-  })
-
-  const { data: datasets = [] } = useQuery({
-    ...listDatasetsOptions(),
-    enabled: !!projectInfo,
-  })
-
-  const { data: syncs = [] } = useQuery({
-    ...listSyncsOptions(),
-    enabled: !!projectInfo,
-  })
-
-  const { data: pipelines = [] } = useQuery({
-    ...listPipelinesOptions(),
-    enabled: !!projectInfo,
-  })
-
-  const { data: projections } = useQuery({
-    ...listProjectionsOptions(),
-    enabled: !!projectInfo,
-  })
-  const projectionCount = projections
-    ? projections.objectProjections.length +
-      projections.linkProjections.length +
-      projections.telemetryProjections.length
-    : 0
 
   const { data: workflows = [] } = useQuery({
     ...listWorkflowsOptions(),
@@ -293,45 +254,19 @@ export function ProjectWorkspace() {
     enabled: !!projectInfo,
   })
 
-  const { data: rules = [] } = useQuery({
-    ...listRulesOptions(),
-    enabled: !!projectInfo,
-  })
-
-  const { data: agents = [] } = useQuery({
-    ...listAgentsOptions(),
-    enabled: !!projectInfo,
-  })
-
   const selectedObjectIdForSidebar = objectIdFromUrl
 
   useEffect(() => {
     setSidebarData({
       objectCount: globalObjectCountQuery.data ?? objectTypeTotal,
-      datasetCount: datasets.length,
-      connectorCount: connectors.length,
-      syncCount: syncs.length,
-      pipelineCount: pipelines.length,
-      projectionCount,
       workflowCount: workflows.length,
       actionCount: actions.length,
-      agentCount: agents.length,
-      ruleCount: rules.length,
-      ontologyCount: objectTypes.length,
     })
   }, [
     globalObjectCountQuery.data,
     objectTypeTotal,
-    datasets.length,
-    connectors.length,
-    syncs.length,
-    pipelines.length,
-    projectionCount,
     workflows.length,
     actions.length,
-    agents.length,
-    rules.length,
-    objectTypes.length,
     setSidebarData,
   ])
 
@@ -424,7 +359,6 @@ export function ProjectWorkspace() {
                   <ObjectsWorkbench
                     projectName={resolvedProjectName}
                     objectPageSize={OBJECT_PAGE_SIZE}
-                    allObjectsTotal={allObjectsTotal}
                     objectTypeCounts={objectTypeCounts}
                     overviewSections={objectTypePreviewSections}
                     overviewLoading={overviewLoading}

--- a/packages/atlas/src/pages/ProjectionsPage.tsx
+++ b/packages/atlas/src/pages/ProjectionsPage.tsx
@@ -14,10 +14,8 @@ import {
   Card,
   CollectionCardButton,
   CollectionCardGrid,
-  CollectionHeader,
   CollectionViewToggle,
   EmptyState,
-  Input,
   Table,
   TableBody,
   TableCell,
@@ -43,6 +41,7 @@ import {
 } from "lucide-react"
 import { useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { CollectionPageHeader } from "../components/CollectionPageHeader"
 import { SixbFailureSummary } from "../components/SixbFailureSummary"
 import { humanizeIdentifier } from "../lib/labels"
 import { formatRelativeTime } from "../lib/time"
@@ -316,10 +315,20 @@ export function ProjectionsPage() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl">
-      <CollectionHeader
+    <div className="mx-auto w-full max-w-6xl">
+      <CollectionPageHeader
         title="Projections"
-        count={filteredProjections.length}
+        count={projections.length}
+        singularLabel="projection"
+        search={
+          projections.length > 0
+            ? {
+                value: searchQuery,
+                placeholder: "Search projections, kinds, or datasets…",
+                onChange: setSearchQuery,
+              }
+            : undefined
+        }
         actions={
           projections.length > 0 ? (
             <CollectionViewToggle
@@ -333,19 +342,6 @@ export function ProjectionsPage() {
           ) : null
         }
       />
-
-      {projections.length > 0 && (
-        <div className="relative mt-2">
-          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="text"
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder="Search projections, kinds, or datasets..."
-            className="pl-9"
-          />
-        </div>
-      )}
 
       <div className="mt-4">
         {projections.length === 0 ? (

--- a/packages/atlas/src/pages/RulesPage.tsx
+++ b/packages/atlas/src/pages/RulesPage.tsx
@@ -11,10 +11,8 @@ import {
   Card,
   CollectionCardButton,
   CollectionCardGrid,
-  CollectionHeader,
   CollectionViewToggle,
   EmptyState,
-  Input,
   Table,
   TableBody,
   TableCell,
@@ -27,6 +25,7 @@ import { useQuery } from "@tanstack/react-query"
 import { BellRing, ChevronLeft, ChevronRight, ListChecks, Loader2, Search } from "lucide-react"
 import { useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { CollectionPageHeader } from "../components/CollectionPageHeader"
 import {
   isUnconfiguredStorageError,
   UnrecordedHistoryState,
@@ -665,10 +664,20 @@ export function RulesPage() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl">
-      <CollectionHeader
+    <div className="mx-auto w-full max-w-6xl">
+      <CollectionPageHeader
         title="Rules"
-        count={filteredRules.length}
+        count={rules.length}
+        singularLabel="rule"
+        search={
+          rules.length > 0
+            ? {
+                value: searchQuery,
+                placeholder: "Search rules, subjects, or predicates…",
+                onChange: setSearchQuery,
+              }
+            : undefined
+        }
         actions={
           rules.length > 0 ? (
             <CollectionViewToggle
@@ -682,19 +691,6 @@ export function RulesPage() {
           ) : null
         }
       />
-
-      {rules.length > 0 && (
-        <div className="relative mt-2">
-          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="text"
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder="Search rules, subjects, or predicates..."
-            className="pl-9"
-          />
-        </div>
-      )}
 
       <div className="mt-4">
         <RulesContent

--- a/packages/atlas/src/pages/SyncsPage.tsx
+++ b/packages/atlas/src/pages/SyncsPage.tsx
@@ -11,10 +11,8 @@ import {
   Card,
   CollectionCardButton,
   CollectionCardGrid,
-  CollectionHeader,
   CollectionViewToggle,
   EmptyState,
-  Input,
   Table,
   TableBody,
   TableCell,
@@ -40,6 +38,7 @@ import {
 } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { CollectionPageHeader } from "../components/CollectionPageHeader"
 import { SixbFailureSummary } from "../components/SixbFailureSummary"
 import {
   isUnconfiguredStorageError,
@@ -613,10 +612,20 @@ export function SyncsPage() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl">
-      <CollectionHeader
+    <div className="mx-auto w-full max-w-6xl">
+      <CollectionPageHeader
         title="Syncs"
-        count={filteredSyncs.length}
+        count={syncs.length}
+        singularLabel="sync"
+        search={
+          syncs.length > 0
+            ? {
+                value: searchQuery,
+                placeholder: "Search syncs, connectors, or datasets…",
+                onChange: setSearchQuery,
+              }
+            : undefined
+        }
         actions={
           syncs.length > 0 ? (
             <CollectionViewToggle
@@ -630,19 +639,6 @@ export function SyncsPage() {
           ) : null
         }
       />
-
-      {syncs.length > 0 && (
-        <div className="relative mt-2">
-          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="text"
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder="Search syncs, connectors, or datasets..."
-            className="pl-9"
-          />
-        </div>
-      )}
 
       <div className="mt-4">
         {syncs.length === 0 ? (

--- a/packages/atlas/src/pages/WorkflowsPage.tsx
+++ b/packages/atlas/src/pages/WorkflowsPage.tsx
@@ -1,12 +1,16 @@
 import { listWorkflowsOptions } from "@sixb/client/hooks"
 import { Card, EmptyState, Tabs, TabsContent, TabsList, TabsTrigger } from "@sixb/ui/components"
 import { useQuery } from "@tanstack/react-query"
-import { Workflow } from "lucide-react"
+import { Search, Workflow } from "lucide-react"
+import { useMemo } from "react"
 import { useSearchParams } from "react-router-dom"
+import { CollectionSearchInput } from "../components/CollectionPageHeader"
 import { ErrorPage, LoadingPage, PageFrame } from "../components/common"
 import { WorkflowRunHistoryTab } from "../features/workflows/components/runs/WorkflowRunHistoryTab"
 import { WorkflowCard } from "../features/workflows/components/workflows/WorkflowCard"
 import { useWorkflowLiveUpdates } from "../features/workflows/hooks/useWorkflowLiveUpdates"
+import type { WorkflowSummary } from "../features/workflows/utils/workflows"
+import { humanizeIdentifier } from "../lib/labels"
 
 type WorkflowsPageTab = "workflows" | "runs"
 
@@ -27,7 +31,7 @@ export function WorkflowsPage() {
   return (
     <PageFrame title="Workflows" headerDivider={false}>
       <Tabs value={activeTab} onValueChange={handleTabChange} className="gap-4">
-        <TabsList variant="line" className="border-b border-border">
+        <TabsList variant="line">
           <TabsTrigger value="workflows">Workflows</TabsTrigger>
           <TabsTrigger value="runs">Runs</TabsTrigger>
         </TabsList>
@@ -44,7 +48,26 @@ export function WorkflowsPage() {
 
 function WorkflowDefinitionsTab() {
   const workflowsQuery = useQuery(listWorkflowsOptions())
+  const [searchParams, setSearchParams] = useSearchParams()
   const workflows = workflowsQuery.data ?? []
+  const query = searchParams.get("q") ?? ""
+  const filteredWorkflows = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase()
+    if (!normalizedQuery) return workflows
+    return workflows.filter((workflow) => workflowSearchText(workflow).includes(normalizedQuery))
+  }, [query, workflows])
+
+  const updateQuery = (value: string) => {
+    setSearchParams(
+      (previous) => {
+        const next = new URLSearchParams(previous)
+        if (value) next.set("q", value)
+        else next.delete("q")
+        return next
+      },
+      { replace: true }
+    )
+  }
 
   if (workflowsQuery.isLoading) {
     return <LoadingPage label="Loading workflows..." />
@@ -56,23 +79,68 @@ function WorkflowDefinitionsTab() {
     )
   }
 
+  if (workflows.length === 0) {
+    return (
+      <Card>
+        <EmptyState
+          icon={<Workflow className="size-12 stroke-1" />}
+          title="No workflows registered"
+          description="Create a workflow definition to see it appear here."
+        />
+      </Card>
+    )
+  }
+
   return (
-    <section className="space-y-3">
-      {workflows.length === 0 ? (
+    <section className="space-y-4">
+      <div className="sticky top-0 z-20 bg-background/92 py-2 backdrop-blur-xl supports-[backdrop-filter]:bg-background/82">
+        <div className="flex flex-col gap-1.5 sm:flex-row sm:items-center">
+          <CollectionSearchInput
+            value={query}
+            onChange={updateQuery}
+            placeholder="Search workflows, nodes, triggers, or inputs…"
+          />
+          <p className="shrink-0 px-1 text-xs tabular-nums text-muted-foreground">
+            {query.trim()
+              ? `${filteredWorkflows.length} of ${workflows.length} workflows`
+              : `${workflows.length} workflow${workflows.length === 1 ? "" : "s"}`}
+          </p>
+        </div>
+      </div>
+
+      {filteredWorkflows.length === 0 ? (
         <Card>
           <EmptyState
-            icon={<Workflow className="size-12 stroke-1" />}
-            title="No workflows registered"
-            description="Create a workflow definition to see it appear here."
+            icon={<Search className="size-10 stroke-1" />}
+            title="No matching workflows"
+            description="Try another workflow name, node, trigger, or input."
           />
         </Card>
       ) : (
         <div className="grid gap-3 lg:grid-cols-2">
-          {workflows.map((workflow) => (
+          {filteredWorkflows.map((workflow) => (
             <WorkflowCard key={workflow.id} workflow={workflow} />
           ))}
         </div>
       )}
     </section>
   )
+}
+
+function workflowSearchText(workflow: WorkflowSummary): string {
+  const nodeValues = workflow.nodes.flatMap((node) => [
+    node.key,
+    node.type,
+    "objectTypeId" in node ? (node.objectTypeId ?? "") : "",
+    "agentId" in node ? node.agentId : "",
+  ])
+  return [
+    workflow.id,
+    humanizeIdentifier(workflow.id),
+    ...Object.keys(workflow.input ?? {}),
+    ...workflow.triggers.map((trigger) => trigger.scheduleId),
+    ...nodeValues,
+  ]
+    .join(" ")
+    .toLowerCase()
 }

--- a/packages/atlas/tests/atlas-collection-ui.test.tsx
+++ b/packages/atlas/tests/atlas-collection-ui.test.tsx
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { renderToStaticMarkup } from "react-dom/server"
+import { MemoryRouter } from "react-router-dom"
+import { WorkflowCard } from "../src/features/workflows/components/workflows/WorkflowCard"
+import type { WorkflowSummary } from "../src/features/workflows/utils/workflows"
+import { getObjectViewStyle } from "../src/lib/userPreferences"
+
+const workflow = {
+  id: "service-response",
+  input: { serviceCaseId: "string" },
+  triggers: [{ type: "schedule", scheduleId: "hourly" }],
+  nodes: [
+    { type: "step", id: "one", key: "loadContext", input: {}, output: {} },
+    { type: "intervention", id: "two", key: "reviewDispatch", input: {}, response: {} },
+    { type: "action", id: "three", key: "dispatchWorkOrder", params: {} },
+    { type: "agent", id: "four", key: "summarizeVisit", agentId: "ops", input: {}, output: {} },
+    { type: "step", id: "five", key: "recordOutcome", input: {}, output: {} },
+    { type: "step", id: "six", key: "notifyCustomer", input: {}, output: {} },
+  ],
+  latestRun: null,
+} satisfies WorkflowSummary
+
+test("object collections default to the table workbench", () => {
+  expect(getObjectViewStyle()).toBe("table")
+})
+
+test("workflow cards keep the catalog summary compact", () => {
+  const markup = renderToStaticMarkup(
+    <MemoryRouter>
+      <WorkflowCard workflow={workflow} />
+    </MemoryRouter>
+  )
+
+  expect(markup).toContain("Service Response")
+  expect(markup).toContain('href="/workflows/service-response"')
+  expect(markup).toContain("6 nodes · 1 trigger · 1 input field")
+  expect(markup).toContain("No runs recorded")
+  expect(markup).not.toContain("Structure")
+  expect(markup).not.toContain("Run workflow")
+})


### PR DESCRIPTION
## Summary
- reorganize and polish Atlas workspace navigation with grouped sections, command search, refined branding, and Chat labeling
- standardize collection headers, search, filters, widths, cards, and tables across objects, actions, workflows, connectors, datasets, syncs, pipelines, projections, logs, and rules
- improve object filtering history and clear-filter behavior while simplifying duplicated and dead UI code
- keep ontology graph layout and navigation behavior intact while presenting graph search in the clean bottom toolbar

## Verification
- bun test ./packages/atlas/tests/ — 53 passed, 0 failed
- bun --filter @sixb/atlas typecheck
- bun --filter @sixb/atlas build
- bunx biome check packages/atlas/src packages/atlas/tests
- git diff --check

## Screenshots

<img width="1356" height="1302" alt="Screenshot 2026-09-01 at 1 30 25 PM" src="https://github.com/user-attachments/assets/736b59cf-6051-4103-8af7-36e6afe0207a" />
<img width="1544" height="1324" alt="Screenshot 2026-09-01 at 1 30 15 PM" src="https://github.com/user-attachments/assets/af65f046-43bd-4f1c-a8b7-a7de9fc1a500" />
