### PR TITLE
agents: enforce aggregate AI usage limits

### DIFF
--- a/docs/agents/defining-agents.md
+++ b/docs/agents/defining-agents.md
@@ -314,6 +314,13 @@ The model integration's optional `costEstimator` prices **returned token usage**
 context limits and preflight token estimates. It runs for completed calls even when a provider
 charge is available. Local rates require no administrative credentials or financial API requests.
 
+The optional `costEstimator.estimateReservation({ inputTokens, outputTokens })` estimates token
+cost before a provider call. It returns USD nanounits, or `undefined` when the configured model
+cannot be priced safely. Built-in providers use the highest applicable cache and tier rates.
+Custom integrations can reuse `estimateModelReservation` with their rate card. A cost limit
+requires this capability; token limits do not. Input tokens and the output allowance remain
+estimates, so this admission check is not a hard ceiling on the final provider charge.
+
 ### What gets stored
 
 | Selected cost | Stored status | `priceSource.sourceId` | Detail |

--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -50,11 +50,11 @@ Each boundary exposes only the codes it can persist.
 | --- | --- |
 | Action run or phase | `action.phase_failed`, `internal.unexpected`, `queue.enqueue_failed`, `runtime.cancelled` |
 | Sync run | `internal.unexpected`, `queue.enqueue_failed`, `runtime.cancelled`, `sync.execution_failed` |
-| Agent execution | `agent.execution_failed`, `internal.unexpected`, `runtime.cancelled` |
+| Agent execution | `agent.execution_failed`, `ai.usage_limit_exceeded`, `ai.usage_limit_unavailable`, `internal.unexpected`, `runtime.cancelled` |
 | Connector connection run | `connector.adapter_invalid`, `connector.authorization_invalid`, `connector.authorization_required`, `connector.credentials_unavailable`, `connector.not_found`, `connector.operation_conflict`, `connector.operation_in_progress`, `connector.provider_failed`, `connector.provider_unavailable`, `internal.unexpected` |
 | Projection run | `internal.unexpected`, `projection.execution_failed`, `queue.enqueue_failed`, `runtime.cancelled` |
 | Pipeline run or step | `internal.unexpected`, `pipeline.step_failed`, `queue.enqueue_failed`, `runtime.cancelled` |
-| Workflow run or node | `internal.unexpected`, `runtime.cancelled`, `workflow.node_failed` |
+| Workflow run or node | `ai.usage_limit_exceeded`, `ai.usage_limit_unavailable`, `internal.unexpected`, `runtime.cancelled`, `workflow.node_failed` |
 | Webhook run | `internal.unexpected`, `webhook.delivery_failed`, `webhook.delivery_rejected` |
 | Ontology outbox | `event.delivery_failed` |
 
@@ -84,6 +84,8 @@ Additional rules:
 | --- | --- | --- | --- |
 | `action.phase_failed` | No | An Action phase could not complete successfully. | Inspect `details.phase` and the native error reported to `onError`. |
 | `agent.execution_failed` | No | An active Agent execution failed. | Inspect the run identity and the native error reported to `onError`. |
+| `ai.usage_limit_exceeded` | No | An applicable AI usage limit has no capacity for another model call. | Wait until `details.resetAt`, or raise or disable the applicable limit policy. |
+| `ai.usage_limit_unavailable` | Yes | Sixb could not evaluate an applicable AI usage limit safely. | Restore complete accounting or the limit storage provider, then retry. |
 | `connector.adapter_invalid` | No | A connector adapter returned data that violates its Sixb contract. | Fix or upgrade the adapter before retrying. |
 | `connector.authorization_invalid` | No | An OAuth connection run or authorization transition is no longer valid. | Start a new connector connection run. |
 | `connector.authorization_required` | No | The connection cannot provide credentials in its current state. | Reauthorize the connector and select an account when requested. |

--- a/models/anthropic/src/provider.ts
+++ b/models/anthropic/src/provider.ts
@@ -1,6 +1,7 @@
 import {
   assertJsonObject,
   defineLanguageModel,
+  estimateModelReservation,
   isJsonObject,
   isModelReasoning,
   type JsonObject,
@@ -338,6 +339,7 @@ class AnthropicLanguageModel implements LanguageModel {
       ...(options.capabilities === undefined ? {} : { capabilities: options.capabilities }),
     })
     this.costEstimator = {
+      estimateReservation: (tokens) => estimateModelReservation({ ...tokens, rateCard }),
       estimate: ({ usage }) => rateModelCall({ usage, rateCard }),
     }
   }

