### PR TITLE
core: add AI usage-limit storage

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -137,6 +137,12 @@
       "import": "./dist/storage/ai-cost/provider.js",
       "default": "./dist/storage/ai-cost/provider.js"
     },
+    "./internal/ai-limit-storage-provider": {
+      "types": "./dist/storage/ai-limits/provider.d.ts",
+      "bun": "./src/storage/ai-limits/provider.ts",
+      "import": "./dist/storage/ai-limits/provider.js",
+      "default": "./dist/storage/ai-limits/provider.js"
+    },
     "./internal/auth": {
       "types": "./dist/auth/index.d.ts",
       "bun": "./src/auth/index.ts",

--- a/packages/core/src/storage/ai-cost/in-memory.ts
+++ b/packages/core/src/storage/ai-cost/in-memory.ts
@@ -89,6 +89,12 @@ export class InMemoryAiCostStorage implements AiCostStorage {
     replaceMap(this.recordsByUsage, snapshot.recordsByUsage)
   }
 
+  /** @internal Immutable accounting source used by in-memory AI limit enforcement. */
+  getRecord(projectId: string, usageRecordId: string): AiModelCallCostRecord | null {
+    const record = this.recordsByUsage.get(usageRecordKey(projectId, usageRecordId))
+    return record ? structuredClone(record) : null
+  }
+
   private usageRecord(projectId: string, id: string): AiModelCallUsageRecord | undefined {
     return [...this.usage.snapshot().records.values()].find(
       (record) => record.projectId === projectId && record.id === id

--- a/packages/core/src/storage/ai-limits/errors.ts
+++ b/packages/core/src/storage/ai-limits/errors.ts
@@ -1,0 +1,23 @@
+export type AiLimitStorageErrorCode =
+  | "duplicate_policy"
+  | "missing_policy"
+  | "missing_execution"
+  | "missing_reservation"
+  | "missing_usage_record"
+  | "usage_mismatch"
+  | "unavailable_actuals"
+  | "reservation_conflict"
+  | "reconciliation_conflict"
+  | "invalid_reservation_state"
+
+/** Stable storage failure for AI limit policies and reservations. */
+export class AiLimitStorageError extends Error {
+  readonly name = "AiLimitStorageError"
+
+  constructor(
+    readonly code: AiLimitStorageErrorCode,
+    message: string
+  ) {
+    super(message)
+  }
+}

--- a/packages/core/src/storage/ai-limits/in-memory.ts
+++ b/packages/core/src/storage/ai-limits/in-memory.ts
@@ -1,0 +1,635 @@
+import type { AiModelCallCostRecord } from "../ai-cost"
+import type { AiModelCallUsageRecord } from "../ai-usage"
+import type { ExecutionRecord } from "../executions"
+import { AiLimitStorageError } from "./errors"
+import { aiLimitCalendarMonth } from "./period"
+import type { AiLimitAccountingEntry } from "./provider"
+import {
+  aiLimitAccountingEntryAppliesToSubject,
+  aiLimitAmountKey,
+  aiLimitPolicyDimensionKey,
+  aiLimitQuantityFromAmount,
+  aiLimitReservationBuckets,
+  aiLimitReservationRequestKey,
+  aiLimitReservationRequestMatches,
+  aiLimitSubjectKey,
+  aiLimitSubjectsFromAccountingEntry,
+  aiModelCallReservationKey,
+  assertAiLimitAccountingMatchesReservation,
+  assertNonBlank,
+  cloneAiLimitPolicy,
+  cloneValidDate,
+  type NormalizedAiLimitAmount,
+  normalizeAiLimitAmount,
+  normalizeAiModelCallReservationIdentity,
+  normalizeCreateAiLimitPolicy,
+  normalizeReserveAiModelCall,
+  normalizeUpdateAiLimitPolicy,
+  resolveAiLimitActual,
+} from "./provider"
+import type {
+  AiLimitPeriod,
+  AiLimitPolicy,
+  AiLimitPolicyStatus,
+  AiLimitQuantity,
+  AiLimitStorage,
+  AiLimitSubject,
+  AiModelCallReservation,
+  CreateAiLimitPolicyInput,
+  DeleteAiLimitPolicyInput,
+  GetAiLimitPolicyInput,
+  ListAiLimitPoliciesInput,
+  ListAiLimitPolicyStatusesInput,
+  MarkAiModelCallReservationUnknownInput,
+  ReconcileAiModelCallInput,
+  RecordAiModelCallLimitActualsInput,
+  ReserveAiModelCallInput,
+  ReserveAiModelCallResult,
+  UpdateAiLimitPolicyInput,
+} from "./types"
+
+interface AiLimitPeriodState {
+  readonly projectId: string
+  readonly subject: AiLimitSubject
+  readonly meter: AiLimitQuantity["meter"]
+  readonly currency: string
+  readonly period: AiLimitPeriod
+  actual: bigint
+  reserved: bigint
+  unknown: bigint
+  accountingStatus: "complete" | "unavailable"
+  updatedAt: Date
+}
+
+export interface InMemoryAiLimitStorageOptions {
+  readonly executionExists?: (input: {
+    readonly projectId: string
+    readonly executionId: string
+  }) => boolean | Promise<boolean>
+  readonly resolveExecution?: (input: {
+    readonly projectId: string
+    readonly executionId: string
+  }) => ExecutionRecord | null | Promise<ExecutionRecord | null>
+  readonly resolveUsageRecord?: (input: {
+    readonly projectId: string
+    readonly usageRecordId: string
+  }) => AiModelCallUsageRecord | null | Promise<AiModelCallUsageRecord | null>
+  readonly resolveCostRecord?: (input: {
+    readonly projectId: string
+    readonly usageRecordId: string
+  }) => AiModelCallCostRecord | null | Promise<AiModelCallCostRecord | null>
+  readonly listUsageRecords?: (input: {
+    readonly projectId: string
+  }) => readonly AiModelCallUsageRecord[] | Promise<readonly AiModelCallUsageRecord[]>
+}
+
+export interface InMemoryAiLimitStorageSnapshot {
+  readonly policies: Map<string, AiLimitPolicy>
+  readonly policyIdsByDimension: Map<string, string>
+  readonly periodStates: Map<string, AiLimitPeriodState>
+  readonly reservations: Map<string, AiModelCallReservation>
+}
+
+/** In-memory AI limit provider used by development runtimes and contract tests. */
+export class InMemoryAiLimitStorage implements AiLimitStorage {
+  private readonly policies = new Map<string, AiLimitPolicy>()
+  private readonly policyIdsByDimension = new Map<string, string>()
+  private readonly periodStates = new Map<string, AiLimitPeriodState>()
+  private readonly reservations = new Map<string, AiModelCallReservation>()
+
+  constructor(private readonly options: InMemoryAiLimitStorageOptions = {}) {}
+
+  async createPolicy(input: CreateAiLimitPolicyInput): Promise<AiLimitPolicy> {
+    const policy = normalizeCreateAiLimitPolicy(input)
+    const key = policyKey(policy.projectId, policy.id)
+    const dimensionKey = aiLimitPolicyDimensionKey(policy)
+    if (this.policies.has(key) || this.policyIdsByDimension.has(dimensionKey)) {
+      throw new AiLimitStorageError(
+        "duplicate_policy",
+        `[Sixb] An AI limit policy already exists for '${aiLimitSubjectKey(policy.subject)}' and '${aiLimitAmountKey(normalizeAiLimitAmount(policy.limit))}'.`
+      )
+    }
+    this.policies.set(key, structuredClone(policy))
+    this.policyIdsByDimension.set(dimensionKey, key)
+    return cloneAiLimitPolicy(policy)
+  }
+
+  async updatePolicy(input: UpdateAiLimitPolicyInput): Promise<AiLimitPolicy> {
+    const update = normalizeUpdateAiLimitPolicy(input)
+    const key = policyKey(update.projectId, update.id)
+    const existing = this.policies.get(key)
+    if (!existing) throw missingPolicy(update.projectId, update.id)
+    if (update.limit !== undefined) {
+      const previous = normalizeAiLimitAmount(existing.limit)
+      const next = normalizeAiLimitAmount(update.limit)
+      if (aiLimitAmountKey(previous) !== aiLimitAmountKey(next)) {
+        throw new TypeError("[Sixb] AI limit policy meter and cost currency are immutable.")
+      }
+    }
+    const policy: AiLimitPolicy = {
+      ...existing,
+      ...(update.limit === undefined ? {} : { limit: update.limit }),
+      ...(update.enabled === undefined ? {} : { enabled: update.enabled }),
+      updatedAt: update.updatedAt,
+    }
+    this.policies.set(key, structuredClone(policy))
+    return cloneAiLimitPolicy(policy)
+  }
+
+  async deletePolicy(input: DeleteAiLimitPolicyInput): Promise<boolean> {
+    validatePolicyIdentity(input)
+    const key = policyKey(input.projectId, input.id)
+    const existing = this.policies.get(key)
+    if (!existing) return false
+    this.policies.delete(key)
+    this.policyIdsByDimension.delete(aiLimitPolicyDimensionKey(existing))
+    return true
+  }
+
+  async getPolicy(input: GetAiLimitPolicyInput): Promise<AiLimitPolicy | null> {
+    validatePolicyIdentity(input)
+    const policy = this.policies.get(policyKey(input.projectId, input.id))
+    return policy ? cloneAiLimitPolicy(policy) : null
+  }
+
+  async listPolicies(input: ListAiLimitPoliciesInput): Promise<readonly AiLimitPolicy[]> {
+    assertNonBlank(input.projectId, "projectId")
+    return [...this.policies.values()]
+      .filter(
+        (policy) =>
+          policy.projectId === input.projectId && (input.includeDisabled || policy.enabled)
+      )
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map(cloneAiLimitPolicy)
+  }
+
+  async listPolicyStatuses(
+    input: ListAiLimitPolicyStatusesInput
+  ): Promise<readonly AiLimitPolicyStatus[]> {
+    assertNonBlank(input.projectId, "projectId")
+    const period = aiLimitCalendarMonth(input.at ?? new Date())
+    const existingGroups =
+      input.existingGroupIds === undefined ? undefined : new Set(input.existingGroupIds)
+    const policies = await this.listPolicies({
+      projectId: input.projectId,
+      includeDisabled: input.includeDisabled,
+    })
+    return Promise.all(policies.map((policy) => this.policyStatus(policy, period, existingGroups)))
+  }
+
+  async reserveModelCall(input: ReserveAiModelCallInput): Promise<ReserveAiModelCallResult> {
+    const request = normalizeReserveAiModelCall(input)
+    const reservationKey = aiModelCallReservationKey(request.identity)
+    const existing = this.reservations.get(reservationKey)
+    if (existing) {
+      if (!aiLimitReservationRequestMatches(existing, request)) {
+        throw new AiLimitStorageError(
+          "reservation_conflict",
+          `[Sixb] AI model-call reservation '${input.callId}' was replayed with different subjects, estimates, or period.`
+        )
+      }
+      if (existing.state !== "active") {
+        return { status: "terminal", reservation: structuredClone(existing), created: false }
+      }
+      return { status: "reserved", reservation: structuredClone(existing), created: false }
+    }
+    await this.assertExecutionExists(request.identity.projectId, request.identity.executionId)
+
+    const enabledPolicies = [...this.policies.values()].filter(
+      (policy) => policy.projectId === request.identity.projectId && policy.enabled
+    )
+    const subjectKeys = new Set(request.subjects.map(aiLimitSubjectKey))
+    const estimates = new Map(
+      request.estimates.map((quantity) => {
+        const amount = normalizeAiLimitAmount(quantity)
+        return [aiLimitAmountKey(amount), amount] as const
+      })
+    )
+    const exhaustedPolicies: AiLimitPolicyStatus[] = []
+    const unavailablePolicies: AiLimitPolicyStatus[] = []
+    const unavailableReasons = new Set<"missingEstimate" | "incompleteAccounting">()
+    for (const policy of enabledPolicies) {
+      if (!subjectKeys.has(aiLimitSubjectKey(policy.subject))) continue
+      const limit = normalizeAiLimitAmount(policy.limit)
+      const estimate = estimates.get(aiLimitAmountKey(limit))
+      const status = await this.policyStatus(policy, request.period)
+      if (!estimate || status.accountingStatus === "unavailable") {
+        unavailablePolicies.push(status)
+        if (!estimate) unavailableReasons.add("missingEstimate")
+        if (status.accountingStatus === "unavailable") {
+          unavailableReasons.add("incompleteAccounting")
+        }
+        continue
+      }
+      const actual = normalizeAiLimitAmount(status.consumption.actual).amount
+      const reserved = normalizeAiLimitAmount(status.consumption.reserved).amount
+      const unknown = normalizeAiLimitAmount(status.consumption.unknown).amount
+      if (actual + reserved + unknown + estimate.amount > limit.amount) {
+        exhaustedPolicies.push(status)
+      }
+    }
+    if (unavailablePolicies.length > 0) {
+      unavailablePolicies.sort((left, right) => left.policy.id.localeCompare(right.policy.id))
+      return {
+        status: "unavailable",
+        unavailablePolicies,
+        reasons: [...unavailableReasons].sort(),
+      }
+    }
+    if (exhaustedPolicies.length > 0) {
+      exhaustedPolicies.sort((left, right) => left.policy.id.localeCompare(right.policy.id))
+      return {
+        status: "denied",
+        exhaustedPolicies,
+        resetAt: new Date(
+          Math.min(...exhaustedPolicies.map((status) => status.period.resetAt.getTime()))
+        ),
+      }
+    }
+
+    const buckets = aiLimitReservationBuckets(enabledPolicies, request.subjects, request.estimates)
+    if (buckets.length === 0) return { status: "notRequired" }
+    for (const bucket of buckets) {
+      const amount = normalizeAiLimitAmount(bucket.estimate)
+      const state = this.requirePeriodState(
+        request.identity.projectId,
+        bucket.subject,
+        amount,
+        request.period
+      )
+      state.reserved += amount.amount
+      state.updatedAt = new Date(request.reservedAt)
+    }
+    const reservation: AiModelCallReservation = {
+      ...request.identity,
+      buckets,
+      requestKey: aiLimitReservationRequestKey(request),
+      period: request.period,
+      state: "active",
+      reservedAt: request.reservedAt,
+      updatedAt: new Date(request.reservedAt),
+    }
+    this.reservations.set(reservationKey, structuredClone(reservation))
+    return { status: "reserved", reservation: structuredClone(reservation), created: true }
+  }
+
+  async recordModelCallActuals(input: RecordAiModelCallLimitActualsInput): Promise<void> {
+    assertNonBlank(input.projectId, "projectId")
+    assertNonBlank(input.usageRecordId, "usageRecordId")
+    const recordedAt = cloneValidDate(input.recordedAt ?? new Date(), "recordedAt")
+    const entry = await this.requireAccountingEntry(input.projectId, input.usageRecordId)
+    const period = aiLimitCalendarMonth(entry.occurredAt)
+    const subjectKeys = new Set(aiLimitSubjectsFromAccountingEntry(entry).map(aiLimitSubjectKey))
+    for (const state of this.periodStates.values()) {
+      if (
+        state.projectId !== input.projectId ||
+        state.period.start.getTime() !== period.start.getTime() ||
+        !subjectKeys.has(aiLimitSubjectKey(state.subject))
+      ) {
+        continue
+      }
+      const actual = resolveAiLimitActual([entry], state)
+      state.actual += actual.amount
+      if (actual.accountingStatus === "unavailable") state.accountingStatus = "unavailable"
+      state.updatedAt = new Date(recordedAt)
+    }
+  }
+
+  async reconcileModelCall(input: ReconcileAiModelCallInput): Promise<AiModelCallReservation> {
+    const identity = normalizeAiModelCallReservationIdentity(input)
+    assertNonBlank(input.usageRecordId, "usageRecordId")
+    const reconciledAt = cloneValidDate(input.reconciledAt ?? new Date(), "reconciledAt")
+    const key = aiModelCallReservationKey(identity)
+    const reservation = this.reservations.get(key)
+    if (!reservation) throw missingReservation(identity)
+    if (reservation.state === "reconciled") {
+      if (reservation.usageRecordId === input.usageRecordId) {
+        return structuredClone(reservation)
+      }
+      throw new AiLimitStorageError(
+        "reconciliation_conflict",
+        `[Sixb] AI model-call reservation '${identity.callId}' was reconciled with a different usage record.`
+      )
+    }
+    const accounting = await this.requireAccountingEntry(identity.projectId, input.usageRecordId)
+    assertAiLimitAccountingMatchesReservation(reservation, accounting)
+    this.reconcileEstimateCounters(reservation, accounting, reconciledAt)
+    const reconciled: AiModelCallReservation = {
+      ...reservation,
+      state: "reconciled",
+      usageRecordId: input.usageRecordId,
+      updatedAt: reconciledAt,
+    }
+    this.reservations.set(key, structuredClone(reconciled))
+    return structuredClone(reconciled)
+  }
+
+  async markReservationUnknown(
+    input: MarkAiModelCallReservationUnknownInput
+  ): Promise<AiModelCallReservation> {
+    const identity = normalizeAiModelCallReservationIdentity(input)
+    const markedAt = cloneValidDate(input.markedAt ?? new Date(), "markedAt")
+    const key = aiModelCallReservationKey(identity)
+    const reservation = this.reservations.get(key)
+    if (!reservation) throw missingReservation(identity)
+    if (reservation.state === "unknown") return structuredClone(reservation)
+    if (reservation.state !== "active") throw invalidState(reservation, "mark unknown")
+    this.moveEstimateCounter(reservation, "reserved", -1n, markedAt)
+    this.moveEstimateCounter(reservation, "unknown", 1n, markedAt)
+    const unknown: AiModelCallReservation = {
+      ...reservation,
+      state: "unknown",
+      updatedAt: markedAt,
+    }
+    this.reservations.set(key, structuredClone(unknown))
+    return structuredClone(unknown)
+  }
+
+  snapshot(): InMemoryAiLimitStorageSnapshot {
+    return structuredClone({
+      policies: this.policies,
+      policyIdsByDimension: this.policyIdsByDimension,
+      periodStates: this.periodStates,
+      reservations: this.reservations,
+    })
+  }
+
+  restore(snapshot: InMemoryAiLimitStorageSnapshot): void {
+    replaceMap(this.policies, snapshot.policies)
+    replaceMap(this.policyIdsByDimension, snapshot.policyIdsByDimension)
+    replaceMap(this.periodStates, snapshot.periodStates)
+    replaceMap(this.reservations, snapshot.reservations)
+  }
+
+  private async policyStatus(
+    policy: AiLimitPolicy,
+    period: AiLimitPeriod,
+    existingGroups?: ReadonlySet<string>
+  ): Promise<AiLimitPolicyStatus> {
+    const limit = normalizeAiLimitAmount(policy.limit)
+    const state = await this.ensurePeriodState(policy, period)
+    const reserved = state.reserved
+    const unknown = state.unknown
+    const consumed = state.actual + reserved + unknown
+    const remaining = limit.amount > consumed ? limit.amount - consumed : 0n
+    const quantity = (amount: bigint): AiLimitQuantity =>
+      aiLimitQuantityFromAmount({ ...limit, amount })
+    return {
+      policy: cloneAiLimitPolicy(policy),
+      period: structuredClone(period),
+      consumption: {
+        actual: quantity(state.actual),
+        reserved: quantity(reserved),
+        unknown: quantity(unknown),
+        remaining: quantity(remaining),
+      },
+      accountingStatus: state.accountingStatus,
+      exhausted: consumed >= limit.amount,
+      orphaned:
+        policy.subject.type === "group" &&
+        existingGroups !== undefined &&
+        !existingGroups.has(policy.subject.id),
+    }
+  }
+
+  private async ensurePeriodState(
+    policy: AiLimitPolicy,
+    period: AiLimitPeriod
+  ): Promise<AiLimitPeriodState> {
+    const amount = normalizeAiLimitAmount(policy.limit)
+    const key = periodStateKey(policy.projectId, policy.subject, amount, period)
+    const existing = this.periodStates.get(key)
+    if (existing) return existing
+    const actual = await this.resolvePolicyActual(policy, period, amount)
+    const state: AiLimitPeriodState = {
+      projectId: policy.projectId,
+      subject: structuredClone(policy.subject),
+      meter: amount.meter,
+      currency: amount.currency,
+      period: structuredClone(period),
+      actual: actual.amount,
+      reserved: 0n,
+      unknown: 0n,
+      accountingStatus: actual.accountingStatus,
+      updatedAt: new Date(),
+    }
+    this.periodStates.set(key, state)
+    return state
+  }
+
+  private moveEstimateCounter(
+    reservation: AiModelCallReservation,
+    counter: "reserved" | "unknown",
+    direction: 1n | -1n,
+    updatedAt: Date
+  ): void {
+    for (const bucket of reservation.buckets) {
+      const amount = normalizeAiLimitAmount(bucket.estimate)
+      const state = this.requirePeriodState(
+        reservation.projectId,
+        bucket.subject,
+        amount,
+        reservation.period
+      )
+      state[counter] += direction * amount.amount
+      if (state[counter] < 0n) {
+        throw new Error(`[Sixb] In-memory AI limit ${counter} counter became negative.`)
+      }
+      state.updatedAt = new Date(updatedAt)
+    }
+  }
+
+  private reconcileEstimateCounters(
+    reservation: AiModelCallReservation,
+    entry: AiLimitAccountingEntry,
+    updatedAt: Date
+  ): void {
+    for (const bucket of reservation.buckets) {
+      const amount = normalizeAiLimitAmount(bucket.estimate)
+      const state = this.requirePeriodState(
+        reservation.projectId,
+        bucket.subject,
+        amount,
+        reservation.period
+      )
+      const counter = reservation.state === "active" ? "reserved" : "unknown"
+      const actual = resolveAiLimitActual([entry], amount)
+      if (actual.accountingStatus === "complete") {
+        state[counter] -= amount.amount
+      } else if (reservation.state === "active") {
+        state.reserved -= amount.amount
+        state.unknown += amount.amount
+      }
+      if (state.reserved < 0n || state.unknown < 0n) {
+        throw new Error("[Sixb] In-memory AI limit reservation counter became negative.")
+      }
+      state.updatedAt = new Date(updatedAt)
+    }
+  }
+
+  private requirePeriodState(
+    projectId: string,
+    subject: AiLimitSubject,
+    amount: NormalizedAiLimitAmount,
+    period: AiLimitPeriod
+  ): AiLimitPeriodState {
+    const state = this.periodStates.get(periodStateKey(projectId, subject, amount, period))
+    if (!state) throw new Error("[Sixb] In-memory AI limit period state is inconsistent.")
+    return state
+  }
+
+  private async assertExecutionExists(projectId: string, executionId: string): Promise<void> {
+    if (this.options.resolveExecution) {
+      if (await this.options.resolveExecution({ projectId, executionId })) return
+      throw new AiLimitStorageError(
+        "missing_execution",
+        `[Sixb] AI limit execution '${executionId}' does not exist in project '${projectId}'.`
+      )
+    }
+    if (
+      this.options.executionExists &&
+      (await this.options.executionExists({ projectId, executionId }))
+    ) {
+      return
+    }
+    throw new AiLimitStorageError(
+      "missing_execution",
+      `[Sixb] AI limit execution '${executionId}' does not exist in project '${projectId}'.`
+    )
+  }
+
+  private async resolvePolicyActual(
+    policy: AiLimitPolicy,
+    period: AiLimitPeriod,
+    dimension: NormalizedAiLimitAmount
+  ): Promise<ReturnType<typeof resolveAiLimitActual>> {
+    if (
+      !this.options.listUsageRecords ||
+      ((policy.subject.type === "user" || policy.subject.type === "serviceAccount") &&
+        !this.options.resolveExecution)
+    ) {
+      return { amount: 0n, accountingStatus: "unavailable" }
+    }
+    const records = await this.options.listUsageRecords({ projectId: policy.projectId })
+    const entries = await Promise.all(
+      records
+        .filter(
+          (record) =>
+            record.occurredAt.getTime() >= period.start.getTime() &&
+            record.occurredAt.getTime() < period.end.getTime()
+        )
+        .map((record) => this.accountingEntry(record))
+    )
+    return resolveAiLimitActual(
+      entries.filter((entry) => aiLimitAccountingEntryAppliesToSubject(entry, policy.subject)),
+      dimension
+    )
+  }
+
+  private async requireAccountingEntry(
+    projectId: string,
+    usageRecordId: string
+  ): Promise<AiLimitAccountingEntry> {
+    if (!this.options.resolveUsageRecord) {
+      throw new AiLimitStorageError(
+        "unavailable_actuals",
+        "[Sixb] In-memory AI limit storage has no immutable accounting source."
+      )
+    }
+    const record = await this.options.resolveUsageRecord({ projectId, usageRecordId })
+    if (!record) {
+      throw new AiLimitStorageError(
+        "missing_usage_record",
+        `[Sixb] AI usage record '${usageRecordId}' does not exist in project '${projectId}'.`
+      )
+    }
+    return this.accountingEntry(record)
+  }
+
+  private async accountingEntry(record: AiModelCallUsageRecord): Promise<AiLimitAccountingEntry> {
+    const [execution, cost] = await Promise.all([
+      this.options.resolveExecution?.({
+        projectId: record.projectId,
+        executionId: record.executionId,
+      }),
+      this.options.resolveCostRecord?.({
+        projectId: record.projectId,
+        usageRecordId: record.id,
+      }),
+    ])
+    const requester = execution?.requestedBy
+    return {
+      projectId: record.projectId,
+      usageRecordId: record.id,
+      executionId: record.executionId,
+      attempt: record.attempt,
+      callId: record.callId,
+      occurredAt: new Date(record.occurredAt),
+      ...(record.usage.totalTokens === undefined ? {} : { totalTokens: record.usage.totalTokens }),
+      requesterGroupIds: [...record.requesterGroupIds],
+      ...(requester?.type === "user" || requester?.type === "serviceAccount"
+        ? { requester: { type: requester.type, id: requester.id } }
+        : {}),
+      ...(cost?.status === "rated"
+        ? { valuation: { status: "rated" as const, money: structuredClone(cost.money) } }
+        : cost
+          ? { valuation: { status: "unavailable" as const } }
+          : {}),
+    }
+  }
+}
+
+function policyKey(projectId: string, id: string): string {
+  return JSON.stringify([projectId, id])
+}
+
+function periodStateKey(
+  projectId: string,
+  subject: AiLimitSubject,
+  amount: Pick<NormalizedAiLimitAmount, "meter" | "currency">,
+  period: AiLimitPeriod
+): string {
+  return JSON.stringify([
+    projectId,
+    aiLimitSubjectKey(subject),
+    amount.meter,
+    amount.currency,
+    period.start.toISOString(),
+  ])
+}
+
+function validatePolicyIdentity(input: GetAiLimitPolicyInput): void {
+  assertNonBlank(input.projectId, "projectId")
+  assertNonBlank(input.id, "policy id")
+}
+
+function missingPolicy(projectId: string, id: string): AiLimitStorageError {
+  return new AiLimitStorageError(
+    "missing_policy",
+    `[Sixb] AI limit policy '${id}' does not exist in project '${projectId}'.`
+  )
+}
+
+function missingReservation(identity: {
+  readonly projectId: string
+  readonly executionId: string
+  readonly attempt: number
+  readonly callId: string
+}): AiLimitStorageError {
+  return new AiLimitStorageError(
+    "missing_reservation",
+    `[Sixb] AI model-call reservation '${identity.callId}' does not exist for execution '${identity.executionId}' attempt ${identity.attempt}.`
+  )
+}
+
+function invalidState(reservation: AiModelCallReservation, operation: string): AiLimitStorageError {
+  return new AiLimitStorageError(
+    "invalid_reservation_state",
+    `[Sixb] Cannot ${operation} AI model-call reservation '${reservation.callId}' in state '${reservation.state}'.`
+  )
+}
+
+function replaceMap<TKey, TValue>(target: Map<TKey, TValue>, source: Map<TKey, TValue>): void {
+  target.clear()
+  for (const [key, value] of structuredClone(source)) target.set(key, value)
+}

--- a/packages/core/src/storage/ai-limits/in-memory.ts
+++ b/packages/core/src/storage/ai-limits/in-memory.ts
@@ -5,6 +5,7 @@ import { AiLimitStorageError } from "./errors"
 import { aiLimitCalendarMonth } from "./period"
 import type { AiLimitAccountingEntry } from "./provider"
 import {
+  AiLimitOperationLock,
   aiLimitAccountingEntryAppliesToSubject,
   aiLimitAmountKey,
   aiLimitPolicyDimensionKey,
@@ -96,54 +97,66 @@ export class InMemoryAiLimitStorage implements AiLimitStorage {
   private readonly policyIdsByDimension = new Map<string, string>()
   private readonly periodStates = new Map<string, AiLimitPeriodState>()
   private readonly reservations = new Map<string, AiModelCallReservation>()
+  private readonly operations = new AiLimitOperationLock()
 
   constructor(private readonly options: InMemoryAiLimitStorageOptions = {}) {}
 
+  /** @internal The root transaction must settle queued work before restoring its snapshot. */
+  settleOperations(): Promise<void> {
+    return this.operations.settle()
+  }
+
   async createPolicy(input: CreateAiLimitPolicyInput): Promise<AiLimitPolicy> {
-    const policy = normalizeCreateAiLimitPolicy(input)
-    const key = policyKey(policy.projectId, policy.id)
-    const dimensionKey = aiLimitPolicyDimensionKey(policy)
-    if (this.policies.has(key) || this.policyIdsByDimension.has(dimensionKey)) {
-      throw new AiLimitStorageError(
-        "duplicate_policy",
-        `[Sixb] An AI limit policy already exists for '${aiLimitSubjectKey(policy.subject)}' and '${aiLimitAmountKey(normalizeAiLimitAmount(policy.limit))}'.`
-      )
-    }
-    this.policies.set(key, structuredClone(policy))
-    this.policyIdsByDimension.set(dimensionKey, key)
-    return cloneAiLimitPolicy(policy)
+    return this.operations.run(async () => {
+      const policy = normalizeCreateAiLimitPolicy(input)
+      const key = policyKey(policy.projectId, policy.id)
+      const dimensionKey = aiLimitPolicyDimensionKey(policy)
+      if (this.policies.has(key) || this.policyIdsByDimension.has(dimensionKey)) {
+        throw new AiLimitStorageError(
+          "duplicate_policy",
+          `[Sixb] An AI limit policy already exists for '${aiLimitSubjectKey(policy.subject)}' and '${aiLimitAmountKey(normalizeAiLimitAmount(policy.limit))}'.`
+        )
+      }
+      this.policies.set(key, structuredClone(policy))
+      this.policyIdsByDimension.set(dimensionKey, key)
+      return cloneAiLimitPolicy(policy)
+    })
   }
 
   async updatePolicy(input: UpdateAiLimitPolicyInput): Promise<AiLimitPolicy> {
-    const update = normalizeUpdateAiLimitPolicy(input)
-    const key = policyKey(update.projectId, update.id)
-    const existing = this.policies.get(key)
-    if (!existing) throw missingPolicy(update.projectId, update.id)
-    if (update.limit !== undefined) {
-      const previous = normalizeAiLimitAmount(existing.limit)
-      const next = normalizeAiLimitAmount(update.limit)
-      if (aiLimitAmountKey(previous) !== aiLimitAmountKey(next)) {
-        throw new TypeError("[Sixb] AI limit policy meter and cost currency are immutable.")
+    return this.operations.run(async () => {
+      const update = normalizeUpdateAiLimitPolicy(input)
+      const key = policyKey(update.projectId, update.id)
+      const existing = this.policies.get(key)
+      if (!existing) throw missingPolicy(update.projectId, update.id)
+      if (update.limit !== undefined) {
+        const previous = normalizeAiLimitAmount(existing.limit)
+        const next = normalizeAiLimitAmount(update.limit)
+        if (aiLimitAmountKey(previous) !== aiLimitAmountKey(next)) {
+          throw new TypeError("[Sixb] AI limit policy meter and cost currency are immutable.")
+        }
       }
-    }
-    const policy: AiLimitPolicy = {
-      ...existing,
-      ...(update.limit === undefined ? {} : { limit: update.limit }),
-      ...(update.enabled === undefined ? {} : { enabled: update.enabled }),
-      updatedAt: update.updatedAt,
-    }
-    this.policies.set(key, structuredClone(policy))
-    return cloneAiLimitPolicy(policy)
+      const policy: AiLimitPolicy = {
+        ...existing,
+        ...(update.limit === undefined ? {} : { limit: update.limit }),
+        ...(update.enabled === undefined ? {} : { enabled: update.enabled }),
+        updatedAt: update.updatedAt,
+      }
+      this.policies.set(key, structuredClone(policy))
+      return cloneAiLimitPolicy(policy)
+    })
   }
 
   async deletePolicy(input: DeleteAiLimitPolicyInput): Promise<boolean> {
-    validatePolicyIdentity(input)
-    const key = policyKey(input.projectId, input.id)
-    const existing = this.policies.get(key)
-    if (!existing) return false
-    this.policies.delete(key)
-    this.policyIdsByDimension.delete(aiLimitPolicyDimensionKey(existing))
-    return true
+    return this.operations.run(async () => {
+      validatePolicyIdentity(input)
+      const key = policyKey(input.projectId, input.id)
+      const existing = this.policies.get(key)
+      if (!existing) return false
+      this.policies.delete(key)
+      this.policyIdsByDimension.delete(aiLimitPolicyDimensionKey(existing))
+      return true
+    })
   }
 
   async getPolicy(input: GetAiLimitPolicyInput): Promise<AiLimitPolicy | null> {
@@ -166,183 +179,199 @@ export class InMemoryAiLimitStorage implements AiLimitStorage {
   async listPolicyStatuses(
     input: ListAiLimitPolicyStatusesInput
   ): Promise<readonly AiLimitPolicyStatus[]> {
-    assertNonBlank(input.projectId, "projectId")
-    const period = aiLimitCalendarMonth(input.at ?? new Date())
-    const existingGroups =
-      input.existingGroupIds === undefined ? undefined : new Set(input.existingGroupIds)
-    const policies = await this.listPolicies({
-      projectId: input.projectId,
-      includeDisabled: input.includeDisabled,
+    return this.operations.run(async () => {
+      assertNonBlank(input.projectId, "projectId")
+      const period = aiLimitCalendarMonth(input.at ?? new Date())
+      const existingGroups =
+        input.existingGroupIds === undefined ? undefined : new Set(input.existingGroupIds)
+      const policies = await this.listPolicies({
+        projectId: input.projectId,
+        includeDisabled: input.includeDisabled,
+      })
+      return Promise.all(
+        policies.map((policy) => this.policyStatus(policy, period, existingGroups))
+      )
     })
-    return Promise.all(policies.map((policy) => this.policyStatus(policy, period, existingGroups)))
   }
 
   async reserveModelCall(input: ReserveAiModelCallInput): Promise<ReserveAiModelCallResult> {
-    const request = normalizeReserveAiModelCall(input)
-    const reservationKey = aiModelCallReservationKey(request.identity)
-    const existing = this.reservations.get(reservationKey)
-    if (existing) {
-      if (!aiLimitReservationRequestMatches(existing, request)) {
-        throw new AiLimitStorageError(
-          "reservation_conflict",
-          `[Sixb] AI model-call reservation '${input.callId}' was replayed with different subjects, estimates, or period.`
-        )
-      }
-      if (existing.state !== "active") {
-        return { status: "terminal", reservation: structuredClone(existing), created: false }
-      }
-      return { status: "reserved", reservation: structuredClone(existing), created: false }
-    }
-    await this.assertExecutionExists(request.identity.projectId, request.identity.executionId)
-
-    const enabledPolicies = [...this.policies.values()].filter(
-      (policy) => policy.projectId === request.identity.projectId && policy.enabled
-    )
-    const subjectKeys = new Set(request.subjects.map(aiLimitSubjectKey))
-    const estimates = new Map(
-      request.estimates.map((quantity) => {
-        const amount = normalizeAiLimitAmount(quantity)
-        return [aiLimitAmountKey(amount), amount] as const
-      })
-    )
-    const exhaustedPolicies: AiLimitPolicyStatus[] = []
-    const unavailablePolicies: AiLimitPolicyStatus[] = []
-    const unavailableReasons = new Set<"missingEstimate" | "incompleteAccounting">()
-    for (const policy of enabledPolicies) {
-      if (!subjectKeys.has(aiLimitSubjectKey(policy.subject))) continue
-      const limit = normalizeAiLimitAmount(policy.limit)
-      const estimate = estimates.get(aiLimitAmountKey(limit))
-      const status = await this.policyStatus(policy, request.period)
-      if (!estimate || status.accountingStatus === "unavailable") {
-        unavailablePolicies.push(status)
-        if (!estimate) unavailableReasons.add("missingEstimate")
-        if (status.accountingStatus === "unavailable") {
-          unavailableReasons.add("incompleteAccounting")
+    return this.operations.run(async () => {
+      const request = normalizeReserveAiModelCall(input)
+      const reservationKey = aiModelCallReservationKey(request.identity)
+      const existing = this.reservations.get(reservationKey)
+      if (existing) {
+        if (!aiLimitReservationRequestMatches(existing, request)) {
+          throw new AiLimitStorageError(
+            "reservation_conflict",
+            `[Sixb] AI model-call reservation '${input.callId}' was replayed with different subjects, estimates, or period.`
+          )
         }
-        continue
+        if (existing.state !== "active") {
+          return { status: "terminal", reservation: structuredClone(existing), created: false }
+        }
+        return { status: "reserved", reservation: structuredClone(existing), created: false }
       }
-      const actual = normalizeAiLimitAmount(status.consumption.actual).amount
-      const reserved = normalizeAiLimitAmount(status.consumption.reserved).amount
-      const unknown = normalizeAiLimitAmount(status.consumption.unknown).amount
-      if (actual + reserved + unknown + estimate.amount > limit.amount) {
-        exhaustedPolicies.push(status)
-      }
-    }
-    if (unavailablePolicies.length > 0) {
-      unavailablePolicies.sort((left, right) => left.policy.id.localeCompare(right.policy.id))
-      return {
-        status: "unavailable",
-        unavailablePolicies,
-        reasons: [...unavailableReasons].sort(),
-      }
-    }
-    if (exhaustedPolicies.length > 0) {
-      exhaustedPolicies.sort((left, right) => left.policy.id.localeCompare(right.policy.id))
-      return {
-        status: "denied",
-        exhaustedPolicies,
-        resetAt: new Date(
-          Math.min(...exhaustedPolicies.map((status) => status.period.resetAt.getTime()))
-        ),
-      }
-    }
+      await this.assertExecutionExists(request.identity.projectId, request.identity.executionId)
 
-    const buckets = aiLimitReservationBuckets(enabledPolicies, request.subjects, request.estimates)
-    if (buckets.length === 0) return { status: "notRequired" }
-    for (const bucket of buckets) {
-      const amount = normalizeAiLimitAmount(bucket.estimate)
-      const state = this.requirePeriodState(
-        request.identity.projectId,
-        bucket.subject,
-        amount,
-        request.period
+      const enabledPolicies = [...this.policies.values()].filter(
+        (policy) => policy.projectId === request.identity.projectId && policy.enabled
       )
-      state.reserved += amount.amount
-      state.updatedAt = new Date(request.reservedAt)
-    }
-    const reservation: AiModelCallReservation = {
-      ...request.identity,
-      buckets,
-      requestKey: aiLimitReservationRequestKey(request),
-      period: request.period,
-      state: "active",
-      reservedAt: request.reservedAt,
-      updatedAt: new Date(request.reservedAt),
-    }
-    this.reservations.set(reservationKey, structuredClone(reservation))
-    return { status: "reserved", reservation: structuredClone(reservation), created: true }
+      const subjectKeys = new Set(request.subjects.map(aiLimitSubjectKey))
+      const estimates = new Map(
+        request.estimates.map((quantity) => {
+          const amount = normalizeAiLimitAmount(quantity)
+          return [aiLimitAmountKey(amount), amount] as const
+        })
+      )
+      const exhaustedPolicies: AiLimitPolicyStatus[] = []
+      const unavailablePolicies: AiLimitPolicyStatus[] = []
+      const unavailableReasons = new Set<"missingEstimate" | "incompleteAccounting">()
+      for (const policy of enabledPolicies) {
+        if (!subjectKeys.has(aiLimitSubjectKey(policy.subject))) continue
+        const limit = normalizeAiLimitAmount(policy.limit)
+        const estimate = estimates.get(aiLimitAmountKey(limit))
+        const status = await this.policyStatus(policy, request.period)
+        if (!estimate || status.accountingStatus === "unavailable") {
+          unavailablePolicies.push(status)
+          if (!estimate) unavailableReasons.add("missingEstimate")
+          if (status.accountingStatus === "unavailable") {
+            unavailableReasons.add("incompleteAccounting")
+          }
+          continue
+        }
+        const actual = normalizeAiLimitAmount(status.consumption.actual).amount
+        const reserved = normalizeAiLimitAmount(status.consumption.reserved).amount
+        const unknown = normalizeAiLimitAmount(status.consumption.unknown).amount
+        if (actual + reserved + unknown + estimate.amount > limit.amount) {
+          exhaustedPolicies.push(status)
+        }
+      }
+      if (unavailablePolicies.length > 0) {
+        unavailablePolicies.sort((left, right) => left.policy.id.localeCompare(right.policy.id))
+        return {
+          status: "unavailable",
+          unavailablePolicies,
+          reasons: [...unavailableReasons].sort(),
+        }
+      }
+      if (exhaustedPolicies.length > 0) {
+        exhaustedPolicies.sort((left, right) => left.policy.id.localeCompare(right.policy.id))
+        return {
+          status: "denied",
+          exhaustedPolicies,
+          resetAt: new Date(
+            Math.min(...exhaustedPolicies.map((status) => status.period.resetAt.getTime()))
+          ),
+        }
+      }
+
+      const buckets = aiLimitReservationBuckets(
+        enabledPolicies,
+        request.subjects,
+        request.estimates
+      )
+      if (buckets.length === 0) return { status: "notRequired" }
+      for (const bucket of buckets) {
+        const amount = normalizeAiLimitAmount(bucket.estimate)
+        const state = this.requirePeriodState(
+          request.identity.projectId,
+          bucket.subject,
+          amount,
+          request.period
+        )
+        state.reserved += amount.amount
+        state.updatedAt = new Date(request.reservedAt)
+      }
+      const reservation: AiModelCallReservation = {
+        ...request.identity,
+        buckets,
+        requestKey: aiLimitReservationRequestKey(request),
+        period: request.period,
+        state: "active",
+        reservedAt: request.reservedAt,
+        updatedAt: new Date(request.reservedAt),
+      }
+      this.reservations.set(reservationKey, structuredClone(reservation))
+      return { status: "reserved", reservation: structuredClone(reservation), created: true }
+    })
   }
 
   async recordModelCallActuals(input: RecordAiModelCallLimitActualsInput): Promise<void> {
-    assertNonBlank(input.projectId, "projectId")
-    assertNonBlank(input.usageRecordId, "usageRecordId")
-    const recordedAt = cloneValidDate(input.recordedAt ?? new Date(), "recordedAt")
-    const entry = await this.requireAccountingEntry(input.projectId, input.usageRecordId)
-    const period = aiLimitCalendarMonth(entry.occurredAt)
-    const subjectKeys = new Set(aiLimitSubjectsFromAccountingEntry(entry).map(aiLimitSubjectKey))
-    for (const state of this.periodStates.values()) {
-      if (
-        state.projectId !== input.projectId ||
-        state.period.start.getTime() !== period.start.getTime() ||
-        !subjectKeys.has(aiLimitSubjectKey(state.subject))
-      ) {
-        continue
+    return this.operations.run(async () => {
+      assertNonBlank(input.projectId, "projectId")
+      assertNonBlank(input.usageRecordId, "usageRecordId")
+      const recordedAt = cloneValidDate(input.recordedAt ?? new Date(), "recordedAt")
+      const entry = await this.requireAccountingEntry(input.projectId, input.usageRecordId)
+      const period = aiLimitCalendarMonth(entry.occurredAt)
+      const subjectKeys = new Set(aiLimitSubjectsFromAccountingEntry(entry).map(aiLimitSubjectKey))
+      for (const state of this.periodStates.values()) {
+        if (
+          state.projectId !== input.projectId ||
+          state.period.start.getTime() !== period.start.getTime() ||
+          !subjectKeys.has(aiLimitSubjectKey(state.subject))
+        ) {
+          continue
+        }
+        const actual = resolveAiLimitActual([entry], state)
+        state.actual += actual.amount
+        if (actual.accountingStatus === "unavailable") state.accountingStatus = "unavailable"
+        state.updatedAt = new Date(recordedAt)
       }
-      const actual = resolveAiLimitActual([entry], state)
-      state.actual += actual.amount
-      if (actual.accountingStatus === "unavailable") state.accountingStatus = "unavailable"
-      state.updatedAt = new Date(recordedAt)
-    }
+    })
   }
 
   async reconcileModelCall(input: ReconcileAiModelCallInput): Promise<AiModelCallReservation> {
-    const identity = normalizeAiModelCallReservationIdentity(input)
-    assertNonBlank(input.usageRecordId, "usageRecordId")
-    const reconciledAt = cloneValidDate(input.reconciledAt ?? new Date(), "reconciledAt")
-    const key = aiModelCallReservationKey(identity)
-    const reservation = this.reservations.get(key)
-    if (!reservation) throw missingReservation(identity)
-    if (reservation.state === "reconciled") {
-      if (reservation.usageRecordId === input.usageRecordId) {
-        return structuredClone(reservation)
+    return this.operations.run(async () => {
+      const identity = normalizeAiModelCallReservationIdentity(input)
+      assertNonBlank(input.usageRecordId, "usageRecordId")
+      const reconciledAt = cloneValidDate(input.reconciledAt ?? new Date(), "reconciledAt")
+      const key = aiModelCallReservationKey(identity)
+      const reservation = this.reservations.get(key)
+      if (!reservation) throw missingReservation(identity)
+      if (reservation.state === "reconciled") {
+        if (reservation.usageRecordId === input.usageRecordId) {
+          return structuredClone(reservation)
+        }
+        throw new AiLimitStorageError(
+          "reconciliation_conflict",
+          `[Sixb] AI model-call reservation '${identity.callId}' was reconciled with a different usage record.`
+        )
       }
-      throw new AiLimitStorageError(
-        "reconciliation_conflict",
-        `[Sixb] AI model-call reservation '${identity.callId}' was reconciled with a different usage record.`
-      )
-    }
-    const accounting = await this.requireAccountingEntry(identity.projectId, input.usageRecordId)
-    assertAiLimitAccountingMatchesReservation(reservation, accounting)
-    this.reconcileEstimateCounters(reservation, accounting, reconciledAt)
-    const reconciled: AiModelCallReservation = {
-      ...reservation,
-      state: "reconciled",
-      usageRecordId: input.usageRecordId,
-      updatedAt: reconciledAt,
-    }
-    this.reservations.set(key, structuredClone(reconciled))
-    return structuredClone(reconciled)
+      const accounting = await this.requireAccountingEntry(identity.projectId, input.usageRecordId)
+      assertAiLimitAccountingMatchesReservation(reservation, accounting)
+      this.reconcileEstimateCounters(reservation, accounting, reconciledAt)
+      const reconciled: AiModelCallReservation = {
+        ...reservation,
+        state: "reconciled",
+        usageRecordId: input.usageRecordId,
+        updatedAt: reconciledAt,
+      }
+      this.reservations.set(key, structuredClone(reconciled))
+      return structuredClone(reconciled)
+    })
   }
 
   async markReservationUnknown(
     input: MarkAiModelCallReservationUnknownInput
   ): Promise<AiModelCallReservation> {
-    const identity = normalizeAiModelCallReservationIdentity(input)
-    const markedAt = cloneValidDate(input.markedAt ?? new Date(), "markedAt")
-    const key = aiModelCallReservationKey(identity)
-    const reservation = this.reservations.get(key)
-    if (!reservation) throw missingReservation(identity)
-    if (reservation.state === "unknown") return structuredClone(reservation)
-    if (reservation.state !== "active") throw invalidState(reservation, "mark unknown")
-    this.moveEstimateCounter(reservation, "reserved", -1n, markedAt)
-    this.moveEstimateCounter(reservation, "unknown", 1n, markedAt)
-    const unknown: AiModelCallReservation = {
-      ...reservation,
-      state: "unknown",
-      updatedAt: markedAt,
-    }
-    this.reservations.set(key, structuredClone(unknown))
-    return structuredClone(unknown)
+    return this.operations.run(async () => {
+      const identity = normalizeAiModelCallReservationIdentity(input)
+      const markedAt = cloneValidDate(input.markedAt ?? new Date(), "markedAt")
+      const key = aiModelCallReservationKey(identity)
+      const reservation = this.reservations.get(key)
+      if (!reservation) throw missingReservation(identity)
+      if (reservation.state === "unknown") return structuredClone(reservation)
+      if (reservation.state !== "active") throw invalidState(reservation, "mark unknown")
+      this.moveEstimateCounter(reservation, "reserved", -1n, markedAt)
+      this.moveEstimateCounter(reservation, "unknown", 1n, markedAt)
+      const unknown: AiModelCallReservation = {
+        ...reservation,
+        state: "unknown",
+        updatedAt: markedAt,
+      }
+      this.reservations.set(key, structuredClone(unknown))
+      return structuredClone(unknown)
+    })
   }
 
   snapshot(): InMemoryAiLimitStorageSnapshot {

--- a/packages/core/src/storage/ai-limits/in-memory.ts
+++ b/packages/core/src/storage/ai-limits/in-memory.ts
@@ -428,8 +428,15 @@ export class InMemoryAiLimitStorage implements AiLimitStorage {
     const amount = normalizeAiLimitAmount(policy.limit)
     const key = periodStateKey(policy.projectId, policy.subject, amount, period)
     const existing = this.periodStates.get(key)
-    if (existing) return existing
+    if (existing?.accountingStatus === "complete") return existing
+    // A late valuation can repair the ledger after this period was cached as unavailable.
     const actual = await this.resolvePolicyActual(policy, period, amount)
+    if (existing) {
+      existing.actual = actual.amount
+      existing.accountingStatus = actual.accountingStatus
+      existing.updatedAt = new Date()
+      return existing
+    }
     const state: AiLimitPeriodState = {
       projectId: policy.projectId,
       subject: structuredClone(policy.subject),

--- a/packages/core/src/storage/ai-limits/index.ts
+++ b/packages/core/src/storage/ai-limits/index.ts
@@ -1,0 +1,31 @@
+export type { AiLimitStorageErrorCode } from "./errors"
+export { AiLimitStorageError } from "./errors"
+export type { InMemoryAiLimitStorageOptions, InMemoryAiLimitStorageSnapshot } from "./in-memory"
+export { InMemoryAiLimitStorage } from "./in-memory"
+export { aiLimitCalendarMonth } from "./period"
+export type {
+  AiLimitConsumption,
+  AiLimitMeter,
+  AiLimitPeriod,
+  AiLimitPeriodKind,
+  AiLimitPolicy,
+  AiLimitPolicyStatus,
+  AiLimitQuantity,
+  AiLimitReservationBucket,
+  AiLimitStorage,
+  AiLimitSubject,
+  AiModelCallReservation,
+  AiModelCallReservationIdentity,
+  AiModelCallReservationState,
+  CreateAiLimitPolicyInput,
+  DeleteAiLimitPolicyInput,
+  GetAiLimitPolicyInput,
+  ListAiLimitPoliciesInput,
+  ListAiLimitPolicyStatusesInput,
+  MarkAiModelCallReservationUnknownInput,
+  ReconcileAiModelCallInput,
+  RecordAiModelCallLimitActualsInput,
+  ReserveAiModelCallInput,
+  ReserveAiModelCallResult,
+  UpdateAiLimitPolicyInput,
+} from "./types"

--- a/packages/core/src/storage/ai-limits/period.ts
+++ b/packages/core/src/storage/ai-limits/period.ts
@@ -1,0 +1,11 @@
+import type { AiLimitPeriod } from "./types"
+
+/** Return the UTC calendar month containing `at`, with an inclusive start and exclusive end. */
+export function aiLimitCalendarMonth(at: Date): AiLimitPeriod {
+  if (!(at instanceof Date) || !Number.isFinite(at.getTime())) {
+    throw new TypeError("[Sixb] AI limit period date must be a valid Date.")
+  }
+  const start = new Date(Date.UTC(at.getUTCFullYear(), at.getUTCMonth(), 1))
+  const end = new Date(Date.UTC(at.getUTCFullYear(), at.getUTCMonth() + 1, 1))
+  return { kind: "calendarMonth", start, end, resetAt: new Date(end) }
+}

--- a/packages/core/src/storage/ai-limits/provider.ts
+++ b/packages/core/src/storage/ai-limits/provider.ts
@@ -1,0 +1,406 @@
+import type { AiMoney } from "../ai-cost"
+import { AiLimitStorageError } from "./errors"
+import { aiLimitCalendarMonth } from "./period"
+import type {
+  AiLimitPeriod,
+  AiLimitPolicy,
+  AiLimitQuantity,
+  AiLimitReservationBucket,
+  AiLimitSubject,
+  AiModelCallReservation,
+  AiModelCallReservationIdentity,
+  CreateAiLimitPolicyInput,
+  ReserveAiModelCallInput,
+  UpdateAiLimitPolicyInput,
+} from "./types"
+
+const SIGNED_INT64_MAX = 9_223_372_036_854_775_807n
+
+/** @internal Canonical integer quantity used by storage providers. */
+export interface NormalizedAiLimitAmount {
+  readonly meter: AiLimitQuantity["meter"]
+  readonly currency: string
+  readonly amount: bigint
+}
+
+/** @internal Minimal immutable accounting facts consumed by limit providers. */
+export interface AiLimitAccountingEntry {
+  readonly projectId: string
+  readonly usageRecordId: string
+  readonly executionId: string
+  readonly attempt: number
+  readonly callId: string
+  readonly occurredAt: Date
+  readonly totalTokens?: number
+  readonly requesterGroupIds: readonly string[]
+  readonly requester?:
+    | { readonly type: "user"; readonly id: string }
+    | { readonly type: "serviceAccount"; readonly id: string }
+  readonly valuation?:
+    | { readonly status: "rated"; readonly money: AiMoney }
+    | { readonly status: "unavailable" }
+}
+
+export interface ResolvedAiLimitActual {
+  readonly amount: bigint
+  readonly accountingStatus: "complete" | "unavailable"
+}
+
+export function normalizeAiLimitSubject(subject: AiLimitSubject): AiLimitSubject {
+  if (!subject || typeof subject !== "object") {
+    throw new TypeError("[Sixb] AI limit subject must be an object.")
+  }
+  if (subject.type === "project") return { type: "project" }
+  if (subject.type === "group" || subject.type === "user" || subject.type === "serviceAccount") {
+    assertNonBlank(subject.id, "subject id")
+    return { type: subject.type, id: subject.id }
+  }
+  throw new TypeError("[Sixb] AI limit subject type is unsupported.")
+}
+
+export function normalizeAiLimitSubjects(
+  subjects: readonly AiLimitSubject[]
+): readonly AiLimitSubject[] {
+  if (!Array.isArray(subjects)) {
+    throw new TypeError("[Sixb] AI limit subjects must be an array.")
+  }
+  const normalized = [
+    normalizeAiLimitSubject({ type: "project" }),
+    ...subjects.map(normalizeAiLimitSubject),
+  ]
+  const byKey = new Map(normalized.map((subject) => [aiLimitSubjectKey(subject), subject]))
+  return [...byKey.values()].sort((left, right) =>
+    aiLimitSubjectKey(left).localeCompare(aiLimitSubjectKey(right))
+  )
+}
+
+export function aiLimitSubjectKey(subject: AiLimitSubject): string {
+  return subject.type === "project" ? "project:" : `${subject.type}:${subject.id}`
+}
+
+export function aiLimitSubjectParts(subject: AiLimitSubject): {
+  readonly type: AiLimitSubject["type"]
+  readonly id: string
+} {
+  return { type: subject.type, id: subject.type === "project" ? "" : subject.id }
+}
+
+export function aiLimitSubjectFromParts(type: AiLimitSubject["type"], id: string): AiLimitSubject {
+  return normalizeAiLimitSubject(type === "project" ? { type } : { type, id })
+}
+
+export function normalizeAiLimitQuantity(quantity: AiLimitQuantity): AiLimitQuantity {
+  const normalized = normalizeAiLimitAmount(quantity)
+  return aiLimitQuantityFromAmount(normalized)
+}
+
+export function normalizeAiLimitQuantities(
+  quantities: readonly AiLimitQuantity[],
+  label: string
+): readonly AiLimitQuantity[] {
+  if (!Array.isArray(quantities) || quantities.length === 0) {
+    throw new TypeError(`[Sixb] AI limit ${label} must contain at least one quantity.`)
+  }
+  const byKey = new Map<string, AiLimitQuantity>()
+  for (const quantity of quantities) {
+    const normalized = normalizeAiLimitQuantity(quantity)
+    const key = aiLimitAmountKey(normalizeAiLimitAmount(normalized))
+    if (byKey.has(key)) {
+      throw new TypeError(`[Sixb] AI limit ${label} contains duplicate meter '${key}'.`)
+    }
+    byKey.set(key, normalized)
+  }
+  return [...byKey.values()].sort((left, right) =>
+    aiLimitAmountKey(normalizeAiLimitAmount(left)).localeCompare(
+      aiLimitAmountKey(normalizeAiLimitAmount(right))
+    )
+  )
+}
+
+export function normalizeAiLimitAmount(quantity: AiLimitQuantity): NormalizedAiLimitAmount {
+  if (!quantity || typeof quantity !== "object") {
+    throw new TypeError("[Sixb] AI limit quantity must be an object.")
+  }
+  if (quantity.meter === "tokens.total") {
+    if (!Number.isSafeInteger(quantity.amount) || quantity.amount < 0) {
+      throw new TypeError("[Sixb] AI limit token amount must be a non-negative safe integer.")
+    }
+    return { meter: quantity.meter, currency: "", amount: BigInt(quantity.amount) }
+  }
+  if (quantity.meter === "cost.catalogEstimated") {
+    const money = normalizeAiMoney(quantity.amount)
+    return { meter: quantity.meter, currency: money.currency, amount: BigInt(money.amountNanos) }
+  }
+  throw new TypeError("[Sixb] AI limit meter is unsupported.")
+}
+
+export function aiLimitQuantityFromAmount(amount: NormalizedAiLimitAmount): AiLimitQuantity {
+  if (amount.amount < 0n) {
+    throw new TypeError("[Sixb] AI limit amount cannot be negative.")
+  }
+  if (amount.meter === "tokens.total") {
+    const tokens = Number(amount.amount)
+    if (!Number.isSafeInteger(tokens)) {
+      throw new RangeError("[Sixb] AI limit token amount exceeds JavaScript's safe integer range.")
+    }
+    return { meter: amount.meter, amount: tokens }
+  }
+  if (amount.currency !== "USD") {
+    throw new TypeError("[Sixb] AI limit catalog-estimated cost currency must be 'USD'.")
+  }
+  return {
+    meter: amount.meter,
+    amount: { currency: "USD", amountNanos: amount.amount.toString() },
+  }
+}
+
+export function aiLimitAmountKey(
+  amount: Pick<NormalizedAiLimitAmount, "meter" | "currency">
+): string {
+  return `${amount.meter}:${amount.currency}`
+}
+
+export function normalizeCreateAiLimitPolicy(input: CreateAiLimitPolicyInput): AiLimitPolicy {
+  assertNonBlank(input.id, "policy id")
+  assertNonBlank(input.projectId, "projectId")
+  const createdAt = cloneValidDate(input.createdAt ?? new Date(), "createdAt")
+  return {
+    id: input.id,
+    projectId: input.projectId,
+    subject: normalizeAiLimitSubject(input.subject),
+    limit: normalizeAiLimitQuantity(input.limit),
+    period: "calendarMonth",
+    enabled: input.enabled ?? true,
+    createdAt,
+    updatedAt: new Date(createdAt),
+  }
+}
+
+export function normalizeUpdateAiLimitPolicy(input: UpdateAiLimitPolicyInput): {
+  readonly projectId: string
+  readonly id: string
+  readonly limit?: AiLimitQuantity
+  readonly enabled?: boolean
+  readonly updatedAt: Date
+} {
+  assertNonBlank(input.projectId, "projectId")
+  assertNonBlank(input.id, "policy id")
+  if (input.limit === undefined && input.enabled === undefined) {
+    throw new TypeError("[Sixb] AI limit policy update must change limit or enabled.")
+  }
+  if (input.enabled !== undefined && typeof input.enabled !== "boolean") {
+    throw new TypeError("[Sixb] AI limit enabled must be a boolean.")
+  }
+  return {
+    projectId: input.projectId,
+    id: input.id,
+    ...(input.limit === undefined ? {} : { limit: normalizeAiLimitQuantity(input.limit) }),
+    ...(input.enabled === undefined ? {} : { enabled: input.enabled }),
+    updatedAt: cloneValidDate(input.updatedAt ?? new Date(), "updatedAt"),
+  }
+}
+
+export function normalizeReserveAiModelCall(input: ReserveAiModelCallInput): {
+  readonly identity: AiModelCallReservationIdentity
+  readonly subjects: readonly AiLimitSubject[]
+  readonly estimates: readonly AiLimitQuantity[]
+  readonly period: AiLimitPeriod
+  readonly reservedAt: Date
+} {
+  const identity = normalizeAiModelCallReservationIdentity(input)
+  const reservedAt = cloneValidDate(input.reservedAt ?? new Date(), "reservedAt")
+  return {
+    identity,
+    subjects: normalizeAiLimitSubjects(input.subjects),
+    estimates: normalizeAiLimitQuantities(input.estimates, "estimates"),
+    period: aiLimitCalendarMonth(reservedAt),
+    reservedAt,
+  }
+}
+
+export function normalizeAiModelCallReservationIdentity(
+  input: AiModelCallReservationIdentity
+): AiModelCallReservationIdentity {
+  assertNonBlank(input.projectId, "projectId")
+  assertNonBlank(input.executionId, "executionId")
+  if (!Number.isSafeInteger(input.attempt) || input.attempt <= 0) {
+    throw new TypeError("[Sixb] AI limit reservation attempt must be a positive safe integer.")
+  }
+  assertNonBlank(input.callId, "callId")
+  return {
+    projectId: input.projectId,
+    executionId: input.executionId,
+    attempt: input.attempt,
+    callId: input.callId,
+  }
+}
+
+export function aiModelCallReservationKey(identity: AiModelCallReservationIdentity): string {
+  return JSON.stringify([
+    identity.projectId,
+    identity.executionId,
+    identity.attempt,
+    identity.callId,
+  ])
+}
+
+export function aiLimitPolicyDimensionKey(
+  policy: Pick<AiLimitPolicy, "projectId" | "subject" | "limit">
+): string {
+  const amount = normalizeAiLimitAmount(policy.limit)
+  return JSON.stringify([
+    policy.projectId,
+    aiLimitSubjectKey(policy.subject),
+    amount.meter,
+    amount.currency,
+  ])
+}
+
+export function aiLimitReservationRequestMatches(
+  reservation: AiModelCallReservation,
+  request: ReturnType<typeof normalizeReserveAiModelCall>
+): boolean {
+  return reservation.requestKey === aiLimitReservationRequestKey(request)
+}
+
+export function aiLimitReservationRequestKey(
+  request: ReturnType<typeof normalizeReserveAiModelCall>
+): string {
+  return JSON.stringify([
+    request.period.start.toISOString(),
+    request.subjects.map(aiLimitSubjectKey),
+    request.estimates.map((quantity) => {
+      const amount = normalizeAiLimitAmount(quantity)
+      return [amount.meter, amount.currency, amount.amount.toString()]
+    }),
+  ])
+}
+
+export function aiLimitReservationBuckets(
+  policies: readonly AiLimitPolicy[],
+  subjects: readonly AiLimitSubject[],
+  estimates: readonly AiLimitQuantity[]
+): readonly AiLimitReservationBucket[] {
+  const subjectKeys = new Set(subjects.map(aiLimitSubjectKey))
+  const estimatesByDimension = new Map(
+    estimates.map((estimate) => {
+      const amount = normalizeAiLimitAmount(estimate)
+      return [aiLimitAmountKey(amount), estimate] as const
+    })
+  )
+  return policies
+    .filter((policy) => subjectKeys.has(aiLimitSubjectKey(policy.subject)))
+    .flatMap((policy) => {
+      const estimate = estimatesByDimension.get(
+        aiLimitAmountKey(normalizeAiLimitAmount(policy.limit))
+      )
+      return estimate ? [{ subject: policy.subject, estimate }] : []
+    })
+    .sort((left, right) => {
+      const subject = aiLimitSubjectKey(left.subject).localeCompare(
+        aiLimitSubjectKey(right.subject)
+      )
+      if (subject !== 0) return subject
+      return aiLimitAmountKey(normalizeAiLimitAmount(left.estimate)).localeCompare(
+        aiLimitAmountKey(normalizeAiLimitAmount(right.estimate))
+      )
+    })
+}
+
+export function aiLimitAccountingEntryAppliesToSubject(
+  entry: AiLimitAccountingEntry,
+  subject: AiLimitSubject
+): boolean {
+  if (subject.type === "project") return true
+  if (subject.type === "group") return entry.requesterGroupIds.includes(subject.id)
+  return entry.requester?.type === subject.type && entry.requester.id === subject.id
+}
+
+export function aiLimitSubjectsFromAccountingEntry(
+  entry: AiLimitAccountingEntry
+): readonly AiLimitSubject[] {
+  return normalizeAiLimitSubjects([
+    ...entry.requesterGroupIds.map((id) => ({ type: "group" as const, id })),
+    ...(entry.requester ? [entry.requester] : []),
+  ])
+}
+
+export function resolveAiLimitActual(
+  entries: readonly AiLimitAccountingEntry[],
+  dimension: Pick<NormalizedAiLimitAmount, "meter" | "currency">
+): ResolvedAiLimitActual {
+  let amount = 0n
+  let accountingStatus: ResolvedAiLimitActual["accountingStatus"] = "complete"
+  for (const entry of entries) {
+    if (dimension.meter === "tokens.total") {
+      if (entry.totalTokens === undefined) {
+        accountingStatus = "unavailable"
+      } else {
+        amount += BigInt(entry.totalTokens)
+      }
+      continue
+    }
+    if (
+      entry.valuation?.status !== "rated" ||
+      entry.valuation.money.currency !== dimension.currency
+    ) {
+      accountingStatus = "unavailable"
+      continue
+    }
+    amount += BigInt(entry.valuation.money.amountNanos)
+  }
+  return { amount, accountingStatus }
+}
+
+export function assertAiLimitAccountingMatchesReservation(
+  reservation: AiModelCallReservation,
+  entry: AiLimitAccountingEntry
+): void {
+  if (
+    entry.projectId !== reservation.projectId ||
+    entry.executionId !== reservation.executionId ||
+    entry.attempt !== reservation.attempt ||
+    entry.callId !== reservation.callId
+  ) {
+    throw new AiLimitStorageError(
+      "usage_mismatch",
+      `[Sixb] AI usage record '${entry.usageRecordId}' does not belong to reservation '${reservation.callId}'.`
+    )
+  }
+}
+
+export function cloneAiLimitPolicy(policy: AiLimitPolicy): AiLimitPolicy {
+  return structuredClone(policy)
+}
+
+function normalizeAiMoney(money: AiMoney): AiMoney & { readonly currency: "USD" } {
+  if (!money || typeof money !== "object") {
+    throw new TypeError("[Sixb] AI limit cost amount must be AiMoney.")
+  }
+  assertNonBlank(money.currency, "cost currency")
+  if (money.currency !== "USD") {
+    throw new TypeError("[Sixb] AI limit catalog-estimated cost currency must be 'USD'.")
+  }
+  if (!/^(0|[1-9][0-9]*)$/.test(money.amountNanos)) {
+    throw new TypeError(
+      "[Sixb] AI limit cost amountNanos must be a canonical non-negative integer string."
+    )
+  }
+  if (BigInt(money.amountNanos) > SIGNED_INT64_MAX) {
+    throw new RangeError("[Sixb] AI limit cost amountNanos exceeds the supported range.")
+  }
+  return { currency: "USD", amountNanos: money.amountNanos }
+}
+
+export function assertNonBlank(value: string, label: string): void {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TypeError(`[Sixb] AI limit ${label} must be nonblank.`)
+  }
+}
+
+export function cloneValidDate(value: Date, label: string): Date {
+  if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+    throw new TypeError(`[Sixb] AI limit ${label} must be a valid Date.`)
+  }
+  return new Date(value)
+}

--- a/packages/core/src/storage/ai-limits/provider.ts
+++ b/packages/core/src/storage/ai-limits/provider.ts
@@ -16,6 +16,30 @@ import type {
 
 const SIGNED_INT64_MAX = 9_223_372_036_854_775_807n
 
+/** @internal Serialize compound limit operations, including within an existing transaction. */
+export class AiLimitOperationLock {
+  private tail: Promise<void> = Promise.resolve()
+
+  /** Wait for already queued operations before the owning transaction commits or rolls back. */
+  settle(): Promise<void> {
+    return this.tail
+  }
+
+  async run<T>(operation: () => Promise<T> | T): Promise<T> {
+    const previous = this.tail
+    let release!: () => void
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    await previous
+    try {
+      return await operation()
+    } finally {
+      release()
+    }
+  }
+}
+
 /** @internal Canonical integer quantity used by storage providers. */
 export interface NormalizedAiLimitAmount {
   readonly meter: AiLimitQuantity["meter"]

--- a/packages/core/src/storage/ai-limits/types.ts
+++ b/packages/core/src/storage/ai-limits/types.ts
@@ -1,0 +1,195 @@
+import type { AiMoney } from "../ai-cost"
+
+/** A project-wide, group, or durable requester identity charged for AI model calls. */
+export type AiLimitSubject =
+  | { readonly type: "project" }
+  | { readonly type: "group"; readonly id: string }
+  | { readonly type: "user"; readonly id: string }
+  | { readonly type: "serviceAccount"; readonly id: string }
+
+/** Aggregate meters supported by the first AI usage-limit release. */
+export type AiLimitMeter = "tokens.total" | "cost.catalogEstimated"
+
+/** An exact quantity for one supported meter. */
+export type AiLimitQuantity =
+  | { readonly meter: "tokens.total"; readonly amount: number }
+  | {
+      readonly meter: "cost.catalogEstimated"
+      readonly amount: AiMoney & { readonly currency: "USD" }
+    }
+
+export type AiLimitPeriodKind = "calendarMonth"
+
+/** Inclusive start and exclusive end of one UTC accounting period. */
+export interface AiLimitPeriod {
+  readonly kind: AiLimitPeriodKind
+  readonly start: Date
+  readonly end: Date
+  /** The first instant at which a denied call may be admitted in the next period. */
+  readonly resetAt: Date
+}
+
+/** Editable policy. Consumption is intentionally stored independently from this record. */
+export interface AiLimitPolicy {
+  readonly id: string
+  readonly projectId: string
+  readonly subject: AiLimitSubject
+  readonly limit: AiLimitQuantity
+  readonly period: AiLimitPeriodKind
+  readonly enabled: boolean
+  readonly createdAt: Date
+  readonly updatedAt: Date
+}
+
+export interface CreateAiLimitPolicyInput {
+  readonly id: string
+  readonly projectId: string
+  readonly subject: AiLimitSubject
+  readonly limit: AiLimitQuantity
+  readonly enabled?: boolean
+  readonly createdAt?: Date
+}
+
+export interface UpdateAiLimitPolicyInput {
+  readonly projectId: string
+  readonly id: string
+  /** The meter and cost currency are immutable; only the amount may change. */
+  readonly limit?: AiLimitQuantity
+  readonly enabled?: boolean
+  readonly updatedAt?: Date
+}
+
+export interface GetAiLimitPolicyInput {
+  readonly projectId: string
+  readonly id: string
+}
+
+export interface DeleteAiLimitPolicyInput extends GetAiLimitPolicyInput {}
+
+export interface ListAiLimitPoliciesInput {
+  readonly projectId: string
+  readonly includeDisabled?: boolean
+}
+
+/** Current-period consumption for one policy, all expressed in the policy's meter. */
+export interface AiLimitConsumption {
+  readonly actual: AiLimitQuantity
+  readonly reserved: AiLimitQuantity
+  readonly unknown: AiLimitQuantity
+  readonly remaining: AiLimitQuantity
+}
+
+export interface AiLimitPolicyStatus {
+  readonly policy: AiLimitPolicy
+  readonly period: AiLimitPeriod
+  readonly consumption: AiLimitConsumption
+  /** Whether every applicable immutable ledger record could be measured for this policy. */
+  readonly accountingStatus: "complete" | "unavailable"
+  readonly exhausted: boolean
+  /** True only when the caller supplied the current group set and this group is absent. */
+  readonly orphaned: boolean
+}
+
+export interface ListAiLimitPolicyStatusesInput {
+  readonly projectId: string
+  readonly at?: Date
+  readonly includeDisabled?: boolean
+  /** Optional current group IDs used to report policies whose snapshotted group disappeared. */
+  readonly existingGroupIds?: readonly string[]
+}
+
+export interface AiModelCallReservationIdentity {
+  readonly projectId: string
+  readonly executionId: string
+  readonly attempt: number
+  readonly callId: string
+}
+
+export interface AiLimitReservationBucket {
+  readonly subject: AiLimitSubject
+  readonly estimate: AiLimitQuantity
+}
+
+export type AiModelCallReservationState = "active" | "reconciled" | "unknown"
+
+/** Durable reservation for one Sixb-owned provider attempt. */
+export interface AiModelCallReservation extends AiModelCallReservationIdentity {
+  /** Only policy dimensions that were applicable at admission time. */
+  readonly buckets: readonly AiLimitReservationBucket[]
+  /** Canonical admission request used to reject conflicting idempotent replays. */
+  readonly requestKey: string
+  readonly period: AiLimitPeriod
+  readonly state: AiModelCallReservationState
+  readonly usageRecordId?: string
+  readonly reservedAt: Date
+  readonly updatedAt: Date
+}
+
+export interface ReserveAiModelCallInput extends AiModelCallReservationIdentity {
+  /** The project subject is always added, even when omitted here. */
+  readonly subjects: readonly AiLimitSubject[]
+  readonly estimates: readonly AiLimitQuantity[]
+  readonly reservedAt?: Date
+}
+
+export type ReserveAiModelCallResult =
+  | {
+      readonly status: "reserved"
+      readonly reservation: AiModelCallReservation
+      /** False when the exact reservation identity and request were replayed. */
+      readonly created: boolean
+    }
+  | {
+      /** No enabled policy matched a supplied subject and estimate. */
+      readonly status: "notRequired"
+    }
+  | {
+      /** Exact replay of a reservation that can no longer authorize a provider call. */
+      readonly status: "terminal"
+      readonly reservation: AiModelCallReservation
+      readonly created: false
+    }
+  | {
+      readonly status: "denied"
+      /** Every applicable policy that the proposed reservation would exceed. */
+      readonly exhaustedPolicies: readonly AiLimitPolicyStatus[]
+      readonly resetAt: Date
+    }
+  | {
+      /** Admission failed closed because an applicable policy could not be measured safely. */
+      readonly status: "unavailable"
+      readonly unavailablePolicies: readonly AiLimitPolicyStatus[]
+      readonly reasons: readonly ("missingEstimate" | "incompleteAccounting")[]
+    }
+
+export interface ReconcileAiModelCallInput extends AiModelCallReservationIdentity {
+  readonly usageRecordId: string
+  readonly reconciledAt?: Date
+}
+
+export interface MarkAiModelCallReservationUnknownInput extends AiModelCallReservationIdentity {
+  readonly markedAt?: Date
+}
+
+export interface RecordAiModelCallLimitActualsInput {
+  readonly projectId: string
+  readonly usageRecordId: string
+  readonly recordedAt?: Date
+}
+
+export interface AiLimitStorage {
+  createPolicy(input: CreateAiLimitPolicyInput): Promise<AiLimitPolicy>
+  updatePolicy(input: UpdateAiLimitPolicyInput): Promise<AiLimitPolicy>
+  deletePolicy(input: DeleteAiLimitPolicyInput): Promise<boolean>
+  getPolicy(input: GetAiLimitPolicyInput): Promise<AiLimitPolicy | null>
+  listPolicies(input: ListAiLimitPoliciesInput): Promise<readonly AiLimitPolicy[]>
+  listPolicyStatuses(input: ListAiLimitPolicyStatusesInput): Promise<readonly AiLimitPolicyStatus[]>
+
+  reserveModelCall(input: ReserveAiModelCallInput): Promise<ReserveAiModelCallResult>
+  /** Applies a newly-created immutable usage record to initialized period counters. */
+  recordModelCallActuals(input: RecordAiModelCallLimitActualsInput): Promise<void>
+  reconcileModelCall(input: ReconcileAiModelCallInput): Promise<AiModelCallReservation>
+  markReservationUnknown(
+    input: MarkAiModelCallReservationUnknownInput
+  ): Promise<AiModelCallReservation>
+}

--- a/packages/core/src/storage/ai-usage/in-memory.ts
+++ b/packages/core/src/storage/ai-usage/in-memory.ts
@@ -144,6 +144,19 @@ export class InMemoryAiUsageStorage implements AiUsageStorage {
     replaceMap(this.groupRows, snapshot.groupRows)
   }
 
+  /** @internal Immutable accounting source used by in-memory AI limit enforcement. */
+  getRecord(projectId: string, id: string): AiModelCallUsageRecord | null {
+    const record = this.records.get(modelCallRecordKey(projectId, id))
+    return record ? structuredClone(record) : null
+  }
+
+  /** @internal Immutable accounting source used by in-memory AI limit status reads. */
+  listRecords(projectId: string): readonly AiModelCallUsageRecord[] {
+    return [...this.records.values()]
+      .filter((record) => record.projectId === projectId)
+      .map((record) => structuredClone(record))
+  }
+
   private async assertExecutionExists(projectId: string, executionId: string): Promise<void> {
     const execution = await this.executions.getById({ projectId, id: executionId })
     if (execution) return

--- a/packages/core/src/storage/in-memory/index.ts
+++ b/packages/core/src/storage/in-memory/index.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks"
 import { InMemoryActionRunStorage } from "../action-runs"
 import { type AgentStorage, InMemoryAgentStorage } from "../agents"
 import { type AiAccountingAttribution, type AiCostStorage, InMemoryAiCostStorage } from "../ai-cost"
+import { type AiLimitStorage, InMemoryAiLimitStorage } from "../ai-limits"
 import { type AiUsageStorage, InMemoryAiUsageStorage } from "../ai-usage"
 import { type AuthStorage, InMemoryAuthStorage } from "../auth"
 import {
@@ -71,6 +72,15 @@ export class InMemoryStorage implements Storage {
   private readonly aiCostStorage = new InMemoryAiCostStorage(this.aiUsageStorage, {
     resolve: (input) => this.resolveAiAccountingAttribution(input),
   })
+  private readonly aiLimitStorage = new InMemoryAiLimitStorage({
+    resolveExecution: ({ projectId, executionId }) =>
+      this.executionStorage.getById({ projectId, id: executionId }),
+    resolveUsageRecord: ({ projectId, usageRecordId }) =>
+      this.aiUsageStorage.getRecord(projectId, usageRecordId),
+    resolveCostRecord: ({ projectId, usageRecordId }) =>
+      this.aiCostStorage.getRecord(projectId, usageRecordId),
+    listUsageRecords: ({ projectId }) => this.aiUsageStorage.listRecords(projectId),
+  })
   private readonly actionRunStorage = new InMemoryActionRunStorage(this.executionStorage)
   private readonly syncRunStorage = new InMemorySyncRunStorage(this.executionStorage)
   private readonly pipelineRunStorage = new InMemoryPipelineRunStorage(this.executionStorage)
@@ -88,6 +98,7 @@ export class InMemoryStorage implements Storage {
   readonly agents: AgentStorage
   readonly aiUsage: AiUsageStorage
   readonly aiCosts: AiCostStorage
+  readonly aiLimits: AiLimitStorage
   readonly actionRuns: InMemoryActionRunStorage
   readonly syncRuns: SyncRunStorage
   readonly pipelineRuns: PipelineRunStorage
@@ -114,6 +125,7 @@ export class InMemoryStorage implements Storage {
     this.agents = createAgentOperationScope(this.agentStorage, scope)
     this.aiUsage = createOperationScopedFacade(this.aiUsageStorage, scope)
     this.aiCosts = createOperationScopedFacade(this.aiCostStorage, scope)
+    this.aiLimits = createOperationScopedFacade(this.aiLimitStorage, scope)
     this.actionRuns = createOperationScopedFacade(this.actionRunStorage, scope)
     this.syncRuns = createOperationScopedFacade(this.syncRunStorage, scope)
     this.pipelineRuns = createOperationScopedFacade(this.pipelineRunStorage, scope)
@@ -297,6 +309,7 @@ export class InMemoryStorage implements Storage {
       agents: this.agentStorage,
       aiUsage: this.aiUsageStorage,
       aiCosts: this.aiCostStorage,
+      aiLimits: this.aiLimitStorage,
       actionRuns: this.actionRunStorage,
       syncRuns: this.syncRunStorage,
       pipelineRuns: this.pipelineRunStorage,
@@ -324,6 +337,7 @@ export class InMemoryStorage implements Storage {
       agents: this.agentStorage.snapshot(),
       aiUsage: this.aiUsageStorage.snapshot(),
       aiCosts: this.aiCostStorage.snapshot(),
+      aiLimits: this.aiLimitStorage.snapshot(),
       actionRuns: this.actionRunStorage.snapshot(),
       syncRuns: this.syncRunStorage.snapshot(),
       pipelineRuns: this.pipelineRunStorage.snapshot(),
@@ -346,6 +360,7 @@ export class InMemoryStorage implements Storage {
     this.agentStorage.restore(snapshot.agents)
     this.aiUsageStorage.restore(snapshot.aiUsage)
     this.aiCostStorage.restore(snapshot.aiCosts)
+    this.aiLimitStorage.restore(snapshot.aiLimits)
     this.actionRunStorage.restore(snapshot.actionRuns)
     this.syncRunStorage.restore(snapshot.syncRuns)
     this.pipelineRunStorage.restore(snapshot.pipelineRuns)
@@ -368,6 +383,7 @@ export interface InMemoryStorageSnapshot {
   readonly agents: ReturnType<InMemoryAgentStorage["snapshot"]>
   readonly aiUsage: ReturnType<InMemoryAiUsageStorage["snapshot"]>
   readonly aiCosts: ReturnType<InMemoryAiCostStorage["snapshot"]>
+  readonly aiLimits: ReturnType<InMemoryAiLimitStorage["snapshot"]>
   readonly actionRuns: ReturnType<InMemoryActionRunStorage["snapshot"]>
   readonly syncRuns: ReturnType<InMemorySyncRunStorage["snapshot"]>
   readonly pipelineRuns: ReturnType<InMemoryPipelineRunStorage["snapshot"]>

--- a/packages/core/src/storage/in-memory/index.ts
+++ b/packages/core/src/storage/in-memory/index.ts
@@ -236,7 +236,13 @@ export class InMemoryStorage implements Storage {
       this.materializationLifecycles.set(transactionToken, materializationLifecycle)
 
       try {
-        const result = await this.transactionScope.run(transactionToken, async () => run(tx))
+        const result = await this.transactionScope.run(transactionToken, async () => {
+          try {
+            return await run(tx)
+          } finally {
+            await this.aiLimitStorage.settleOperations()
+          }
+        })
         materializationLifecycle.assertCommittable()
         return result
       } catch (error) {

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -133,6 +133,36 @@ export type {
 } from "./ai-cost"
 export { AiCostStorageError, InMemoryAiCostStorage } from "./ai-cost"
 export type {
+  AiLimitConsumption,
+  AiLimitMeter,
+  AiLimitPeriod,
+  AiLimitPeriodKind,
+  AiLimitPolicy,
+  AiLimitPolicyStatus,
+  AiLimitQuantity,
+  AiLimitReservationBucket,
+  AiLimitStorage,
+  AiLimitStorageErrorCode,
+  AiLimitSubject,
+  AiModelCallReservation,
+  AiModelCallReservationIdentity,
+  AiModelCallReservationState,
+  CreateAiLimitPolicyInput,
+  DeleteAiLimitPolicyInput,
+  GetAiLimitPolicyInput,
+  InMemoryAiLimitStorageOptions,
+  InMemoryAiLimitStorageSnapshot,
+  ListAiLimitPoliciesInput,
+  ListAiLimitPolicyStatusesInput,
+  MarkAiModelCallReservationUnknownInput,
+  ReconcileAiModelCallInput,
+  RecordAiModelCallLimitActualsInput,
+  ReserveAiModelCallInput,
+  ReserveAiModelCallResult,
+  UpdateAiLimitPolicyInput,
+} from "./ai-limits"
+export { AiLimitStorageError, aiLimitCalendarMonth, InMemoryAiLimitStorage } from "./ai-limits"
+export type {
   AiModelCallUsage,
   AiModelCallUsageInput,
   AiModelCallUsageRecord,

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1,6 +1,7 @@
 import type { ActionRunStorage } from "./action-runs"
 import type { AgentStorage } from "./agents"
 import type { AiCostStorage } from "./ai-cost"
+import type { AiLimitStorage } from "./ai-limits"
 import type { AiUsageStorage } from "./ai-usage"
 import type { AuthStorage } from "./auth"
 import type { ConnectorConnectionStorage } from "./connector-connections"
@@ -62,6 +63,34 @@ export type {
   StartAgentRunInput,
 } from "./agents"
 export { AGENT_RUN_FAILURE_CODES, AgentStorageError } from "./agents"
+export type {
+  AiLimitConsumption,
+  AiLimitMeter,
+  AiLimitPeriod,
+  AiLimitPeriodKind,
+  AiLimitPolicy,
+  AiLimitPolicyStatus,
+  AiLimitQuantity,
+  AiLimitReservationBucket,
+  AiLimitStorage,
+  AiLimitStorageErrorCode,
+  AiLimitSubject,
+  AiModelCallReservation,
+  AiModelCallReservationIdentity,
+  AiModelCallReservationState,
+  CreateAiLimitPolicyInput,
+  DeleteAiLimitPolicyInput,
+  GetAiLimitPolicyInput,
+  ListAiLimitPoliciesInput,
+  ListAiLimitPolicyStatusesInput,
+  MarkAiModelCallReservationUnknownInput,
+  ReconcileAiModelCallInput,
+  RecordAiModelCallLimitActualsInput,
+  ReserveAiModelCallInput,
+  ReserveAiModelCallResult,
+  UpdateAiLimitPolicyInput,
+} from "./ai-limits"
+export { AiLimitStorageError, aiLimitCalendarMonth } from "./ai-limits"
 export type {
   AiModelCallUsage,
   AiModelCallUsageInput,
@@ -295,6 +324,7 @@ export interface Storage {
   agents?: AgentStorage
   aiUsage?: AiUsageStorage
   aiCosts?: AiCostStorage
+  aiLimits?: AiLimitStorage
   actionRuns?: ActionRunStorage
   syncRuns?: SyncRunStorage
   pipelineRuns?: PipelineRunStorage

--- a/packages/core/src/testing/ai-limit-storage-contract.ts
+++ b/packages/core/src/testing/ai-limit-storage-contract.ts
@@ -1,0 +1,940 @@
+import { describe, expect, test } from "bun:test"
+import type {
+  AiCostStorage,
+  AiLimitQuantity,
+  AiLimitStorage,
+  AiLimitSubject,
+  AiModelCallCostRecord,
+  AiModelCallUsageInput,
+  AiUsageStorage,
+  AuthStorage,
+  ExecutionStorage,
+  ReserveAiModelCallInput,
+  Storage,
+} from "../storage"
+import { aiLimitCalendarMonth } from "../storage"
+
+export interface AiLimitStorageContractStorage {
+  readonly aiLimits: AiLimitStorage
+  readonly aiCosts: AiCostStorage
+  readonly aiUsage: AiUsageStorage
+  readonly auth: AuthStorage
+  readonly executions: ExecutionStorage
+  readonly transaction: Storage["transaction"]
+}
+
+export interface AiLimitStorageContractSuiteOptions<
+  TStorage extends AiLimitStorageContractStorage = AiLimitStorageContractStorage,
+> {
+  readonly createStorage: () => TStorage | Promise<TStorage>
+  readonly setup?: (storage: TStorage) => void | Promise<void>
+  readonly cleanup?: (storage: TStorage) => void | Promise<void>
+}
+
+const projectId = "ai-limit-contract"
+const executionId = "exec_ai_limit_1"
+
+const project: AiLimitSubject = { type: "project" }
+const support: AiLimitSubject = { type: "group", id: "support" }
+const user = { type: "user" as const, id: "user-1" }
+
+function at(value: string): Date {
+  return new Date(value)
+}
+
+function reservation(
+  callId: string,
+  tokens: number,
+  overrides: Partial<ReserveAiModelCallInput> = {}
+): ReserveAiModelCallInput {
+  return {
+    projectId,
+    executionId,
+    attempt: 1,
+    callId,
+    subjects: [support, user],
+    estimates: [{ meter: "tokens.total", amount: tokens }],
+    reservedAt: at("2026-08-15T12:00:00.000Z"),
+    ...overrides,
+  }
+}
+
+/** Run the provider-neutral AI policy, period-state, and reservation contract. */
+export function runAiLimitStorageContractSuite<TStorage extends AiLimitStorageContractStorage>(
+  label: string,
+  options: AiLimitStorageContractSuiteOptions<TStorage>
+): void {
+  const withStorage = async (body: (storage: TStorage) => Promise<void>): Promise<void> => {
+    const storage = await options.createStorage()
+    try {
+      await seedAiLimitStorageContractExecution(storage.auth, storage.executions)
+      await options.setup?.(storage)
+      await body(storage)
+    } finally {
+      await options.cleanup?.(storage)
+    }
+  }
+
+  describe(label, () => {
+    test("uses inclusive-start, exclusive-end UTC calendar months", () => {
+      expect(aiLimitCalendarMonth(at("2026-12-31T23:59:59.999-05:00"))).toEqual({
+        kind: "calendarMonth",
+        start: at("2027-01-01T00:00:00.000Z"),
+        end: at("2027-02-01T00:00:00.000Z"),
+        resetAt: at("2027-02-01T00:00:00.000Z"),
+      })
+    })
+
+    test("creates, lists, edits, disables, and deletes policies without ambiguous dimensions", async () => {
+      await withStorage(async ({ aiLimits }) => {
+        const created = await aiLimits.createPolicy({
+          id: "project-tokens",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 100 },
+          createdAt: at("2026-08-10T00:00:00.000Z"),
+        })
+        expect(created).toMatchObject({ enabled: true, period: "calendarMonth" })
+        await expect(
+          aiLimits.createPolicy({
+            id: "duplicate-dimension",
+            projectId,
+            subject: project,
+            limit: { meter: "tokens.total", amount: 200 },
+          })
+        ).rejects.toMatchObject({ code: "duplicate_policy" })
+
+        await expect(
+          aiLimits.updatePolicy({
+            projectId,
+            id: created.id,
+            limit: { meter: "tokens.total", amount: 250 },
+            enabled: false,
+            updatedAt: at("2026-08-11T00:00:00.000Z"),
+          })
+        ).resolves.toMatchObject({ limit: { amount: 250 }, enabled: false })
+        await expect(aiLimits.listPolicies({ projectId })).resolves.toEqual([])
+        await expect(
+          aiLimits.listPolicies({ projectId, includeDisabled: true })
+        ).resolves.toHaveLength(1)
+        await expect(aiLimits.deletePolicy({ projectId, id: created.id })).resolves.toBe(true)
+        await expect(aiLimits.deletePolicy({ projectId, id: created.id })).resolves.toBe(false)
+        await expect(
+          aiLimits.createPolicy({
+            id: "cost-out-of-range",
+            projectId,
+            subject: project,
+            limit: {
+              meter: "cost.catalogEstimated",
+              amount: { currency: "USD", amountNanos: "9223372036854775808" },
+            },
+          })
+        ).rejects.toThrow("exceeds the supported range")
+        await expect(
+          aiLimits.createPolicy({
+            id: "cost-unsupported-currency",
+            projectId,
+            subject: { type: "group", id: "europe" },
+            limit: {
+              meter: "cost.catalogEstimated",
+              amount: { currency: "EUR", amountNanos: "100" },
+            } as unknown as AiLimitQuantity,
+          })
+        ).rejects.toThrow("catalog-estimated cost currency must be 'USD'")
+      })
+    })
+
+    test("returns every applicable exhausted policy and the earliest reset", async () => {
+      await withStorage(async ({ aiLimits }) => {
+        for (const [id, subject, amount] of [
+          ["project", project, 10],
+          ["support", support, 8],
+          ["user", user, 100],
+        ] as const) {
+          await aiLimits.createPolicy({
+            id,
+            projectId,
+            subject,
+            limit: { meter: "tokens.total", amount },
+          })
+        }
+        const result = await aiLimits.reserveModelCall(reservation("denied", 11))
+        expect(result).toMatchObject({
+          status: "denied",
+          exhaustedPolicies: [{ policy: { id: "project" } }, { policy: { id: "support" } }],
+          resetAt: at("2026-09-01T00:00:00.000Z"),
+        })
+        const statuses = await aiLimits.listPolicyStatuses({
+          projectId,
+          at: at("2026-08-20T00:00:00.000Z"),
+          existingGroupIds: [],
+        })
+        expect(statuses.find((status) => status.policy.id === "support")?.orphaned).toBe(true)
+        expect(statuses.every((status) => status.consumption.reserved.amount === 0)).toBe(true)
+      })
+    })
+
+    test("atomically prevents concurrent reservations from oversubscribing", async () => {
+      await withStorage(async ({ aiLimits }) => {
+        await aiLimits.createPolicy({
+          id: "project",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 10 },
+        })
+        const results = await Promise.all([
+          aiLimits.reserveModelCall(reservation("call-a", 6)),
+          aiLimits.reserveModelCall(reservation("call-b", 6)),
+        ])
+        expect(results.map((result) => result.status).sort()).toEqual(["denied", "reserved"])
+        const [status] = await aiLimits.listPolicyStatuses({ projectId, at: at("2026-08-20Z") })
+        expect(status?.consumption).toMatchObject({
+          actual: { amount: 0 },
+          reserved: { amount: 6 },
+          unknown: { amount: 0 },
+          remaining: { amount: 4 },
+        })
+      })
+    })
+
+    test("reserves only exact subject-meter policy buckets", async () => {
+      await withStorage(async ({ aiLimits }) => {
+        await aiLimits.createPolicy({
+          id: "project-tokens",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 100 },
+        })
+        await aiLimits.createPolicy({
+          id: "user-cost",
+          projectId,
+          subject: user,
+          limit: {
+            meter: "cost.catalogEstimated",
+            amount: { currency: "USD", amountNanos: "100" },
+          },
+        })
+        const result = await aiLimits.reserveModelCall(
+          reservation("exact-buckets", 5, {
+            estimates: [
+              { meter: "tokens.total", amount: 5 },
+              {
+                meter: "cost.catalogEstimated",
+                amount: { currency: "USD", amountNanos: "7" },
+              },
+            ],
+          })
+        )
+        expect(result).toMatchObject({
+          status: "reserved",
+          reservation: {
+            buckets: [
+              { subject: project, estimate: { meter: "tokens.total", amount: 5 } },
+              {
+                subject: user,
+                estimate: {
+                  meter: "cost.catalogEstimated",
+                  amount: { currency: "USD", amountNanos: "7" },
+                },
+              },
+            ],
+          },
+        })
+      })
+    })
+
+    test("replays an identical reservation and rejects a mismatched identity replay", async () => {
+      await withStorage(async ({ aiLimits }) => {
+        await aiLimits.createPolicy({
+          id: "replay-policy",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 100 },
+        })
+        const first = await aiLimits.reserveModelCall(reservation("replay", 5))
+        const replay = await aiLimits.reserveModelCall(reservation("replay", 5))
+        expect(first).toMatchObject({ status: "reserved", created: true })
+        expect(replay).toMatchObject({ status: "reserved", created: false })
+        await expect(aiLimits.reserveModelCall(reservation("replay", 6))).rejects.toMatchObject({
+          code: "reservation_conflict",
+        })
+      })
+    })
+
+    test("does not authorize a terminal reservation replay", async () => {
+      await withStorage(async (storage) => {
+        const { aiLimits } = storage
+        await aiLimits.createPolicy({
+          id: "terminal-policy",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 10 },
+        })
+        const identity = reservation("terminal-replay", 5)
+        await aiLimits.reserveModelCall(identity)
+        await recordUsage(storage.aiUsage, "usage-terminal", identity.callId, 3)
+        await aiLimits.recordModelCallActuals({
+          projectId,
+          usageRecordId: "usage-terminal",
+        })
+        await aiLimits.reconcileModelCall({ ...identity, usageRecordId: "usage-terminal" })
+        await expect(aiLimits.reserveModelCall(identity)).resolves.toMatchObject({
+          status: "terminal",
+          created: false,
+          reservation: { state: "reconciled" },
+        })
+      })
+    })
+
+    test("fails closed when an applicable policy has no estimate", async () => {
+      await withStorage(async ({ aiLimits }) => {
+        await aiLimits.createPolicy({
+          id: "tokens",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 10 },
+        })
+        const result = await aiLimits.reserveModelCall(
+          reservation("missing-estimate", 1, {
+            estimates: [
+              {
+                meter: "cost.catalogEstimated",
+                amount: { currency: "USD", amountNanos: "1" },
+              },
+            ],
+          })
+        )
+        expect(result).toMatchObject({
+          status: "unavailable",
+          unavailablePolicies: [{ policy: { id: "tokens" } }],
+          reasons: ["missingEstimate"],
+        })
+      })
+    })
+
+    test("reconciles estimates to actual usage exactly once", async () => {
+      await withStorage(async (storage) => {
+        const { aiLimits } = storage
+        await aiLimits.createPolicy({
+          id: "project",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 20 },
+        })
+        await aiLimits.reserveModelCall(reservation("reconcile", 10))
+        await recordUsage(storage.aiUsage, "usage-reconcile", "reconcile", 7)
+        await aiLimits.recordModelCallActuals({
+          projectId,
+          usageRecordId: "usage-reconcile",
+        })
+        const input = {
+          projectId,
+          executionId,
+          attempt: 1,
+          callId: "reconcile",
+          usageRecordId: "usage-reconcile",
+          reconciledAt: at("2026-08-15T12:00:01.000Z"),
+        }
+        await expect(aiLimits.reconcileModelCall(input)).resolves.toMatchObject({
+          state: "reconciled",
+          usageRecordId: "usage-reconcile",
+        })
+        await expect(aiLimits.reconcileModelCall(input)).resolves.toMatchObject({
+          state: "reconciled",
+        })
+        await expect(
+          aiLimits.reconcileModelCall({ ...input, usageRecordId: "another-usage" })
+        ).rejects.toMatchObject({ code: "reconciliation_conflict" })
+        const [status] = await aiLimits.listPolicyStatuses({ projectId, at: input.reconciledAt })
+        expect(status?.consumption).toMatchObject({
+          actual: { amount: 7 },
+          reserved: { amount: 0 },
+          unknown: { amount: 0 },
+          remaining: { amount: 13 },
+        })
+      })
+    })
+
+    test("rejects a usage record that belongs to another provider call", async () => {
+      await withStorage(async (storage) => {
+        await storage.aiLimits.createPolicy({
+          id: "usage-mismatch-policy",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 100 },
+        })
+        const identity = reservation("expected-call", 5)
+        await storage.aiLimits.reserveModelCall(identity)
+        await recordUsage(storage.aiUsage, "usage-wrong-call", "different-call", 3)
+        await expect(
+          storage.aiLimits.reconcileModelCall({
+            ...identity,
+            usageRecordId: "usage-wrong-call",
+          })
+        ).rejects.toMatchObject({ code: "usage_mismatch" })
+      })
+    })
+
+    test("conservatively converts a reservation to unknown when actuals are unavailable", async () => {
+      await withStorage(async (storage) => {
+        await storage.aiLimits.createPolicy({
+          id: "tokens",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 10 },
+        })
+        const identity = reservation("partial-reconciliation", 5)
+        await storage.aiLimits.reserveModelCall(identity)
+        await recordUsageInput(storage.aiUsage, {
+          id: "usage-partial-reconciliation",
+          callId: identity.callId,
+          usage: { inputTokens: 3 },
+        })
+        await storage.aiLimits.recordModelCallActuals({
+          projectId,
+          usageRecordId: "usage-partial-reconciliation",
+        })
+        await expect(
+          storage.aiLimits.reconcileModelCall({
+            ...identity,
+            usageRecordId: "usage-partial-reconciliation",
+          })
+        ).resolves.toMatchObject({ state: "reconciled" })
+        const [status] = await storage.aiLimits.listPolicyStatuses({
+          projectId,
+          at: identity.reservedAt,
+        })
+        expect(status).toMatchObject({
+          accountingStatus: "unavailable",
+          consumption: { reserved: { amount: 0 }, unknown: { amount: 5 } },
+        })
+      })
+    })
+
+    test("fails closed when historical token accounting is incomplete", async () => {
+      await withStorage(async (storage) => {
+        await recordUsageInput(storage.aiUsage, {
+          id: "usage-partial",
+          callId: "partial",
+          usage: { inputTokens: 3 },
+        })
+        await storage.aiLimits.createPolicy({
+          id: "tokens",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 10 },
+        })
+        const [status] = await storage.aiLimits.listPolicyStatuses({
+          projectId,
+          at: at("2026-08-15T12:00:01.000Z"),
+        })
+        expect(status).toMatchObject({
+          accountingStatus: "unavailable",
+          consumption: { actual: { amount: 0 } },
+        })
+        await expect(
+          storage.aiLimits.reserveModelCall(reservation("after-partial", 1))
+        ).resolves.toMatchObject({
+          status: "unavailable",
+          reasons: ["incompleteAccounting"],
+        })
+      })
+    })
+
+    test("charges actuals to the ledger occurrence month", async () => {
+      await withStorage(async (storage) => {
+        await storage.aiLimits.createPolicy({
+          id: "tokens",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 20 },
+        })
+        const identity = reservation("month-boundary", 10, {
+          reservedAt: at("2026-08-31T23:59:59.000Z"),
+        })
+        await storage.aiLimits.reserveModelCall(identity)
+        await recordUsage(storage.aiUsage, "usage-month-boundary", "month-boundary", 7, {
+          occurredAt: at("2026-09-01T00:00:00.000Z"),
+        })
+        await storage.aiLimits.recordModelCallActuals({
+          projectId,
+          usageRecordId: "usage-month-boundary",
+        })
+        await expect(
+          storage.aiLimits.reconcileModelCall({
+            ...identity,
+            usageRecordId: "usage-month-boundary",
+            reconciledAt: at("2026-09-01T00:00:01.000Z"),
+          })
+        ).resolves.toMatchObject({ state: "reconciled" })
+        const [august] = await storage.aiLimits.listPolicyStatuses({
+          projectId,
+          at: at("2026-08-31T23:59:59.999Z"),
+        })
+        const [september] = await storage.aiLimits.listPolicyStatuses({
+          projectId,
+          at: at("2026-09-01T00:00:00.000Z"),
+        })
+        expect(august?.consumption).toMatchObject({
+          actual: { amount: 0 },
+          reserved: { amount: 0 },
+        })
+        expect(september?.consumption).toMatchObject({
+          actual: { amount: 7 },
+          remaining: { amount: 13 },
+        })
+      })
+    })
+
+    test("holds unknown capacity until it is reconciled", async () => {
+      await withStorage(async (storage) => {
+        const { aiLimits } = storage
+        await aiLimits.createPolicy({
+          id: "project",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 10 },
+        })
+        const identity = reservation("unknown", 8)
+        await aiLimits.reserveModelCall(identity)
+        await aiLimits.markReservationUnknown({ ...identity, markedAt: at("2026-08-15T12:01Z") })
+        let [status] = await aiLimits.listPolicyStatuses({ projectId, at: identity.reservedAt })
+        expect(status?.consumption).toMatchObject({
+          reserved: { amount: 0 },
+          unknown: { amount: 8 },
+          remaining: { amount: 2 },
+        })
+        await recordUsage(storage.aiUsage, "usage-unknown", identity.callId, 3)
+        await aiLimits.recordModelCallActuals({ projectId, usageRecordId: "usage-unknown" })
+        await aiLimits.reconcileModelCall({
+          ...identity,
+          usageRecordId: "usage-unknown",
+          reconciledAt: at("2026-08-15T12:02Z"),
+        })
+        ;[status] = await aiLimits.listPolicyStatuses({ projectId, at: identity.reservedAt })
+        expect(status?.consumption).toMatchObject({
+          actual: { amount: 3 },
+          unknown: { amount: 0 },
+          remaining: { amount: 7 },
+        })
+      })
+    })
+
+    test("counts usage recorded before a policy is created and preserves it across recreation", async () => {
+      await withStorage(async (storage) => {
+        const identity = reservation("before-policy", 10)
+        await recordUsage(storage.aiUsage, "usage-before-policy", "before-policy", 7)
+        await storage.aiLimits.createPolicy({
+          id: "created-mid-month",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 10 },
+        })
+        let [status] = await storage.aiLimits.listPolicyStatuses({
+          projectId,
+          at: identity.reservedAt,
+        })
+        expect(status?.consumption.actual).toEqual({ meter: "tokens.total", amount: 7 })
+        await storage.aiLimits.updatePolicy({
+          projectId,
+          id: "created-mid-month",
+          limit: { meter: "tokens.total", amount: 20 },
+        })
+        await storage.aiLimits.deletePolicy({ projectId, id: "created-mid-month" })
+        await storage.aiLimits.createPolicy({
+          id: "recreated",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 30 },
+        })
+        ;[status] = await storage.aiLimits.listPolicyStatuses({
+          projectId,
+          at: identity.reservedAt,
+        })
+        expect(status?.consumption).toMatchObject({
+          actual: { amount: 7 },
+          remaining: { amount: 23 },
+        })
+      })
+    })
+
+    test("derives each subject's actuals from immutable execution and usage attribution", async () => {
+      await withStorage(async (storage) => {
+        const engineering = { type: "group" as const, id: "engineering" }
+        const serviceAccount = { type: "serviceAccount" as const, id: "automation" }
+        await recordUsage(storage.aiUsage, "usage-all-subjects", "all-subjects", 7, {
+          requesterGroupIds: ["support", "engineering"],
+        })
+
+        const serviceExecutionId = "exec_ai_limit_service"
+        await seedPrincipalExecution(
+          storage.auth,
+          storage.executions,
+          serviceExecutionId,
+          serviceAccount
+        )
+        await recordUsage(storage.aiUsage, "usage-service-account", "service-account", 3, {
+          executionId: serviceExecutionId,
+          requesterGroupIds: [],
+        })
+
+        for (const [id, subject] of [
+          ["project-subject", project],
+          ["support-subject", support],
+          ["engineering-subject", engineering],
+          ["user-subject", user],
+          ["service-account-subject", serviceAccount],
+        ] as const) {
+          await storage.aiLimits.createPolicy({
+            id,
+            projectId,
+            subject,
+            limit: { meter: "tokens.total", amount: 20 },
+          })
+        }
+        const august = await storage.aiLimits.listPolicyStatuses({
+          projectId,
+          at: at("2026-08-31T23:59:59.999Z"),
+        })
+        expect(
+          Object.fromEntries(
+            august.map((status) => [status.policy.id, status.consumption.actual.amount])
+          )
+        ).toEqual({
+          "engineering-subject": 7,
+          "project-subject": 10,
+          "service-account-subject": 3,
+          "support-subject": 7,
+          "user-subject": 7,
+        })
+        const september = await storage.aiLimits.listPolicyStatuses({
+          projectId,
+          at: at("2026-09-01T00:00:00.000Z"),
+        })
+        expect(september.map((status) => status.consumption.actual.amount)).toEqual([0, 0, 0, 0, 0])
+      })
+    })
+
+    test("derives catalog-estimated cost from the immutable valuation ledger", async () => {
+      await withStorage(async (storage) => {
+        await storage.aiLimits.createPolicy({
+          id: "cost",
+          projectId,
+          subject: project,
+          limit: {
+            meter: "cost.catalogEstimated",
+            amount: { currency: "USD", amountNanos: "1000000000" },
+          },
+        })
+        const identity = reservation("cost", 1, {
+          estimates: [
+            {
+              meter: "cost.catalogEstimated",
+              amount: { currency: "USD", amountNanos: "250000000" },
+            },
+          ],
+        })
+        const result = await storage.aiLimits.reserveModelCall(identity)
+        expect(result.status).toBe("reserved")
+        await recordUsage(storage.aiUsage, "usage-cost", "cost", 1)
+        await storage.aiCosts.recordModelCallCost(ratedCost("usage-cost", "250000000"))
+        await storage.aiLimits.recordModelCallActuals({
+          projectId,
+          usageRecordId: "usage-cost",
+        })
+        await expect(
+          storage.aiLimits.reconcileModelCall({
+            ...identity,
+            usageRecordId: "usage-cost",
+          })
+        ).resolves.toMatchObject({ state: "reconciled" })
+        const [status] = await storage.aiLimits.listPolicyStatuses({
+          projectId,
+          at: at("2026-08-15T12:00:00.000Z"),
+        })
+        expect(status).toMatchObject({
+          accountingStatus: "complete",
+          consumption: {
+            actual: { amount: { currency: "USD", amountNanos: "250000000" } },
+            reserved: { amount: { currency: "USD", amountNanos: "0" } },
+            remaining: { amount: { currency: "USD", amountNanos: "750000000" } },
+          },
+        })
+      })
+    })
+
+    test("fails cost admission closed until every applicable call is valued", async () => {
+      await withStorage(async (storage) => {
+        await recordUsage(storage.aiUsage, "usage-unvalued", "unvalued", 1)
+        await storage.aiLimits.createPolicy({
+          id: "cost",
+          projectId,
+          subject: project,
+          limit: {
+            meter: "cost.catalogEstimated",
+            amount: { currency: "USD", amountNanos: "1000000000" },
+          },
+        })
+        await expect(
+          storage.aiLimits.reserveModelCall(
+            reservation("after-unvalued", 1, {
+              estimates: [
+                {
+                  meter: "cost.catalogEstimated",
+                  amount: { currency: "USD", amountNanos: "1" },
+                },
+              ],
+            })
+          )
+        ).resolves.toMatchObject({
+          status: "unavailable",
+          reasons: ["incompleteAccounting"],
+        })
+
+        await storage.aiCosts.recordModelCallCost(unpriceableCost("usage-unvalued"))
+        await expect(
+          storage.aiLimits.reserveModelCall(
+            reservation("after-unpriceable", 1, {
+              estimates: [
+                {
+                  meter: "cost.catalogEstimated",
+                  amount: { currency: "USD", amountNanos: "1" },
+                },
+              ],
+            })
+          )
+        ).resolves.toMatchObject({
+          status: "unavailable",
+          reasons: ["incompleteAccounting"],
+        })
+      })
+    })
+
+    test("rolls policy and reservation state back with the root storage transaction", async () => {
+      await withStorage(async (storage) => {
+        await expect(
+          storage.transaction(async (tx) => {
+            const limits = tx.aiLimits
+            if (!limits) throw new Error("Expected AI limit storage in transaction")
+            await limits.createPolicy({
+              id: "rolled-back",
+              projectId,
+              subject: project,
+              limit: { meter: "tokens.total", amount: 10 },
+            })
+            await limits.reserveModelCall(reservation("rolled-back", 5))
+            throw new Error("rollback")
+          })
+        ).rejects.toThrow("rollback")
+        await expect(
+          storage.aiLimits.getPolicy({ projectId, id: "rolled-back" })
+        ).resolves.toBeNull()
+        await expect(
+          storage.aiLimits.reserveModelCall(reservation("after-rollback", 10))
+        ).resolves.toEqual({ status: "notRequired" })
+      })
+    })
+
+    test("rolls ledger accounting and reconciliation back together", async () => {
+      await withStorage(async (storage) => {
+        await storage.aiLimits.createPolicy({
+          id: "transactional-accounting",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 10 },
+        })
+        const identity = reservation("transactional-accounting", 5)
+        await storage.aiLimits.reserveModelCall(identity)
+
+        await expect(
+          storage.transaction(async (tx) => {
+            if (!tx.aiUsage || !tx.aiLimits) {
+              throw new Error("Expected AI accounting and limit storage in transaction")
+            }
+            await recordUsage(tx.aiUsage, "usage-transactional-accounting", identity.callId, 3)
+            await tx.aiLimits.recordModelCallActuals({
+              projectId,
+              usageRecordId: "usage-transactional-accounting",
+            })
+            await tx.aiLimits.reconcileModelCall({
+              ...identity,
+              usageRecordId: "usage-transactional-accounting",
+            })
+            throw new Error("rollback accounting")
+          })
+        ).rejects.toThrow("rollback accounting")
+
+        await expect(
+          storage.aiUsage.summarizeExecution({ projectId, executionId })
+        ).resolves.toMatchObject({ modelCallCount: 0 })
+        const [status] = await storage.aiLimits.listPolicyStatuses({
+          projectId,
+          at: identity.reservedAt,
+        })
+        expect(status?.consumption).toMatchObject({
+          actual: { amount: 0 },
+          reserved: { amount: 5 },
+          remaining: { amount: 5 },
+        })
+      })
+    })
+  })
+}
+
+export async function seedAiLimitStorageContractExecution(
+  auth: AuthStorage,
+  executions: ExecutionStorage
+): Promise<void> {
+  if (!(await auth.users.getById({ projectId, id: user.id }))) {
+    await auth.users.create({
+      id: user.id,
+      projectId,
+      email: "ai-limit-user@example.test",
+      createdAt: at("2026-08-01T00:00:00.000Z"),
+      updatedAt: at("2026-08-01T00:00:00.000Z"),
+    })
+  }
+  if (await executions.getById({ projectId, id: executionId })) return
+  const primitive = { kind: "workflow" as const, id: "ai-limit-contract", runId: executionId }
+  await executions.create({
+    id: executionId,
+    projectId,
+    requestedBy: user,
+    executor: { type: "primitive", kind: primitive.kind, runId: primitive.runId },
+    source: { type: "event", eventId: `test_event:${executionId}` },
+    correlationId: `test_correlation:${executionId}`,
+    authorizationRef: { type: "trustedPrimitive", primitive },
+  })
+}
+
+async function seedPrincipalExecution(
+  auth: AuthStorage,
+  executions: ExecutionStorage,
+  id: string,
+  principal:
+    | { readonly type: "user"; readonly id: string }
+    | { readonly type: "serviceAccount"; readonly id: string }
+): Promise<void> {
+  if (principal.type === "serviceAccount") {
+    if (!(await auth.serviceAccounts.getById({ projectId, id: principal.id }))) {
+      await auth.serviceAccounts.create({
+        id: principal.id,
+        projectId,
+        name: "AI limit contract service account",
+        createdAt: at("2026-08-01T00:00:00.000Z"),
+        updatedAt: at("2026-08-01T00:00:00.000Z"),
+      })
+    }
+  }
+  if (await executions.getById({ projectId, id })) return
+  const primitive = { kind: "workflow" as const, id: "ai-limit-contract", runId: id }
+  await executions.create({
+    id,
+    projectId,
+    requestedBy: principal,
+    executor: { type: "primitive", kind: primitive.kind, runId: primitive.runId },
+    source: { type: "event", eventId: `test_event:${id}` },
+    correlationId: `test_correlation:${id}`,
+    authorizationRef: { type: "trustedPrimitive", primitive },
+  })
+}
+
+async function recordUsage(
+  storage: AiUsageStorage,
+  id: string,
+  callId: string,
+  totalTokens: number,
+  overrides: {
+    readonly executionId?: string
+    readonly requesterGroupIds?: readonly string[]
+    readonly occurredAt?: Date
+  } = {}
+): Promise<void> {
+  await recordUsageInput(storage, {
+    id,
+    callId,
+    executionId: overrides.executionId,
+    requesterGroupIds: overrides.requesterGroupIds,
+    occurredAt: overrides.occurredAt,
+    usage: { inputTokens: totalTokens, outputTokens: 0 },
+  })
+}
+
+async function recordUsageInput(
+  storage: AiUsageStorage,
+  input: {
+    readonly id: string
+    readonly callId: string
+    readonly executionId?: string
+    readonly requesterGroupIds?: readonly string[]
+    readonly occurredAt?: Date
+    readonly usage: AiModelCallUsageInput
+  }
+): Promise<void> {
+  await storage.recordModelCall({
+    id: input.id,
+    projectId,
+    executionId: input.executionId ?? executionId,
+    attempt: 1,
+    callId: input.callId,
+    requesterGroupIds: input.requesterGroupIds ?? ["support"],
+    providerId: "test",
+    requestedModelId: "test/model",
+    responseId: `response:${input.callId}`,
+    usage: input.usage,
+    occurredAt: input.occurredAt ?? at("2026-08-15T12:00:00.500Z"),
+    recordedAt: at("2026-08-15T12:00:00.600Z"),
+  })
+}
+
+function ratedCost(usageRecordId: string, amountNanos: string): AiModelCallCostRecord {
+  return {
+    projectId,
+    usageRecordId,
+    status: "rated",
+    billingIdentity: { providerId: "test", modelId: "test/model" },
+    pricingContext: {},
+    priceSource: {
+      sourceId: "test-catalog",
+      sourceEntryId: "test/model",
+      sourceVersion: "v1",
+      sourceUrl: "https://example.test/catalog.json",
+      observedAt: at("2026-08-01T00:00:00.000Z"),
+    },
+    money: { currency: "USD", amountNanos },
+    components: [
+      {
+        meter: "tokens.input.total",
+        quantity: "1",
+        rateAmountNanosPerMillion: "250000000000000",
+        chargeAmountNanos: amountNanos,
+      },
+      {
+        meter: "tokens.output.total",
+        quantity: "0",
+        rateAmountNanosPerMillion: "0",
+        chargeAmountNanos: "0",
+      },
+    ],
+    ratedAt: at("2026-08-15T12:00:00.700Z"),
+  }
+}
+
+function unpriceableCost(usageRecordId: string): AiModelCallCostRecord {
+  return {
+    projectId,
+    usageRecordId,
+    status: "unpriceable",
+    billingIdentity: { providerId: "test", modelId: "test/model" },
+    pricingContext: {},
+    priceSource: {
+      sourceId: "test-catalog",
+      sourceEntryId: "test/model",
+      sourceVersion: "v1",
+      sourceUrl: "https://example.test/catalog.json",
+      observedAt: at("2026-08-01T00:00:00.000Z"),
+    },
+    reason: "unsupportedPricingDimension",
+    ratedAt: at("2026-08-15T12:00:00.700Z"),
+  }
+}

--- a/packages/core/src/testing/ai-limit-storage-contract.ts
+++ b/packages/core/src/testing/ai-limit-storage-contract.ts
@@ -758,6 +758,105 @@ export function runAiLimitStorageContractSuite<TStorage extends AiLimitStorageCo
       })
     })
 
+    // Regression check: remove the unavailable-period refresh in the provider's status
+    // path and run this suite with --test-name-pattern "refreshes repaired cost accounting".
+    for (const initialized of [false, true]) {
+      for (const via of ["status", "admission"] as const) {
+        test(`refreshes repaired cost accounting via ${via} (initialized=${initialized})`, async () => {
+          await withStorage(async (storage) => {
+            const cost = (amountNanos: string): AiLimitQuantity => ({
+              meter: "cost.catalogEstimated",
+              amount: { currency: "USD", amountNanos },
+            })
+            const request = (callId: string, amount: string) =>
+              reservation(callId, 0, { estimates: [cost(amount)] })
+            const statuses = () =>
+              storage.aiLimits.listPolicyStatuses({
+                projectId,
+                at: at("2026-08-15T12:00:00.000Z"),
+              })
+            await storage.aiLimits.createPolicy({
+              id: "cost",
+              projectId,
+              subject: support,
+              limit: cost("1000"),
+            })
+            if (initialized) {
+              expect(
+                (await storage.aiLimits.reserveModelCall(request("active", "100"))).status
+              ).toBe("reserved")
+              expect(
+                (await storage.aiLimits.reserveModelCall(request("unknown", "200"))).status
+              ).toBe("reserved")
+              await storage.aiLimits.markReservationUnknown(request("unknown", "200"))
+            }
+            for (const id of ["missing-a", "missing-b"]) {
+              await recordUsage(storage.aiUsage, id, id, 1)
+              if (initialized) {
+                await storage.aiLimits.recordModelCallActuals({ projectId, usageRecordId: id })
+              }
+            }
+            expect((await statuses())[0]?.accountingStatus).toBe("unavailable")
+            await storage.aiCosts.recordModelCallCost(ratedCost("missing-a", "150"))
+            expect((await statuses())[0]).toMatchObject({
+              accountingStatus: "unavailable",
+              consumption: { actual: cost("150") },
+            })
+            await expect(
+              storage.aiLimits.reserveModelCall(request("still-incomplete", "1"))
+            ).resolves.toMatchObject({ status: "unavailable", reasons: ["incompleteAccounting"] })
+
+            await expect(
+              storage.transaction(async (tx) => {
+                if (!tx.aiCosts || !tx.aiLimits) throw new Error("Expected accounting storage")
+                await tx.aiCosts.recordModelCallCost(ratedCost("missing-b", "50"))
+                const [status] = await tx.aiLimits.listPolicyStatuses({
+                  projectId,
+                  at: at("2026-08-15T12:00:00.000Z"),
+                })
+                expect(status?.accountingStatus).toBe("complete")
+                throw new Error("roll back accounting repair")
+              })
+            ).rejects.toThrow("roll back accounting repair")
+            expect((await statuses())[0]?.accountingStatus).toBe("unavailable")
+
+            // Recovery appends the missing valuation, but replays an existing usage record:
+            // recordModelCallActuals must not be called again or tokens would be double-counted.
+            await storage.aiCosts.recordModelCallCost(ratedCost("missing-b", "50"))
+            if (via === "admission") {
+              await expect(
+                storage.aiLimits.reserveModelCall(request("too-large", "1001"))
+              ).resolves.toMatchObject({ status: "denied" })
+            }
+            for (let read = 0; read < 2; read++) {
+              expect((await statuses())[0]).toMatchObject({
+                accountingStatus: "complete",
+                consumption: {
+                  actual: cost("200"),
+                  reserved: cost(initialized ? "100" : "0"),
+                  unknown: cost(initialized ? "200" : "0"),
+                  remaining: cost(initialized ? "500" : "800"),
+                },
+              })
+            }
+            await recordUsage(storage.aiUsage, "next-actual", "next-actual", 1)
+            await storage.aiCosts.recordModelCallCost(ratedCost("next-actual", "50"))
+            await storage.aiLimits.recordModelCallActuals({
+              projectId,
+              usageRecordId: "next-actual",
+            })
+            const remaining = initialized ? 450 : 750
+            await expect(
+              storage.aiLimits.reserveModelCall(request("over-budget", String(remaining + 1)))
+            ).resolves.toMatchObject({ status: "denied" })
+            await expect(
+              storage.aiLimits.reserveModelCall(request("fits", String(remaining)))
+            ).resolves.toMatchObject({ status: "reserved" })
+          })
+        })
+      }
+    }
+
     test("fails cost admission closed until every applicable call is valued", async () => {
       await withStorage(async (storage) => {
         await recordUsage(storage.aiUsage, "usage-unvalued", "unvalued", 1)
@@ -1001,7 +1100,7 @@ function ratedCost(usageRecordId: string, amountNanos: string): AiModelCallCostR
       {
         meter: "tokens.input.total",
         quantity: "1",
-        rateAmountNanosPerMillion: "250000000000000",
+        rateAmountNanosPerMillion: (BigInt(amountNanos) * 1_000_000n).toString(),
         chargeAmountNanos: amountNanos,
       },
       {

--- a/packages/core/src/testing/ai-limit-storage-contract.ts
+++ b/packages/core/src/testing/ai-limit-storage-contract.ts
@@ -197,6 +197,101 @@ export function runAiLimitStorageContractSuite<TStorage extends AiLimitStorageCo
       })
     })
 
+    // Regression check: remove the provider's local operation lock and run this suite. Database
+    // locks do not serialize concurrent operations using the same transaction client.
+    for (const initialized of [false, true]) {
+      test(`serializes reservations within one transaction (initialized=${initialized})`, async () => {
+        await withStorage(async (storage) => {
+          await storage.aiLimits.createPolicy({
+            id: "project",
+            projectId,
+            subject: project,
+            limit: { meter: "tokens.total", amount: 10 },
+          })
+          if (initialized) {
+            await storage.aiLimits.listPolicyStatuses({ projectId, at: at("2026-08-20Z") })
+          }
+          await storage.transaction(async (tx) => {
+            const limits = tx.aiLimits!
+            const results = await Promise.all([
+              limits.reserveModelCall(reservation("call-a", 6)),
+              limits.reserveModelCall(reservation("call-b", 6)),
+            ])
+            expect(results.map((result) => result.status).sort()).toEqual(["denied", "reserved"])
+            const [status] = await limits.listPolicyStatuses({ projectId, at: at("2026-08-20Z") })
+            expect(status?.consumption.reserved.amount).toBe(6)
+            expect(status?.consumption.remaining.amount).toBe(4)
+          })
+        })
+      })
+    }
+
+    test("serializes reservation replays and unknown transitions within one transaction", async () => {
+      await withStorage(async (storage) => {
+        await storage.aiLimits.createPolicy({
+          id: "project",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 10 },
+        })
+        await storage.transaction(async (tx) => {
+          const limits = tx.aiLimits!
+          const identity = reservation("replay", 6)
+          const results = await Promise.all([
+            limits.reserveModelCall(identity),
+            limits.reserveModelCall(identity),
+          ])
+          expect(results).toMatchObject([
+            { status: "reserved", created: true },
+            { status: "reserved", created: false },
+          ])
+          await expect(limits.reserveModelCall(reservation("replay", 7))).rejects.toMatchObject({
+            code: "reservation_conflict",
+          })
+          await Promise.all([
+            limits.markReservationUnknown(identity),
+            limits.markReservationUnknown(identity),
+          ])
+          const [status] = await limits.listPolicyStatuses({ projectId, at: at("2026-08-20Z") })
+          expect(status?.consumption).toMatchObject({
+            reserved: { amount: 0 },
+            unknown: { amount: 6 },
+            remaining: { amount: 4 },
+          })
+        })
+      })
+    })
+
+    test("rolls back queued limit operations when a parallel operation rejects", async () => {
+      await withStorage(async (storage) => {
+        await storage.aiLimits.createPolicy({
+          id: "project",
+          projectId,
+          subject: project,
+          limit: { meter: "tokens.total", amount: 10 },
+        })
+        await expect(
+          storage.transaction(async (tx) => {
+            await Promise.all([
+              tx.aiLimits!.reserveModelCall(reservation("invalid", 1, { attempt: 0 })),
+              tx.aiLimits!.reserveModelCall(reservation("queued", 6)),
+            ])
+          })
+        ).rejects.toBeInstanceOf(TypeError)
+        const [status] = await storage.aiLimits.listPolicyStatuses({
+          projectId,
+          at: at("2026-08-20Z"),
+        })
+        expect(status?.consumption.reserved.amount).toBe(0)
+        await expect(
+          storage.aiLimits.reserveModelCall(reservation("queued", 6))
+        ).resolves.toMatchObject({
+          status: "reserved",
+          created: true,
+        })
+      })
+    })
+
     test("reserves only exact subject-meter policy buckets", async () => {
       await withStorage(async ({ aiLimits }) => {
         await aiLimits.createPolicy({

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -13,6 +13,12 @@ export {
   seedAiCostStorageContractUsage,
 } from "./ai-cost-storage-contract"
 export {
+  type AiLimitStorageContractStorage,
+  type AiLimitStorageContractSuiteOptions,
+  runAiLimitStorageContractSuite,
+  seedAiLimitStorageContractExecution,
+} from "./ai-limit-storage-contract"
+export {
   type AiUsageStorageContractSuiteOptions,
   runAiUsageStorageContractSuite,
   seedAiUsageStorageContractExecutions,

--- a/packages/core/tests/ai-limit-storage.test.ts
+++ b/packages/core/tests/ai-limit-storage.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test"
+import { InMemoryAiLimitStorage } from "../src/storage/ai-limits"
+import { InMemoryStorage } from "../src/storage/in-memory"
+import { runAiLimitStorageContractSuite } from "../src/testing/ai-limit-storage-contract"
+
+runAiLimitStorageContractSuite("InMemoryAiLimitStorage", {
+  createStorage: () => new InMemoryStorage(),
+})
+
+test("standalone in-memory limits fail closed without an immutable accounting source", async () => {
+  const limits = new InMemoryAiLimitStorage({ executionExists: () => true })
+  await limits.createPolicy({
+    id: "tokens",
+    projectId: "project",
+    subject: { type: "project" },
+    limit: { meter: "tokens.total", amount: 10 },
+  })
+
+  await expect(
+    limits.reserveModelCall({
+      projectId: "project",
+      executionId: "execution",
+      attempt: 1,
+      callId: "call",
+      subjects: [],
+      estimates: [{ meter: "tokens.total", amount: 1 }],
+      reservedAt: new Date("2026-08-15T00:00:00.000Z"),
+    })
+  ).resolves.toMatchObject({
+    status: "unavailable",
+    reasons: ["incompleteAccounting"],
+  })
+})
+
+test("initialized period counters avoid repeated immutable-ledger scans", async () => {
+  let scans = 0
+  const limits = new InMemoryAiLimitStorage({
+    executionExists: () => true,
+    listUsageRecords: () => {
+      scans += 1
+      return []
+    },
+  })
+  await limits.createPolicy({
+    id: "tokens",
+    projectId: "project",
+    subject: { type: "project" },
+    limit: { meter: "tokens.total", amount: 10 },
+  })
+
+  await limits.listPolicyStatuses({ projectId: "project", at: new Date("2026-08-15Z") })
+  await limits.listPolicyStatuses({ projectId: "project", at: new Date("2026-08-20Z") })
+  await limits.reserveModelCall({
+    projectId: "project",
+    executionId: "execution",
+    attempt: 1,
+    callId: "call",
+    subjects: [],
+    estimates: [{ meter: "tokens.total", amount: 1 }],
+    reservedAt: new Date("2026-08-21Z"),
+  })
+
+  expect(scans).toBe(1)
+})

--- a/packages/core/tests/ai-limit-storage.test.ts
+++ b/packages/core/tests/ai-limit-storage.test.ts
@@ -62,3 +62,31 @@ test("initialized period counters avoid repeated immutable-ledger scans", async 
 
   expect(scans).toBe(1)
 })
+
+// Regression check: remove InMemoryAiLimitStorage's operation lock; both calls are admitted.
+test("standalone in-memory limits serialize competing reservations", async () => {
+  const limits = new InMemoryAiLimitStorage({
+    executionExists: () => true,
+    listUsageRecords: () => [],
+  })
+  await limits.createPolicy({
+    id: "tokens",
+    projectId: "project",
+    subject: { type: "project" },
+    limit: { meter: "tokens.total", amount: 10 },
+  })
+  const results = await Promise.all(
+    ["a", "b"].map((callId) =>
+      limits.reserveModelCall({
+        projectId: "project",
+        executionId: "execution",
+        attempt: 1,
+        callId,
+        subjects: [],
+        estimates: [{ meter: "tokens.total", amount: 6 }],
+        reservedAt: new Date("2026-08-15Z"),
+      })
+    )
+  )
+  expect(results.map((result) => result.status).sort()).toEqual(["denied", "reserved"])
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -66,6 +66,9 @@
       "@sixb/core/internal/ai-cost-storage-provider": [
         "./packages/core/src/storage/ai-cost/provider.ts"
       ],
+      "@sixb/core/internal/ai-limit-storage-provider": [
+        "./packages/core/src/storage/ai-limits/provider.ts"
+      ],
       "@sixb/core/internal/auth": ["./packages/core/src/auth/index.ts"],
       "@sixb/core/internal/authorization": ["./packages/core/src/authorization/index.ts"],
       "@sixb/core/internal/bootstrap": ["./packages/core/src/bootstrap/index.ts"],


### PR DESCRIPTION

## Summary

Introduce the provider-neutral storage contract for aggregate AI usage limits and provide the
in-memory reference implementation.

This PR defines how Sixb represents monthly project, group, user, and service-account limits; how
workers reserve capacity safely; and how reservations reconcile with the existing immutable AI
usage and cost ledgers. It deliberately stops at storage semantics. No Agent call is denied yet,
and no HTTP or Atlas management surface is introduced here.

## Why this is the first stack layer

Enforcement must have one precise concurrency and idempotency contract before it is connected to a
provider call. Keeping that contract in `@sixb/core` gives the in-memory, SQLite, and PostgreSQL
implementations the same observable behavior and lets later worker code remain provider-neutral.

The existing usage and cost ledgers remain the accounting source of truth. Limit policies are
editable control records; they do not own or rewrite historical consumption.

## What changes

- Add `AiLimitStorage` and public types for:
  - project, group, user, and service-account subjects;
  - total-token and catalog-estimated USD cost meters;
  - UTC calendar-month periods;
  - editable policies and current-period status;
  - active, reconciled, and unknown model-call reservations.
- Add shared normalization and invariant helpers for policy dimensions, exact quantities,
  reservation identity, replay matching, and ledger-derived actuals.
- Add an in-memory implementation with transaction snapshot and restore support.
- Wire optional `aiLimits` support through the root storage contract, scoped facades, and in-memory
  transactions.
- Add a reusable storage contract suite that downstream providers must pass unchanged.

## Important design decisions

- Consumption is bucketed by subject, meter, currency, and period—not policy ID. Editing, deleting,
  or recreating a policy cannot reset current-month usage.
- Actual consumption is derived from immutable usage and valuation records. Mutable counters track
  only reservations and unknown capacity.
- Exact reservation replay is idempotent. A conflicting replay or reconciliation is rejected.
- A provider attempt that may have been billed but cannot be measured safely retains capacity in an
  `unknown` state.
- Cost amounts reuse exact `AiMoney` nanounit strings and are fixed to USD for the first release.

## Reviewer guide

Suggested review order:

1. `packages/core/src/storage/ai-limits/types.ts` for the public contract.
2. `packages/core/src/storage/ai-limits/provider.ts` for shared invariants.
3. `packages/core/src/storage/ai-limits/in-memory.ts` for the reference behavior.
4. `packages/core/src/testing/ai-limit-storage-contract.ts` for the cross-provider guarantees.
5. Root storage and export wiring.

The contract suite is intentionally detailed: the durable providers in the next PR use it as their
behavioral specification.

## Validation performed

- `bun test packages/core/tests/ai-limit-storage.test.ts` — 22 passed.
- `bun --filter @sixb/core typecheck` — passed on this branch.
- `bun run check` — passed on this branch.
- The complete stack tip also passed the full monorepo build, publish-boundary validation, and
  guarded unit suite.

## Not in this PR

- SQLite or PostgreSQL persistence.
- Agent preflight or provider-call enforcement.
- New public error codes, HTTP routes, generated client methods, or Atlas UI.

## Stack

This is PR 1 of 5 in GitHub stack #514. Next:
[#510](https://github.com/sixb-ai/sixb/pull/510), which implements this exact contract in SQLite
and PostgreSQL.

