### PR TITLE
storage: persist AI usage limits

### DIFF
--- a/storage/pg/src/index.ts
+++ b/storage/pg/src/index.ts
@@ -20,6 +20,7 @@ import {
 } from "@sixb/core/internal/storage-operation-scope"
 import {
   type AiCostStorage,
+  type AiLimitStorage,
   type AiUsageStorage,
   createTransactionStorageProxy,
   type ObjectStorage,
@@ -33,6 +34,7 @@ import { createPostgresStorageMigrators, dropSchema } from "./migrations"
 import { PgOntologyStorage, type PgOntologyTransactionContext } from "./ontology-storage"
 import { PgActionRunStorage } from "./pg-action-run-storage"
 import { PgAiCostStorage } from "./pg-ai-cost-storage"
+import { PgAiLimitStorage } from "./pg-ai-limit-storage"
 import { PgAiUsageStorage } from "./pg-ai-usage-storage"
 import { createPgClient, type SQL, type SQLClient } from "./pg-client"
 import { PgExecutionStorage } from "./pg-execution-storage"
@@ -138,6 +140,7 @@ export class PostgresStorage implements MigrationCapableStorage {
   readonly agents: PgAgentStorage
   readonly aiUsage: AiUsageStorage
   readonly aiCosts: AiCostStorage
+  readonly aiLimits: AiLimitStorage
   readonly actionRuns: PgActionRunStorage
   readonly pipelineRuns: PgPipelineRunStorage
   readonly workflowRuns: PgWorkflowRunStorage
@@ -212,6 +215,7 @@ export class PostgresStorage implements MigrationCapableStorage {
     this.agents = createAgentOperationScope(stores.agents, scope)
     this.aiUsage = createOperationScopedFacade(stores.aiUsage, scope)
     this.aiCosts = createOperationScopedFacade(stores.aiCosts, scope)
+    this.aiLimits = createOperationScopedFacade(stores.aiLimits, scope)
     this.actionRuns = createOperationScopedFacade(stores.actionRuns, scope)
     this.pipelineRuns = createOperationScopedFacade(stores.pipelineRuns, scope)
     this.workflowRuns = createWorkflowRunOperationScope(stores.workflowRuns, scope)
@@ -342,6 +346,7 @@ function createPostgresStores(
     agents: new PgAgentStorage({ sql, executions }),
     aiUsage: new PgAiUsageStorage(sql),
     aiCosts: new PgAiCostStorage(sql),
+    aiLimits: new PgAiLimitStorage(sql),
     actionRuns: new PgActionRunStorage(sql, executions),
     pipelineRuns: new PgPipelineRunStorage(sql, executions),
     workflowRuns: new PgWorkflowRunStorage(sql, executions),
@@ -363,6 +368,7 @@ interface PostgresStoreSet {
   readonly agents: PgAgentStorage
   readonly aiUsage: PgAiUsageStorage
   readonly aiCosts: PgAiCostStorage
+  readonly aiLimits: PgAiLimitStorage
   readonly actionRuns: PgActionRunStorage
   readonly pipelineRuns: PgPipelineRunStorage
   readonly workflowRuns: PgWorkflowRunStorage

--- a/storage/pg/src/index.ts
+++ b/storage/pg/src/index.ts
@@ -262,6 +262,7 @@ export class PostgresStorage implements MigrationCapableStorage {
             transactionContext.materializations.assertCommittable()
             return result
           } finally {
+            await txStorage.aiLimits.settleOperations()
             transactionContext.active = false
             txStorage.ontology.deactivateSessions()
             transactionContext.materializations.deactivate()
@@ -309,7 +310,7 @@ export class PostgresStorage implements MigrationCapableStorage {
   private createTransactionStorage(
     client: PgStoreClient,
     transactionContext: PgOntologyTransactionContext
-  ): Storage & { readonly ontology: PgOntologyStorage } {
+  ): Storage & { readonly ontology: PgOntologyStorage; readonly aiLimits: PgAiLimitStorage } {
     return {
       ...createPostgresStores(client, {
         runOntologyOperation: async (run) => run(client),

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -74,6 +74,7 @@ import objectOverrideEditTimesSql from "./migrations/028-object-override-edit-ti
   type: "text",
 }
 import modelAccountingSql from "./migrations/029-model-accounting.sql" with { type: "text" }
+import aiUsageLimitsSql from "./migrations/030-ai-usage-limits.sql" with { type: "text" }
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -356,6 +357,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("027-agent-context-checkpoints", agentContextCheckpointsSql),
     pgSql("028-object-override-edit-times", objectOverrideEditTimesSql),
     pgSql("029-model-accounting", modelAccountingSql),
+    pgSql("030-ai-usage-limits", aiUsageLimitsSql),
   ],
 })
 

--- a/storage/pg/src/migrations/030-ai-usage-limits.sql
+++ b/storage/pg/src/migrations/030-ai-usage-limits.sql
@@ -1,0 +1,94 @@
+CREATE TABLE ai_usage_limits (
+  project_id TEXT NOT NULL CHECK (length(btrim(project_id)) > 0),
+  id TEXT NOT NULL CHECK (length(btrim(id)) > 0),
+  subject_type TEXT NOT NULL CHECK (
+    subject_type IN ('project', 'group', 'user', 'serviceAccount')
+  ),
+  subject_id TEXT NOT NULL CHECK (
+    (subject_type = 'project' AND subject_id = '')
+    OR (subject_type <> 'project' AND length(btrim(subject_id)) > 0)
+  ),
+  meter TEXT NOT NULL CHECK (meter IN ('tokens.total', 'cost.catalogEstimated')),
+  currency TEXT NOT NULL CHECK (
+    (meter = 'tokens.total' AND currency = '')
+    OR (meter = 'cost.catalogEstimated' AND currency = 'USD')
+  ),
+  limit_amount NUMERIC(78, 0) NOT NULL CHECK (limit_amount >= 0),
+  period_kind TEXT NOT NULL CHECK (period_kind = 'calendarMonth'),
+  enabled BOOLEAN NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (project_id, id),
+  UNIQUE (project_id, subject_type, subject_id, meter, currency)
+);
+
+CREATE INDEX idx_ai_usage_limits_project_enabled
+  ON ai_usage_limits (project_id, enabled, subject_type, subject_id, meter, currency);
+
+CREATE TABLE ai_usage_limit_periods (
+  project_id TEXT NOT NULL CHECK (length(btrim(project_id)) > 0),
+  subject_type TEXT NOT NULL CHECK (
+    subject_type IN ('project', 'group', 'user', 'serviceAccount')
+  ),
+  subject_id TEXT NOT NULL CHECK (
+    (subject_type = 'project' AND subject_id = '')
+    OR (subject_type <> 'project' AND length(btrim(subject_id)) > 0)
+  ),
+  meter TEXT NOT NULL CHECK (meter IN ('tokens.total', 'cost.catalogEstimated')),
+  currency TEXT NOT NULL CHECK (
+    (meter = 'tokens.total' AND currency = '')
+    OR (meter = 'cost.catalogEstimated' AND currency = 'USD')
+  ),
+  period_start TIMESTAMPTZ NOT NULL,
+  period_end TIMESTAMPTZ NOT NULL,
+  actual_amount NUMERIC(78, 0) NOT NULL DEFAULT 0 CHECK (actual_amount >= 0),
+  reserved_amount NUMERIC(78, 0) NOT NULL DEFAULT 0 CHECK (reserved_amount >= 0),
+  unknown_amount NUMERIC(78, 0) NOT NULL DEFAULT 0 CHECK (unknown_amount >= 0),
+  accounting_status TEXT NOT NULL DEFAULT 'complete' CHECK (
+    accounting_status IN ('complete', 'unavailable')
+  ),
+  updated_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (
+    project_id, subject_type, subject_id, meter, currency, period_start
+  )
+);
+
+CREATE INDEX idx_ai_usage_limit_periods_subject_period
+  ON ai_usage_limit_periods (
+    project_id, subject_type, subject_id, period_start, period_end, meter, currency
+  );
+
+CREATE TABLE ai_model_call_reservations (
+  project_id TEXT NOT NULL CHECK (length(btrim(project_id)) > 0),
+  execution_id TEXT NOT NULL CHECK (length(btrim(execution_id)) > 0),
+  attempt BIGINT NOT NULL CHECK (attempt >= 1),
+  call_id TEXT NOT NULL CHECK (length(btrim(call_id)) > 0),
+  buckets JSONB NOT NULL CHECK (jsonb_typeof(buckets) = 'array'),
+  request_key TEXT NOT NULL,
+  period_start TIMESTAMPTZ NOT NULL,
+  period_end TIMESTAMPTZ NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('active', 'reconciled', 'unknown')),
+  usage_record_id TEXT,
+  reserved_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (project_id, execution_id, attempt, call_id),
+  FOREIGN KEY (project_id, execution_id)
+    REFERENCES executions(project_id, id)
+    ON DELETE RESTRICT,
+  FOREIGN KEY (project_id, usage_record_id)
+    REFERENCES ai_model_call_usage(project_id, id)
+    ON DELETE RESTRICT,
+  CHECK (
+    (
+      state = 'reconciled'
+      AND usage_record_id IS NOT NULL
+    )
+    OR (
+      state <> 'reconciled'
+      AND usage_record_id IS NULL
+    )
+  )
+);
+
+CREATE INDEX idx_ai_model_call_reservations_active
+  ON ai_model_call_reservations (project_id, state, period_end, execution_id, attempt, call_id);

--- a/storage/pg/src/pg-ai-limit-storage.ts
+++ b/storage/pg/src/pg-ai-limit-storage.ts
@@ -1,0 +1,882 @@
+import {
+  type AiLimitAccountingEntry,
+  aiLimitAmountKey,
+  aiLimitQuantityFromAmount,
+  aiLimitReservationBuckets,
+  aiLimitReservationRequestKey,
+  aiLimitReservationRequestMatches,
+  aiLimitSubjectFromParts,
+  aiLimitSubjectKey,
+  aiLimitSubjectParts,
+  aiLimitSubjectsFromAccountingEntry,
+  assertAiLimitAccountingMatchesReservation,
+  assertNonBlank,
+  cloneValidDate,
+  type NormalizedAiLimitAmount,
+  normalizeAiLimitAmount,
+  normalizeAiLimitQuantities,
+  normalizeAiModelCallReservationIdentity,
+  normalizeCreateAiLimitPolicy,
+  normalizeReserveAiModelCall,
+  normalizeUpdateAiLimitPolicy,
+  resolveAiLimitActual,
+} from "@sixb/core/internal/ai-limit-storage-provider"
+import type {
+  AiLimitPeriod,
+  AiLimitPolicy,
+  AiLimitPolicyStatus,
+  AiLimitQuantity,
+  AiLimitReservationBucket,
+  AiLimitStorage,
+  AiLimitSubject,
+  AiModelCallReservation,
+  CreateAiLimitPolicyInput,
+  DeleteAiLimitPolicyInput,
+  GetAiLimitPolicyInput,
+  ListAiLimitPoliciesInput,
+  ListAiLimitPolicyStatusesInput,
+  MarkAiModelCallReservationUnknownInput,
+  ReconcileAiModelCallInput,
+  RecordAiModelCallLimitActualsInput,
+  ReserveAiModelCallInput,
+  ReserveAiModelCallResult,
+  UpdateAiLimitPolicyInput,
+} from "@sixb/core/storage"
+import { AiLimitStorageError, aiLimitCalendarMonth } from "@sixb/core/storage"
+import type { SQLClient } from "./pg-client"
+import { lockAdvisoryKeys, type PgStoreClient, runPgTransaction } from "./transactions"
+
+/** PostgreSQL-backed editable AI limits and atomic model-call reservations. */
+export class PgAiLimitStorage implements AiLimitStorage {
+  constructor(private readonly sql: PgStoreClient) {}
+
+  async createPolicy(input: CreateAiLimitPolicyInput): Promise<AiLimitPolicy> {
+    const policy = normalizeCreateAiLimitPolicy(input)
+    return this.withProjectLock(policy.projectId, async (tx) => {
+      const subject = aiLimitSubjectParts(policy.subject)
+      const limit = normalizeAiLimitAmount(policy.limit)
+      const inserted = await tx<{ id: string }[]>`
+        INSERT INTO ai_usage_limits (
+          project_id, id, subject_type, subject_id, meter, currency, limit_amount,
+          period_kind, enabled, created_at, updated_at
+        ) VALUES (
+          ${policy.projectId}, ${policy.id}, ${subject.type}, ${subject.id}, ${limit.meter},
+          ${limit.currency}, ${limit.amount.toString()}, ${policy.period}, ${policy.enabled},
+          ${policy.createdAt}, ${policy.updatedAt}
+        )
+        ON CONFLICT DO NOTHING
+        RETURNING id
+      `
+      if (inserted.length === 0) throw duplicatePolicy(policy)
+      return this.requirePolicy(tx, policy.projectId, policy.id)
+    })
+  }
+
+  async updatePolicy(input: UpdateAiLimitPolicyInput): Promise<AiLimitPolicy> {
+    const update = normalizeUpdateAiLimitPolicy(input)
+    return this.withProjectLock(update.projectId, async (tx) => {
+      const existing = await this.requirePolicy(tx, update.projectId, update.id)
+      if (update.limit !== undefined) assertSameDimension(existing.limit, update.limit)
+      const limit = normalizeAiLimitAmount(update.limit ?? existing.limit)
+      await tx`
+        UPDATE ai_usage_limits
+        SET limit_amount = ${limit.amount.toString()},
+            enabled = ${update.enabled ?? existing.enabled},
+            updated_at = ${update.updatedAt}
+        WHERE project_id = ${update.projectId} AND id = ${update.id}
+      `
+      return this.requirePolicy(tx, update.projectId, update.id)
+    })
+  }
+
+  async deletePolicy(input: DeleteAiLimitPolicyInput): Promise<boolean> {
+    validatePolicyIdentity(input)
+    return this.withProjectLock(input.projectId, async (tx) => {
+      const deleted = await tx<{ id: string }[]>`
+        DELETE FROM ai_usage_limits
+        WHERE project_id = ${input.projectId} AND id = ${input.id}
+        RETURNING id
+      `
+      return deleted.length > 0
+    })
+  }
+
+  async getPolicy(input: GetAiLimitPolicyInput): Promise<AiLimitPolicy | null> {
+    validatePolicyIdentity(input)
+    const [row] = await this.sql<AiLimitPolicyRow[]>`
+      SELECT * FROM ai_usage_limits
+      WHERE project_id = ${input.projectId} AND id = ${input.id}
+    `
+    return row ? policyFromRow(row) : null
+  }
+
+  async listPolicies(input: ListAiLimitPoliciesInput): Promise<readonly AiLimitPolicy[]> {
+    assertNonBlank(input.projectId, "projectId")
+    return (await this.policyRows(this.sql, input.projectId, input.includeDisabled ?? false)).map(
+      policyFromRow
+    )
+  }
+
+  async listPolicyStatuses(
+    input: ListAiLimitPolicyStatusesInput
+  ): Promise<readonly AiLimitPolicyStatus[]> {
+    assertNonBlank(input.projectId, "projectId")
+    const period = aiLimitCalendarMonth(input.at ?? new Date())
+    const existingGroups =
+      input.existingGroupIds === undefined ? undefined : new Set(input.existingGroupIds)
+    return this.withProjectLock(input.projectId, async (tx) => {
+      const rows = await this.policyRows(tx, input.projectId, input.includeDisabled ?? false)
+      return Promise.all(
+        rows.map((row) => this.statusForPolicy(tx, policyFromRow(row), period, existingGroups))
+      )
+    })
+  }
+
+  async reserveModelCall(input: ReserveAiModelCallInput): Promise<ReserveAiModelCallResult> {
+    const request = normalizeReserveAiModelCall(input)
+    return this.withProjectLock(request.identity.projectId, async (tx) => {
+      const existing = await this.findReservation(tx, request.identity)
+      if (existing) {
+        if (!aiLimitReservationRequestMatches(existing, request)) {
+          throw new AiLimitStorageError(
+            "reservation_conflict",
+            `[SixbPg] AI model-call reservation '${input.callId}' was replayed with different subjects, estimates, or period.`
+          )
+        }
+        if (existing.state !== "active") {
+          return { status: "terminal", reservation: existing, created: false }
+        }
+        return { status: "reserved", reservation: existing, created: false }
+      }
+      await this.assertExecutionExists(tx, request.identity.projectId, request.identity.executionId)
+
+      const subjectKeys = new Set(request.subjects.map(aiLimitSubjectKey))
+      const estimates = new Map(
+        request.estimates.map((quantity) => {
+          const amount = normalizeAiLimitAmount(quantity)
+          return [aiLimitAmountKey(amount), amount] as const
+        })
+      )
+      const enabledPolicies = (await this.policyRows(tx, request.identity.projectId, false)).map(
+        policyFromRow
+      )
+      const exhaustedPolicies: AiLimitPolicyStatus[] = []
+      const unavailablePolicies: AiLimitPolicyStatus[] = []
+      const unavailableReasons = new Set<"missingEstimate" | "incompleteAccounting">()
+      for (const policy of enabledPolicies) {
+        if (!subjectKeys.has(aiLimitSubjectKey(policy.subject))) continue
+        const limit = normalizeAiLimitAmount(policy.limit)
+        const estimate = estimates.get(aiLimitAmountKey(limit))
+        const status = await this.statusForPolicy(tx, policy, request.period)
+        if (!estimate || status.accountingStatus === "unavailable") {
+          unavailablePolicies.push(status)
+          if (!estimate) unavailableReasons.add("missingEstimate")
+          if (status.accountingStatus === "unavailable") {
+            unavailableReasons.add("incompleteAccounting")
+          }
+          continue
+        }
+        const consumed =
+          normalizeAiLimitAmount(status.consumption.actual).amount +
+          normalizeAiLimitAmount(status.consumption.reserved).amount +
+          normalizeAiLimitAmount(status.consumption.unknown).amount
+        if (consumed + estimate.amount > limit.amount) exhaustedPolicies.push(status)
+      }
+      if (unavailablePolicies.length > 0) {
+        unavailablePolicies.sort((left, right) => left.policy.id.localeCompare(right.policy.id))
+        return {
+          status: "unavailable",
+          unavailablePolicies,
+          reasons: [...unavailableReasons].sort(),
+        }
+      }
+      if (exhaustedPolicies.length > 0) {
+        exhaustedPolicies.sort((left, right) => left.policy.id.localeCompare(right.policy.id))
+        return {
+          status: "denied",
+          exhaustedPolicies,
+          resetAt: new Date(
+            Math.min(...exhaustedPolicies.map((status) => status.period.resetAt.getTime()))
+          ),
+        }
+      }
+
+      const buckets = aiLimitReservationBuckets(
+        enabledPolicies,
+        request.subjects,
+        request.estimates
+      )
+      if (buckets.length === 0) return { status: "notRequired" }
+      for (const bucket of buckets) {
+        const amount = normalizeAiLimitAmount(bucket.estimate)
+        await this.changeCounters(
+          tx,
+          request.identity.projectId,
+          bucket.subject,
+          amount,
+          request.period,
+          { reserved: amount.amount },
+          request.reservedAt
+        )
+      }
+      const reservation: AiModelCallReservation = {
+        ...request.identity,
+        buckets,
+        requestKey: aiLimitReservationRequestKey(request),
+        period: request.period,
+        state: "active",
+        reservedAt: request.reservedAt,
+        updatedAt: new Date(request.reservedAt),
+      }
+      await this.insertReservation(tx, reservation)
+      return { status: "reserved", reservation: structuredClone(reservation), created: true }
+    })
+  }
+
+  async recordModelCallActuals(input: RecordAiModelCallLimitActualsInput): Promise<void> {
+    assertNonBlank(input.projectId, "projectId")
+    assertNonBlank(input.usageRecordId, "usageRecordId")
+    const recordedAt = cloneValidDate(input.recordedAt ?? new Date(), "recordedAt")
+    await this.withProjectLock(input.projectId, async (tx) => {
+      const entry = await this.requireAccountingEntry(tx, input.projectId, input.usageRecordId)
+      const period = aiLimitCalendarMonth(entry.occurredAt)
+      for (const subjectValue of aiLimitSubjectsFromAccountingEntry(entry)) {
+        const subject = aiLimitSubjectParts(subjectValue)
+        const rows = await tx<AiLimitActualStateRow[]>`
+          SELECT meter, currency, actual_amount, accounting_status
+          FROM ai_usage_limit_periods
+          WHERE project_id = ${input.projectId}
+            AND subject_type = ${subject.type}
+            AND subject_id = ${subject.id}
+            AND period_start = ${period.start}
+          FOR UPDATE
+        `
+        for (const row of rows) {
+          const actual = resolveAiLimitActual([entry], row)
+          await tx`
+            UPDATE ai_usage_limit_periods
+            SET actual_amount = ${(BigInt(row.actual_amount) + actual.amount).toString()},
+                accounting_status = ${
+                  row.accounting_status === "unavailable" ||
+                  actual.accountingStatus === "unavailable"
+                    ? "unavailable"
+                    : "complete"
+                },
+                updated_at = ${recordedAt}
+            WHERE project_id = ${input.projectId}
+              AND subject_type = ${subject.type}
+              AND subject_id = ${subject.id}
+              AND meter = ${row.meter}
+              AND currency = ${row.currency}
+              AND period_start = ${period.start}
+          `
+        }
+      }
+    })
+  }
+
+  async reconcileModelCall(input: ReconcileAiModelCallInput): Promise<AiModelCallReservation> {
+    const identity = normalizeAiModelCallReservationIdentity(input)
+    assertNonBlank(input.usageRecordId, "usageRecordId")
+    const reconciledAt = cloneValidDate(input.reconciledAt ?? new Date(), "reconciledAt")
+    return this.withProjectLock(identity.projectId, async (tx) => {
+      const reservation = await this.findReservation(tx, identity)
+      if (!reservation) throw missingReservation(identity)
+      if (reservation.state === "reconciled") {
+        if (reservation.usageRecordId === input.usageRecordId) {
+          return reservation
+        }
+        throw reconciliationConflict(identity.callId)
+      }
+      const accounting = await this.requireAccountingEntry(
+        tx,
+        identity.projectId,
+        input.usageRecordId
+      )
+      assertAiLimitAccountingMatchesReservation(reservation, accounting)
+      await this.reconcileEstimateCounters(tx, reservation, accounting, reconciledAt)
+      const reconciled: AiModelCallReservation = {
+        ...reservation,
+        state: "reconciled",
+        usageRecordId: input.usageRecordId,
+        updatedAt: reconciledAt,
+      }
+      await this.updateReservation(tx, reconciled)
+      return structuredClone(reconciled)
+    })
+  }
+
+  async markReservationUnknown(
+    input: MarkAiModelCallReservationUnknownInput
+  ): Promise<AiModelCallReservation> {
+    const identity = normalizeAiModelCallReservationIdentity(input)
+    const markedAt = cloneValidDate(input.markedAt ?? new Date(), "markedAt")
+    return this.withProjectLock(identity.projectId, async (tx) => {
+      const reservation = await this.findReservation(tx, identity)
+      if (!reservation) throw missingReservation(identity)
+      if (reservation.state === "unknown") return reservation
+      if (reservation.state !== "active") throw invalidState(reservation, "mark unknown")
+      await this.moveEstimateCounters(tx, reservation, { reserved: -1n, unknown: 1n }, markedAt)
+      const unknown = { ...reservation, state: "unknown" as const, updatedAt: markedAt }
+      await this.updateReservation(tx, unknown)
+      return structuredClone(unknown)
+    })
+  }
+
+  private async withProjectLock<T>(
+    projectId: string,
+    run: (tx: SQLClient) => Promise<T>
+  ): Promise<T> {
+    return runPgTransaction(this.sql, async (tx) => {
+      await lockAdvisoryKeys(tx, [`ai-limit:${projectId}`])
+      return run(tx)
+    })
+  }
+
+  private policyRows(
+    sql: PgStoreClient,
+    projectId: string,
+    includeDisabled: boolean
+  ): Promise<AiLimitPolicyRow[]> {
+    return sql<AiLimitPolicyRow[]>`
+      SELECT * FROM ai_usage_limits
+      WHERE project_id = ${projectId} AND (${includeDisabled} OR enabled)
+      ORDER BY id
+    `
+  }
+
+  private async requirePolicy(
+    sql: PgStoreClient,
+    projectId: string,
+    id: string
+  ): Promise<AiLimitPolicy> {
+    const [row] = await sql<AiLimitPolicyRow[]>`
+      SELECT * FROM ai_usage_limits WHERE project_id = ${projectId} AND id = ${id}
+    `
+    if (row) return policyFromRow(row)
+    throw new AiLimitStorageError(
+      "missing_policy",
+      `[SixbPg] AI limit policy '${id}' does not exist in project '${projectId}'.`
+    )
+  }
+
+  private async statusForPolicy(
+    sql: PgStoreClient,
+    policy: AiLimitPolicy,
+    period: AiLimitPeriod,
+    existingGroups?: ReadonlySet<string>
+  ): Promise<AiLimitPolicyStatus> {
+    const subject = aiLimitSubjectParts(policy.subject)
+    const limit = normalizeAiLimitAmount(policy.limit)
+    let [row] = await sql<AiLimitPeriodStateRow[]>`
+      SELECT actual_amount, reserved_amount, unknown_amount, accounting_status
+      FROM ai_usage_limit_periods
+      WHERE project_id = ${policy.projectId}
+        AND subject_type = ${subject.type}
+        AND subject_id = ${subject.id}
+        AND meter = ${limit.meter}
+        AND currency = ${limit.currency}
+        AND period_start = ${period.start}
+    `
+    if (!row) {
+      const actual = resolveAiLimitActual(await this.accountingEntries(sql, policy, period), limit)
+      const [inserted] = await sql<AiLimitPeriodStateRow[]>`
+        INSERT INTO ai_usage_limit_periods (
+          project_id, subject_type, subject_id, meter, currency, period_start, period_end,
+          actual_amount, reserved_amount, unknown_amount, accounting_status, updated_at
+        ) VALUES (
+          ${policy.projectId}, ${subject.type}, ${subject.id}, ${limit.meter}, ${limit.currency},
+          ${period.start}, ${period.end}, ${actual.amount.toString()}, 0, 0,
+          ${actual.accountingStatus}, ${new Date()}
+        )
+        RETURNING actual_amount, reserved_amount, unknown_amount, accounting_status
+      `
+      row = inserted
+    }
+    if (!row) throw new Error("[SixbPg] Failed to initialize AI limit period state.")
+    return policyStatus(policy, period, row, existingGroups)
+  }
+
+  private async changeCounters(
+    sql: PgStoreClient,
+    projectId: string,
+    subjectValue: AiLimitSubject,
+    amount: NormalizedAiLimitAmount,
+    period: AiLimitPeriod,
+    changes: { readonly reserved?: bigint; readonly unknown?: bigint },
+    updatedAt: Date
+  ): Promise<void> {
+    const subject = aiLimitSubjectParts(subjectValue)
+    const [row] = await sql<AiLimitPeriodStateRow[]>`
+      SELECT actual_amount, reserved_amount, unknown_amount, accounting_status
+      FROM ai_usage_limit_periods
+      WHERE project_id = ${projectId}
+        AND subject_type = ${subject.type}
+        AND subject_id = ${subject.id}
+        AND meter = ${amount.meter}
+        AND currency = ${amount.currency}
+        AND period_start = ${period.start}
+      FOR UPDATE
+    `
+    const reserved = BigInt(row?.reserved_amount ?? "0") + (changes.reserved ?? 0n)
+    const unknown = BigInt(row?.unknown_amount ?? "0") + (changes.unknown ?? 0n)
+    if (reserved < 0n || unknown < 0n) {
+      throw new Error("[SixbPg] AI limit period counter became negative.")
+    }
+    await sql`
+      INSERT INTO ai_usage_limit_periods (
+        project_id, subject_type, subject_id, meter, currency, period_start, period_end,
+        actual_amount, reserved_amount, unknown_amount, accounting_status, updated_at
+      ) VALUES (
+        ${projectId}, ${subject.type}, ${subject.id}, ${amount.meter}, ${amount.currency},
+        ${period.start}, ${period.end}, ${row?.actual_amount ?? "0"}, ${reserved.toString()},
+        ${unknown.toString()}, ${row?.accounting_status ?? "complete"}, ${updatedAt}
+      )
+      ON CONFLICT (project_id, subject_type, subject_id, meter, currency, period_start)
+      DO UPDATE SET
+        period_end = excluded.period_end,
+        actual_amount = excluded.actual_amount,
+        reserved_amount = excluded.reserved_amount,
+        unknown_amount = excluded.unknown_amount,
+        accounting_status = excluded.accounting_status,
+        updated_at = excluded.updated_at
+    `
+  }
+
+  private async moveEstimateCounters(
+    sql: PgStoreClient,
+    reservation: AiModelCallReservation,
+    directions: { readonly reserved?: bigint; readonly unknown?: bigint },
+    updatedAt: Date
+  ): Promise<void> {
+    for (const bucket of reservation.buckets) {
+      const amount = normalizeAiLimitAmount(bucket.estimate)
+      await this.changeCounters(
+        sql,
+        reservation.projectId,
+        bucket.subject,
+        amount,
+        reservation.period,
+        {
+          ...(directions.reserved === undefined
+            ? {}
+            : { reserved: directions.reserved * amount.amount }),
+          ...(directions.unknown === undefined
+            ? {}
+            : { unknown: directions.unknown * amount.amount }),
+        },
+        updatedAt
+      )
+    }
+  }
+
+  private async reconcileEstimateCounters(
+    sql: PgStoreClient,
+    reservation: AiModelCallReservation,
+    entry: AiLimitAccountingEntry,
+    updatedAt: Date
+  ): Promise<void> {
+    for (const bucket of reservation.buckets) {
+      const amount = normalizeAiLimitAmount(bucket.estimate)
+      const actual = resolveAiLimitActual([entry], amount)
+      if (actual.accountingStatus === "complete") {
+        await this.changeCounters(
+          sql,
+          reservation.projectId,
+          bucket.subject,
+          amount,
+          reservation.period,
+          reservation.state === "active"
+            ? { reserved: -amount.amount }
+            : { unknown: -amount.amount },
+          updatedAt
+        )
+      } else if (reservation.state === "active") {
+        await this.changeCounters(
+          sql,
+          reservation.projectId,
+          bucket.subject,
+          amount,
+          reservation.period,
+          { reserved: -amount.amount, unknown: amount.amount },
+          updatedAt
+        )
+      }
+    }
+  }
+
+  private async insertReservation(
+    sql: PgStoreClient,
+    reservation: AiModelCallReservation
+  ): Promise<void> {
+    await sql`
+      INSERT INTO ai_model_call_reservations (
+        project_id, execution_id, attempt, call_id, buckets, request_key,
+        period_start, period_end, state, usage_record_id, reserved_at, updated_at
+      ) VALUES (
+        ${reservation.projectId}, ${reservation.executionId}, ${reservation.attempt},
+        ${reservation.callId}, ${JSON.stringify(reservation.buckets)}::text::jsonb,
+        ${reservation.requestKey}, ${reservation.period.start},
+        ${reservation.period.end}, ${reservation.state}, ${reservation.usageRecordId ?? null},
+        ${reservation.reservedAt}, ${reservation.updatedAt}
+      )
+    `
+  }
+
+  private async updateReservation(
+    sql: PgStoreClient,
+    reservation: AiModelCallReservation
+  ): Promise<void> {
+    await sql`
+      UPDATE ai_model_call_reservations
+      SET state = ${reservation.state},
+          usage_record_id = ${reservation.usageRecordId ?? null},
+          updated_at = ${reservation.updatedAt}
+      WHERE project_id = ${reservation.projectId}
+        AND execution_id = ${reservation.executionId}
+        AND attempt = ${reservation.attempt}
+        AND call_id = ${reservation.callId}
+    `
+  }
+
+  private async findReservation(
+    sql: PgStoreClient,
+    input: {
+      readonly projectId: string
+      readonly executionId: string
+      readonly attempt: number
+      readonly callId: string
+    }
+  ): Promise<AiModelCallReservation | null> {
+    const [row] = await sql<AiModelCallReservationRow[]>`
+      SELECT * FROM ai_model_call_reservations
+      WHERE project_id = ${input.projectId}
+        AND execution_id = ${input.executionId}
+        AND attempt = ${input.attempt}
+        AND call_id = ${input.callId}
+    `
+    return row ? reservationFromRow(row) : null
+  }
+
+  private async accountingEntries(
+    sql: PgStoreClient,
+    policy: AiLimitPolicy,
+    period: AiLimitPeriod
+  ): Promise<readonly AiLimitAccountingEntry[]> {
+    const subject = aiLimitSubjectParts(policy.subject)
+    const rows = await sql<AiLimitAccountingRow[]>`
+      SELECT usage.project_id, usage.id AS usage_record_id, usage.execution_id,
+             usage.attempt, usage.call_id, usage.occurred_at,
+             usage.total_tokens::text AS total_tokens,
+             executions.requested_by_user_id,
+             executions.requested_by_service_account_id,
+             valuations.status AS valuation_status,
+             valuations.currency AS valuation_currency,
+             valuations.amount_nanos::text AS valuation_amount_nanos
+      FROM ai_model_call_usage AS usage
+      JOIN executions
+        ON executions.project_id = usage.project_id AND executions.id = usage.execution_id
+      LEFT JOIN ai_model_call_valuations AS valuations
+        ON valuations.project_id = usage.project_id
+       AND valuations.usage_record_id = usage.id
+      WHERE usage.project_id = ${policy.projectId}
+        AND usage.occurred_at >= ${period.start}
+        AND usage.occurred_at < ${period.end}
+        AND (
+          ${subject.type} = 'project'
+          OR (
+            ${subject.type} = 'group'
+            AND EXISTS (
+              SELECT 1 FROM ai_model_call_usage_groups AS usage_groups
+              WHERE usage_groups.project_id = usage.project_id
+                AND usage_groups.usage_record_id = usage.id
+                AND usage_groups.group_id = ${subject.id}
+            )
+          )
+          OR (${subject.type} = 'user' AND executions.requested_by_user_id = ${subject.id})
+          OR (
+            ${subject.type} = 'serviceAccount'
+            AND executions.requested_by_service_account_id = ${subject.id}
+          )
+        )
+      ORDER BY usage.occurred_at, usage.id
+    `
+    return rows.map((row) => accountingEntryFromRow(row, policy.subject))
+  }
+
+  private async requireAccountingEntry(
+    sql: PgStoreClient,
+    projectId: string,
+    usageRecordId: string
+  ): Promise<AiLimitAccountingEntry> {
+    const [row] = await sql<AiLimitAccountingRow[]>`
+      SELECT usage.project_id, usage.id AS usage_record_id, usage.execution_id,
+             usage.attempt, usage.call_id, usage.occurred_at,
+             usage.total_tokens::text AS total_tokens,
+             executions.requested_by_user_id,
+             executions.requested_by_service_account_id,
+             valuations.status AS valuation_status,
+             valuations.currency AS valuation_currency,
+             valuations.amount_nanos::text AS valuation_amount_nanos
+      FROM ai_model_call_usage AS usage
+      JOIN executions
+        ON executions.project_id = usage.project_id AND executions.id = usage.execution_id
+      LEFT JOIN ai_model_call_valuations AS valuations
+        ON valuations.project_id = usage.project_id
+       AND valuations.usage_record_id = usage.id
+      WHERE usage.project_id = ${projectId} AND usage.id = ${usageRecordId}
+    `
+    if (row) {
+      const groups = await sql<{ group_id: string }[]>`
+        SELECT group_id FROM ai_model_call_usage_groups
+        WHERE project_id = ${projectId} AND usage_record_id = ${usageRecordId}
+        ORDER BY group_id
+      `
+      return accountingEntryFromRow(
+        row,
+        undefined,
+        groups.map((group) => group.group_id)
+      )
+    }
+    throw new AiLimitStorageError(
+      "missing_usage_record",
+      `[SixbPg] AI usage record '${usageRecordId}' does not exist in project '${projectId}'.`
+    )
+  }
+
+  private async assertExecutionExists(
+    sql: PgStoreClient,
+    projectId: string,
+    executionId: string
+  ): Promise<void> {
+    const [row] = await sql<{ exists: boolean }[]>`
+      SELECT EXISTS (
+        SELECT 1 FROM executions WHERE project_id = ${projectId} AND id = ${executionId}
+      ) AS exists
+    `
+    if (row?.exists) return
+    throw new AiLimitStorageError(
+      "missing_execution",
+      `[SixbPg] AI limit execution '${executionId}' does not exist in project '${projectId}'.`
+    )
+  }
+}
+
+interface AiLimitPolicyRow {
+  readonly project_id: string
+  readonly id: string
+  readonly subject_type: AiLimitSubject["type"]
+  readonly subject_id: string
+  readonly meter: AiLimitQuantity["meter"]
+  readonly currency: string
+  readonly limit_amount: string
+  readonly period_kind: "calendarMonth"
+  readonly enabled: boolean
+  readonly created_at: Date | string
+  readonly updated_at: Date | string
+}
+
+interface AiLimitPeriodStateRow {
+  readonly actual_amount: string
+  readonly reserved_amount: string
+  readonly unknown_amount: string
+  readonly accounting_status: "complete" | "unavailable"
+}
+
+interface AiLimitActualStateRow {
+  readonly meter: AiLimitQuantity["meter"]
+  readonly currency: string
+  readonly actual_amount: string
+  readonly accounting_status: "complete" | "unavailable"
+}
+
+interface AiLimitAccountingRow {
+  readonly project_id: string
+  readonly usage_record_id: string
+  readonly execution_id: string
+  readonly attempt: number | string
+  readonly call_id: string
+  readonly occurred_at: Date | string
+  readonly total_tokens: string | null
+  readonly requested_by_user_id: string | null
+  readonly requested_by_service_account_id: string | null
+  readonly valuation_status: "rated" | "unpriceable" | null
+  readonly valuation_currency: string | null
+  readonly valuation_amount_nanos: string | null
+}
+
+interface AiModelCallReservationRow {
+  readonly project_id: string
+  readonly execution_id: string
+  readonly attempt: number | string
+  readonly call_id: string
+  readonly buckets: readonly AiLimitReservationBucket[] | string
+  readonly request_key: string
+  readonly period_start: Date | string
+  readonly period_end: Date | string
+  readonly state: AiModelCallReservation["state"]
+  readonly usage_record_id: string | null
+  readonly reserved_at: Date | string
+  readonly updated_at: Date | string
+}
+
+function policyFromRow(row: AiLimitPolicyRow): AiLimitPolicy {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    subject: aiLimitSubjectFromParts(row.subject_type, row.subject_id),
+    limit: aiLimitQuantityFromAmount({
+      meter: row.meter,
+      currency: row.currency,
+      amount: BigInt(row.limit_amount),
+    }),
+    period: row.period_kind,
+    enabled: row.enabled,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  }
+}
+
+function policyStatus(
+  policy: AiLimitPolicy,
+  period: AiLimitPeriod,
+  row: AiLimitPeriodStateRow,
+  existingGroups?: ReadonlySet<string>
+): AiLimitPolicyStatus {
+  const limit = normalizeAiLimitAmount(policy.limit)
+  const actual = BigInt(row.actual_amount)
+  const reserved = BigInt(row.reserved_amount)
+  const unknown = BigInt(row.unknown_amount)
+  const consumed = actual + reserved + unknown
+  const quantity = (amount: bigint) => aiLimitQuantityFromAmount({ ...limit, amount })
+  return {
+    policy,
+    period: structuredClone(period),
+    consumption: {
+      actual: quantity(actual),
+      reserved: quantity(reserved),
+      unknown: quantity(unknown),
+      remaining: quantity(limit.amount > consumed ? limit.amount - consumed : 0n),
+    },
+    accountingStatus: row.accounting_status,
+    exhausted: consumed >= limit.amount,
+    orphaned:
+      policy.subject.type === "group" &&
+      existingGroups !== undefined &&
+      !existingGroups.has(policy.subject.id),
+  }
+}
+
+function accountingEntryFromRow(
+  row: AiLimitAccountingRow,
+  subject?: AiLimitSubject,
+  requesterGroupIds = subject?.type === "group" ? [subject.id] : []
+): AiLimitAccountingEntry {
+  const totalTokens = row.total_tokens === null ? undefined : Number(row.total_tokens)
+  const requester = row.requested_by_user_id
+    ? ({ type: "user", id: row.requested_by_user_id } as const)
+    : row.requested_by_service_account_id
+      ? ({ type: "serviceAccount", id: row.requested_by_service_account_id } as const)
+      : undefined
+  return {
+    projectId: row.project_id,
+    usageRecordId: row.usage_record_id,
+    executionId: row.execution_id,
+    attempt: Number(row.attempt),
+    callId: row.call_id,
+    occurredAt: new Date(row.occurred_at),
+    ...(totalTokens !== undefined && Number.isSafeInteger(totalTokens) ? { totalTokens } : {}),
+    requesterGroupIds,
+    ...(requester ? { requester } : {}),
+    ...(row.valuation_status === "rated" &&
+    row.valuation_currency !== null &&
+    row.valuation_amount_nanos !== null
+      ? {
+          valuation: {
+            status: "rated" as const,
+            money: {
+              currency: row.valuation_currency,
+              amountNanos: row.valuation_amount_nanos,
+            },
+          },
+        }
+      : row.valuation_status === "unpriceable"
+        ? { valuation: { status: "unavailable" as const } }
+        : {}),
+  }
+}
+
+function reservationFromRow(row: AiModelCallReservationRow): AiModelCallReservation {
+  const buckets = jsonValue<readonly AiLimitReservationBucket[]>(row.buckets)
+  return {
+    projectId: row.project_id,
+    executionId: row.execution_id,
+    attempt: Number(row.attempt),
+    callId: row.call_id,
+    buckets: buckets.map((bucket) => ({
+      subject: structuredClone(bucket.subject),
+      estimate: normalizeAiLimitQuantities([bucket.estimate], "stored bucket")[0]!,
+    })),
+    requestKey: row.request_key,
+    period: {
+      kind: "calendarMonth",
+      start: new Date(row.period_start),
+      end: new Date(row.period_end),
+      resetAt: new Date(row.period_end),
+    },
+    state: row.state,
+    ...(row.usage_record_id === null ? {} : { usageRecordId: row.usage_record_id }),
+    reservedAt: new Date(row.reserved_at),
+    updatedAt: new Date(row.updated_at),
+  }
+}
+
+function jsonValue<T>(value: T | string): T {
+  return typeof value === "string" ? (JSON.parse(value) as T) : value
+}
+
+function assertSameDimension(previous: AiLimitQuantity, next: AiLimitQuantity): void {
+  if (
+    aiLimitAmountKey(normalizeAiLimitAmount(previous)) !==
+    aiLimitAmountKey(normalizeAiLimitAmount(next))
+  ) {
+    throw new TypeError("[Sixb] AI limit policy meter and cost currency are immutable.")
+  }
+}
+
+function validatePolicyIdentity(input: GetAiLimitPolicyInput): void {
+  assertNonBlank(input.projectId, "projectId")
+  assertNonBlank(input.id, "policy id")
+}
+
+function duplicatePolicy(policy: AiLimitPolicy): AiLimitStorageError {
+  return new AiLimitStorageError(
+    "duplicate_policy",
+    `[SixbPg] An AI limit policy already exists for policy ID or subject-meter dimension '${policy.id}'.`
+  )
+}
+
+function missingReservation(input: {
+  readonly executionId: string
+  readonly attempt: number
+  readonly callId: string
+}): AiLimitStorageError {
+  return new AiLimitStorageError(
+    "missing_reservation",
+    `[SixbPg] AI model-call reservation '${input.callId}' does not exist for execution '${input.executionId}' attempt ${input.attempt}.`
+  )
+}
+
+function reconciliationConflict(callId: string): AiLimitStorageError {
+  return new AiLimitStorageError(
+    "reconciliation_conflict",
+    `[SixbPg] AI model-call reservation '${callId}' was reconciled with a different usage record.`
+  )
+}
+
+function invalidState(reservation: AiModelCallReservation, operation: string): AiLimitStorageError {
+  return new AiLimitStorageError(
+    "invalid_reservation_state",
+    `[SixbPg] Cannot ${operation} AI model-call reservation '${reservation.callId}' in state '${reservation.state}'.`
+  )
+}

--- a/storage/pg/src/pg-ai-limit-storage.ts
+++ b/storage/pg/src/pg-ai-limit-storage.ts
@@ -391,7 +391,8 @@ export class PgAiLimitStorage implements AiLimitStorage {
         AND currency = ${limit.currency}
         AND period_start = ${period.start}
     `
-    if (!row) {
+    // Re-read incomplete accounting under the project lock; retain in-flight estimates.
+    if (!row || row.accounting_status === "unavailable") {
       const actual = resolveAiLimitActual(await this.accountingEntries(sql, policy, period), limit)
       const [inserted] = await sql<AiLimitPeriodStateRow[]>`
         INSERT INTO ai_usage_limit_periods (
@@ -402,6 +403,11 @@ export class PgAiLimitStorage implements AiLimitStorage {
           ${period.start}, ${period.end}, ${actual.amount.toString()}, 0, 0,
           ${actual.accountingStatus}, ${new Date()}
         )
+        ON CONFLICT (project_id, subject_type, subject_id, meter, currency, period_start)
+        DO UPDATE SET
+          actual_amount = excluded.actual_amount,
+          accounting_status = excluded.accounting_status,
+          updated_at = excluded.updated_at
         RETURNING actual_amount, reserved_amount, unknown_amount, accounting_status
       `
       row = inserted

--- a/storage/pg/src/pg-ai-limit-storage.ts
+++ b/storage/pg/src/pg-ai-limit-storage.ts
@@ -1,5 +1,6 @@
 import {
   type AiLimitAccountingEntry,
+  AiLimitOperationLock,
   aiLimitAmountKey,
   aiLimitQuantityFromAmount,
   aiLimitReservationBuckets,
@@ -48,7 +49,14 @@ import { lockAdvisoryKeys, type PgStoreClient, runPgTransaction } from "./transa
 
 /** PostgreSQL-backed editable AI limits and atomic model-call reservations. */
 export class PgAiLimitStorage implements AiLimitStorage {
+  private readonly operations = new AiLimitOperationLock()
+
   constructor(private readonly sql: PgStoreClient) {}
+
+  /** @internal Keep queued work inside the lifetime of the owning SQL transaction. */
+  settleOperations(): Promise<void> {
+    return this.operations.settle()
+  }
 
   async createPolicy(input: CreateAiLimitPolicyInput): Promise<AiLimitPolicy> {
     const policy = normalizeCreateAiLimitPolicy(input)
@@ -328,8 +336,13 @@ export class PgAiLimitStorage implements AiLimitStorage {
     run: (tx: SQLClient) => Promise<T>
   ): Promise<T> {
     return runPgTransaction(this.sql, async (tx) => {
-      await lockAdvisoryKeys(tx, [`ai-limit:${projectId}`])
-      return run(tx)
+      const operation = async () => {
+        await lockAdvisoryKeys(tx, [`ai-limit:${projectId}`])
+        return run(tx)
+      }
+      // Advisory locks are reentrant within one transaction. Serialize calls sharing this
+      // transaction's store locally; independent root transactions retain their concurrency.
+      return tx === this.sql ? this.operations.run(operation) : operation()
     })
   }
 

--- a/storage/pg/tests/pg-ai-limit-storage.e2e.ts
+++ b/storage/pg/tests/pg-ai-limit-storage.e2e.ts
@@ -1,0 +1,10 @@
+import { runAiLimitStorageContractSuite } from "@sixb/core/testing"
+import { createTestStorage } from "./helpers"
+
+runAiLimitStorageContractSuite("PgAiLimitStorage", {
+  createStorage: async () => (await createTestStorage()).storage,
+  cleanup: async (storage) => {
+    await storage.dropSchema()
+    await storage.close()
+  },
+})

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -168,6 +168,7 @@ describe("Postgres storage migrations", () => {
             "027-agent-context-checkpoints",
             "028-object-override-edit-times",
             "029-model-accounting",
+            "030-ai-usage-limits",
           ],
         },
       ])
@@ -374,6 +375,13 @@ describe("Postgres storage migrations", () => {
           id: "029-model-accounting",
           status: "applied",
           version: 29,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "030-ai-usage-limits",
+          status: "applied",
+          version: 30,
         },
       ])
     })
@@ -1860,6 +1868,13 @@ describe("Postgres storage migrations", () => {
           id: "029-model-accounting",
           status: "applied",
           version: 29,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "030-ai-usage-limits",
+          status: "applied",
+          version: 30,
         },
       ])
     } finally {

--- a/storage/sqlite/src/ai-limit-storage.ts
+++ b/storage/sqlite/src/ai-limit-storage.ts
@@ -1,0 +1,975 @@
+import type { SQLQueryBindings } from "bun:sqlite"
+import {
+  type AiLimitAccountingEntry,
+  aiLimitAmountKey,
+  aiLimitQuantityFromAmount,
+  aiLimitReservationBuckets,
+  aiLimitReservationRequestKey,
+  aiLimitReservationRequestMatches,
+  aiLimitSubjectFromParts,
+  aiLimitSubjectKey,
+  aiLimitSubjectParts,
+  aiLimitSubjectsFromAccountingEntry,
+  assertAiLimitAccountingMatchesReservation,
+  assertNonBlank,
+  cloneValidDate,
+  type NormalizedAiLimitAmount,
+  normalizeAiLimitAmount,
+  normalizeAiLimitQuantities,
+  normalizeAiModelCallReservationIdentity,
+  normalizeCreateAiLimitPolicy,
+  normalizeReserveAiModelCall,
+  normalizeUpdateAiLimitPolicy,
+  resolveAiLimitActual,
+} from "@sixb/core/internal/ai-limit-storage-provider"
+import type {
+  AiLimitPeriod,
+  AiLimitPolicy,
+  AiLimitPolicyStatus,
+  AiLimitQuantity,
+  AiLimitReservationBucket,
+  AiLimitStorage,
+  AiLimitSubject,
+  AiModelCallReservation,
+  CreateAiLimitPolicyInput,
+  DeleteAiLimitPolicyInput,
+  GetAiLimitPolicyInput,
+  ListAiLimitPoliciesInput,
+  ListAiLimitPolicyStatusesInput,
+  MarkAiModelCallReservationUnknownInput,
+  ReconcileAiModelCallInput,
+  RecordAiModelCallLimitActualsInput,
+  ReserveAiModelCallInput,
+  ReserveAiModelCallResult,
+  UpdateAiLimitPolicyInput,
+} from "@sixb/core/storage"
+import { AiLimitStorageError, aiLimitCalendarMonth } from "@sixb/core/storage"
+import { installFreshSqliteSchema } from "./migrations"
+import {
+  closeSqliteStoreConnection,
+  openSqliteStoreConnection,
+  runImmediateTransaction,
+  type SqliteStoreConnection,
+} from "./transactions"
+
+export interface SqliteAiLimitStorageOptions {
+  readonly path?: string
+  readonly connection?: SqliteStoreConnection
+}
+
+/** SQLite-backed editable AI limits and atomic model-call reservations. */
+export class SqliteAiLimitStorage implements AiLimitStorage {
+  private readonly connection: SqliteStoreConnection
+
+  constructor(options: SqliteAiLimitStorageOptions = {}) {
+    this.connection = openSqliteStoreConnection(options)
+    if (this.connection.installFreshSchema) installFreshSqliteSchema(this.connection.db)
+  }
+
+  async createPolicy(input: CreateAiLimitPolicyInput): Promise<AiLimitPolicy> {
+    const policy = normalizeCreateAiLimitPolicy(input)
+    return runImmediateTransaction(this.connection.db, () => {
+      const subject = aiLimitSubjectParts(policy.subject)
+      const limit = normalizeAiLimitAmount(policy.limit)
+      try {
+        this.connection.db
+          .query(
+            `
+              INSERT INTO ai_usage_limits (
+                project_id, id, subject_type, subject_id, meter, currency, limit_amount,
+                period_kind, enabled, created_at, updated_at
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `
+          )
+          .run(
+            policy.projectId,
+            policy.id,
+            subject.type,
+            subject.id,
+            limit.meter,
+            limit.currency,
+            limit.amount.toString(),
+            policy.period,
+            policy.enabled ? 1 : 0,
+            policy.createdAt.toISOString(),
+            policy.updatedAt.toISOString()
+          )
+      } catch (error) {
+        if (!isConstraintError(error)) throw error
+        throw duplicatePolicy(policy)
+      }
+      return this.requirePolicy(policy.projectId, policy.id)
+    })
+  }
+
+  async updatePolicy(input: UpdateAiLimitPolicyInput): Promise<AiLimitPolicy> {
+    const update = normalizeUpdateAiLimitPolicy(input)
+    return runImmediateTransaction(this.connection.db, () => {
+      const existing = this.requirePolicy(update.projectId, update.id)
+      if (update.limit !== undefined) assertSameDimension(existing.limit, update.limit)
+      const limit = normalizeAiLimitAmount(update.limit ?? existing.limit)
+      this.connection.db
+        .query(
+          `
+            UPDATE ai_usage_limits
+            SET limit_amount = ?, enabled = ?, updated_at = ?
+            WHERE project_id = ? AND id = ?
+          `
+        )
+        .run(
+          limit.amount.toString(),
+          (update.enabled ?? existing.enabled) ? 1 : 0,
+          update.updatedAt.toISOString(),
+          update.projectId,
+          update.id
+        )
+      return this.requirePolicy(update.projectId, update.id)
+    })
+  }
+
+  async deletePolicy(input: DeleteAiLimitPolicyInput): Promise<boolean> {
+    validatePolicyIdentity(input)
+    return runImmediateTransaction(this.connection.db, () => {
+      const result = this.connection.db
+        .query("DELETE FROM ai_usage_limits WHERE project_id = ? AND id = ?")
+        .run(input.projectId, input.id)
+      return result.changes > 0
+    })
+  }
+
+  async getPolicy(input: GetAiLimitPolicyInput): Promise<AiLimitPolicy | null> {
+    validatePolicyIdentity(input)
+    const row = this.connection.db
+      .query("SELECT * FROM ai_usage_limits WHERE project_id = ? AND id = ?")
+      .get(input.projectId, input.id) as AiLimitPolicyRow | null
+    return row ? policyFromRow(row) : null
+  }
+
+  async listPolicies(input: ListAiLimitPoliciesInput): Promise<readonly AiLimitPolicy[]> {
+    assertNonBlank(input.projectId, "projectId")
+    return this.policyRows(input.projectId, input.includeDisabled ?? false).map(policyFromRow)
+  }
+
+  async listPolicyStatuses(
+    input: ListAiLimitPolicyStatusesInput
+  ): Promise<readonly AiLimitPolicyStatus[]> {
+    assertNonBlank(input.projectId, "projectId")
+    const period = aiLimitCalendarMonth(input.at ?? new Date())
+    const existingGroups =
+      input.existingGroupIds === undefined ? undefined : new Set(input.existingGroupIds)
+    return runImmediateTransaction(this.connection.db, () =>
+      this.policyRows(input.projectId, input.includeDisabled ?? false).map((row) =>
+        this.statusForPolicy(policyFromRow(row), period, existingGroups)
+      )
+    )
+  }
+
+  async reserveModelCall(input: ReserveAiModelCallInput): Promise<ReserveAiModelCallResult> {
+    const request = normalizeReserveAiModelCall(input)
+    return runImmediateTransaction(this.connection.db, () => {
+      const existing = this.findReservation(request.identity)
+      if (existing) {
+        if (!aiLimitReservationRequestMatches(existing, request)) {
+          throw new AiLimitStorageError(
+            "reservation_conflict",
+            `[SixbSqlite] AI model-call reservation '${input.callId}' was replayed with different subjects, estimates, or period.`
+          )
+        }
+        if (existing.state !== "active") {
+          return { status: "terminal", reservation: existing, created: false }
+        }
+        return { status: "reserved", reservation: existing, created: false }
+      }
+      this.assertExecutionExists(request.identity.projectId, request.identity.executionId)
+
+      const subjectKeys = new Set(request.subjects.map(aiLimitSubjectKey))
+      const estimates = new Map(
+        request.estimates.map((quantity) => {
+          const amount = normalizeAiLimitAmount(quantity)
+          return [aiLimitAmountKey(amount), amount] as const
+        })
+      )
+      const enabledPolicies = this.policyRows(request.identity.projectId, false).map(policyFromRow)
+      const exhaustedPolicies: AiLimitPolicyStatus[] = []
+      const unavailablePolicies: AiLimitPolicyStatus[] = []
+      const unavailableReasons = new Set<"missingEstimate" | "incompleteAccounting">()
+      for (const policy of enabledPolicies) {
+        if (!subjectKeys.has(aiLimitSubjectKey(policy.subject))) continue
+        const limit = normalizeAiLimitAmount(policy.limit)
+        const estimate = estimates.get(aiLimitAmountKey(limit))
+        const status = this.statusForPolicy(policy, request.period)
+        if (!estimate || status.accountingStatus === "unavailable") {
+          unavailablePolicies.push(status)
+          if (!estimate) unavailableReasons.add("missingEstimate")
+          if (status.accountingStatus === "unavailable") {
+            unavailableReasons.add("incompleteAccounting")
+          }
+          continue
+        }
+        const consumption = status.consumption
+        const consumed =
+          normalizeAiLimitAmount(consumption.actual).amount +
+          normalizeAiLimitAmount(consumption.reserved).amount +
+          normalizeAiLimitAmount(consumption.unknown).amount
+        if (consumed + estimate.amount > limit.amount) exhaustedPolicies.push(status)
+      }
+      if (unavailablePolicies.length > 0) {
+        unavailablePolicies.sort((left, right) => left.policy.id.localeCompare(right.policy.id))
+        return {
+          status: "unavailable",
+          unavailablePolicies,
+          reasons: [...unavailableReasons].sort(),
+        }
+      }
+      if (exhaustedPolicies.length > 0) {
+        exhaustedPolicies.sort((left, right) => left.policy.id.localeCompare(right.policy.id))
+        return {
+          status: "denied",
+          exhaustedPolicies,
+          resetAt: new Date(
+            Math.min(...exhaustedPolicies.map((status) => status.period.resetAt.getTime()))
+          ),
+        }
+      }
+
+      const buckets = aiLimitReservationBuckets(
+        enabledPolicies,
+        request.subjects,
+        request.estimates
+      )
+      if (buckets.length === 0) return { status: "notRequired" }
+      for (const bucket of buckets) {
+        const amount = normalizeAiLimitAmount(bucket.estimate)
+        this.changeCounters(
+          request.identity.projectId,
+          bucket.subject,
+          amount,
+          request.period,
+          { reserved: amount.amount },
+          request.reservedAt
+        )
+      }
+      const reservation: AiModelCallReservation = {
+        ...request.identity,
+        buckets,
+        requestKey: aiLimitReservationRequestKey(request),
+        period: request.period,
+        state: "active",
+        reservedAt: request.reservedAt,
+        updatedAt: new Date(request.reservedAt),
+      }
+      this.insertReservation(reservation)
+      return { status: "reserved", reservation: structuredClone(reservation), created: true }
+    })
+  }
+
+  async recordModelCallActuals(input: RecordAiModelCallLimitActualsInput): Promise<void> {
+    assertNonBlank(input.projectId, "projectId")
+    assertNonBlank(input.usageRecordId, "usageRecordId")
+    const recordedAt = cloneValidDate(input.recordedAt ?? new Date(), "recordedAt")
+    runImmediateTransaction(this.connection.db, () => {
+      const entry = this.requireAccountingEntry(input.projectId, input.usageRecordId)
+      const period = aiLimitCalendarMonth(entry.occurredAt)
+      for (const subjectValue of aiLimitSubjectsFromAccountingEntry(entry)) {
+        const subject = aiLimitSubjectParts(subjectValue)
+        const rows = this.connection.db
+          .query(
+            `
+              SELECT meter, currency, actual_amount, accounting_status
+              FROM ai_usage_limit_periods
+              WHERE project_id = ? AND subject_type = ? AND subject_id = ?
+                AND period_start = ?
+            `
+          )
+          .all(
+            input.projectId,
+            subject.type,
+            subject.id,
+            period.start.toISOString()
+          ) as AiLimitActualStateRow[]
+        for (const row of rows) {
+          const actual = resolveAiLimitActual([entry], row)
+          this.connection.db
+            .query(
+              `
+                UPDATE ai_usage_limit_periods
+                SET actual_amount = ?, accounting_status = ?, updated_at = ?
+                WHERE project_id = ? AND subject_type = ? AND subject_id = ?
+                  AND meter = ? AND currency = ? AND period_start = ?
+              `
+            )
+            .run(
+              (BigInt(row.actual_amount) + actual.amount).toString(),
+              row.accounting_status === "unavailable" || actual.accountingStatus === "unavailable"
+                ? "unavailable"
+                : "complete",
+              recordedAt.toISOString(),
+              input.projectId,
+              subject.type,
+              subject.id,
+              row.meter,
+              row.currency,
+              period.start.toISOString()
+            )
+        }
+      }
+    })
+  }
+
+  async reconcileModelCall(input: ReconcileAiModelCallInput): Promise<AiModelCallReservation> {
+    const identity = normalizeAiModelCallReservationIdentity(input)
+    assertNonBlank(input.usageRecordId, "usageRecordId")
+    const reconciledAt = cloneValidDate(input.reconciledAt ?? new Date(), "reconciledAt")
+    return runImmediateTransaction(this.connection.db, () => {
+      const reservation = this.findReservation(identity)
+      if (!reservation) throw missingReservation(identity)
+      if (reservation.state === "reconciled") {
+        if (reservation.usageRecordId === input.usageRecordId) {
+          return reservation
+        }
+        throw reconciliationConflict(identity.callId)
+      }
+      const accounting = this.requireAccountingEntry(identity.projectId, input.usageRecordId)
+      assertAiLimitAccountingMatchesReservation(reservation, accounting)
+      this.reconcileEstimateCounters(reservation, accounting, reconciledAt)
+      const reconciled: AiModelCallReservation = {
+        ...reservation,
+        state: "reconciled",
+        usageRecordId: input.usageRecordId,
+        updatedAt: reconciledAt,
+      }
+      this.updateReservation(reconciled)
+      return structuredClone(reconciled)
+    })
+  }
+
+  async markReservationUnknown(
+    input: MarkAiModelCallReservationUnknownInput
+  ): Promise<AiModelCallReservation> {
+    const identity = normalizeAiModelCallReservationIdentity(input)
+    const markedAt = cloneValidDate(input.markedAt ?? new Date(), "markedAt")
+    return runImmediateTransaction(this.connection.db, () => {
+      const reservation = this.findReservation(identity)
+      if (!reservation) throw missingReservation(identity)
+      if (reservation.state === "unknown") return reservation
+      if (reservation.state !== "active") throw invalidState(reservation, "mark unknown")
+      this.moveEstimateCounters(reservation, { reserved: -1n, unknown: 1n }, markedAt)
+      const unknown = { ...reservation, state: "unknown" as const, updatedAt: markedAt }
+      this.updateReservation(unknown)
+      return structuredClone(unknown)
+    })
+  }
+
+  close(): void {
+    closeSqliteStoreConnection(this.connection)
+  }
+
+  private policyRows(projectId: string, includeDisabled: boolean): AiLimitPolicyRow[] {
+    return this.connection.db
+      .query(
+        `
+          SELECT * FROM ai_usage_limits
+          WHERE project_id = ? AND (? = 1 OR enabled = 1)
+          ORDER BY id
+        `
+      )
+      .all(projectId, includeDisabled ? 1 : 0) as AiLimitPolicyRow[]
+  }
+
+  private requirePolicy(projectId: string, id: string): AiLimitPolicy {
+    const row = this.connection.db
+      .query("SELECT * FROM ai_usage_limits WHERE project_id = ? AND id = ?")
+      .get(projectId, id) as AiLimitPolicyRow | null
+    if (row) return policyFromRow(row)
+    throw new AiLimitStorageError(
+      "missing_policy",
+      `[SixbSqlite] AI limit policy '${id}' does not exist in project '${projectId}'.`
+    )
+  }
+
+  private statusForPolicy(
+    policy: AiLimitPolicy,
+    period: AiLimitPeriod,
+    existingGroups?: ReadonlySet<string>
+  ): AiLimitPolicyStatus {
+    const subject = aiLimitSubjectParts(policy.subject)
+    const limit = normalizeAiLimitAmount(policy.limit)
+    let row = this.connection.db
+      .query(
+        `
+          SELECT actual_amount, reserved_amount, unknown_amount, accounting_status
+          FROM ai_usage_limit_periods
+          WHERE project_id = ? AND subject_type = ? AND subject_id = ?
+            AND meter = ? AND currency = ? AND period_start = ?
+        `
+      )
+      .get(
+        policy.projectId,
+        subject.type,
+        subject.id,
+        limit.meter,
+        limit.currency,
+        period.start.toISOString()
+      ) as AiLimitPeriodStateRow | null
+    if (!row) {
+      const actual = resolveAiLimitActual(this.accountingEntries(policy, period), limit)
+      row = {
+        actual_amount: actual.amount.toString(),
+        reserved_amount: "0",
+        unknown_amount: "0",
+        accounting_status: actual.accountingStatus,
+      }
+      this.connection.db
+        .query(
+          `
+            INSERT INTO ai_usage_limit_periods (
+              project_id, subject_type, subject_id, meter, currency, period_start, period_end,
+              actual_amount, reserved_amount, unknown_amount, accounting_status, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, '0', '0', ?, ?)
+          `
+        )
+        .run(
+          policy.projectId,
+          subject.type,
+          subject.id,
+          limit.meter,
+          limit.currency,
+          period.start.toISOString(),
+          period.end.toISOString(),
+          row.actual_amount,
+          row.accounting_status,
+          new Date().toISOString()
+        )
+    }
+    return policyStatus(policy, period, row, existingGroups)
+  }
+
+  private changeCounters(
+    projectId: string,
+    subjectValue: AiLimitSubject,
+    amount: NormalizedAiLimitAmount,
+    period: AiLimitPeriod,
+    changes: { readonly reserved?: bigint; readonly unknown?: bigint },
+    updatedAt: Date
+  ): void {
+    const subject = aiLimitSubjectParts(subjectValue)
+    const row = this.connection.db
+      .query(
+        `
+          SELECT actual_amount, reserved_amount, unknown_amount, accounting_status
+          FROM ai_usage_limit_periods
+          WHERE project_id = ? AND subject_type = ? AND subject_id = ?
+            AND meter = ? AND currency = ? AND period_start = ?
+        `
+      )
+      .get(
+        projectId,
+        subject.type,
+        subject.id,
+        amount.meter,
+        amount.currency,
+        period.start.toISOString()
+      ) as AiLimitPeriodStateRow | null
+    const reserved = BigInt(row?.reserved_amount ?? "0") + (changes.reserved ?? 0n)
+    const unknown = BigInt(row?.unknown_amount ?? "0") + (changes.unknown ?? 0n)
+    if (reserved < 0n || unknown < 0n) {
+      throw new Error("[SixbSqlite] AI limit period counter became negative.")
+    }
+    this.connection.db
+      .query(
+        `
+          INSERT INTO ai_usage_limit_periods (
+            project_id, subject_type, subject_id, meter, currency, period_start, period_end,
+            actual_amount, reserved_amount, unknown_amount, accounting_status, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT (project_id, subject_type, subject_id, meter, currency, period_start)
+          DO UPDATE SET
+            period_end = excluded.period_end,
+            actual_amount = excluded.actual_amount,
+            reserved_amount = excluded.reserved_amount,
+            unknown_amount = excluded.unknown_amount,
+            accounting_status = excluded.accounting_status,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        projectId,
+        subject.type,
+        subject.id,
+        amount.meter,
+        amount.currency,
+        period.start.toISOString(),
+        period.end.toISOString(),
+        row?.actual_amount ?? "0",
+        reserved.toString(),
+        unknown.toString(),
+        row?.accounting_status ?? "complete",
+        updatedAt.toISOString()
+      )
+  }
+
+  private moveEstimateCounters(
+    reservation: AiModelCallReservation,
+    directions: { readonly reserved?: bigint; readonly unknown?: bigint },
+    updatedAt: Date
+  ): void {
+    for (const bucket of reservation.buckets) {
+      const amount = normalizeAiLimitAmount(bucket.estimate)
+      this.changeCounters(
+        reservation.projectId,
+        bucket.subject,
+        amount,
+        reservation.period,
+        {
+          ...(directions.reserved === undefined
+            ? {}
+            : { reserved: directions.reserved * amount.amount }),
+          ...(directions.unknown === undefined
+            ? {}
+            : { unknown: directions.unknown * amount.amount }),
+        },
+        updatedAt
+      )
+    }
+  }
+
+  private reconcileEstimateCounters(
+    reservation: AiModelCallReservation,
+    entry: AiLimitAccountingEntry,
+    updatedAt: Date
+  ): void {
+    for (const bucket of reservation.buckets) {
+      const amount = normalizeAiLimitAmount(bucket.estimate)
+      const actual = resolveAiLimitActual([entry], amount)
+      if (actual.accountingStatus === "complete") {
+        this.changeCounters(
+          reservation.projectId,
+          bucket.subject,
+          amount,
+          reservation.period,
+          reservation.state === "active"
+            ? { reserved: -amount.amount }
+            : { unknown: -amount.amount },
+          updatedAt
+        )
+      } else if (reservation.state === "active") {
+        this.changeCounters(
+          reservation.projectId,
+          bucket.subject,
+          amount,
+          reservation.period,
+          { reserved: -amount.amount, unknown: amount.amount },
+          updatedAt
+        )
+      }
+    }
+  }
+
+  private insertReservation(reservation: AiModelCallReservation): void {
+    this.connection.db
+      .query(
+        `
+          INSERT INTO ai_model_call_reservations (
+            project_id, execution_id, attempt, call_id, buckets, request_key,
+            period_start, period_end, state, usage_record_id, reserved_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(...reservationSqlValues(reservation))
+  }
+
+  private updateReservation(reservation: AiModelCallReservation): void {
+    this.connection.db
+      .query(
+        `
+          UPDATE ai_model_call_reservations
+          SET state = ?, usage_record_id = ?, updated_at = ?
+          WHERE project_id = ? AND execution_id = ? AND attempt = ? AND call_id = ?
+        `
+      )
+      .run(
+        reservation.state,
+        reservation.usageRecordId ?? null,
+        reservation.updatedAt.toISOString(),
+        reservation.projectId,
+        reservation.executionId,
+        reservation.attempt,
+        reservation.callId
+      )
+  }
+
+  private findReservation(input: {
+    readonly projectId: string
+    readonly executionId: string
+    readonly attempt: number
+    readonly callId: string
+  }): AiModelCallReservation | null {
+    const row = this.connection.db
+      .query(
+        `
+          SELECT * FROM ai_model_call_reservations
+          WHERE project_id = ? AND execution_id = ? AND attempt = ? AND call_id = ?
+        `
+      )
+      .get(
+        input.projectId,
+        input.executionId,
+        input.attempt,
+        input.callId
+      ) as AiModelCallReservationRow | null
+    return row ? reservationFromRow(row) : null
+  }
+
+  private accountingEntries(
+    policy: AiLimitPolicy,
+    period: AiLimitPeriod
+  ): readonly AiLimitAccountingEntry[] {
+    const subject = aiLimitSubjectParts(policy.subject)
+    const rows = this.connection.db
+      .query(
+        `
+          SELECT usage.project_id, usage.id AS usage_record_id, usage.execution_id,
+                 usage.attempt, usage.call_id, usage.occurred_at,
+                 CAST(usage.total_tokens AS TEXT) AS total_tokens,
+                 executions.requested_by_user_id,
+                 executions.requested_by_service_account_id,
+                 valuations.status AS valuation_status,
+                 valuations.currency AS valuation_currency,
+                 CAST(valuations.amount_nanos AS TEXT) AS valuation_amount_nanos
+          FROM ai_model_call_usage AS usage
+          JOIN executions
+            ON executions.project_id = usage.project_id AND executions.id = usage.execution_id
+          LEFT JOIN ai_model_call_valuations AS valuations
+            ON valuations.project_id = usage.project_id
+           AND valuations.usage_record_id = usage.id
+          WHERE usage.project_id = ? AND usage.occurred_at >= ? AND usage.occurred_at < ?
+            AND (
+              ? = 'project'
+              OR (
+                ? = 'group'
+                AND EXISTS (
+                  SELECT 1 FROM ai_model_call_usage_groups AS usage_groups
+                  WHERE usage_groups.project_id = usage.project_id
+                    AND usage_groups.usage_record_id = usage.id
+                    AND usage_groups.group_id = ?
+                )
+              )
+              OR (? = 'user' AND executions.requested_by_user_id = ?)
+              OR (
+                ? = 'serviceAccount'
+                AND executions.requested_by_service_account_id = ?
+              )
+            )
+          ORDER BY usage.occurred_at, usage.id
+        `
+      )
+      .all(
+        policy.projectId,
+        period.start.toISOString(),
+        period.end.toISOString(),
+        subject.type,
+        subject.type,
+        subject.id,
+        subject.type,
+        subject.id,
+        subject.type,
+        subject.id
+      ) as AiLimitAccountingRow[]
+    return rows.map((row) => accountingEntryFromRow(row, policy.subject))
+  }
+
+  private requireAccountingEntry(projectId: string, usageRecordId: string): AiLimitAccountingEntry {
+    const row = this.connection.db
+      .query(
+        `
+          SELECT usage.project_id, usage.id AS usage_record_id, usage.execution_id,
+                 usage.attempt, usage.call_id, usage.occurred_at,
+                 CAST(usage.total_tokens AS TEXT) AS total_tokens,
+                 executions.requested_by_user_id,
+                 executions.requested_by_service_account_id,
+                 valuations.status AS valuation_status,
+                 valuations.currency AS valuation_currency,
+                 CAST(valuations.amount_nanos AS TEXT) AS valuation_amount_nanos
+          FROM ai_model_call_usage AS usage
+          JOIN executions
+            ON executions.project_id = usage.project_id AND executions.id = usage.execution_id
+          LEFT JOIN ai_model_call_valuations AS valuations
+            ON valuations.project_id = usage.project_id
+           AND valuations.usage_record_id = usage.id
+          WHERE usage.project_id = ? AND usage.id = ?
+        `
+      )
+      .get(projectId, usageRecordId) as AiLimitAccountingRow | null
+    if (row) {
+      const groups = this.connection.db
+        .query(
+          `
+            SELECT group_id FROM ai_model_call_usage_groups
+            WHERE project_id = ? AND usage_record_id = ?
+            ORDER BY group_id
+          `
+        )
+        .all(projectId, usageRecordId) as { readonly group_id: string }[]
+      return accountingEntryFromRow(
+        row,
+        undefined,
+        groups.map((group) => group.group_id)
+      )
+    }
+    throw new AiLimitStorageError(
+      "missing_usage_record",
+      `[SixbSqlite] AI usage record '${usageRecordId}' does not exist in project '${projectId}'.`
+    )
+  }
+
+  private assertExecutionExists(projectId: string, executionId: string): void {
+    const row = this.connection.db
+      .query("SELECT 1 FROM executions WHERE project_id = ? AND id = ?")
+      .get(projectId, executionId)
+    if (row) return
+    throw new AiLimitStorageError(
+      "missing_execution",
+      `[SixbSqlite] AI limit execution '${executionId}' does not exist in project '${projectId}'.`
+    )
+  }
+}
+
+interface AiLimitPolicyRow {
+  readonly project_id: string
+  readonly id: string
+  readonly subject_type: AiLimitSubject["type"]
+  readonly subject_id: string
+  readonly meter: AiLimitQuantity["meter"]
+  readonly currency: string
+  readonly limit_amount: string
+  readonly period_kind: "calendarMonth"
+  readonly enabled: number
+  readonly created_at: string
+  readonly updated_at: string
+}
+
+interface AiLimitPeriodStateRow {
+  readonly actual_amount: string
+  readonly reserved_amount: string
+  readonly unknown_amount: string
+  readonly accounting_status: "complete" | "unavailable"
+}
+
+interface AiLimitActualStateRow {
+  readonly meter: AiLimitQuantity["meter"]
+  readonly currency: string
+  readonly actual_amount: string
+  readonly accounting_status: "complete" | "unavailable"
+}
+
+interface AiLimitAccountingRow {
+  readonly project_id: string
+  readonly usage_record_id: string
+  readonly execution_id: string
+  readonly attempt: number
+  readonly call_id: string
+  readonly occurred_at: string
+  readonly total_tokens: string | null
+  readonly requested_by_user_id: string | null
+  readonly requested_by_service_account_id: string | null
+  readonly valuation_status: "rated" | "unpriceable" | null
+  readonly valuation_currency: string | null
+  readonly valuation_amount_nanos: string | null
+}
+
+interface AiModelCallReservationRow {
+  readonly project_id: string
+  readonly execution_id: string
+  readonly attempt: number
+  readonly call_id: string
+  readonly buckets: string
+  readonly request_key: string
+  readonly period_start: string
+  readonly period_end: string
+  readonly state: AiModelCallReservation["state"]
+  readonly usage_record_id: string | null
+  readonly reserved_at: string
+  readonly updated_at: string
+}
+
+function policyFromRow(row: AiLimitPolicyRow): AiLimitPolicy {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    subject: aiLimitSubjectFromParts(row.subject_type, row.subject_id),
+    limit: aiLimitQuantityFromAmount({
+      meter: row.meter,
+      currency: row.currency,
+      amount: BigInt(row.limit_amount),
+    }),
+    period: row.period_kind,
+    enabled: row.enabled === 1,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  }
+}
+
+function policyStatus(
+  policy: AiLimitPolicy,
+  period: AiLimitPeriod,
+  row: AiLimitPeriodStateRow,
+  existingGroups?: ReadonlySet<string>
+): AiLimitPolicyStatus {
+  const limit = normalizeAiLimitAmount(policy.limit)
+  const actual = BigInt(row.actual_amount)
+  const reserved = BigInt(row.reserved_amount)
+  const unknown = BigInt(row.unknown_amount)
+  const consumed = actual + reserved + unknown
+  const quantity = (amount: bigint) => aiLimitQuantityFromAmount({ ...limit, amount })
+  return {
+    policy,
+    period: structuredClone(period),
+    consumption: {
+      actual: quantity(actual),
+      reserved: quantity(reserved),
+      unknown: quantity(unknown),
+      remaining: quantity(limit.amount > consumed ? limit.amount - consumed : 0n),
+    },
+    accountingStatus: row.accounting_status,
+    exhausted: consumed >= limit.amount,
+    orphaned:
+      policy.subject.type === "group" &&
+      existingGroups !== undefined &&
+      !existingGroups.has(policy.subject.id),
+  }
+}
+
+function accountingEntryFromRow(
+  row: AiLimitAccountingRow,
+  subject?: AiLimitSubject,
+  requesterGroupIds = subject?.type === "group" ? [subject.id] : []
+): AiLimitAccountingEntry {
+  const totalTokens = row.total_tokens === null ? undefined : Number(row.total_tokens)
+  const requester = row.requested_by_user_id
+    ? ({ type: "user", id: row.requested_by_user_id } as const)
+    : row.requested_by_service_account_id
+      ? ({ type: "serviceAccount", id: row.requested_by_service_account_id } as const)
+      : undefined
+  return {
+    projectId: row.project_id,
+    usageRecordId: row.usage_record_id,
+    executionId: row.execution_id,
+    attempt: row.attempt,
+    callId: row.call_id,
+    occurredAt: new Date(row.occurred_at),
+    ...(totalTokens !== undefined && Number.isSafeInteger(totalTokens) ? { totalTokens } : {}),
+    requesterGroupIds,
+    ...(requester ? { requester } : {}),
+    ...(row.valuation_status === "rated" &&
+    row.valuation_currency !== null &&
+    row.valuation_amount_nanos !== null
+      ? {
+          valuation: {
+            status: "rated" as const,
+            money: {
+              currency: row.valuation_currency,
+              amountNanos: row.valuation_amount_nanos,
+            },
+          },
+        }
+      : row.valuation_status === "unpriceable"
+        ? { valuation: { status: "unavailable" as const } }
+        : {}),
+  }
+}
+
+function reservationFromRow(row: AiModelCallReservationRow): AiModelCallReservation {
+  return {
+    projectId: row.project_id,
+    executionId: row.execution_id,
+    attempt: row.attempt,
+    callId: row.call_id,
+    buckets: normalizeBucketsJson(row.buckets),
+    requestKey: row.request_key,
+    period: {
+      kind: "calendarMonth",
+      start: new Date(row.period_start),
+      end: new Date(row.period_end),
+      resetAt: new Date(row.period_end),
+    },
+    state: row.state,
+    ...(row.usage_record_id === null ? {} : { usageRecordId: row.usage_record_id }),
+    reservedAt: new Date(row.reserved_at),
+    updatedAt: new Date(row.updated_at),
+  }
+}
+
+function normalizeBucketsJson(value: string): readonly AiLimitReservationBucket[] {
+  const buckets = JSON.parse(value) as readonly AiLimitReservationBucket[]
+  return buckets.map((bucket) => ({
+    subject: structuredClone(bucket.subject),
+    estimate: normalizeAiLimitQuantities([bucket.estimate], "stored bucket")[0]!,
+  }))
+}
+
+function reservationSqlValues(reservation: AiModelCallReservation): SQLQueryBindings[] {
+  return [
+    reservation.projectId,
+    reservation.executionId,
+    reservation.attempt,
+    reservation.callId,
+    JSON.stringify(reservation.buckets),
+    reservation.requestKey,
+    reservation.period.start.toISOString(),
+    reservation.period.end.toISOString(),
+    reservation.state,
+    reservation.usageRecordId ?? null,
+    reservation.reservedAt.toISOString(),
+    reservation.updatedAt.toISOString(),
+  ]
+}
+
+function assertSameDimension(previous: AiLimitQuantity, next: AiLimitQuantity): void {
+  if (
+    aiLimitAmountKey(normalizeAiLimitAmount(previous)) !==
+    aiLimitAmountKey(normalizeAiLimitAmount(next))
+  ) {
+    throw new TypeError("[Sixb] AI limit policy meter and cost currency are immutable.")
+  }
+}
+
+function validatePolicyIdentity(input: GetAiLimitPolicyInput): void {
+  assertNonBlank(input.projectId, "projectId")
+  assertNonBlank(input.id, "policy id")
+}
+
+function duplicatePolicy(policy: AiLimitPolicy): AiLimitStorageError {
+  return new AiLimitStorageError(
+    "duplicate_policy",
+    `[SixbSqlite] An AI limit policy already exists for policy ID or subject-meter dimension '${policy.id}'.`
+  )
+}
+
+function missingReservation(input: {
+  readonly executionId: string
+  readonly attempt: number
+  readonly callId: string
+}): AiLimitStorageError {
+  return new AiLimitStorageError(
+    "missing_reservation",
+    `[SixbSqlite] AI model-call reservation '${input.callId}' does not exist for execution '${input.executionId}' attempt ${input.attempt}.`
+  )
+}
+
+function reconciliationConflict(callId: string): AiLimitStorageError {
+  return new AiLimitStorageError(
+    "reconciliation_conflict",
+    `[SixbSqlite] AI model-call reservation '${callId}' was reconciled with a different usage record.`
+  )
+}
+
+function invalidState(reservation: AiModelCallReservation, operation: string): AiLimitStorageError {
+  return new AiLimitStorageError(
+    "invalid_reservation_state",
+    `[SixbSqlite] Cannot ${operation} AI model-call reservation '${reservation.callId}' in state '${reservation.state}'.`
+  )
+}
+
+function isConstraintError(error: unknown): boolean {
+  return error instanceof Error && /constraint/i.test(error.message)
+}

--- a/storage/sqlite/src/ai-limit-storage.ts
+++ b/storage/sqlite/src/ai-limit-storage.ts
@@ -411,12 +411,13 @@ export class SqliteAiLimitStorage implements AiLimitStorage {
         limit.currency,
         period.start.toISOString()
       ) as AiLimitPeriodStateRow | null
-    if (!row) {
+    // Re-read incomplete accounting inside the transaction; retain in-flight estimates.
+    if (!row || row.accounting_status === "unavailable") {
       const actual = resolveAiLimitActual(this.accountingEntries(policy, period), limit)
       row = {
         actual_amount: actual.amount.toString(),
-        reserved_amount: "0",
-        unknown_amount: "0",
+        reserved_amount: row?.reserved_amount ?? "0",
+        unknown_amount: row?.unknown_amount ?? "0",
         accounting_status: actual.accountingStatus,
       }
       this.connection.db
@@ -426,6 +427,11 @@ export class SqliteAiLimitStorage implements AiLimitStorage {
               project_id, subject_type, subject_id, meter, currency, period_start, period_end,
               actual_amount, reserved_amount, unknown_amount, accounting_status, updated_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, '0', '0', ?, ?)
+            ON CONFLICT (project_id, subject_type, subject_id, meter, currency, period_start)
+            DO UPDATE SET
+              actual_amount = excluded.actual_amount,
+              accounting_status = excluded.accounting_status,
+              updated_at = excluded.updated_at
           `
         )
         .run(

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -20,6 +20,7 @@ import {
 } from "@sixb/core/internal/storage-operation-scope"
 import {
   type AiCostStorage,
+  type AiLimitStorage,
   type AiUsageStorage,
   createTransactionStorageProxy,
   StorageTransactionError,
@@ -28,6 +29,7 @@ import {
 import { SqliteActionRunStorage } from "./action-run-storage"
 import { SqliteAgentStorage } from "./agents"
 import { SqliteAiCostStorage } from "./ai-cost-storage"
+import { SqliteAiLimitStorage } from "./ai-limit-storage"
 import { SqliteAiUsageStorage } from "./ai-usage-storage"
 import { SqliteAuthStorage } from "./auth-storage"
 import { SqliteConnectorConnectionStorage } from "./connector-connection-storage"
@@ -84,6 +86,7 @@ export class SqliteStorage implements MigrationCapableStorage {
   readonly agents: SqliteAgentStorage
   readonly aiUsage: AiUsageStorage
   readonly aiCosts: AiCostStorage
+  readonly aiLimits: AiLimitStorage
   readonly actionRuns: SqliteActionRunStorage
   readonly pipelineRuns: SqlitePipelineRunStorage
   readonly syncRuns: SqliteSyncRunStorage
@@ -147,6 +150,7 @@ export class SqliteStorage implements MigrationCapableStorage {
     this.agents = createAgentOperationScope(stores.agents, scope)
     this.aiUsage = createOperationScopedFacade(stores.aiUsage, scope)
     this.aiCosts = createOperationScopedFacade(stores.aiCosts, scope)
+    this.aiLimits = createOperationScopedFacade(stores.aiLimits, scope)
     this.actionRuns = createOperationScopedFacade(stores.actionRuns, scope)
     this.pipelineRuns = createOperationScopedFacade(stores.pipelineRuns, scope)
     this.timeseries = createOperationScopedFacade(readTimeseries, readScope)
@@ -303,6 +307,7 @@ function createSqliteStores(
     agents: new SqliteAgentStorage({ connection, executions }),
     aiUsage: new SqliteAiUsageStorage({ connection }),
     aiCosts: new SqliteAiCostStorage(connection),
+    aiLimits: new SqliteAiLimitStorage({ connection }),
     actionRuns: new SqliteActionRunStorage({ connection, executions }),
     pipelineRuns: new SqlitePipelineRunStorage({ connection, executions }),
     timeseries: new SqliteTimeseriesStorage({ connection }),
@@ -324,6 +329,7 @@ interface SqliteStoreSet {
   readonly agents: SqliteAgentStorage
   readonly aiUsage: SqliteAiUsageStorage
   readonly aiCosts: SqliteAiCostStorage
+  readonly aiLimits: SqliteAiLimitStorage
   readonly actionRuns: SqliteActionRunStorage
   readonly pipelineRuns: SqlitePipelineRunStorage
   readonly syncRuns: SqliteSyncRunStorage

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -77,6 +77,7 @@ import objectOverrideEditTimesSql from "./migrations/028-object-override-edit-ti
   type: "text",
 }
 import modelAccountingSql from "./migrations/029-model-accounting.sql" with { type: "text" }
+import aiUsageLimitsSql from "./migrations/030-ai-usage-limits.sql" with { type: "text" }
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -161,6 +162,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("027-agent-context-checkpoints", agentContextCheckpointsSql),
     sqliteSql("028-object-override-edit-times", objectOverrideEditTimesSql),
     sqliteSql("029-model-accounting", modelAccountingSql),
+    sqliteSql("030-ai-usage-limits", aiUsageLimitsSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/030-ai-usage-limits.sql
+++ b/storage/sqlite/src/migrations/030-ai-usage-limits.sql
@@ -1,0 +1,100 @@
+CREATE TABLE ai_usage_limits (
+  project_id TEXT NOT NULL CHECK (length(trim(project_id)) > 0),
+  id TEXT NOT NULL CHECK (length(trim(id)) > 0),
+  subject_type TEXT NOT NULL CHECK (
+    subject_type IN ('project', 'group', 'user', 'serviceAccount')
+  ),
+  subject_id TEXT NOT NULL CHECK (
+    (subject_type = 'project' AND subject_id = '')
+    OR (subject_type <> 'project' AND length(trim(subject_id)) > 0)
+  ),
+  meter TEXT NOT NULL CHECK (meter IN ('tokens.total', 'cost.catalogEstimated')),
+  currency TEXT NOT NULL CHECK (
+    (meter = 'tokens.total' AND currency = '')
+    OR (meter = 'cost.catalogEstimated' AND currency = 'USD')
+  ),
+  limit_amount TEXT NOT NULL CHECK (
+    limit_amount = '0'
+    OR (
+      limit_amount NOT GLOB '*[^0-9]*'
+      AND substr(limit_amount, 1, 1) BETWEEN '1' AND '9'
+    )
+  ),
+  period_kind TEXT NOT NULL CHECK (period_kind = 'calendarMonth'),
+  enabled INTEGER NOT NULL CHECK (enabled IN (0, 1)),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (project_id, id),
+  UNIQUE (project_id, subject_type, subject_id, meter, currency)
+);
+
+CREATE INDEX idx_ai_usage_limits_project_enabled
+  ON ai_usage_limits (project_id, enabled, subject_type, subject_id, meter, currency);
+
+CREATE TABLE ai_usage_limit_periods (
+  project_id TEXT NOT NULL CHECK (length(trim(project_id)) > 0),
+  subject_type TEXT NOT NULL CHECK (
+    subject_type IN ('project', 'group', 'user', 'serviceAccount')
+  ),
+  subject_id TEXT NOT NULL CHECK (
+    (subject_type = 'project' AND subject_id = '')
+    OR (subject_type <> 'project' AND length(trim(subject_id)) > 0)
+  ),
+  meter TEXT NOT NULL CHECK (meter IN ('tokens.total', 'cost.catalogEstimated')),
+  currency TEXT NOT NULL CHECK (
+    (meter = 'tokens.total' AND currency = '')
+    OR (meter = 'cost.catalogEstimated' AND currency = 'USD')
+  ),
+  period_start TEXT NOT NULL,
+  period_end TEXT NOT NULL,
+  actual_amount TEXT NOT NULL DEFAULT '0',
+  reserved_amount TEXT NOT NULL DEFAULT '0',
+  unknown_amount TEXT NOT NULL DEFAULT '0',
+  accounting_status TEXT NOT NULL DEFAULT 'complete' CHECK (
+    accounting_status IN ('complete', 'unavailable')
+  ),
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (
+    project_id, subject_type, subject_id, meter, currency, period_start
+  )
+);
+
+CREATE INDEX idx_ai_usage_limit_periods_subject_period
+  ON ai_usage_limit_periods (
+    project_id, subject_type, subject_id, period_start, period_end, meter, currency
+  );
+
+CREATE TABLE ai_model_call_reservations (
+  project_id TEXT NOT NULL CHECK (length(trim(project_id)) > 0),
+  execution_id TEXT NOT NULL CHECK (length(trim(execution_id)) > 0),
+  attempt INTEGER NOT NULL CHECK (attempt >= 1),
+  call_id TEXT NOT NULL CHECK (length(trim(call_id)) > 0),
+  buckets TEXT NOT NULL CHECK (json_valid(buckets) AND json_type(buckets) = 'array'),
+  request_key TEXT NOT NULL,
+  period_start TEXT NOT NULL,
+  period_end TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('active', 'reconciled', 'unknown')),
+  usage_record_id TEXT,
+  reserved_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (project_id, execution_id, attempt, call_id),
+  FOREIGN KEY (project_id, execution_id)
+    REFERENCES executions(project_id, id)
+    ON DELETE RESTRICT,
+  FOREIGN KEY (project_id, usage_record_id)
+    REFERENCES ai_model_call_usage(project_id, id)
+    ON DELETE RESTRICT,
+  CHECK (
+    (
+      state = 'reconciled'
+      AND usage_record_id IS NOT NULL
+    )
+    OR (
+      state <> 'reconciled'
+      AND usage_record_id IS NULL
+    )
+  )
+);
+
+CREATE INDEX idx_ai_model_call_reservations_active
+  ON ai_model_call_reservations (project_id, state, period_end, execution_id, attempt, call_id);

--- a/storage/sqlite/tests/sqlite-ai-limit-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-ai-limit-storage.test.ts
@@ -1,0 +1,7 @@
+import { runAiLimitStorageContractSuite } from "@sixb/core/testing"
+import { SqliteStorage } from "../src"
+
+runAiLimitStorageContractSuite("SqliteAiLimitStorage", {
+  createStorage: () => new SqliteStorage(),
+  cleanup: (storage) => storage.close(),
+})

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -231,6 +231,13 @@ const expectedStorageMigrationRows = [
     status: "applied",
     version: 29,
   },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "030-ai-usage-limits",
+    status: "applied",
+    version: 30,
+  },
 ]
 
 afterEach(async () => {


### PR DESCRIPTION

## Summary

Implement the AI usage-limit storage contract in the built-in SQLite and PostgreSQL providers.

This PR adds durable policy, current-period state, and model-call reservation persistence to both
SQL backends. Each implementation passes the shared contract introduced by the parent PR, including
concurrent admission, idempotent replay, ledger-derived actuals, incomplete-accounting behavior,
month boundaries, and transaction rollback.

## Why these providers are reviewed together

The schema and behavioral contract are identical, while the concurrency primitives are
provider-specific. Reviewing them in one stack layer makes it possible to compare how both backends
establish the same atomic boundary without mixing that work into Agent runtime enforcement.

Landing both providers before enforcement also prevents a built-in storage choice from becoming an
accidental feature flag. Once the worker begins requiring `storage.aiLimits`, every supported SQL
backend is ready.

## What changes

- Add migration `029-ai-usage-limits.sql` to SQLite and PostgreSQL.
- Persist editable policies separately from policy-independent period consumption.
- Persist model-call reservations keyed by project, execution, delivery attempt, and Sixb-owned
  call ID.
- Add the indexes required for policy lookup, subject-period aggregation, and active reservation
  reconciliation.
- Implement policy CRUD, status reads, atomic reservation, actual recording, reconciliation, and
  unknown transitions in both providers.
- Register `aiLimits` on the SQLite and PostgreSQL root storage implementations.
- Run the same provider contract suite against both implementations.

## Concurrency model

- SQLite uses its immediate transaction boundary to serialize competing reservations.
- PostgreSQL acquires deterministic transaction-scoped advisory locks for the affected project and
  subject-period dimensions before evaluating and reserving capacity.
- Both providers derive actual token and cost consumption from immutable ledger rows rather than
  trusting caller-supplied totals.

## Reviewer guide

Suggested review order:

1. Compare the two `029-ai-usage-limits.sql` migrations and their constraints.
2. Review the SQLite implementation against the parent contract.
3. Review PostgreSQL locking order and transaction boundaries.
4. Confirm both thin test entrypoints invoke the same shared contract suite.
5. Check migration registration and current-version assertions.

Pay particular attention to deterministic lock ordering, terminal reservation replay, and the
distinction between the reservation month and the usage record's occurrence month.

## Validation performed

- Both changed SQLite suites — 58 passed.
- Both changed PostgreSQL suites, with the package's Docker preload — 47 passed.
- `@sixb/sqlite` and `@sixb/pg` typechecks — passed.
- `bun run check` — passed on this branch.
- A package-wide PostgreSQL attempt lost its shared Docker database mid-run; rerunning the two
  changed suites against a fresh database passed completely. The complete stack tip also passed
  the full monorepo build, publish-boundary validation, and guarded unit suite.

## Not in this PR

- Agent admission or accounting integration.
- Public limit failure codes or HTTP behavior.
- Authorization, management APIs, generated client methods, or Atlas UI.

## Stack

This is PR 2 of 5 in GitHub stack #514. It depends on
[#509](https://github.com/sixb-ai/sixb/pull/509). Next:
[#511](https://github.com/sixb-ai/sixb/pull/511), which connects the completed storage capability
to every current Agent model-call path.