--- a/models/anthropic/tests/provider.test.ts
+++ b/models/anthropic/tests/provider.test.ts
@@ -51,6 +51,28 @@ async function collect(stream: AsyncIterable<LanguageModelStreamEvent>) {
 }
 
 describe("Anthropic provider", () => {
+  test("reserves ordinary Anthropic calls without a cache TTL accounting option", () => {
+    // Removal proof: remove estimateReservation from the provider; every estimate disappears.
+    const provider = createAnthropic({
+      fetch: async () => {
+        throw new Error("No catalog I/O expected")
+      },
+    })
+    for (const request of [undefined, { cache_control: { type: "ephemeral", ttl: "1h" } }]) {
+      expect(
+        provider("claude-opus-5", { request }).costEstimator?.estimateReservation?.({
+          inputTokens: 1000,
+          outputTokens: 200,
+        })
+      ).toEqual({ currency: "USD", amountNanos: "15000000" })
+    }
+    expect(
+      provider("claude-opus-5", {
+        providerTools: [{ type: "web_search_20260209", name: "web_search" }],
+      }).costEstimator?.estimateReservation?.({ inputTokens: 1000, outputTokens: 200 })
+    ).toBeUndefined()
+  })
+
   test.each([
     "$defs",
     "definitions",

--- a/models/vercel-ai-gateway/src/provider.ts
+++ b/models/vercel-ai-gateway/src/provider.ts
@@ -2,6 +2,7 @@ import {
   assertJsonObject,
   defineLanguageModel,
   defineModelRateCard,
+  estimateModelReservation,
   isJsonObject,
   isModelReasoning,
   type JsonObject,
@@ -137,6 +138,13 @@ export const vercelGateway = createVercelGateway({
 
 class RemoteVercelGatewayCatalog implements VercelGatewayCatalog {
   private readonly rateCards = new Map<string, LanguageModelRateCard>()
+
+  estimateReservation(
+    modelId: string,
+    tokens: { readonly inputTokens: number; readonly outputTokens: number }
+  ) {
+    return estimateModelReservation({ ...tokens, rateCard: this.rateCards.get(modelId) })
+  }
 
   estimate(modelId: string, usage: ModelUsage) {
     const card = this.rateCards.get(modelId)
@@ -414,6 +422,10 @@ class VercelGatewayLanguageModel implements LanguageModel {
   ) {
     this.modelId = modelId
     this.costEstimator = {
+      estimateReservation: (tokens) =>
+        !hasFixedTokenPricing(options) || options.providerTools?.length
+          ? undefined
+          : catalog.estimateReservation(modelId, tokens),
       // A model-only card cannot price routing overrides or provider-native tool charges.
       estimate: ({ usage, route, responseModelId }) =>
         !hasFixedTokenPricing(options) ||

--- a/models/vercel-ai-gateway/tests/provider.test.ts
+++ b/models/vercel-ai-gateway/tests/provider.test.ts
@@ -583,6 +583,13 @@ describe("Vercel AI Gateway provider", () => {
       { providerOptions: { gateway: { caching: "off" } } },
     ]
     for (const options of safeOptions) {
+      // Removal proof: remove the provider's reservation estimator; this fails before inference.
+      expect(
+        provider("test/model", options).costEstimator?.estimateReservation?.({
+          inputTokens: 1000,
+          outputTokens: 200,
+        })
+      ).toEqual({ currency: "USD", amountNanos: "6000000" })
       expect(
         provider("test/model", options).costEstimator?.estimate({
           usage: { inputTokens: 1000, outputTokens: 200 },
@@ -599,6 +606,12 @@ describe("Vercel AI Gateway provider", () => {
           usage: { inputTokens: 1000, outputTokens: 200 },
         })
       ).toMatchObject({ status: "unpriceable" })
+      expect(
+        provider("test/model", options).costEstimator?.estimateReservation?.({
+          inputTokens: 1000,
+          outputTokens: 200,
+        })
+      ).toBeUndefined()
     }
   })
   test("declines native decoding for schemas outside the strict Responses subset", () => {

--- a/packages/agent-worker/src/context-compaction.ts
+++ b/packages/agent-worker/src/context-compaction.ts
@@ -293,7 +293,7 @@ async function generateCheckpointSummary(input: {
   let result: Awaited<ReturnType<typeof runModelLoop<string>>>
   try {
     result = await runModelLoop({
-      model: input.agent.model,
+      model: input.runtime.usageRecorder.wrapModel(input.agent.model),
       // Hidden reasoning consumes the same bounded output budget needed for summary text.
       reasoning: "none",
       ...(input.agent.loop?.caching === undefined ? {} : { caching: input.agent.loop.caching }),

--- a/packages/agent-worker/src/failure.ts
+++ b/packages/agent-worker/src/failure.ts
@@ -55,7 +55,10 @@ function translateAgentExecutionError(
 
   if (
     isSixbError(error) &&
-    (error.code === "internal.unexpected" || error.code === "agent.execution_failed")
+    (error.code === "internal.unexpected" ||
+      error.code === "agent.execution_failed" ||
+      error.code === "ai.usage_limit_exceeded" ||
+      error.code === "ai.usage_limit_unavailable")
   ) {
     return error
   }

--- a/packages/agent-worker/src/model-call-accounting.ts
+++ b/packages/agent-worker/src/model-call-accounting.ts
@@ -7,6 +7,7 @@ import { assertJsonObject, type ModelCostEstimate } from "@sixb/core/models"
 import type {
   AiBillableMeter,
   AiCostStorage,
+  AiLimitStorage,
   AiModelCallCostRecord,
   AiModelCallUsageRecord,
   AiPricingContext,
@@ -24,6 +25,7 @@ interface RecordAiModelCallAccountingInput extends RecoverAiModelCallInput {
 interface AiAccountingCapabilities {
   readonly aiUsage: AiUsageStorage
   readonly aiCosts: AiCostStorage
+  readonly aiLimits: AiLimitStorage
 }
 
 /** Atomically append one provider call's usage and the valuation captured by the model runtime. */
@@ -31,7 +33,7 @@ export async function recordAiModelCallAccounting(
   input: RecordAiModelCallAccountingInput
 ): Promise<RecordAiModelCallResult> {
   return input.storage.transaction(async (tx) => {
-    const { aiUsage, aiCosts } = requireAccountingCapabilities(tx)
+    const { aiUsage, aiCosts, aiLimits } = requireAccountingCapabilities(tx)
     const usage = await aiUsage.recordModelCall(input.usage)
     // Usage deduplicates provider lifecycle replays by execution/call identity. Always attach the
     // valuation to the canonical row it returns, not the fresh candidate ID from a replay.
@@ -62,6 +64,23 @@ export async function recordAiModelCallAccounting(
                   },
           }),
     })
+    if (usage.created) {
+      await aiLimits.recordModelCallActuals({
+        projectId: usage.record.projectId,
+        usageRecordId: usage.record.id,
+        recordedAt: input.ratedAt,
+      })
+    }
+    if (input.reconcileLimitReservation) {
+      await aiLimits.reconcileModelCall({
+        projectId: usage.record.projectId,
+        executionId: usage.record.executionId,
+        attempt: usage.record.attempt,
+        callId: usage.record.callId,
+        usageRecordId: usage.record.id,
+        reconciledAt: input.ratedAt,
+      })
+    }
     return usage
   })
 }
@@ -180,10 +199,10 @@ function normalizeMissingMeters(
 }
 
 function requireAccountingCapabilities(storage: Storage): AiAccountingCapabilities {
-  if (!storage.aiUsage || !storage.aiCosts) {
+  if (!storage.aiUsage || !storage.aiCosts || !storage.aiLimits) {
     throw new Error(
-      "[SixbAgentWorker] AI model-call accounting requires storage.aiUsage and storage.aiCosts."
+      "[SixbAgentWorker] AI model-call accounting requires storage.aiUsage, storage.aiCosts, and storage.aiLimits."
     )
   }
-  return { aiUsage: storage.aiUsage, aiCosts: storage.aiCosts }
+  return { aiUsage: storage.aiUsage, aiCosts: storage.aiCosts, aiLimits: storage.aiLimits }
 }

--- a/packages/agent-worker/src/model-call-admission.ts
+++ b/packages/agent-worker/src/model-call-admission.ts
@@ -1,0 +1,127 @@
+import type { ModelCostEstimator } from "@sixb/core/models"
+import type { AiModelCallReservationIdentity } from "@sixb/core/storage"
+
+/** Fixed internal allowance used only to estimate aggregate-budget reservations. */
+export const AI_MODEL_CALL_OUTPUT_TOKEN_ALLOWANCE = 4_096
+
+export type AiModelCallInputTokenEstimate =
+  | {
+      readonly status: "estimated"
+      readonly tokens: number
+      readonly method: "utf8BytesDividedByFour"
+    }
+  | {
+      readonly status: "unavailable"
+      readonly reason: "nonTextInput" | "unserializableInput"
+    }
+
+/** Provider-neutral snapshot passed to aggregate-budget admission before a provider request. */
+export interface AiModelCallAdmissionInput {
+  readonly projectId: string
+  readonly executionId: string
+  readonly attempt: number
+  readonly requesterGroupIds: readonly string[]
+  readonly callId: string
+  readonly providerId: string
+  readonly modelId: string
+  readonly costEstimator?: ModelCostEstimator
+  readonly inputTokens: AiModelCallInputTokenEstimate
+  readonly outputTokenAllowance: number
+  readonly estimatedTotalTokens?: number
+}
+
+export interface AiModelCallAdmissionDecision {
+  /** Active means accounting must reconcile the reservation for this provider attempt. */
+  readonly reservation: "active" | "none"
+}
+
+export type BeforeAiModelCall = (
+  input: AiModelCallAdmissionInput
+) => AiModelCallAdmissionDecision | Promise<AiModelCallAdmissionDecision>
+
+export type MarkAiModelCallUnknown = (input: AiModelCallReservationIdentity) => void | Promise<void>
+
+/**
+ * Estimate the exact, prepared provider request without requiring a provider-specific tokenizer.
+ *
+ * The heuristic is intentionally explicit so reservations are reproducible. Non-text inputs are
+ * reported as unavailable; an enforced token or cost policy can then fail closed instead of
+ * pretending that an image, file, or provider-defined payload has no token cost.
+ */
+export function estimateAiModelCallInputTokens(input: {
+  readonly prompt: unknown
+  readonly tools: unknown
+  readonly responseFormat: unknown
+}): AiModelCallInputTokenEstimate {
+  if (containsNonTextInput(input.prompt)) {
+    return { status: "unavailable", reason: "nonTextInput" }
+  }
+
+  let serialized: string | undefined
+  try {
+    serialized = JSON.stringify(input)
+  } catch {
+    return { status: "unavailable", reason: "unserializableInput" }
+  }
+  if (serialized === undefined) {
+    return { status: "unavailable", reason: "unserializableInput" }
+  }
+
+  const bytes = new TextEncoder().encode(serialized).byteLength
+  return {
+    status: "estimated",
+    tokens: Math.ceil(bytes / 4),
+    method: "utf8BytesDividedByFour",
+  }
+}
+
+export function aiModelCallOutputTokenAllowance(maxOutputTokens: number | undefined): number {
+  if (maxOutputTokens === undefined) return AI_MODEL_CALL_OUTPUT_TOKEN_ALLOWANCE
+  if (!Number.isSafeInteger(maxOutputTokens) || maxOutputTokens <= 0) {
+    throw new TypeError(
+      "[SixbAgentWorker] AI model-call maxOutputTokens must be a positive safe integer."
+    )
+  }
+  return maxOutputTokens
+}
+
+export function estimatedAiModelCallTotalTokens(
+  inputTokens: AiModelCallInputTokenEstimate,
+  outputTokenAllowance: number
+): number | undefined {
+  if (inputTokens.status !== "estimated") return undefined
+  const total = inputTokens.tokens + outputTokenAllowance
+  if (!Number.isSafeInteger(total)) {
+    throw new TypeError("[SixbAgentWorker] AI model-call token estimate exceeds the safe range.")
+  }
+  return total
+}
+
+function containsNonTextInput(value: unknown, seen = new WeakSet<object>()): boolean {
+  if (value === null || typeof value !== "object") return false
+  if (
+    value instanceof URL ||
+    value instanceof ArrayBuffer ||
+    ArrayBuffer.isView(value) ||
+    (typeof Blob !== "undefined" && value instanceof Blob)
+  ) {
+    return true
+  }
+  if (seen.has(value)) return false
+  seen.add(value)
+
+  if (!Array.isArray(value)) {
+    const type = Reflect.get(value, "type")
+    if (
+      type === "image" ||
+      type === "file" ||
+      type === "reasoning-file" ||
+      type === "custom" ||
+      type === "provider-state"
+    ) {
+      return true
+    }
+  }
+
+  return Object.values(value).some((entry) => containsNonTextInput(entry, seen))
+}

--- a/packages/agent-worker/src/model-call-limits.ts
+++ b/packages/agent-worker/src/model-call-limits.ts
@@ -1,0 +1,135 @@
+import type { AuthorizablePrincipal } from "@sixb/core"
+import {
+  aiLimitSubjectsFromAttribution,
+  aiUsageLimitExceededError,
+  aiUsageLimitUnavailableError,
+  applicableAiLimitPolicies,
+} from "@sixb/core/internal/ai-limit-enforcement"
+import { isSixbError } from "@sixb/core/internal/errors"
+import type {
+  AiLimitPolicy,
+  AiLimitQuantity,
+  AiModelCallReservationIdentity,
+  ReserveAiModelCallResult,
+} from "@sixb/core/storage"
+import type {
+  AiModelCallAdmissionDecision,
+  AiModelCallAdmissionInput,
+  BeforeAiModelCall,
+  MarkAiModelCallUnknown,
+} from "./model-call-admission"
+import type { AgentWorkerStorage } from "./types"
+
+export interface AiModelCallLimitController {
+  readonly beforeModelCall: BeforeAiModelCall
+  readonly markModelCallUnknown: MarkAiModelCallUnknown
+}
+
+/** Build the shared reservation lifecycle used by conversation and workflow model calls. */
+export function createAiModelCallLimitController(input: {
+  readonly storage: AgentWorkerStorage
+  readonly projectId: string
+  readonly requestedBy?: AuthorizablePrincipal
+  readonly requesterGroupIds: readonly string[]
+}): AiModelCallLimitController {
+  const subjects = aiLimitSubjectsFromAttribution(input.requestedBy, input.requesterGroupIds)
+
+  return {
+    beforeModelCall: async (admission) => {
+      let applicable: readonly AiLimitPolicy[]
+      try {
+        const policies = await input.storage.aiLimits.listPolicies({
+          projectId: input.projectId,
+        })
+        applicable = applicableAiLimitPolicies(policies, subjects)
+      } catch (error) {
+        throw limitStorageUnavailable(error)
+      }
+      // This read is the fast no-policy path. A concurrently created policy linearizes after it;
+      // every later call will see it, while existing policies always continue to atomic reserve.
+      if (applicable.length === 0) return { reservation: "none" }
+
+      const estimates = reservationEstimates(
+        admission,
+        applicable.some((policy) => policy.limit.meter === "cost.catalogEstimated")
+      )
+      if (estimates.length === 0) {
+        throw aiUsageLimitUnavailableError(["missingEstimate"])
+      }
+
+      let result: ReserveAiModelCallResult
+      try {
+        result = await input.storage.aiLimits.reserveModelCall({
+          ...reservationIdentity(admission),
+          subjects,
+          estimates,
+        })
+      } catch (error) {
+        throw limitStorageUnavailable(error)
+      }
+      switch (result.status) {
+        case "reserved":
+          return { reservation: "active" } satisfies AiModelCallAdmissionDecision
+        case "notRequired":
+          return { reservation: "none" } satisfies AiModelCallAdmissionDecision
+        case "denied":
+          throw aiUsageLimitExceededError(result.resetAt)
+        case "unavailable":
+          throw aiUsageLimitUnavailableError(result.reasons)
+        case "terminal":
+          throw aiUsageLimitUnavailableError(["terminalReservationReplay"])
+      }
+    },
+    markModelCallUnknown: async (identity) => {
+      try {
+        await input.storage.aiLimits.markReservationUnknown(identity)
+      } catch (error) {
+        throw limitStorageUnavailable(error)
+      }
+    },
+  }
+}
+
+function reservationEstimates(
+  input: AiModelCallAdmissionInput,
+  needsCost: boolean
+): readonly AiLimitQuantity[] {
+  if (input.inputTokens.status !== "estimated" || input.estimatedTotalTokens === undefined) {
+    return []
+  }
+  const estimates: AiLimitQuantity[] = [
+    { meter: "tokens.total", amount: input.estimatedTotalTokens },
+  ]
+  if (needsCost) {
+    try {
+      const money = input.costEstimator?.estimateReservation?.({
+        inputTokens: input.inputTokens.tokens,
+        outputTokens: input.outputTokenAllowance,
+      })
+      if (money) estimates.push({ meter: "cost.catalogEstimated", amount: money })
+    } catch {
+      // An unavailable price must not prevent a token-only policy from being evaluated.
+      return estimates
+    }
+  }
+  return estimates
+}
+
+function reservationIdentity(input: AiModelCallAdmissionInput): AiModelCallReservationIdentity {
+  return {
+    projectId: input.projectId,
+    executionId: input.executionId,
+    attempt: input.attempt,
+    callId: input.callId,
+  }
+}
+
+function limitStorageUnavailable(error: unknown): unknown {
+  if (
+    isSixbError(error) &&
+    (error.code === "ai.usage_limit_exceeded" || error.code === "ai.usage_limit_unavailable")
+  ) {
+    return error
+  }
+  return aiUsageLimitUnavailableError(["limitStorageUnavailable"])
+}

--- a/packages/agent-worker/src/model-call-recorder.ts
+++ b/packages/agent-worker/src/model-call-recorder.ts
@@ -1,9 +1,21 @@
 import { randomUUID } from "node:crypto"
-import type { ModelCallEndEvent, ModelUsage } from "@sixb/core/models"
+import type {
+  LanguageModel,
+  LanguageModelRequest,
+  ModelCallEndEvent,
+  ModelUsage,
+} from "@sixb/core/models"
 import type { ReadonlyJsonObject, RecordAiModelCallInput } from "@sixb/core/storage"
 import { AgentUsageRecordingError } from "./errors"
 import { aiModelCallUsageFromModel } from "./model-adapters"
 import { normalizeModelCallAccounting, recordAiModelCallAccounting } from "./model-call-accounting"
+import {
+  aiModelCallOutputTokenAllowance,
+  type BeforeAiModelCall,
+  estimateAiModelCallInputTokens,
+  estimatedAiModelCallTotalTokens,
+  type MarkAiModelCallUnknown,
+} from "./model-call-admission"
 import { isPermanentAiUsageRecoveryError } from "./model-call-recovery"
 import type { AgentWorkerStorage, RecoverAiModelCall, RecoverAiModelCallInput } from "./types"
 
@@ -15,6 +27,8 @@ export interface AiModelCallRecorderInput {
   readonly executionId: string
   readonly attempt: number
   readonly requesterGroupIds: readonly string[]
+  readonly beforeModelCall?: BeforeAiModelCall
+  readonly markModelCallUnknown?: MarkAiModelCallUnknown
   readonly recoverAiModelCall: RecoverAiModelCall
   /** Run identity used only in terminal recorder diagnostics. */
   readonly errorRunId: string
@@ -35,6 +49,8 @@ export class AiModelCallRecorder {
   private readonly retryDelaysMs: readonly number[]
   private readonly sleep: (ms: number) => Promise<void>
   private readonly recordAccounting: (input: RecoverAiModelCallInput) => Promise<void>
+  private readonly reservations = new Set<string>()
+  private admissionError: unknown
   private recordingError: AgentUsageRecordingError | undefined
 
   constructor(
@@ -50,6 +66,63 @@ export class AiModelCallRecorder {
       (async (recovery) => {
         await recordAiModelCallAccounting({ storage: this.input.storage, ...recovery })
       })
+  }
+
+  /** Wrap the resolved model so conversation, compaction, and workflow calls share admission. */
+  wrapModel(model: LanguageModel): LanguageModel {
+    return {
+      providerId: model.providerId,
+      modelId: model.modelId,
+      definition: model.definition,
+      costEstimator: model.costEstimator,
+      stream: async (request) => {
+        this.assertHealthy()
+        const inputTokens = estimateAiModelCallInputTokens({
+          prompt: request.messages,
+          tools: request.tools,
+          responseFormat: request.responseFormat,
+        })
+        const outputTokenAllowance = aiModelCallOutputTokenAllowance(request.maxOutputTokens)
+        let decision: Awaited<ReturnType<BeforeAiModelCall>> | undefined
+        try {
+          decision = await this.input.beforeModelCall?.({
+            ...this.identity(request),
+            requesterGroupIds: this.input.requesterGroupIds,
+            providerId: model.providerId,
+            modelId: model.modelId,
+            costEstimator: model.costEstimator,
+            inputTokens,
+            outputTokenAllowance,
+            estimatedTotalTokens: estimatedAiModelCallTotalTokens(
+              inputTokens,
+              outputTokenAllowance
+            ),
+          })
+        } catch (error) {
+          // Compaction and workflow boundaries must retain the original coded admission failure.
+          this.admissionError = error
+          throw error
+        }
+        if (decision?.reservation === "active") this.reservations.add(request.callId)
+        try {
+          return await model.stream(request)
+        } catch (error) {
+          if (this.reservations.has(request.callId)) {
+            await this.input.markModelCallUnknown?.(this.identity(request))
+          }
+          throw error
+        }
+      },
+    }
+  }
+
+  private identity(request: Pick<LanguageModelRequest, "callId">) {
+    return {
+      projectId: this.input.projectId,
+      executionId: this.input.executionId,
+      attempt: this.input.attempt,
+      callId: request.callId,
+    }
   }
 
   readonly onModelCallEnd = async (event: ModelCallEndEvent): Promise<void> => {
@@ -82,6 +155,7 @@ export class AiModelCallRecorder {
         ...(event.estimate === undefined ? {} : { estimate: event.estimate }),
         ...(event.route === undefined ? {} : { route: event.route }),
         ratedAt: new Date(occurredAt),
+        ...(this.reservations.has(event.callId) ? { reconcileLimitReservation: true } : {}),
       })
 
       try {
@@ -123,6 +197,7 @@ export class AiModelCallRecorder {
   }
 
   assertHealthy(): void {
+    if (this.admissionError !== undefined) throw this.admissionError
     if (this.recordingError) throw this.recordingError
   }
 }

--- a/packages/agent-worker/src/model-call-recovery.ts
+++ b/packages/agent-worker/src/model-call-recovery.ts
@@ -14,6 +14,7 @@ import type {
 } from "@sixb/core/storage"
 import {
   AiCostStorageError,
+  AiLimitStorageError,
   AiUsageStorageError,
   normalizeAiModelCallRecord,
 } from "@sixb/core/storage"
@@ -75,9 +76,26 @@ export async function recordRecoveredAiModelCall(
 ): Promise<RecordAiModelCallResult> {
   const usage = fromQueuePayload(job)
   const accounting = accountingFromQueuePayload(job)
-  return accounting
-    ? recordAiModelCallAccounting({ storage, usage, ...accounting })
-    : storage.aiUsage.recordModelCall(usage)
+  if (accounting) return recordAiModelCallAccounting({ storage, usage, ...accounting })
+  return storage.transaction(async (tx) => {
+    if (!tx.aiUsage || !tx.aiLimits)
+      throw new Error("[SixbAgentWorker] Recovery requires usage and limit storage.")
+    const result = await tx.aiUsage.recordModelCall(usage)
+    if (result.created)
+      await tx.aiLimits.recordModelCallActuals({
+        projectId: result.record.projectId,
+        usageRecordId: result.record.id,
+      })
+    if (job.payload.accounting?.reconcileLimitReservation)
+      await tx.aiLimits.reconcileModelCall({
+        projectId: result.record.projectId,
+        executionId: result.record.executionId,
+        attempt: result.record.attempt,
+        callId: result.record.callId,
+        usageRecordId: result.record.id,
+      })
+    return result
+  })
 }
 
 /** Validation and referential-integrity failures cannot become valid through queue redelivery. */
@@ -88,7 +106,15 @@ export function isPermanentAiUsageRecoveryError(error: unknown): boolean {
     (error instanceof AiUsageStorageError &&
       (error.code === "duplicate_id" || error.code === "missing_execution")) ||
     (error instanceof AiCostStorageError &&
-      (error.code === "missing_usage" || error.code === "cost_mismatch"))
+      (error.code === "missing_usage" || error.code === "cost_mismatch")) ||
+    (error instanceof AiLimitStorageError &&
+      (error.code === "missing_execution" ||
+        error.code === "missing_reservation" ||
+        error.code === "missing_usage_record" ||
+        error.code === "usage_mismatch" ||
+        error.code === "reservation_conflict" ||
+        error.code === "reconciliation_conflict" ||
+        error.code === "invalid_reservation_state"))
   )
 }
 
@@ -121,6 +147,7 @@ function toAccountingPayload(input: RecoverAiModelCallInput): AgentAiUsageAccoun
     ...(input.estimate === undefined ? {} : { estimate: structuredClone(input.estimate) }),
     ...(input.route === undefined ? {} : { route: structuredClone(input.route) }),
     ratedAt: input.ratedAt.toISOString(),
+    ...(input.reconcileLimitReservation ? { reconcileLimitReservation: true } : {}),
   }
 }
 
@@ -170,6 +197,7 @@ function accountingFromQueuePayload(
       : { estimate: structuredClone(accounting.estimate) }),
     ...(accounting.route === undefined ? {} : { route: structuredClone(accounting.route) }),
     ratedAt: parseDate(accounting.ratedAt, job.id, "ratedAt"),
+    reconcileLimitReservation: accounting.reconcileLimitReservation === true,
   }
 }
 

--- a/packages/agent-worker/src/run-agent-turn.ts
+++ b/packages/agent-worker/src/run-agent-turn.ts
@@ -98,7 +98,26 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
   const sandboxReadiness = monitorSandboxReadiness(context.sandboxReady)
   // Preflight and the answer share accounting and one deadline. Direct callers own their runtime.
   const ownsRuntime = input.runtime === undefined
-  const runtime = input.runtime ?? createAgentTurnRuntime({ context, run, signal })
+  let runtime = input.runtime
+  if (!runtime) {
+    const durableExecution = await storage.executions.getById({
+      projectId,
+      id: run.executionId,
+    })
+    if (!durableExecution) {
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbAgentWorker] Agent run '${runId}' references missing execution '${run.executionId}'.`,
+        { details: { agentId: run.agentId, runId, executionId: run.executionId } }
+      )
+    }
+    runtime = createAgentTurnRuntime({
+      context,
+      run,
+      signal,
+      requestedBy: durableExecution.requestedBy,
+    })
+  }
   const usageRecorder = runtime.usageRecorder
   const abortSignal = AbortSignal.any([runtime.signal, sandboxReadiness.signal])
   let interruptedParts: readonly AgentMessagePart[] | undefined
@@ -154,7 +173,7 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
     let result: Awaited<ReturnType<typeof runModelLoop>>
     try {
       result = await runModelLoop({
-        model: agent.model,
+        model: usageRecorder.wrapModel(agent.model),
         messages: [
           {
             role: "system",

--- a/packages/agent-worker/src/run-workflow-agent-node.ts
+++ b/packages/agent-worker/src/run-workflow-agent-node.ts
@@ -96,7 +96,7 @@ export async function runWorkflowAgentNode(
   let finishReason: AgentRunFinishReason | undefined
   try {
     const research = await runModelLoop({
-      model: input.agent.model,
+      model: input.usageRecorder.wrapModel(input.agent.model),
       messages: [
         {
           role: "system",
@@ -159,7 +159,7 @@ export async function runWorkflowAgentNode(
     for (let attempt = 1; attempt <= WORKFLOW_OUTPUT_FINALIZATION_ATTEMPTS; attempt += 1) {
       try {
         const finalization = await runModelLoop({
-          model: input.agent.model,
+          model: input.usageRecorder.wrapModel(input.agent.model),
           messages: finalizerMessages,
           output: {
             name: input.agentStep.id,

--- a/packages/agent-worker/src/turn-runtime.ts
+++ b/packages/agent-worker/src/turn-runtime.ts
@@ -1,6 +1,8 @@
+import type { AuthorizablePrincipal } from "@sixb/core"
 import { QueueDeliveryLeaseLostError } from "@sixb/core/internal/workers"
 import type { AgentRunRecord } from "@sixb/core/storage"
 import { AgentTurnTimeoutError } from "./errors"
+import { createAiModelCallLimitController } from "./model-call-limits"
 import { AiModelCallRecorder } from "./model-call-recorder"
 import type { AgentTurnContext } from "./types"
 
@@ -24,13 +26,22 @@ export function createAgentTurnRuntime(input: {
   >
   readonly run: AgentRunRecord
   readonly signal: AbortSignal
+  readonly requestedBy?: AuthorizablePrincipal
 }): AgentTurnRuntime {
+  const modelCallLimits = createAiModelCallLimitController({
+    storage: input.context.storage,
+    projectId: input.context.id,
+    requestedBy: input.requestedBy,
+    requesterGroupIds: input.run.requesterGroupIds,
+  })
   const usageRecorder = new AiModelCallRecorder({
     storage: input.context.storage,
     projectId: input.context.id,
     executionId: input.run.executionId,
     attempt: input.run.attempt,
     requesterGroupIds: input.run.requesterGroupIds,
+    beforeModelCall: modelCallLimits.beforeModelCall,
+    markModelCallUnknown: modelCallLimits.markModelCallUnknown,
     recoverAiModelCall: input.context.recoverAiModelCall,
     errorRunId: input.run.id,
   })

--- a/packages/agent-worker/src/types.ts
+++ b/packages/agent-worker/src/types.ts
@@ -17,6 +17,7 @@ import type { ModelCallCost, ModelCostEstimate, ModelRoute, ModelTool } from "@s
 import type {
   AgentStorage,
   AiCostStorage,
+  AiLimitStorage,
   AiUsageStorage,
   AuthStorage,
   RecordAiModelCallInput,
@@ -31,6 +32,7 @@ export type AgentWorkerStorage = Storage & {
   readonly agents: AgentStorage
   readonly aiUsage: AiUsageStorage
   readonly aiCosts: AiCostStorage
+  readonly aiLimits: AiLimitStorage
   readonly auth: AuthStorage
 }
 
@@ -40,6 +42,8 @@ export interface RecoverAiModelCallInput {
   readonly estimate?: ModelCostEstimate
   readonly route?: ModelRoute
   readonly ratedAt: Date
+  /** True only when admission created an aggregate-budget reservation for this provider attempt. */
+  readonly reconcileLimitReservation?: boolean
 }
 
 export type RecoverAiModelCall = (input: RecoverAiModelCallInput) => Promise<void>

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -324,6 +324,7 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
         context: executionContext,
         run,
         signal: turnSignal,
+        requestedBy: durableExecution.requestedBy,
       })
       const prepared = await prepareAgentConversationContext({
         context: executionContext,
@@ -789,6 +790,12 @@ function assertAgentWorkerStorage(
     throw createSixbError(
       "internal.unexpected",
       "[SixbAgentWorker] Agent workers require storage.aiCosts support."
+    )
+  }
+  if (!storage.aiLimits) {
+    throw createSixbError(
+      "internal.unexpected",
+      "[SixbAgentWorker] Agent workers require storage.aiLimits support."
     )
   }
 }

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -29,6 +29,7 @@ import type {
 import type {
   AgentRunFinishReason,
   ExecutionRecord,
+  ReadonlyJsonObject,
   WorkflowAgentNodeRunExecution,
   WorkflowAgentNodeRunRecord,
   WorkflowNodeRunRecord,
@@ -40,6 +41,7 @@ import { AGENT_RUN_FAILURE_CODES, WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/
 import { AgentUsageRecordingError } from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
 import { toAgentExecutionFailure } from "./failure"
+import { createAiModelCallLimitController } from "./model-call-limits"
 import { AiModelCallRecorder } from "./model-call-recorder"
 import {
   type AgentExecutionEnvironment,
@@ -127,12 +129,20 @@ export async function executeWorkflowAgentNode(
       { details: workflowAgentErrorDetails(agent.id, nodeRun) }
     )
   }
+  const modelCallLimits = createAiModelCallLimitController({
+    storage: context.storage,
+    projectId: context.id,
+    requestedBy: durableExecution.requestedBy,
+    requesterGroupIds: workflowRun.requesterGroupIds,
+  })
   const usageRecorder = new AiModelCallRecorder({
     storage: context.storage,
     projectId: context.id,
     executionId: executionRecord.executionId,
     attempt: reserved.attempt,
     requesterGroupIds: workflowRun.requesterGroupIds,
+    beforeModelCall: modelCallLimits.beforeModelCall,
+    markModelCallUnknown: modelCallLimits.markModelCallUnknown,
     recoverAiModelCall: context.recoverAiModelCall,
     errorRunId: nodeRun.id,
   })
@@ -210,8 +220,10 @@ export async function executeWorkflowAgentNode(
     try {
       usageRecorder.assertHealthy()
     } catch (recordingError) {
+      const sameAdmissionFailure =
+        isAiUsageLimitFailure(executionError) && isAiUsageLimitFailure(recordingError)
       executionError = recordingError
-      failurePhase = undefined
+      if (!sameAdmissionFailure) failurePhase = undefined
     }
 
     if (signal.aborted) throw executionError
@@ -493,13 +505,15 @@ async function finishWorkflowAgentNodeFailed(input: {
       : attachWorkflowAgentFailureDetails(input.error, input.status, agentErrorDetails)
   const workflowFailureError =
     input.status === "failed"
-      ? createWorkflowNodeFailure(input.error, {
-          workflowId: input.nodeRun.workflowId,
-          workflowRunId: input.nodeRun.workflowRunId,
-          nodeId: input.nodeRun.nodeId,
-          nodeRunId: input.nodeRun.id,
-          child: { type: "agent", agentId: input.agent.id },
-        })
+      ? isAiUsageLimitFailure(agentExecutionError)
+        ? agentExecutionError
+        : createWorkflowNodeFailure(input.error, {
+            workflowId: input.nodeRun.workflowId,
+            workflowRunId: input.nodeRun.workflowRunId,
+            nodeId: input.nodeRun.nodeId,
+            nodeRunId: input.nodeRun.id,
+            child: { type: "agent", agentId: input.agent.id },
+          })
       : createSixbError(
           "runtime.cancelled",
           summarizeErrorMessage(input.error, "Agent workflow node execution failed."),
@@ -568,11 +582,28 @@ function attachWorkflowAgentFailureDetails(
   }
   if (
     isSixbError(error) &&
-    (error.code === "internal.unexpected" || error.code === "agent.execution_failed")
+    (error.code === "internal.unexpected" ||
+      error.code === "agent.execution_failed" ||
+      error.code === "ai.usage_limit_exceeded" ||
+      error.code === "ai.usage_limit_unavailable")
   ) {
-    return createSixbError(error.code, error.message, { cause: error, details })
+    const errorDetails =
+      (error.code === "ai.usage_limit_exceeded" || error.code === "ai.usage_limit_unavailable") &&
+      typeof error.details === "object" &&
+      error.details !== null &&
+      !Array.isArray(error.details)
+        ? { ...(error.details as ReadonlyJsonObject), ...details }
+        : details
+    return createSixbError(error.code, error.message, { cause: error, details: errorDetails })
   }
   return error
+}
+
+function isAiUsageLimitFailure(error: unknown): error is ReturnType<typeof createSixbError> {
+  return (
+    isSixbError(error) &&
+    (error.code === "ai.usage_limit_exceeded" || error.code === "ai.usage_limit_unavailable")
+  )
 }
 
 async function emitNodeSucceeded(

--- a/packages/agent-worker/tests/failure.test.ts
+++ b/packages/agent-worker/tests/failure.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { aiUsageLimitExceededError } from "@sixb/core/internal/ai-limit-enforcement"
 import { createSixbError } from "@sixb/core/internal/errors"
 import { AgentRuntimeProfileError } from "../src/agent-runtime/errors"
 import { AGENT_RUNTIME_PROFILE } from "../src/agent-runtime/profile"
@@ -35,6 +36,20 @@ describe("Agent execution failure", () => {
       retryable: false,
       at: at.toISOString(),
       details: { agentId: details.agentId, runId: details.runId },
+    })
+  })
+
+  test("preserves AI usage-limit failures as a distinct terminal state", () => {
+    const error = aiUsageLimitExceededError(new Date("2026-09-01T00:00:00.000Z"))
+
+    expect(toAgentExecutionFailure(error, { status: "failed", at, details })).toEqual({
+      code: "ai.usage_limit_exceeded",
+      message: "AI usage limit exceeded.",
+      retryable: false,
+      at: at.toISOString(),
+      details: {
+        resetAt: "2026-09-01T00:00:00.000Z",
+      },
     })
   })
 

--- a/packages/agent-worker/tests/model-call-admission.test.ts
+++ b/packages/agent-worker/tests/model-call-admission.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test"
+import {
+  AI_MODEL_CALL_OUTPUT_TOKEN_ALLOWANCE,
+  aiModelCallOutputTokenAllowance,
+  estimateAiModelCallInputTokens,
+  estimatedAiModelCallTotalTokens,
+} from "../src/model-call-admission"
+
+describe("AI model-call admission estimates", () => {
+  test("produces the same estimate for the same prepared text request", () => {
+    const request = {
+      prompt: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+      tools: [{ name: "search", inputSchema: { type: "object" } }],
+      responseFormat: undefined,
+    }
+
+    const first = estimateAiModelCallInputTokens(request)
+    const second = estimateAiModelCallInputTokens(structuredClone(request))
+
+    expect(first).toEqual(second)
+    expect(first).toMatchObject({
+      status: "estimated",
+      method: "utf8BytesDividedByFour",
+    })
+    if (first.status === "estimated") expect(first.tokens).toBeGreaterThan(0)
+  })
+
+  test("reports non-text model inputs as unavailable", () => {
+    expect(
+      estimateAiModelCallInputTokens({
+        prompt: [
+          {
+            role: "user",
+            content: [{ type: "file", mediaType: "image/png", data: "base64" }],
+          },
+        ],
+        tools: undefined,
+        responseFormat: undefined,
+      })
+    ).toEqual({ status: "unavailable", reason: "nonTextInput" })
+  })
+
+  test("uses one internal output allowance without exposing a required setting", () => {
+    const estimate = estimateAiModelCallInputTokens({
+      prompt: [{ role: "user", content: "hello" }],
+      tools: undefined,
+      responseFormat: undefined,
+    })
+    const allowance = aiModelCallOutputTokenAllowance(undefined)
+
+    expect(allowance).toBe(AI_MODEL_CALL_OUTPUT_TOKEN_ALLOWANCE)
+    expect(estimatedAiModelCallTotalTokens(estimate, allowance)).toBe(
+      estimate.status === "estimated" ? estimate.tokens + allowance : undefined
+    )
+  })
+})

--- a/packages/agent-worker/tests/model-call-limits.test.ts
+++ b/packages/agent-worker/tests/model-call-limits.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test"
+import { InMemoryStorage } from "@sixb/core/storage"
+import { createTestAgentExecution } from "@sixb/core/testing"
+import type { AiModelCallAdmissionInput } from "../src/model-call-admission"
+import { createAiModelCallLimitController } from "../src/model-call-limits"
+
+const projectId = "project_1"
+const executionId = "test_agent_execution:run_limits"
+
+function admission(callId: string, overrides: Partial<AiModelCallAdmissionInput> = {}) {
+  return {
+    projectId,
+    executionId,
+    attempt: 1,
+    requesterGroupIds: ["support"],
+    callId,
+    providerId: "gateway",
+    modelId: "openai/gpt-5",
+    inputTokens: {
+      status: "estimated" as const,
+      tokens: 100,
+      method: "utf8BytesDividedByFour" as const,
+    },
+    outputTokenAllowance: 4_096,
+    estimatedTotalTokens: 4_196,
+    ...overrides,
+  }
+}
+
+async function storageWithExecution() {
+  const storage = new InMemoryStorage()
+  await createTestAgentExecution(storage, {
+    projectId,
+    agentId: "assistant",
+    runId: "run_limits",
+    executionId,
+  })
+  return storage
+}
+
+describe("AI model-call limits", () => {
+  test("reserves every applicable attribution subject and denies concurrent overrun", async () => {
+    const storage = await storageWithExecution()
+    await storage.aiLimits.createPolicy({
+      id: "project_tokens",
+      projectId,
+      subject: { type: "project" },
+      limit: { meter: "tokens.total", amount: 5_000 },
+    })
+    await storage.aiLimits.createPolicy({
+      id: "support_tokens",
+      projectId,
+      subject: { type: "group", id: "support" },
+      limit: { meter: "tokens.total", amount: 5_000 },
+    })
+    const controller = createAiModelCallLimitController({
+      storage,
+      projectId,
+      requestedBy: { type: "user", id: "user_1" },
+      requesterGroupIds: ["support"],
+    })
+
+    await expect(controller.beforeModelCall(admission("call_1"))).resolves.toEqual({
+      reservation: "active",
+    })
+    const rejection = await Promise.resolve(controller.beforeModelCall(admission("call_2"))).catch(
+      (error: unknown) => error
+    )
+    expect(rejection).toMatchObject({
+      code: "ai.usage_limit_exceeded",
+      details: {
+        resetAt: expect.any(String),
+      },
+    })
+    expect((rejection as { details?: unknown }).details).not.toHaveProperty("policies")
+  })
+
+  test("fails a catalog-cost policy closed when the model cannot be pre-priced", async () => {
+    const storage = await storageWithExecution()
+    await storage.aiLimits.createPolicy({
+      id: "project_cost",
+      projectId,
+      subject: { type: "project" },
+      limit: {
+        meter: "cost.catalogEstimated",
+        amount: { currency: "USD", amountNanos: "1000000000" },
+      },
+    })
+    const controller = createAiModelCallLimitController({
+      storage,
+      projectId,
+      requesterGroupIds: [],
+    })
+
+    await expect(
+      controller.beforeModelCall(
+        admission("call_unknown", { providerId: "custom", modelId: "private-model" })
+      )
+    ).rejects.toMatchObject({
+      code: "ai.usage_limit_unavailable",
+      details: { reasons: ["missingEstimate"] },
+    })
+  })
+
+  test("moves a billed attempt without usage into unknown capacity", async () => {
+    const storage = await storageWithExecution()
+    await storage.aiLimits.createPolicy({
+      id: "project_tokens",
+      projectId,
+      subject: { type: "project" },
+      limit: { meter: "tokens.total", amount: 10_000 },
+    })
+    const controller = createAiModelCallLimitController({
+      storage,
+      projectId,
+      requesterGroupIds: [],
+    })
+    await controller.beforeModelCall(admission("call_unknown"))
+    await controller.markModelCallUnknown({
+      projectId,
+      executionId,
+      attempt: 1,
+      callId: "call_unknown",
+    })
+
+    await expect(storage.aiLimits.listPolicyStatuses({ projectId })).resolves.toMatchObject([
+      {
+        consumption: {
+          actual: { amount: 0 },
+          reserved: { amount: 0 },
+          unknown: { amount: 4_196 },
+          remaining: { amount: 5_804 },
+        },
+      },
+    ])
+  })
+})

--- a/packages/agent-worker/tests/model-call-recovery.test.ts
+++ b/packages/agent-worker/tests/model-call-recovery.test.ts
@@ -283,6 +283,126 @@ describe("AI usage recovery", () => {
     })
   })
 
+  test("durable accounting recovery reconciles the original reservation", async () => {
+    const queues = new InMemoryQueues()
+    const storage = new InMemoryStorage()
+    await createTestAgentExecution(storage, {
+      projectId,
+      agentId: "assistant",
+      runId: "run_1",
+      executionId,
+    })
+    await storage.aiLimits.createPolicy({
+      id: "project_tokens",
+      projectId,
+      subject: { type: "project" },
+      limit: { meter: "tokens.total", amount: 1_000 },
+    })
+    await storage.aiLimits.reserveModelCall({
+      projectId,
+      executionId,
+      attempt: 2,
+      callId: "call_1",
+      subjects: [{ type: "project" }],
+      estimates: [{ meter: "tokens.total", amount: 100 }],
+    })
+    await enqueueAiModelCallRecovery(queues.agents, {
+      usage: modelCall(),
+      cost: { status: "unpriceable", reason: "missing-rate-card" },
+      ratedAt: new Date("2026-07-01T12:00:01.000Z"),
+      reconcileLimitReservation: true,
+    })
+    const [claimed] = await queues.agents.claim({
+      projectId,
+      workerId: "test-worker",
+      limit: 1,
+    })
+    if (claimed?.job.type !== "agent.ai-usage.record.requested") {
+      throw new Error("Expected an AI usage recovery job.")
+    }
+    expect(claimed.job.payload.accounting?.reconcileLimitReservation).toBe(true)
+
+    await recordRecoveredAiModelCall(storage, claimed.job)
+    await expect(
+      storage.aiLimits.listPolicyStatuses({
+        projectId,
+        at: new Date("2026-07-15T00:00:00.000Z"),
+      })
+    ).resolves.toMatchObject([
+      {
+        consumption: {
+          actual: { amount: 20 },
+          reserved: { amount: 0 },
+          unknown: { amount: 0 },
+        },
+      },
+    ])
+  })
+
+  test("keeps the estimate as unknown when recovered usage cannot be measured", async () => {
+    const queues = new InMemoryQueues()
+    const storage = new InMemoryStorage()
+    await createTestAgentExecution(storage, {
+      projectId,
+      agentId: "assistant",
+      runId: "run_1",
+      executionId,
+    })
+    await storage.aiLimits.createPolicy({
+      id: "project_tokens",
+      projectId,
+      subject: { type: "project" },
+      limit: { meter: "tokens.total", amount: 1_000 },
+    })
+    await storage.aiLimits.reserveModelCall({
+      projectId,
+      executionId,
+      attempt: 2,
+      callId: "call_missing",
+      subjects: [{ type: "project" }],
+      estimates: [{ meter: "tokens.total", amount: 100 }],
+      reservedAt: new Date("2026-07-01T11:59:59.000Z"),
+    })
+    await enqueueAiModelCallRecovery(queues.agents, {
+      usage: {
+        ...modelCall(),
+        id: "usage_missing",
+        callId: "call_missing",
+        usage: {},
+      },
+      cost: { status: "unpriceable", reason: "missing-rate-card" },
+      ratedAt: new Date("2026-07-01T12:00:01.000Z"),
+      reconcileLimitReservation: true,
+    })
+    const [claimed] = await queues.agents.claim({
+      projectId,
+      workerId: "test-worker",
+      limit: 1,
+    })
+    if (claimed?.job.type !== "agent.ai-usage.record.requested") {
+      throw new Error("Expected an AI usage recovery job.")
+    }
+
+    await expect(recordRecoveredAiModelCall(storage, claimed.job)).resolves.toMatchObject({
+      created: true,
+    })
+    await expect(
+      storage.aiLimits.listPolicyStatuses({
+        projectId,
+        at: new Date("2026-07-15T00:00:00.000Z"),
+      })
+    ).resolves.toMatchObject([
+      {
+        accountingStatus: "unavailable",
+        consumption: {
+          actual: { amount: 0 },
+          reserved: { amount: 0 },
+          unknown: { amount: 100 },
+        },
+      },
+    ])
+  })
+
   test("rejects malformed jobs instead of retrying them forever", async () => {
     const record = modelCall()
     const job: AgentAiUsageRecordRequestedQueueJob = {

--- a/packages/agent-worker/tests/model-call-reservations.test.ts
+++ b/packages/agent-worker/tests/model-call-reservations.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test"
+import { runModelLoop } from "@sixb/core/internal/agents"
+import {
+  defineLanguageModel,
+  estimateModelReservation,
+  type LanguageModel,
+  type LanguageModelStreamEvent,
+  rateModelCall,
+} from "@sixb/core/models"
+import { type AiLimitPolicyStatus, InMemoryStorage } from "@sixb/core/storage"
+import { createTestAgentExecution } from "@sixb/core/testing"
+import { createAiModelCallLimitController } from "../src/model-call-limits"
+import { AiModelCallRecorder } from "../src/model-call-recorder"
+
+const projectId = "limits-runtime"
+const executionId = "test_agent_execution:run"
+const rateCard = { currency: "USD", unit: "million-tokens", input: "1", output: "1" } as const
+async function setup(events: () => AsyncIterable<LanguageModelStreamEvent>) {
+  const storage = new InMemoryStorage()
+  await createTestAgentExecution(storage, {
+    projectId,
+    executionId,
+    agentId: "assistant",
+    runId: "run",
+  })
+  const controller = createAiModelCallLimitController({ storage, projectId, requesterGroupIds: [] })
+  const recorder = new AiModelCallRecorder({
+    storage,
+    projectId,
+    executionId,
+    attempt: 1,
+    requesterGroupIds: [],
+    ...controller,
+    errorRunId: "run",
+    recoverAiModelCall: async () => {
+      throw new Error("Unexpected recovery")
+    },
+  })
+  let providerCalls = 0
+  let reservedAtCall: readonly AiLimitPolicyStatus[] = []
+  const model: LanguageModel = {
+    providerId: "test",
+    modelId: "model",
+    definition: defineLanguageModel({
+      kind: "language",
+      providerId: "test",
+      modelId: "model",
+      capabilities: {},
+    }),
+    costEstimator: {
+      estimate: ({ usage }) => rateModelCall({ usage, rateCard }),
+      estimateReservation: (tokens) => estimateModelReservation({ ...tokens, rateCard }),
+    },
+    async stream() {
+      providerCalls++
+      reservedAtCall = await storage.aiLimits.listPolicyStatuses({ projectId })
+      return { events: events() }
+    },
+  }
+  let callIndex = 0
+  const run = () =>
+    runModelLoop({
+      model: recorder.wrapModel(model),
+      messages: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+      tools: [],
+      maxSteps: 2,
+      signal: new AbortController().signal,
+      generateCallId: () => `call-${++callIndex}`,
+      onModelCallEnd: recorder.onModelCallEnd,
+    })
+  return {
+    storage,
+    recorder,
+    model,
+    run,
+    reservedAtCall: () => reservedAtCall,
+    providerCalls: () => providerCalls,
+  }
+}
+
+describe("model runtime reservations", () => {
+  // Removal proof: bypass wrapModel admission/reconciliation and run this file; these guards fail.
+  test("rechecks capacity before each continuation and reconciles the completed call", async () => {
+    const context = await setup(async function* () {
+      yield { type: "stream-start" }
+      yield { type: "finish", finishReason: "pause", usage: { inputTokens: 1000, outputTokens: 0 } }
+    })
+    await context.storage.aiLimits.createPolicy({
+      id: "tokens",
+      projectId,
+      subject: { type: "project" },
+      limit: { meter: "tokens.total", amount: 4500 },
+    })
+    await expect(context.run()).rejects.toMatchObject({ code: "ai.usage_limit_exceeded" })
+    expect(context.providerCalls()).toBe(1)
+    expect(() => context.recorder.assertHealthy()).toThrow(
+      expect.objectContaining({ code: "ai.usage_limit_exceeded" })
+    )
+    expect((await context.storage.aiLimits.listPolicyStatuses({ projectId }))[0]).toMatchObject({
+      consumption: { actual: { amount: 1000 }, reserved: { amount: 0 } },
+    })
+  })
+  test("admits a priced model and replaces its cost reservation with observed consumption", async () => {
+    const context = await setup(async function* () {
+      yield { type: "stream-start" }
+      yield { type: "finish", finishReason: "stop", usage: { inputTokens: 10, outputTokens: 5 } }
+    })
+    await context.storage.aiLimits.createPolicy({
+      id: "cost",
+      projectId,
+      subject: { type: "project" },
+      limit: {
+        meter: "cost.catalogEstimated",
+        amount: { currency: "USD", amountNanos: "1000000000" },
+      },
+    })
+    await context.run()
+    const reservedCost = context.reservedAtCall()[0]?.consumption.reserved
+    if (reservedCost?.meter !== "cost.catalogEstimated")
+      throw new Error("Expected cost reservation")
+    expect(BigInt(reservedCost.amount.amountNanos)).toBeGreaterThan(0n)
+    expect(context.providerCalls()).toBe(1)
+    expect((await context.storage.aiLimits.listPolicyStatuses({ projectId }))[0]).toMatchObject({
+      accountingStatus: "complete",
+      consumption: {
+        actual: { amount: { amountNanos: "15000" } },
+        reserved: { amount: { amountNanos: "0" } },
+      },
+    })
+  })
+  test("retains capacity when an accepted stream fails without final usage", async () => {
+    const context = await setup(async function* () {
+      yield { type: "stream-start" }
+      throw new Error("connection lost")
+    })
+    await context.storage.aiLimits.createPolicy({
+      id: "tokens",
+      projectId,
+      subject: { type: "project" },
+      limit: { meter: "tokens.total", amount: 4500 },
+    })
+    await expect(context.run()).rejects.toThrow("connection lost")
+    const [status] = await context.storage.aiLimits.listPolicyStatuses({ projectId })
+    expect(status).toMatchObject({
+      accountingStatus: "unavailable",
+      consumption: { actual: { amount: 0 }, reserved: { amount: 0 } },
+    })
+    expect(status?.consumption.unknown.amount).toBeGreaterThan(4096)
+  })
+})

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1673,6 +1673,54 @@ function hangingCompactionModel(): WorkerTestModel {
 }
 
 describe("AgentWorker", () => {
+  test("rechecks AI limits after a queued conversation is claimed", async () => {
+    let providerCalls = 0
+    const model = new WorkerTestModel({
+      modelId: "mock-model",
+      stream: async () => {
+        providerCalls += 1
+        throw new Error("A denied conversation call must not reach the provider")
+      },
+    })
+    const sixb = buildSixb(model)
+    const reporter = attachSixbErrorReporter(sixb, () => {})
+    const request = await requestAgent(sixb, { agentId: "assistant", text: "queued first" })
+    await sixb.storage.aiLimits?.createPolicy({
+      id: "project_tokens_exhausted_after_queue",
+      projectId: PROJECT_ID,
+      subject: { type: "project" },
+      limit: { meter: "tokens.total", amount: 0 },
+    })
+
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+    await worker.start()
+    try {
+      const failed = await waitFor(
+        async () => {
+          const run = await agentStorageOf(sixb).runs.getById({
+            projectId: PROJECT_ID,
+            id: request.run.id,
+          })
+          return run?.status === "failed" ? run : null
+        },
+        { label: "queued conversation limit failure" }
+      )
+
+      expect(providerCalls).toBe(0)
+      expect(failed.error).toMatchObject({
+        code: "ai.usage_limit_exceeded",
+        details: {
+          resetAt: expect.any(String),
+        },
+      })
+      expect(failed.error?.details).not.toHaveProperty("policies")
+      expect(await listMessages(agentStorageOf(sixb), request.run.threadId)).toHaveLength(1)
+      await reporter.flush()
+    } finally {
+      await worker.stop()
+    }
+  })
+
   test("requires an API base URL", () => {
     const sixb = buildSixb(toolThenAnswerModel())
 
@@ -2010,6 +2058,66 @@ describe("AgentWorker", () => {
       expect(answerPrompts).toHaveLength(2)
       expect(answerReasoning).toEqual(["high", "high"])
       expect(await listMessages(storage, threadId)).toHaveLength(16)
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("preserves AI limit failure during context compaction", async () => {
+    // Removal proof: bypass wrapModel in generateCheckpointSummary or drop admissionError retention.
+    const summaries: LanguageModelRequest["messages"][] = []
+    const sixb = buildSixb(
+      compactingAnswerModel({
+        captureSummaryPrompt: (prompt) => summaries.push(prompt),
+        captureAnswerPrompt: () => {},
+      }),
+      new InMemoryBroker(),
+      new RecordingSandboxFactory(),
+      { context: { windowTokens: 5000, reserveTokens: 1000, keepRecentTokens: 700 } }
+    )
+    const storage = agentStorageOf(sixb)
+    const threadId = "limited_compaction"
+    await storage.threads.create({
+      id: threadId,
+      projectId: PROJECT_ID,
+      agentId: "assistant",
+      ownerPrincipal: REQUESTER,
+    })
+    await seedCompletedConversationTurn({
+      sixb,
+      threadId,
+      index: 0,
+      text: "Research this organization.",
+      assistantText: "x".repeat(20000),
+    })
+    const request = await requestAgentAs(sixb, REQUESTER, {
+      agentId: "assistant",
+      threadId,
+      text: "Continue.",
+    })
+    await sixb.storage.aiLimits?.createPolicy({
+      id: "exhausted",
+      projectId: PROJECT_ID,
+      subject: { type: "project" },
+      limit: { meter: "tokens.total", amount: 0 },
+    })
+    const reporter = attachSixbErrorReporter(sixb, () => {})
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+    await worker.start()
+    try {
+      const run = await waitFor(
+        async () => {
+          const row = await storage.runs.getById({ projectId: PROJECT_ID, id: request.run.id })
+          return row?.status === "failed" ? row : null
+        },
+        { label: "compaction admission failure" }
+      )
+      expect(run.error?.code).toBe("ai.usage_limit_exceeded")
+      expect(summaries).toHaveLength(0)
+      expect(await storage.checkpoints.getLatest({ projectId: PROJECT_ID, threadId })).toBeNull()
+      const records = await listRunStreamRecords(sixb.broker, run.id)
+      expect(records.map((record) => record.name)).toContain("agent.compaction.started")
+      await reporter.flush()
     } finally {
       await worker.stop()
     }
@@ -3071,6 +3179,146 @@ describe("AgentWorker", () => {
         run: { runId, workflowId: workflow.id },
         failure: run?.error,
       })
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("enforces project AI limits at the workflow agent provider boundary", async () => {
+    let providerCalls = 0
+    const model = new WorkerTestModel({
+      modelId: "mock-model",
+      stream: async () => {
+        providerCalls += 1
+        throw new Error("A denied workflow Agent call must not reach the provider")
+      },
+    })
+    const agent = defineAgent("workflow-limit-agent", {
+      name: "Workflow limit agent",
+      model,
+      instructions: "This call is denied before the provider.",
+      groups: [AGENT_RUNTIME_GROUP],
+    })
+    const agentStep = defineAgentStep("limited-agent-step", agent)
+      .input({ query: "string" })
+      .output({ answer: "string" })
+      .prompt(({ input }) => `Resolve '${input.query}'.`)
+    const workflow = defineWorkflow("agent-limit-workflow")
+      .input({ query: "string" })
+      .then(agentStep)
+    const sixb = new SixbHost({
+      id: PROJECT_ID,
+      ontology: [],
+      agents: [agent],
+      workflows: [workflow],
+      groups: [AGENT_RUNTIME_GROUP],
+      broker: new InMemoryBroker(),
+      storage: new InMemoryStorage(),
+      lakeStorage: new InMemoryLakeStorage(),
+      blobStorage: new InMemoryBlobStorage(),
+      queues: new InMemoryQueues(),
+      sandboxes: new RecordingSandboxFactory(),
+    })
+    const reporter = attachSixbErrorReporter(sixb, () => {})
+    await sixb.storage.aiLimits?.createPolicy({
+      id: "project_tokens_exhausted",
+      projectId: PROJECT_ID,
+      subject: { type: "project" },
+      limit: { meter: "tokens.total", amount: 0 },
+    })
+    const runs = sixb.storage.workflowRuns!
+    const runId = "workflow-agent-limit-run"
+    const nodeRunId = `${runId}:node:0`
+    const executionId = await createTestWorkflowExecution(sixb.storage.executions, {
+      projectId: PROJECT_ID,
+      workflowId: workflow.id,
+      runId,
+    })
+    await runs.queue({
+      id: runId,
+      projectId: PROJECT_ID,
+      executionId,
+      workflowId: workflow.id,
+      input: { query: "alpha" },
+      requesterGroupIds: [],
+    })
+    await runs.start({ id: runId, projectId: PROJECT_ID })
+    await runs.nodes.start({
+      id: nodeRunId,
+      projectId: PROJECT_ID,
+      workflowRunId: runId,
+      workflowId: workflow.id,
+      nodeIndex: 0,
+      nodeType: "agent",
+      nodeId: agentStep.id,
+      nodeKey: "limitedAgentStep",
+      input: { query: "alpha" },
+    })
+    const agentExecutionId = await createTestAgentExecution(sixb.storage, {
+      projectId: PROJECT_ID,
+      agentId: agent.id,
+      runId: nodeRunId,
+      sourceExecutionId: executionId,
+    })
+    await runs.agentNodes.create({
+      projectId: PROJECT_ID,
+      nodeRunId,
+      executionId: agentExecutionId,
+      agentId: agent.id,
+      prompt: "Resolve 'alpha'.",
+    })
+    await runs.nodes.wait({ projectId: PROJECT_ID, id: nodeRunId })
+    await runs.wait({ projectId: PROJECT_ID, id: runId })
+    await sixb.queues.agents.enqueue({
+      projectId: PROJECT_ID,
+      jobs: [
+        {
+          id: `wfa_job_${nodeRunId}`,
+          type: "agent.workflow-node.requested",
+          payload: { nodeRunId },
+        },
+      ],
+    })
+
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+    await worker.start()
+    try {
+      const execution = await waitFor(
+        async () => {
+          const record = await runs.agentNodes.getByNodeRunId({
+            projectId: PROJECT_ID,
+            nodeRunId,
+          })
+          return record?.status === "failed" ? record : null
+        },
+        { label: "workflow agent limit failure" }
+      )
+      const [nodeRun, run] = await Promise.all([
+        runs.nodes.getById({ projectId: PROJECT_ID, id: nodeRunId }),
+        runs.getById({ projectId: PROJECT_ID, id: runId }),
+      ])
+
+      expect(providerCalls).toBe(0)
+      expect(execution.error).toMatchObject({
+        code: "ai.usage_limit_exceeded",
+        details: {
+          agentId: agent.id,
+          workflowId: workflow.id,
+          workflowRunId: runId,
+          nodeRunId,
+          resetAt: expect.any(String),
+        },
+      })
+      expect(execution.error?.details).not.toHaveProperty("policies")
+      expect(run?.error).toMatchObject({
+        code: "ai.usage_limit_exceeded",
+        details: {
+          resetAt: expect.any(String),
+        },
+      })
+      expect(run?.error?.details).not.toHaveProperty("policies")
+      expect(nodeRun?.error).toEqual(run?.error)
+      await reporter.flush()
     } finally {
       await worker.stop()
     }
@@ -4400,13 +4648,15 @@ describe("AgentWorker", () => {
       runId: "usage-recovery",
     })
     const aiUsage = aiUsageStorageOf(sixb)
-    const recordModelCall = aiUsage.recordModelCall.bind(aiUsage)
     let appendAttempts = 0
-    aiUsage.recordModelCall = async (input) => {
-      appendAttempts += 1
-      if (appendAttempts === 1) throw new Error("temporary usage storage failure")
-      return recordModelCall(input)
-    }
+    const workerHost = withStorage(
+      sixb,
+      withAiUsageRecordInterceptor(sixb.storage, async (_input, record) => {
+        appendAttempts += 1
+        if (appendAttempts === 1) throw new Error("temporary usage storage failure")
+        return record()
+      })
+    )
 
     const queue = sixb.queues.agents
     const retry = queue.retry.bind(queue)
@@ -4430,7 +4680,7 @@ describe("AgentWorker", () => {
       occurredAt: new Date("2026-07-01T12:00:00.000Z"),
     })
 
-    const worker = new AgentWorker(sixb, workerOptions())
+    const worker = new AgentWorker(workerHost, workerOptions())
     await worker.start()
     try {
       await waitFor(

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -13548,7 +13548,9 @@
                                 "enum": [
                                   "internal.unexpected",
                                   "runtime.cancelled",
-                                  "workflow.node_failed"
+                                  "workflow.node_failed",
+                                  "ai.usage_limit_exceeded",
+                                  "ai.usage_limit_unavailable"
                                 ]
                               },
                               "message": {
@@ -14012,7 +14014,9 @@
                               "enum": [
                                 "internal.unexpected",
                                 "runtime.cancelled",
-                                "workflow.node_failed"
+                                "workflow.node_failed",
+                                "ai.usage_limit_exceeded",
+                                "ai.usage_limit_unavailable"
                               ]
                             },
                             "message": {
@@ -15497,7 +15501,9 @@
                                 "enum": [
                                   "internal.unexpected",
                                   "runtime.cancelled",
-                                  "workflow.node_failed"
+                                  "workflow.node_failed",
+                                  "ai.usage_limit_exceeded",
+                                  "ai.usage_limit_unavailable"
                                 ]
                               },
                               "message": {
@@ -15688,7 +15694,9 @@
                               "enum": [
                                 "internal.unexpected",
                                 "runtime.cancelled",
-                                "workflow.node_failed"
+                                "workflow.node_failed",
+                                "ai.usage_limit_exceeded",
+                                "ai.usage_limit_unavailable"
                               ]
                             },
                             "message": {
@@ -15912,7 +15920,9 @@
                                 "enum": [
                                   "internal.unexpected",
                                   "runtime.cancelled",
-                                  "workflow.node_failed"
+                                  "workflow.node_failed",
+                                  "ai.usage_limit_exceeded",
+                                  "ai.usage_limit_unavailable"
                                 ]
                               },
                               "message": {
@@ -16807,7 +16817,9 @@
                           "enum": [
                             "internal.unexpected",
                             "runtime.cancelled",
-                            "agent.execution_failed"
+                            "agent.execution_failed",
+                            "ai.usage_limit_exceeded",
+                            "ai.usage_limit_unavailable"
                           ]
                         },
                         "message": {
@@ -17017,7 +17029,9 @@
                               "enum": [
                                 "internal.unexpected",
                                 "runtime.cancelled",
-                                "workflow.node_failed"
+                                "workflow.node_failed",
+                                "ai.usage_limit_exceeded",
+                                "ai.usage_limit_unavailable"
                               ]
                             },
                             "message": {
@@ -17241,7 +17255,9 @@
                                 "enum": [
                                   "internal.unexpected",
                                   "runtime.cancelled",
-                                  "workflow.node_failed"
+                                  "workflow.node_failed",
+                                  "ai.usage_limit_exceeded",
+                                  "ai.usage_limit_unavailable"
                                 ]
                               },
                               "message": {
@@ -25449,7 +25465,9 @@
                               "enum": [
                                 "internal.unexpected",
                                 "runtime.cancelled",
-                                "agent.execution_failed"
+                                "agent.execution_failed",
+                                "ai.usage_limit_exceeded",
+                                "ai.usage_limit_unavailable"
                               ]
                             },
                             "message": {
@@ -25593,6 +25611,51 @@
                     }
                   },
                   "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Response for status 429",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": ["ai.usage_limit_exceeded", "ai.usage_limit_unavailable"],
+                      "description": "Stable machine-readable failure code for programmatic handling."
+                    },
+                    "details": {
+                      "description": "Any JSON-compatible value.",
+                      "nullable": true,
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "array",
+                          "items": {}
+                        },
+                        {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      ]
+                    }
+                  },
+                  "required": ["error", "code"],
                   "additionalProperties": false
                 }
               }
@@ -26092,7 +26155,9 @@
                               "enum": [
                                 "internal.unexpected",
                                 "runtime.cancelled",
-                                "agent.execution_failed"
+                                "agent.execution_failed",
+                                "ai.usage_limit_exceeded",
+                                "ai.usage_limit_unavailable"
                               ]
                             },
                             "message": {
@@ -26463,7 +26528,9 @@
                               "enum": [
                                 "internal.unexpected",
                                 "runtime.cancelled",
-                                "agent.execution_failed"
+                                "agent.execution_failed",
+                                "ai.usage_limit_exceeded",
+                                "ai.usage_limit_unavailable"
                               ]
                             },
                             "message": {
@@ -26590,6 +26657,51 @@
                     }
                   },
                   "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Response for status 429",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": ["ai.usage_limit_exceeded", "ai.usage_limit_unavailable"],
+                      "description": "Stable machine-readable failure code for programmatic handling."
+                    },
+                    "details": {
+                      "description": "Any JSON-compatible value.",
+                      "nullable": true,
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "array",
+                          "items": {}
+                        },
+                        {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      ]
+                    }
+                  },
+                  "required": ["error", "code"],
                   "additionalProperties": false
                 }
               }
@@ -26856,7 +26968,9 @@
                                 "enum": [
                                   "internal.unexpected",
                                   "runtime.cancelled",
-                                  "agent.execution_failed"
+                                  "agent.execution_failed",
+                                  "ai.usage_limit_exceeded",
+                                  "ai.usage_limit_unavailable"
                                 ]
                               },
                               "message": {
@@ -27200,7 +27314,9 @@
                           "enum": [
                             "internal.unexpected",
                             "runtime.cancelled",
-                            "agent.execution_failed"
+                            "agent.execution_failed",
+                            "ai.usage_limit_exceeded",
+                            "ai.usage_limit_unavailable"
                           ]
                         },
                         "message": {

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4690,7 +4690,12 @@ export type ListWorkflowsResponses = {
       startedAt: string
       finishedAt?: string
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed"
+        code:
+          | "internal.unexpected"
+          | "runtime.cancelled"
+          | "workflow.node_failed"
+          | "ai.usage_limit_exceeded"
+          | "ai.usage_limit_unavailable"
         message: string
         retryable: boolean
         at: string
@@ -4870,7 +4875,12 @@ export type GetWorkflowResponses = {
       startedAt: string
       finishedAt?: string
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed"
+        code:
+          | "internal.unexpected"
+          | "runtime.cancelled"
+          | "workflow.node_failed"
+          | "ai.usage_limit_exceeded"
+          | "ai.usage_limit_unavailable"
         message: string
         retryable: boolean
         at: string
@@ -5372,7 +5382,12 @@ export type ListWorkflowRunsResponses = {
       startedAt: string
       finishedAt?: string
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed"
+        code:
+          | "internal.unexpected"
+          | "runtime.cancelled"
+          | "workflow.node_failed"
+          | "ai.usage_limit_exceeded"
+          | "ai.usage_limit_unavailable"
         message: string
         retryable: boolean
         at: string
@@ -5448,7 +5463,12 @@ export type GetWorkflowRunResponses = {
       startedAt: string
       finishedAt?: string
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed"
+        code:
+          | "internal.unexpected"
+          | "runtime.cancelled"
+          | "workflow.node_failed"
+          | "ai.usage_limit_exceeded"
+          | "ai.usage_limit_unavailable"
         message: string
         retryable: boolean
         at: string
@@ -5528,7 +5548,12 @@ export type GetWorkflowRunResponses = {
           | null
       }
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed"
+        code:
+          | "internal.unexpected"
+          | "runtime.cancelled"
+          | "workflow.node_failed"
+          | "ai.usage_limit_exceeded"
+          | "ai.usage_limit_unavailable"
         message: string
         retryable: boolean
         at: string
@@ -5844,7 +5869,12 @@ export type GetWorkflowAgentNodeExecutionResponses = {
     >
     failurePhase?: "agent-loop" | "structured-finalizer"
     error?: {
-      code: "internal.unexpected" | "runtime.cancelled" | "agent.execution_failed"
+      code:
+        | "internal.unexpected"
+        | "runtime.cancelled"
+        | "agent.execution_failed"
+        | "ai.usage_limit_exceeded"
+        | "ai.usage_limit_unavailable"
       message: string
       retryable: boolean
       at: string
@@ -5917,7 +5947,12 @@ export type CancelWorkflowRunResponses = {
       startedAt: string
       finishedAt?: string
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed"
+        code:
+          | "internal.unexpected"
+          | "runtime.cancelled"
+          | "workflow.node_failed"
+          | "ai.usage_limit_exceeded"
+          | "ai.usage_limit_unavailable"
         message: string
         retryable: boolean
         at: string
@@ -5997,7 +6032,12 @@ export type CancelWorkflowRunResponses = {
           | null
       }
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed"
+        code:
+          | "internal.unexpected"
+          | "runtime.cancelled"
+          | "workflow.node_failed"
+          | "ai.usage_limit_exceeded"
+          | "ai.usage_limit_unavailable"
         message: string
         retryable: boolean
         at: string
@@ -8749,6 +8789,28 @@ export type PostAgentThreadMessageErrors = {
     error: string
   }
   /**
+   * Response for status 429
+   */
+  429: {
+    error: string
+    /**
+     * Stable machine-readable failure code for programmatic handling.
+     */
+    code: "ai.usage_limit_exceeded" | "ai.usage_limit_unavailable"
+    /**
+     * Any JSON-compatible value.
+     */
+    details?:
+      | string
+      | number
+      | boolean
+      | Array<unknown>
+      | {
+          [key: string]: unknown
+        }
+      | null
+  }
+  /**
    * Response for status 501
    */
   501: {
@@ -8819,7 +8881,12 @@ export type PostAgentThreadMessageResponses = {
         message: string
       }>
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled" | "agent.execution_failed"
+        code:
+          | "internal.unexpected"
+          | "runtime.cancelled"
+          | "agent.execution_failed"
+          | "ai.usage_limit_exceeded"
+          | "ai.usage_limit_unavailable"
         message: string
         retryable: boolean
         at: string
@@ -9052,7 +9119,12 @@ export type CancelAgentRunResponses = {
         message: string
       }>
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled" | "agent.execution_failed"
+        code:
+          | "internal.unexpected"
+          | "runtime.cancelled"
+          | "agent.execution_failed"
+          | "ai.usage_limit_exceeded"
+          | "ai.usage_limit_unavailable"
         message: string
         retryable: boolean
         at: string
@@ -9109,6 +9181,28 @@ export type RetryAgentRunErrors = {
    */
   409: {
     error: string
+  }
+  /**
+   * Response for status 429
+   */
+  429: {
+    error: string
+    /**
+     * Stable machine-readable failure code for programmatic handling.
+     */
+    code: "ai.usage_limit_exceeded" | "ai.usage_limit_unavailable"
+    /**
+     * Any JSON-compatible value.
+     */
+    details?:
+      | string
+      | number
+      | boolean
+      | Array<unknown>
+      | {
+          [key: string]: unknown
+        }
+      | null
   }
   /**
    * Response for status 501
@@ -9180,7 +9274,12 @@ export type RetryAgentRunResponses = {
         message: string
       }>
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled" | "agent.execution_failed"
+        code:
+          | "internal.unexpected"
+          | "runtime.cancelled"
+          | "agent.execution_failed"
+          | "ai.usage_limit_exceeded"
+          | "ai.usage_limit_unavailable"
         message: string
         retryable: boolean
         at: string
@@ -9306,7 +9405,12 @@ export type ListAgentThreadRunsResponses = {
         message: string
       }>
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled" | "agent.execution_failed"
+        code:
+          | "internal.unexpected"
+          | "runtime.cancelled"
+          | "agent.execution_failed"
+          | "ai.usage_limit_exceeded"
+          | "ai.usage_limit_unavailable"
         message: string
         retryable: boolean
         at: string
@@ -9429,7 +9533,12 @@ export type GetAgentRunResponses = {
       message: string
     }>
     error?: {
-      code: "internal.unexpected" | "runtime.cancelled" | "agent.execution_failed"
+      code:
+        | "internal.unexpected"
+        | "runtime.cancelled"
+        | "agent.execution_failed"
+        | "ai.usage_limit_exceeded"
+        | "ai.usage_limit_unavailable"
       message: string
       retryable: boolean
       at: string

--- a/packages/client/tests/agent-failure.types.ts
+++ b/packages/client/tests/agent-failure.types.ts
@@ -11,6 +11,8 @@ const cancelled: AgentRunFailureCode = "runtime.cancelled"
 const executionFailed: AgentRunFailureCode = "agent.execution_failed"
 const listedUnexpected: ListedAgentRunFailureCode = "internal.unexpected"
 const listedExecutionFailed: ListedAgentRunFailureCode = "agent.execution_failed"
+const limitExceeded: AgentRunFailureCode = "ai.usage_limit_exceeded"
+const listedLimitUnavailable: ListedAgentRunFailureCode = "ai.usage_limit_unavailable"
 
 // Dataset lookup codes belong to HTTP route failures, not persisted agent-run failures.
 // @ts-expect-error the generated agent-run failure contract must stay scoped to its producer
@@ -24,6 +26,8 @@ void [
   executionFailed,
   listedUnexpected,
   listedExecutionFailed,
+  limitExceeded,
+  listedLimitUnavailable,
   unrelatedRun,
   unrelatedListed,
 ]

--- a/packages/client/tests/events-builder.types.ts
+++ b/packages/client/tests/events-builder.types.ts
@@ -273,8 +273,12 @@ events
       (event.type === "workflow.run.finished" || event.type === "workflow.run.node.finished") &&
       event.payload.error
     ) {
-      const code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed" =
-        event.payload.error.code
+      const code:
+        | "internal.unexpected"
+        | "runtime.cancelled"
+        | "workflow.node_failed"
+        | "ai.usage_limit_exceeded"
+        | "ai.usage_limit_unavailable" = event.payload.error.code
       const message: string = event.payload.error.message
       // @ts-expect-error — workflow lifecycle failures expose only their primitive's code union.
       const datasetCode: "dataset.not_found" = event.payload.error.code

--- a/packages/client/tests/workflow-failure.types.ts
+++ b/packages/client/tests/workflow-failure.types.ts
@@ -22,6 +22,8 @@ const nodeCancelled: NodeFailureCode = "runtime.cancelled"
 const agentExecutionCancelled: AgentExecutionFailureCode = "runtime.cancelled"
 const latestNodeFailed: LatestFailureCode = "workflow.node_failed"
 const nodeFailed: NodeFailureCode = "workflow.node_failed"
+const workflowLimitExceeded: ListedFailureCode = "ai.usage_limit_exceeded"
+const agentLimitUnavailable: AgentExecutionFailureCode = "ai.usage_limit_unavailable"
 
 // Dataset lookup codes belong to HTTP route failures, not persisted workflow failures.
 // @ts-expect-error the generated latest-run failure contract must stay scoped to its producer
@@ -41,6 +43,8 @@ void [
   agentExecutionCancelled,
   latestNodeFailed,
   nodeFailed,
+  workflowLimitExceeded,
+  agentLimitUnavailable,
   unrelatedLatest,
   unrelatedListed,
   unrelatedNode,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -143,6 +143,12 @@
       "import": "./dist/storage/ai-limits/provider.js",
       "default": "./dist/storage/ai-limits/provider.js"
     },
+    "./internal/ai-limit-enforcement": {
+      "types": "./dist/storage/ai-limits/enforcement.d.ts",
+      "bun": "./src/storage/ai-limits/enforcement.ts",
+      "import": "./dist/storage/ai-limits/enforcement.js",
+      "default": "./dist/storage/ai-limits/enforcement.js"
+    },
     "./internal/auth": {
       "types": "./dist/auth/index.d.ts",
       "bun": "./src/auth/index.ts",

--- a/packages/core/src/agents/request.ts
+++ b/packages/core/src/agents/request.ts
@@ -15,6 +15,13 @@ import {
   AgentStorageError,
   type AgentThreadRecord,
 } from "../storage/agents"
+import {
+  aiLimitSubjectsFromAttribution,
+  aiUsageLimitExceededError,
+  aiUsageLimitUnavailableError,
+  applicableAiLimitPolicyStatuses,
+} from "../storage/ai-limits/enforcement"
+import type { AiLimitPolicyStatus } from "../storage/ai-limits/types"
 import type { CreateExecutionInput } from "../storage/executions"
 import { ensureAgentExecutionIdentity, resolveAgentExecutionAuthorization } from "./authority"
 import type { AgentContextEntryInput } from "./context"
@@ -79,22 +86,6 @@ export async function requestAgentRun(
   // A scoped runtime is authoritative for caller identity. `input.principal` remains available to
   // privileged server integrations that have already authenticated their request.
   const principal = runtime.authorization?.principal ?? input.principal ?? SYSTEM_PRINCIPAL
-  const { thread, createdThread } = await resolveThread(agents, {
-    projectId,
-    agentId: agent.id,
-    threadId: input.threadId,
-    title: input.title,
-    principal,
-  })
-
-  // Fast single-flight check for a clear error. `runs.create` below is the atomic authority.
-  if (thread.activeRunId !== null) {
-    throw new AgentRequestError(
-      "active_run_exists",
-      `[Sixb] Agent thread '${thread.id}' already has an active run '${thread.activeRunId}'.`
-    )
-  }
-
   const runId = createAgentRunId()
   const durableExecution = await prepareDurableAgentExecution(
     runtime,
@@ -110,6 +101,23 @@ export async function requestAgentRun(
         principal: durableExecution.requestedBy,
       })
     : []
+  await assertAiLimitPreflight(runtime, durableExecution, requesterGroupIds)
+
+  const { thread, createdThread } = await resolveThread(agents, {
+    projectId,
+    agentId: agent.id,
+    threadId: input.threadId,
+    title: input.title,
+    principal,
+  })
+
+  // Fast single-flight check for a clear error. `runs.create` below is the atomic authority.
+  if (thread.activeRunId !== null) {
+    throw new AgentRequestError(
+      "active_run_exists",
+      `[Sixb] Agent thread '${thread.id}' already has an active run '${thread.activeRunId}'.`
+    )
+  }
   const triggerMessageId = input.messageId ?? createAgentMessageId()
   let run: AgentRunRecord
   try {
@@ -200,6 +208,7 @@ export async function retryAgentRun(
         principal: durableExecution.requestedBy,
       })
     : []
+  await assertAiLimitPreflight(runtime, durableExecution, requesterGroupIds)
   const run = await runtime.storage.transaction(async (tx) => {
     const agents = tx.agents
     if (!agents) {
@@ -224,6 +233,38 @@ export async function retryAgentRun(
   await publishRunActivity(runtime, run)
   const jobId = await dispatchAgentRun(runtime, agents, runId)
   return { run, ...(jobId ? { jobId } : {}), createdThread: false }
+}
+
+async function assertAiLimitPreflight(
+  runtime: SixbRuntimeContext,
+  execution: CreateExecutionInput,
+  requesterGroupIds: readonly string[]
+): Promise<void> {
+  const limits = runtime.storage.aiLimits
+  if (!limits) throw aiUsageLimitUnavailableError(["limitStorageUnavailable"])
+
+  const subjects = aiLimitSubjectsFromAttribution(execution.requestedBy, requesterGroupIds)
+  let applicable: readonly AiLimitPolicyStatus[]
+  try {
+    applicable = applicableAiLimitPolicyStatuses(
+      await limits.listPolicyStatuses({ projectId: runtime.projectId }),
+      subjects
+    )
+  } catch {
+    throw aiUsageLimitUnavailableError(["limitStorageUnavailable"])
+  }
+
+  const unavailable = applicable.filter((status) => status.accountingStatus === "unavailable")
+  if (unavailable.length > 0) {
+    throw aiUsageLimitUnavailableError(["incompleteAccounting"])
+  }
+  const exhausted = applicable.filter((status) => status.exhausted)
+  if (exhausted.length > 0) {
+    const resetAt = new Date(
+      Math.min(...exhausted.map((status) => status.period.resetAt.getTime()))
+    )
+    throw aiUsageLimitExceededError(resetAt)
+  }
 }
 
 async function prepareDurableAgentExecution(

--- a/packages/core/src/errors/catalog.ts
+++ b/packages/core/src/errors/catalog.ts
@@ -18,6 +18,14 @@ export const SIXB_ERROR_DEFINITIONS = {
     publicMessage: "Agent execution failed.",
     retryable: false,
   },
+  "ai.usage_limit_exceeded": {
+    publicMessage: "AI usage limit exceeded.",
+    retryable: false,
+  },
+  "ai.usage_limit_unavailable": {
+    publicMessage: "AI usage limit could not be evaluated.",
+    retryable: true,
+  },
   "connector.adapter_invalid": {
     publicMessage: "Connector adapter returned an invalid result.",
     retryable: false,

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -77,7 +77,7 @@ export type {
   ModelMoney,
   ModelReportedCost,
 } from "./pricing"
-export { rateModelCall } from "./pricing"
+export { estimateModelReservation, rateModelCall } from "./pricing"
 export type {
   LanguageModelRateCard,
   ModelPricingTier,

--- a/packages/core/src/models/pricing.ts
+++ b/packages/core/src/models/pricing.ts
@@ -32,6 +32,13 @@ export interface ModelReportedCost {
 export type ModelCostEstimate = Exclude<ModelCallCost, { status: "reported" }>
 
 export interface ModelCostEstimator {
+  /** Conservative token-cost reservation, including cache writes and pricing tiers.
+   * Return undefined when routing or non-token charges prevent a safe local estimate. */
+  estimateReservation?(input: {
+    readonly inputTokens: number
+    readonly outputTokens: number
+  }): ModelMoney | undefined
+
   estimate(input: {
     readonly usage: ModelUsage
     readonly route?: ModelRoute
@@ -67,6 +74,49 @@ export type ModelCallCost =
       readonly reason: "missing-rate-card" | "missing-usage" | "inconsistent-usage"
       readonly missingMeters?: readonly ModelCostMeter[]
     }
+
+/** Reserve at the highest configured token rates, before cache usage and the final tier are known. */
+export function estimateModelReservation(input: {
+  readonly inputTokens: number
+  readonly outputTokens: number
+  readonly rateCard?: LanguageModelRateCard
+}): ModelMoney | undefined {
+  if (!input.rateCard) return undefined
+  if (![input.inputTokens, input.outputTokens].every((n) => Number.isSafeInteger(n) && n >= 0)) {
+    throw new TypeError(
+      "[Sixb] Model reservation token estimates must be nonnegative safe integers."
+    )
+  }
+  const maxRate = (prices: readonly (ModelTokenPrice | undefined)[]) => {
+    const rates = prices.flatMap((price) =>
+      price === undefined
+        ? []
+        : typeof price === "string"
+          ? [price]
+          : [price.default, ...price.tiers.map((tier) => tier.price)]
+    )
+    return rates.reduce((max, price) => {
+      const rate = decimalDollarsToNanos(price)
+      return rate > max ? rate : max
+    }, 0n)
+  }
+  const card = input.rateCard
+  const inputRate = maxRate([
+    card.input,
+    card.cacheReadInput,
+    card.cacheWriteInput,
+    card.cacheWriteInput5m,
+    card.cacheWriteInput1h,
+  ])
+  const outputRate = maxRate([card.output])
+  const charge = (tokens: number, rate: bigint) => (BigInt(tokens) * rate + 999_999n) / 1_000_000n
+  return {
+    currency: "USD",
+    amountNanos: (
+      charge(input.inputTokens, inputRate) + charge(input.outputTokens, outputRate)
+    ).toString(),
+  }
+}
 
 /** Prefer the provider's bill over rate-card estimates, then rate complete token meters locally. */
 export function rateModelCall(input: {

--- a/packages/core/src/queues/types.ts
+++ b/packages/core/src/queues/types.ts
@@ -215,6 +215,8 @@ export interface AgentAiUsageAccountingPayload {
   readonly cost: ModelCallCost
   readonly route?: ModelRoute
   readonly ratedAt: string
+  /** Absent on pre-limit jobs; those model calls did not create a reservation. */
+  readonly reconcileLimitReservation?: boolean
 }
 
 export interface AgentAiUsageRecordRequestedQueueJob

--- a/packages/core/src/storage/agents/types.ts
+++ b/packages/core/src/storage/agents/types.ts
@@ -64,6 +64,8 @@ export const AGENT_RUN_FAILURE_CODES = [
   "internal.unexpected",
   "runtime.cancelled",
   "agent.execution_failed",
+  "ai.usage_limit_exceeded",
+  "ai.usage_limit_unavailable",
 ] as const satisfies readonly [SixbErrorCode, ...SixbErrorCode[]]
 
 export type AgentRunFailureCode = (typeof AGENT_RUN_FAILURE_CODES)[number]

--- a/packages/core/src/storage/ai-limits/enforcement.ts
+++ b/packages/core/src/storage/ai-limits/enforcement.ts
@@ -1,0 +1,68 @@
+import { createSixbError, type SixbCodedError } from "../../errors/internal"
+import type { AuthorizablePrincipal } from "../../execution/types"
+import type { ReadonlyJsonValue } from "../../json"
+import { aiLimitSubjectKey } from "./provider"
+import type { AiLimitPolicy, AiLimitPolicyStatus, AiLimitSubject } from "./types"
+
+/** @internal Resolve the immutable attribution dimensions enforced for one model call. */
+export function aiLimitSubjectsFromAttribution(
+  requestedBy: AuthorizablePrincipal | undefined,
+  requesterGroupIds: readonly string[]
+): readonly AiLimitSubject[] {
+  const subjects: AiLimitSubject[] = [
+    { type: "project" },
+    ...requesterGroupIds.map((id): AiLimitSubject => ({ type: "group", id })),
+  ]
+  if (requestedBy) subjects.push(requestedBy)
+
+  const byKey = new Map(subjects.map((subject) => [aiLimitSubjectKey(subject), subject]))
+  return [...byKey.values()].sort((left, right) =>
+    aiLimitSubjectKey(left).localeCompare(aiLimitSubjectKey(right))
+  )
+}
+
+/** @internal Select every policy that applies to the call's immutable attribution snapshot. */
+export function applicableAiLimitPolicyStatuses(
+  statuses: readonly AiLimitPolicyStatus[],
+  subjects: readonly AiLimitSubject[]
+): readonly AiLimitPolicyStatus[] {
+  const keys = new Set(subjects.map(aiLimitSubjectKey))
+  return statuses.filter((status) => keys.has(aiLimitSubjectKey(status.policy.subject)))
+}
+
+/** @internal Cheap policy-only counterpart used before the authoritative atomic reservation. */
+export function applicableAiLimitPolicies(
+  policies: readonly AiLimitPolicy[],
+  subjects: readonly AiLimitSubject[]
+): readonly AiLimitPolicy[] {
+  const keys = new Set(subjects.map(aiLimitSubjectKey))
+  return policies.filter((policy) => keys.has(aiLimitSubjectKey(policy.subject)))
+}
+
+/** @internal Stable failure safe for callers that may only hold run authority. */
+export function aiUsageLimitExceededError(resetAt: Date): SixbCodedError {
+  return createSixbError(
+    "ai.usage_limit_exceeded",
+    "[Sixb] An applicable AI usage limit has no capacity for this model call.",
+    { details: aiLimitFailureDetails({ resetAt }) }
+  )
+}
+
+/** @internal Fail closed when an applicable policy cannot be measured or reserved safely. */
+export function aiUsageLimitUnavailableError(reasons: readonly string[]): SixbCodedError {
+  return createSixbError(
+    "ai.usage_limit_unavailable",
+    "[Sixb] An applicable AI usage limit could not be evaluated safely.",
+    { details: aiLimitFailureDetails({ reasons }) }
+  )
+}
+
+function aiLimitFailureDetails(input: {
+  readonly resetAt?: Date
+  readonly reasons?: readonly string[]
+}): ReadonlyJsonValue {
+  return {
+    ...(input.resetAt === undefined ? {} : { resetAt: input.resetAt.toISOString() }),
+    ...(input.reasons === undefined ? {} : { reasons: [...input.reasons] }),
+  }
+}

--- a/packages/core/src/storage/workflow-runs/types.ts
+++ b/packages/core/src/storage/workflow-runs/types.ts
@@ -21,6 +21,8 @@ export const WORKFLOW_RUN_FAILURE_CODES = [
   "internal.unexpected",
   "runtime.cancelled",
   "workflow.node_failed",
+  "ai.usage_limit_exceeded",
+  "ai.usage_limit_unavailable",
 ] as const satisfies readonly [SixbErrorCode, ...SixbErrorCode[]]
 
 export type WorkflowRunFailureCode = (typeof WORKFLOW_RUN_FAILURE_CODES)[number]

--- a/packages/core/tests/model-pricing.test.ts
+++ b/packages/core/tests/model-pricing.test.ts
@@ -2,11 +2,44 @@ import { describe, expect, test } from "bun:test"
 import {
   defineLanguageModel,
   defineModelRateCard,
+  estimateModelReservation,
   modelReasoningSupportIssue,
   rateModelCall,
 } from "../src/models"
 
 describe("model definitions and rate cards", () => {
+  test("reserves cache writes and expensive tiers before their usage is known", () => {
+    // Removal proof: ignore cache/tier prices in estimateModelReservation; this amount decreases.
+    expect(
+      estimateModelReservation({
+        inputTokens: 1000,
+        outputTokens: 100,
+        rateCard: {
+          currency: "USD",
+          unit: "million-tokens",
+          input: "2",
+          cacheReadInput: "0.2",
+          cacheWriteInput5m: "2.5",
+          cacheWriteInput1h: "4",
+          output: { default: "10", tiers: [{ minTokens: 2000, price: "20" }] },
+        },
+      })
+    ).toEqual({ currency: "USD", amountNanos: "6000000" })
+    expect(
+      estimateModelReservation({
+        inputTokens: 1,
+        outputTokens: 1,
+        rateCard: {
+          currency: "USD",
+          unit: "million-tokens",
+          input: "0.0000011",
+          output: "0.0000011",
+        },
+      })?.amountNanos
+    ).toBe("2")
+    expect(estimateModelReservation({ inputTokens: 100, outputTokens: 10 })).toBeUndefined()
+  })
+
   test("rates token, cache, and tier meters in exact nanodollars", () => {
     const cost = rateModelCall({
       usage: {

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -747,6 +747,34 @@ describe("bound Sixb operational access", () => {
     ).rejects.toThrow(AuthorizationError)
   })
 
+  test("agent run preflight rejects an exhausted project before creating a thread", async () => {
+    const host = createRuntime()
+    const _sixb = createTestSixb(host)
+    await seedPrincipal(host)
+    await seedRequesterMemberships(host, ["operations"])
+    const limits = host.storage.aiLimits
+    const agents = host.storage.agents
+    if (!limits || !agents) throw new Error("Expected AI limit and Agent storage")
+    await limits.createPolicy({
+      id: "project_tokens_exhausted",
+      projectId: host.id,
+      subject: { type: "project" },
+      limit: { meter: "tokens.total", amount: 0 },
+    })
+
+    const runner = bindPrincipal(host, contextFor(host, ["operations"]))
+    await expect(
+      runner.agents.runs.request({
+        agentId: "contract-agent",
+        text: "This must not create a conversation.",
+      })
+    ).rejects.toMatchObject({ code: "ai.usage_limit_exceeded" })
+    await expect(agents.threads.list({ projectId: host.id })).resolves.toMatchObject({
+      threads: [],
+      total: 0,
+    })
+  })
+
   test("agent run admission never reactivates a suspended managed identity", async () => {
     const host = createRuntime()
     const _sixb = createTestSixb(host)

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -51,7 +51,7 @@ import {
   PostAgentMessageResponseSchema,
   RetryAgentRunResponseSchema,
 } from "../schemas/agents"
-import { ErrorResponseSchema } from "../schemas/common"
+import { codedErrorResponseSchema, ErrorResponseSchema, JsonValueSchema } from "../schemas/common"
 import { FileContentQuerySchema } from "../schemas/files"
 import {
   handleRouteError,
@@ -66,6 +66,11 @@ const AgentMessageFileContentQuerySchema = FileContentQuerySchema.extend({
     .min(1)
     .regex(/^\/parts(?:\/|$)/, "Agent message file content paths must start with /parts/"),
 })
+
+const AiUsageLimitErrorResponseSchema = codedErrorResponseSchema([
+  "ai.usage_limit_exceeded",
+  "ai.usage_limit_unavailable",
+]).extend({ details: JsonValueSchema.optional() })
 
 function serializeAgent(agent: AgentDefinition): ReturnType<typeof AgentCatalogItemSchema.parse> {
   return AgentCatalogItemSchema.parse({
@@ -181,8 +186,8 @@ async function publishQueuedRunCancellation(
 
 function handleAgentRouteError(
   error: unknown,
-  set: { status?: number | string }
-): { error: string } {
+  set: { status?: number | string; headers?: unknown }
+): ReturnType<typeof handleRouteError> {
   // A duplicate id is a conflict, not a bad request. Map it to a generic 409 rather than echoing the
   // provider's raw message (which leaks the id, project, and storage prefix).
   if (error instanceof AgentStorageError && error.code === "duplicate_id") {
@@ -604,6 +609,7 @@ export function registerAgentRoutes(app: Elysia, host: SixbHostView) {
           403: ErrorResponseSchema,
           404: ErrorResponseSchema,
           409: ErrorResponseSchema,
+          429: AiUsageLimitErrorResponseSchema,
           501: ErrorResponseSchema,
         },
         detail: {
@@ -753,6 +759,7 @@ export function registerAgentRoutes(app: Elysia, host: SixbHostView) {
           400: ErrorResponseSchema,
           404: ErrorResponseSchema,
           409: ErrorResponseSchema,
+          429: AiUsageLimitErrorResponseSchema,
           501: ErrorResponseSchema,
         },
         detail: {

--- a/packages/server/src/utils/http.ts
+++ b/packages/server/src/utils/http.ts
@@ -2,6 +2,7 @@ import {
   AuthorizationError,
   OntologyNotFoundError,
   OntologyValidationError,
+  type ReadonlyJsonValue,
   type SixbErrorCode,
 } from "@sixb/core"
 import { isSixbError } from "@sixb/core/internal/errors"
@@ -28,6 +29,13 @@ const HTTP_STATUS_BY_ERROR_CODE: Partial<Record<SixbErrorCode, number>> = {
   "connector.revocation_pending": 409,
   "dataset.not_found": 404,
   "dataset.version_not_found": 404,
+  "ai.usage_limit_exceeded": 429,
+  "ai.usage_limit_unavailable": 429,
+}
+
+interface RouteResponseSet {
+  status?: number | string
+  headers?: unknown
 }
 
 export function toIsoString(value: Date): string {
@@ -79,14 +87,22 @@ export function unconfiguredStorageResponse(
 
 export function handleRouteError(
   error: unknown,
-  set: { status?: number | string }
+  set: RouteResponseSet
 ): {
   error: string
   code?: SixbErrorCode
+  details?: ReadonlyJsonValue
 } {
   if (isSixbError(error)) {
     set.status = HTTP_STATUS_BY_ERROR_CODE[error.code] ?? 500
-    return { error: error.message, code: error.code }
+    if (error.code === "ai.usage_limit_exceeded") setRetryAfterFromDetails(set, error.details)
+    const exposesDetails =
+      error.code === "ai.usage_limit_exceeded" || error.code === "ai.usage_limit_unavailable"
+    return {
+      error: error.message,
+      code: error.code,
+      ...(!exposesDetails || error.details === undefined ? {} : { details: error.details }),
+    }
   }
 
   if (error instanceof AuthorizationError) {
@@ -121,6 +137,21 @@ export function handleRouteError(
   const message = error instanceof Error ? error.message : String(error)
   set.status = 400
   return { error: message }
+}
+
+function setRetryAfterFromDetails(set: RouteResponseSet, details: ReadonlyJsonValue | undefined) {
+  if (typeof details !== "object" || details === null || Array.isArray(details)) return
+  const resetAt = (details as Readonly<Record<string, ReadonlyJsonValue>>).resetAt
+  if (typeof resetAt !== "string") return
+  const resetTime = Date.parse(resetAt)
+  if (!Number.isFinite(resetTime)) return
+  const seconds = String(Math.max(0, Math.ceil((resetTime - Date.now()) / 1_000)))
+  const headers =
+    typeof set.headers === "object" && set.headers !== null
+      ? (set.headers as Record<string, unknown>)
+      : {}
+  headers["Retry-After"] = seconds
+  set.headers = headers
 }
 
 function fileUploadSessionErrorStatus(reason: FileUploadSessionErrorReason): number {

--- a/packages/server/tests/agents-routes.test.ts
+++ b/packages/server/tests/agents-routes.test.ts
@@ -743,6 +743,40 @@ describe("agent routes", () => {
     })
   })
 
+  test("returns a coded 429 and retry time for an exhausted AI usage limit", async () => {
+    const { app, storage, sixb } = createApp()
+    const thread = await storage.agents.threads.create({
+      id: "thread-limit-exhausted",
+      projectId: sixb.id,
+      agentId: "assistant",
+      ownerPrincipal: { type: "system", id: "system" },
+    })
+    await storage.aiLimits.createPolicy({
+      id: "project_tokens_exhausted",
+      projectId: sixb.id,
+      subject: { type: "project" },
+      limit: { meter: "tokens.total", amount: 0 },
+    })
+
+    const response = await app.fetch(
+      jsonRequest(`/api/agent-threads/${thread.id}/messages`, "POST", { text: "blocked" })
+    )
+
+    expect(response.status).toBe(429)
+    expect(Number(response.headers.get("retry-after"))).toBeGreaterThanOrEqual(0)
+    const responseBody = await response.json()
+    expect(responseBody).toMatchObject({
+      code: "ai.usage_limit_exceeded",
+      details: {
+        resetAt: expect.any(String),
+      },
+    })
+    expect(responseBody.details).not.toHaveProperty("policies")
+    await expect(
+      storage.agents.messages.list({ projectId: sixb.id, threadId: thread.id })
+    ).resolves.toMatchObject({ messages: [], total: 0 })
+  })
+
   test("cancels a queued run before a worker starts it", async () => {
     const { app, storage, sixb } = createApp()
     const request = await createTestSixb(sixb).agents.runs.request({

--- a/packages/server/tests/http-utils.test.ts
+++ b/packages/server/tests/http-utils.test.ts
@@ -30,6 +30,26 @@ describe("handleRouteError", () => {
     })
   })
 
+  test("exposes structured details only for declared AI limit errors", () => {
+    const hidden = handleRouteError(
+      createSixbError("dataset.not_found", "Missing", { details: { datasetId: "private" } }),
+      {}
+    )
+    const exposed = handleRouteError(
+      createSixbError("ai.usage_limit_unavailable", "Unavailable", {
+        details: { reasons: ["missingEstimate"] },
+      }),
+      {}
+    )
+
+    expect(hidden).toEqual({ error: "Missing", code: "dataset.not_found" })
+    expect(exposed).toEqual({
+      error: "Unavailable",
+      code: "ai.usage_limit_unavailable",
+      details: { reasons: ["missingEstimate"] },
+    })
+  })
+
   test("does not infer a status from legacy error messages", () => {
     for (const message of ["Unknown property", "Resource not found"]) {
       const set: { status?: number | string } = {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -69,6 +69,9 @@
       "@sixb/core/internal/ai-limit-storage-provider": [
         "./packages/core/src/storage/ai-limits/provider.ts"
       ],
+      "@sixb/core/internal/ai-limit-enforcement": [
+        "./packages/core/src/storage/ai-limits/enforcement.ts"
+      ],
       "@sixb/core/internal/auth": ["./packages/core/src/auth/index.ts"],
       "@sixb/core/internal/authorization": ["./packages/core/src/authorization/index.ts"],
       "@sixb/core/internal/bootstrap": ["./packages/core/src/bootstrap/index.ts"],


### PR DESCRIPTION
## Summary

Enforce monthly AI usage limits before each model call in conversations, context compaction, and workflow Agent nodes. Request-time preflight rejects already exhausted budgets before creating conversation state; the worker then atomically reserves capacity immediately before inference.

Completed calls persist usage, the model runtime's valuation, and reservation reconciliation in one transaction. Ambiguous calls retain capacity. Durable recovery preserves those guarantees without counting usage twice.

## Integration with the model runtime

- Wrap the resolved `LanguageModel` at the worker boundary, using the owned loop's call identity and request. Admission covers ordinary turns, compaction, workflow calls, and structured-output fallback calls.
- Add optional `ModelCostEstimator.estimateReservation({ inputTokens, outputTokens })`. Anthropic and Vercel Gateway implement it using their existing rate cards. `estimateModelReservation` accounts for cache-write rates and pricing tiers, with monetary rounding upward.
- Keep completed-call pricing separate. A provider-reported charge and any retained local estimate continue through the existing accounting path.
- Preserve coded limit failures through compaction and workflow failure handling. Legacy recovery jobs update initialized counters transactionally even when no valuation is available.
- Expose `ai.usage_limit_exceeded` and `ai.usage_limit_unavailable`, map direct rejection to HTTP 429 with `Retry-After`, and regenerate the client contracts.

Unknown prices or unsupported pricing dimensions block cost-limited calls. Token limits do not require a cost estimator. Ordinary Anthropic calls need no separate cache-TTL accounting option; the current provider also knows one-hour cache rates. Input tokens and the 4,096-token default output allowance remain estimates, so reservations are not a hard ceiling on the final provider charge.

## Validation

- Guarded full suite: 4,834 passed, 7 skipped, no failures.
- Seven regression cases fail when the corresponding protections are removed.
- Client generation, full TypeScript checks, Biome, and monorepo build passed.
- Publish-boundary validation passed for all 54 publishable packages.

## Stack

Rebased on `main`, which now includes #509 and #510. Policy-management endpoints remain in #512; Atlas management remains in #513.
