### PR TITLE
atlas: add AI usage-limit management

### DIFF
--- a/docs/agents/_meta.json
+++ b/docs/agents/_meta.json
@@ -2,6 +2,7 @@
   "overview.md",
   "defining-agents.md",
   "running-and-streaming.md",
+  "usage-limits.md",
   "tools-and-gateway.md",
   "authorization.md"
 ]

--- a/docs/agents/usage-limits.md
+++ b/docs/agents/usage-limits.md
@@ -1,0 +1,104 @@
+# AI usage limits
+
+Sixb can stop Agent model calls when a project, group, user, or service account has no remaining
+monthly capacity. Limits are enforced at the shared model-call boundary, so direct conversations
+and workflow Agent nodes use the same rules.
+
+## Supported limits
+
+The first release supports two aggregate meters:
+
+- `tokens.total` uses provider-reported total input and output tokens.
+- `cost.catalogEstimated` uses Sixb's pinned Models.dev pricing catalog in USD. It is an estimate,
+  not a provider invoice. Policies are fixed to USD because the built-in
+  accounting path does not perform foreign-exchange conversion.
+
+Periods are fixed UTC calendar months. Every matching enabled policy applies independently: a call
+must fit the project policy, every snapshotted group policy, and its original user or service-account
+policy. Editing, disabling, deleting, or recreating a policy does not reset the immutable usage and
+cost ledgers.
+
+There is no user-configurable maximum-output-token setting. Sixb reserves a conservative internal
+output allowance before each call, then reconciles the reservation against actual provider usage.
+A response can exceed its reservation; Sixb records the full amount and denies later calls after the
+aggregate limit is exhausted.
+
+## Authorization
+
+AI accounting and current consumption require `can.observe("aiUsage")`. Reading policy definitions
+requires either observation or the separate `can.manage("aiUsage")` grant, while policy changes
+require management.
+
+```ts
+import { can, defineRole } from "@sixb/core"
+import { financeAdmins } from "../groups/finance-admins"
+
+export const aiUsageOperators = defineRole("ai-usage.operators", {
+  grantedTo: [financeAdmins],
+  grants: [can.observe("aiUsage"), can.manage("aiUsage")],
+})
+```
+
+An observer can use Atlas and the status APIs without seeing mutation controls. A manager can list
+and change policies in Atlas, but receives no consumption or accounting visibility unless the role
+also grants observation. Atlas loads the registered groups, users, and service accounts through the
+management grant and presents them as searchable selectors; operators never need to enter a subject
+ID manually.
+
+## API
+
+The protected API surface is:
+
+- `GET /api/ai/accounting/overview`
+- `GET /api/ai/model-calls`
+- `GET /api/ai/limits`
+- `GET /api/ai/limits/status`
+- `GET /api/ai/limits/subjects`
+- `POST /api/ai/limits`
+- `PUT /api/ai/limits/:limitId`
+- `DELETE /api/ai/limits/:limitId`
+
+Token amounts are non-negative safe integers. Cost amounts use exact nanounit strings:
+
+```json
+{
+  "subject": { "type": "group", "id": "finance" },
+  "limit": {
+    "meter": "cost.catalogEstimated",
+    "amount": { "currency": "USD", "amountNanos": "100000000000" }
+  }
+}
+```
+
+That example sets a monthly catalog-estimated limit of USD 100. Status responses distinguish actual,
+reserved, unknown, and remaining amounts and report the next `resetAt`. Group policies whose group
+definition disappeared are returned with `orphaned: true`.
+
+## Enforcement and recovery
+
+Before a provider request, Sixb estimates input tokens plus its conservative output allowance and
+atomically reserves every applicable token and cost bucket. Concurrent workers cannot knowingly
+reserve the same remaining capacity twice.
+
+After the provider returns, immutable usage and valuation records are written and the reservation is
+reconciled in the same storage transaction. Durable accounting recovery replays that reconciliation
+idempotently after queue redelivery. Period totals are initialized from the immutable ledger once,
+then maintained transactionally; routine admission does not rescan month-to-date records.
+
+Sixb fails closed when an enabled meter cannot be evaluated safely:
+
+- unknown model identity or unsupported pricing dimensions block a cost-limited call;
+- incomplete token or valuation accounting blocks later admission;
+- unavailable limit storage prevents Agent workers from starting;
+- a provider attempt that may have been billed without usable actuals becomes `unknown` and retains
+  capacity.
+
+Denied calls use `ai.usage_limit_exceeded`; unsafe evaluation uses
+`ai.usage_limit_unavailable`. Direct HTTP requests return 429, and exhausted responses include
+`Retry-After` based on the earliest applicable reset.
+
+## Provider billing caveat
+
+Sixb limits its own admission decisions. Routed model identity, provider-side tokenization, failed
+requests, and later billing adjustments can differ from the pre-call estimate. Keep provider budgets
+enabled when invoice-level hard stops are required.

--- a/docs/agents/usage-limits.md
+++ b/docs/agents/usage-limits.md
@@ -9,17 +9,19 @@ and workflow Agent nodes use the same rules.
 The first release supports two aggregate meters:
 
 - `tokens.total` uses provider-reported total input and output tokens.
-- `cost.catalogEstimated` uses Sixb's pinned Models.dev pricing catalog in USD. It is an estimate,
-  not a provider invoice. Policies are fixed to USD because the built-in
-  accounting path does not perform foreign-exchange conversion.
+- `cost.catalogEstimated` reserves USD using the model integration's local rate-card estimate.
+  Recorded consumption follows the runtime's selected valuation: a provider-reported charge when
+  available, otherwise a local estimate. This is not provider-invoice reconciliation. Policies are
+  fixed to USD; accounting does not perform foreign-exchange conversion.
 
 Periods are fixed UTC calendar months. Every matching enabled policy applies independently: a call
 must fit the project policy, every snapshotted group policy, and its original user or service-account
 policy. Editing, disabling, deleting, or recreating a policy does not reset the immutable usage and
 cost ledgers.
 
-There is no user-configurable maximum-output-token setting. Sixb reserves a conservative internal
-output allowance before each call, then reconciles the reservation against actual provider usage.
+Usage-limit policies do not configure per-call output ceilings. Sixb reserves the request's
+`maxOutputTokens` when present, otherwise an internal allowance of 4,096 output tokens, then
+reconciles against observed provider usage. The allowance does not impose a generation ceiling.
 A response can exceed its reservation; Sixb records the full amount and denies later calls after the
 aggregate limit is exhausted.
 
@@ -96,9 +98,11 @@ Sixb fails closed when an enabled meter cannot be evaluated safely:
 - a provider attempt that may have been billed without usable actuals becomes `unknown` and retains
   capacity.
 
-Anthropic calls use native cache settings from the prepared messages, tools, and provider options.
-Uncached requests and standard five-minute caching need no extra accounting option. Explicit
-one-hour caching remains unsupported by the pinned pricing snapshot and blocks cost-limited calls.
+Cost admission uses `model.costEstimator.estimateReservation`. The Anthropic and Vercel Gateway
+integrations reserve using their existing rate cards, including cache-write rates and pricing tiers.
+Ordinary Anthropic calls need no separate cache-TTL accounting option; both five-minute and one-hour
+cache rates are supported. Custom models without a reservation estimator can use token limits,
+but cost-limited calls fail closed until a safe estimate is available.
 
 Denied calls use `ai.usage_limit_exceeded`; unsafe evaluation uses
 `ai.usage_limit_unavailable`. Direct HTTP requests return 429, and exhausted responses include

--- a/docs/agents/usage-limits.md
+++ b/docs/agents/usage-limits.md
@@ -84,6 +84,9 @@ After the provider returns, immutable usage and valuation records are written an
 reconciled in the same storage transaction. Durable accounting recovery replays that reconciliation
 idempotently after queue redelivery. Period totals are initialized from the immutable ledger once,
 then maintained transactionally; routine admission does not rescan month-to-date records.
+An incomplete period is refreshed from the ledger on the next status read or admission attempt.
+When a missing valuation arrives, actual consumption and accounting availability recover without
+resetting active or unknown reservations. Partial repairs continue to block admission.
 
 Sixb fails closed when an enabled meter cannot be evaluated safely:
 

--- a/docs/agents/usage-limits.md
+++ b/docs/agents/usage-limits.md
@@ -93,6 +93,10 @@ Sixb fails closed when an enabled meter cannot be evaluated safely:
 - a provider attempt that may have been billed without usable actuals becomes `unknown` and retains
   capacity.
 
+Anthropic calls use native cache settings from the prepared messages, tools, and provider options.
+Uncached requests and standard five-minute caching need no extra accounting option. Explicit
+one-hour caching remains unsupported by the pinned pricing snapshot and blocks cost-limited calls.
+
 Denied calls use `ai.usage_limit_exceeded`; unsafe evaluation uses
 `ai.usage_limit_unavailable`. Direct HTTP requests return 429, and exhausted responses include
 `Retry-After` based on the earliest applicable reset.

--- a/docs/auth/authorization.md
+++ b/docs/auth/authorization.md
@@ -83,7 +83,7 @@ are the union of every role whose `grantedTo` group it belongs to.
 
 A grant pairs a capability with the definitions it covers. Eight capability builders —
 `can.access`, `can.view`, `can.edit`, `can.append`, `can.apply`, `can.run`, `can.manage`, and
-`can.observe` — resolve to **twelve grant kinds**, one per protected target family.
+`can.observe` — resolve to **fourteen grant kinds**, one per protected target family.
 
 | Grant kind | Builder | Allows | Targets |
 | --- | --- | --- | --- |
@@ -98,14 +98,17 @@ A grant pairs a capability with the definitions it covers. Eight capability buil
 | `run:pipeline` | `can.run(...)` | Run pipelines | [Pipelines](../data/pipelines.md) |
 | `run:agent` | `can.run(...)` | Run agents and read their threads | [Agents](../agents/overview.md) |
 | `manage:connector` | `can.manage(...)` | Authorize, select, disconnect, and revoke OAuth connector accounts | [Connectors](../data/connectors.md) |
+| `manage:aiUsage` | `can.manage("aiUsage")` | Create, edit, disable, and delete AI usage limits | [AI usage limits](../agents/usage-limits.md) |
 | `observe:logs` | `can.observe("logs")` | Read captured run logs | [Logging](../logging/overview.md) |
+| `observe:aiUsage` | `can.observe("aiUsage")` | Read project AI accounting and limit status | [AI usage limits](../agents/usage-limits.md) |
 
 `can.access` accepts the built-in `applications.atlas` and `applications.app` definitions.
 `can.view` resolves to `view:object` or `view:dataset` from the definition you pass; `can.run`
 picks between `run:workflow`, `run:sync`, `run:pipeline`, and `run:agent` the same way. Each is
 type-checked, so mixing target families in one call does not compile. `can.manage` accepts connector
-definitions. `can.observe` takes the `"logs"` target literal and grants `observe:logs`, which gates
-reading captured [logs](../logging/overview.md).
+definitions or the `"aiUsage"` project surface. `can.observe` accepts `"logs"` or `"aiUsage"`;
+these independently gate captured [logs](../logging/overview.md) and
+[AI accounting](../agents/usage-limits.md).
 
 > **Only `can.view(Type)` reaches subtypes.** `can.edit` and `can.append` cover exactly the types
 > you name, so adding a type under one you granted never makes it writable on its own.
@@ -131,6 +134,8 @@ Each builder takes one definition, a list, or a breadth selector.
 | Every pipeline | `can.run(every.pipeline())` |
 | Every agent | `can.run(every.agent())` |
 | Every connector | `can.manage(every.connector())` |
+| Observe AI usage | `can.observe("aiUsage")` |
+| Manage AI limits | `can.manage("aiUsage")` |
 | Every application | `can.access(every.application())` |
 | Everything but a few | `can.view(every.object().except([Customer]))` |
 

--- a/packages/atlas/src/components/AiLimitPanel.tsx
+++ b/packages/atlas/src/components/AiLimitPanel.tsx
@@ -1,0 +1,803 @@
+import type {
+  GetAiLimitStatusResponse,
+  GetAiLimitSubjectOptionsResponse,
+  ListAiLimitPoliciesResponse,
+} from "@sixb/client"
+import {
+  createAiLimitPolicyMutation,
+  deleteAiLimitPolicyMutation,
+  getAiLimitStatusOptions,
+  getAiLimitStatusQueryKey,
+  getAiLimitSubjectOptionsOptions,
+  listAiLimitPoliciesOptions,
+  listAiLimitPoliciesQueryKey,
+  updateAiLimitPolicyMutation,
+} from "@sixb/client/hooks"
+import {
+  Alert,
+  AlertDescription,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Badge,
+  Button,
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Combobox,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Input,
+  Label,
+  Switch,
+  ToggleGroup,
+  ToggleGroupItem,
+  toast,
+} from "@sixb/ui/components"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  CircleGauge,
+  Loader2,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  Trash2,
+  TriangleAlert,
+} from "lucide-react"
+import { type SubmitEvent, useState } from "react"
+import {
+  type AiLimitFormMeter,
+  type AiLimitFormQuantity,
+  aiLimitAmountInput,
+  aiLimitSubjectChoices,
+  aiLimitSubjectLabel,
+  aiLimitUsagePercent,
+  formatAiLimitQuantity,
+  formatAiLimitQuantityExact,
+  parseAiLimitFormQuantity,
+} from "../lib/aiLimits"
+import { UsageBar } from "./UsageBar"
+
+type LimitStatus = GetAiLimitStatusResponse["items"][number]
+type LimitPolicy = ListAiLimitPoliciesResponse["items"][number]
+type LimitSubject = LimitPolicy["subject"]
+type LimitSubjectType = LimitSubject["type"]
+type LimitSubjectOptions = GetAiLimitSubjectOptionsResponse
+
+export const AI_LIMIT_STATUS_QUERY = { query: { includeDisabled: "true" as const } }
+
+export function AiLimitPanel() {
+  const queryClient = useQueryClient()
+  const statusQuery = useQuery({ ...getAiLimitStatusOptions(AI_LIMIT_STATUS_QUERY), retry: false })
+  const policyQuery = useQuery({
+    ...listAiLimitPoliciesOptions(AI_LIMIT_STATUS_QUERY),
+    retry: false,
+  })
+  const [dialogPolicy, setDialogPolicy] = useState<LimitPolicy | "new" | null>(null)
+
+  const invalidate = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: getAiLimitStatusQueryKey(AI_LIMIT_STATUS_QUERY) }),
+      queryClient.invalidateQueries({
+        queryKey: listAiLimitPoliciesQueryKey(AI_LIMIT_STATUS_QUERY),
+      }),
+    ])
+  }
+
+  const createPolicy = useMutation({
+    ...createAiLimitPolicyMutation(),
+    onSuccess: async () => {
+      setDialogPolicy(null)
+      toast.success("AI usage limit created.")
+      await invalidate()
+    },
+    onError: (error) => toast.error(aiLimitErrorMessage(error, "Could not create the limit.")),
+  })
+  const updatePolicy = useMutation({
+    ...updateAiLimitPolicyMutation(),
+    onSuccess: async () => {
+      setDialogPolicy(null)
+      toast.success("AI usage limit updated.")
+      await invalidate()
+    },
+    onError: (error) => toast.error(aiLimitErrorMessage(error, "Could not update the limit.")),
+  })
+  const deletePolicy = useMutation({
+    ...deleteAiLimitPolicyMutation(),
+    onSuccess: async () => {
+      toast.success("AI usage limit deleted.")
+      await invalidate()
+    },
+    onError: (error) => toast.error(aiLimitErrorMessage(error, "Could not delete the limit.")),
+  })
+
+  const statusData = statusQuery.data as GetAiLimitStatusResponse | undefined
+  const policyData = policyQuery.data as ListAiLimitPoliciesResponse | undefined
+  const canManage = policyData?.capabilities.manage ?? statusData?.capabilities.manage ?? false
+  const subjectOptionsQuery = useQuery({
+    ...getAiLimitSubjectOptionsOptions(),
+    enabled: canManage,
+    retry: false,
+  })
+  const subjectOptions = subjectOptionsQuery.data as LimitSubjectOptions | undefined
+  const statuses = statusData?.items ?? []
+  const statusByPolicyId = new Map(statuses.map((status) => [status.policy.id, status]))
+  const policies = policyData?.items ?? statuses.map((status) => status.policy)
+  const activePolicyCount = policies.filter((policy) => policy.enabled).length
+  const mutationPending = createPolicy.isPending || updatePolicy.isPending || deletePolicy.isPending
+
+  return (
+    <Card className="gap-0 py-0">
+      <CardHeader className="grid-cols-[1fr_auto] gap-x-4 border-b py-5">
+        <div className="space-y-1.5">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <CircleGauge className="size-4" />
+            Monthly usage limits
+          </CardTitle>
+          <CardDescription>
+            {statuses[0]
+              ? `${formatLimitPeriod(statuses[0].period.start, statuses[0].period.end)} · ${activePolicyCount.toLocaleString()} active ${activePolicyCount === 1 ? "limit" : "limits"}`
+              : "Limits reset at the start of each UTC calendar month."}
+          </CardDescription>
+          <p className="text-xs text-muted-foreground">
+            Current-month limits are not affected by the analytics filters below.
+          </p>
+        </div>
+        <CardAction>
+          {canManage ? (
+            <Button size="sm" onClick={() => setDialogPolicy("new")}>
+              <Plus className="size-4" />
+              Add limit
+            </Button>
+          ) : null}
+        </CardAction>
+      </CardHeader>
+      <CardContent className="p-0">
+        {statusQuery.isLoading && policyQuery.isLoading ? (
+          <div className="flex min-h-28 items-center justify-center text-muted-foreground">
+            <Loader2 className="mr-2 size-4 animate-spin" />
+            Loading limits…
+          </div>
+        ) : !statusData && !policyData ? (
+          <Alert variant="destructive" className="m-5 w-auto">
+            <TriangleAlert />
+            <AlertDescription>
+              {aiLimitErrorMessage(
+                policyQuery.error ?? statusQuery.error,
+                "AI limit status is unavailable. Check limit storage and your project grant."
+              )}
+            </AlertDescription>
+          </Alert>
+        ) : policies.length === 0 ? (
+          <div className="m-5 rounded-lg border border-dashed px-4 py-8 text-center">
+            <p className="text-sm font-medium">No monthly limits configured</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              AI calls are still accounted for, but no aggregate limit is currently enforced.
+            </p>
+            {canManage ? (
+              <Button
+                className="mt-4"
+                size="sm"
+                variant="outline"
+                onClick={() => setDialogPolicy("new")}
+              >
+                <Plus className="size-4" />
+                Add the first limit
+              </Button>
+            ) : null}
+          </div>
+        ) : (
+          <div className="divide-y">
+            {policies.map((policy) => {
+              const status = statusByPolicyId.get(policy.id)
+              const actions = {
+                canManage,
+                subjectOptions,
+                mutationPending,
+                onEdit: () => setDialogPolicy(policy),
+                onToggle: () =>
+                  updatePolicy.mutate({
+                    path: { limitId: policy.id },
+                    body: { enabled: !policy.enabled },
+                  }),
+                onDelete: () => deletePolicy.mutate({ path: { limitId: policy.id } }),
+              }
+              return status ? (
+                <AiLimitStatusRow key={policy.id} status={status} {...actions} />
+              ) : (
+                <AiLimitPolicyRow key={policy.id} policy={policy} {...actions} />
+              )
+            })}
+          </div>
+        )}
+      </CardContent>
+
+      {dialogPolicy !== null ? (
+        <AiLimitPolicyDialog
+          key={dialogPolicy === "new" ? "new" : dialogPolicy.id}
+          policy={dialogPolicy === "new" ? undefined : dialogPolicy}
+          subjectOptions={subjectOptions}
+          subjectOptionsLoading={subjectOptionsQuery.isLoading}
+          subjectOptionsError={subjectOptionsQuery.error}
+          pending={createPolicy.isPending || updatePolicy.isPending}
+          error={createPolicy.error ?? updatePolicy.error}
+          onClose={() => {
+            setDialogPolicy(null)
+            createPolicy.reset()
+            updatePolicy.reset()
+          }}
+          onCreate={(input) => createPolicy.mutate({ body: input })}
+          onUpdate={(policyId, input) =>
+            updatePolicy.mutate({ path: { limitId: policyId }, body: input })
+          }
+        />
+      ) : null}
+    </Card>
+  )
+}
+
+function AiLimitStatusRow({
+  status,
+  canManage,
+  subjectOptions,
+  mutationPending,
+  onEdit,
+  onToggle,
+  onDelete,
+}: {
+  readonly status: LimitStatus
+  readonly canManage: boolean
+  readonly subjectOptions?: LimitSubjectOptions
+  readonly mutationPending: boolean
+  readonly onEdit: () => void
+  readonly onToggle: () => void
+  readonly onDelete: () => void
+}) {
+  const percent = aiLimitUsagePercent({
+    limit: status.policy.limit,
+    actual: status.consumption.actual,
+    reserved: status.consumption.reserved,
+    unknown: status.consumption.unknown,
+  })
+  const color = status.exhausted
+    ? "red"
+    : status.accountingStatus === "unavailable" || quantityIsPositive(status.consumption.unknown)
+      ? "amber"
+      : percent >= 80
+        ? "amber"
+        : "blue"
+
+  const hasUnknown = quantityIsPositive(status.consumption.unknown)
+  const hasReserved = quantityIsPositive(status.consumption.reserved)
+  const percentLabel = formatAiLimitPercent(percent, committedIsPositive(status))
+  const subjectLabel = aiLimitSubjectLabel(status.policy.subject, subjectOptions)
+
+  return (
+    <div className="space-y-3 px-5 py-4">
+      <div className="grid items-start gap-4 md:grid-cols-[minmax(10rem,0.8fr)_minmax(18rem,2fr)_auto]">
+        <div className="min-w-0 space-y-1">
+          <p className="truncate text-sm font-medium">{subjectLabel}</p>
+          <p className="text-xs text-muted-foreground">{meterLabel(status.policy.limit.meter)}</p>
+        </div>
+
+        <div className="min-w-0 space-y-2">
+          <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+            <p className="min-w-0 text-sm font-medium tabular-nums">
+              <span title={formatAiLimitQuantityExact(status.consumption.actual)}>
+                {formatAiLimitQuantity(status.consumption.actual)}
+              </span>{" "}
+              <span className="font-normal text-muted-foreground">
+                of {formatAiLimitQuantity(status.policy.limit)}
+              </span>
+            </p>
+            <p className="text-xs font-medium tabular-nums">{percentLabel} used</p>
+          </div>
+          <UsageBar
+            value={percent}
+            color={color}
+            ariaLabel={`${subjectLabel} monthly ${meterLabel(status.policy.limit.meter).toLowerCase()} usage`}
+            valueText={`${percentLabel} used`}
+          />
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            <span title={formatAiLimitQuantityExact(status.consumption.remaining)}>
+              {formatAiLimitQuantity(status.consumption.remaining)} remaining
+            </span>
+            {hasReserved ? (
+              <span title={formatAiLimitQuantityExact(status.consumption.reserved)}>
+                {formatAiLimitQuantity(status.consumption.reserved)} reserved
+              </span>
+            ) : null}
+            {hasUnknown ? (
+              <span title={formatAiLimitQuantityExact(status.consumption.unknown)}>
+                {formatAiLimitQuantity(status.consumption.unknown)} held for unknown outcomes
+              </span>
+            ) : null}
+            <span>Resets {formatReset(status.period.resetAt)}</span>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-2 md:justify-end">
+          <div className="flex flex-wrap justify-end gap-1.5">
+            {!status.policy.enabled ? <Badge variant="secondary">Disabled</Badge> : null}
+            {status.exhausted && status.policy.enabled ? (
+              <Badge variant="destructive">Exhausted</Badge>
+            ) : null}
+            {status.accountingStatus === "unavailable" ? (
+              <Badge
+                variant="outline"
+                className="border-amber-500/50 text-amber-700 dark:text-amber-300"
+              >
+                Accounting unavailable
+              </Badge>
+            ) : null}
+            {status.orphaned ? <Badge variant="outline">Orphaned group</Badge> : null}
+            {status.policy.enabled &&
+            !status.exhausted &&
+            status.accountingStatus !== "unavailable" ? (
+              <Badge variant="outline">Active</Badge>
+            ) : null}
+          </div>
+          <AiLimitPolicyActions
+            policy={status.policy}
+            subjectLabel={subjectLabel}
+            canManage={canManage}
+            mutationPending={mutationPending}
+            onEdit={onEdit}
+            onToggle={onToggle}
+            onDelete={onDelete}
+          />
+        </div>
+      </div>
+
+      {status.accountingStatus === "unavailable" ? (
+        <p className="rounded-md bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-200">
+          This meter has incomplete accounting. Enforcement fails closed until every applicable
+          ledger record can be measured safely.
+        </p>
+      ) : hasUnknown ? (
+        <p className="rounded-md bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-200">
+          At least one provider outcome is unknown, so its reserved capacity remains held.
+        </p>
+      ) : null}
+      {status.orphaned ? (
+        <p className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">
+          This group is no longer registered. Restore the group or delete this policy; immutable
+          historical attribution is retained either way.
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+function AiLimitPolicyRow({
+  policy,
+  canManage,
+  subjectOptions,
+  mutationPending,
+  onEdit,
+  onToggle,
+  onDelete,
+}: {
+  readonly policy: LimitPolicy
+  readonly canManage: boolean
+  readonly subjectOptions?: LimitSubjectOptions
+  readonly mutationPending: boolean
+  readonly onEdit: () => void
+  readonly onToggle: () => void
+  readonly onDelete: () => void
+}) {
+  const subjectLabel = aiLimitSubjectLabel(policy.subject, subjectOptions)
+  return (
+    <div className="grid items-center gap-4 px-5 py-4 md:grid-cols-[minmax(10rem,0.8fr)_minmax(18rem,2fr)_auto]">
+      <div className="min-w-0 space-y-1">
+        <p className="truncate text-sm font-medium">{subjectLabel}</p>
+        <p className="text-xs text-muted-foreground">{meterLabel(policy.limit.meter)}</p>
+      </div>
+      <div>
+        <p className="text-sm font-medium tabular-nums">
+          {formatAiLimitQuantity(policy.limit)} monthly limit
+        </p>
+        <p className="text-xs text-muted-foreground">Usage requires the AI usage observe grant.</p>
+      </div>
+      <div className="flex items-center justify-between gap-2 md:justify-end">
+        <Badge variant={policy.enabled ? "outline" : "secondary"}>
+          {policy.enabled ? "Active" : "Disabled"}
+        </Badge>
+        <AiLimitPolicyActions
+          policy={policy}
+          subjectLabel={subjectLabel}
+          canManage={canManage}
+          mutationPending={mutationPending}
+          onEdit={onEdit}
+          onToggle={onToggle}
+          onDelete={onDelete}
+        />
+      </div>
+    </div>
+  )
+}
+
+function AiLimitPolicyActions({
+  policy,
+  subjectLabel,
+  canManage,
+  mutationPending,
+  onEdit,
+  onToggle,
+  onDelete,
+}: {
+  readonly policy: LimitPolicy
+  readonly subjectLabel: string
+  readonly canManage: boolean
+  readonly mutationPending: boolean
+  readonly onEdit: () => void
+  readonly onToggle: () => void
+  readonly onDelete: () => void
+}) {
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  if (!canManage) return null
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Actions for ${subjectLabel} ${meterLabel(policy.limit.meter).toLowerCase()}`}
+            disabled={mutationPending}
+          >
+            <MoreHorizontal className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={onEdit}>
+            <Pencil className="size-4" />
+            Edit limit
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onToggle}>
+            {policy.enabled ? "Disable limit" : "Enable limit"}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onSelect={() => setDeleteOpen(true)}>
+            <Trash2 className="size-4" />
+            Delete limit
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this AI usage limit?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Current-period accounting is preserved. Deleting the policy only stops it from
+              enforcing future model calls.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={onDelete}>
+              Delete limit
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
+function AiLimitPolicyDialog({
+  policy,
+  subjectOptions,
+  subjectOptionsLoading,
+  subjectOptionsError,
+  pending,
+  error,
+  onClose,
+  onCreate,
+  onUpdate,
+}: {
+  readonly policy?: LimitPolicy
+  readonly subjectOptions?: LimitSubjectOptions
+  readonly subjectOptionsLoading: boolean
+  readonly subjectOptionsError: unknown
+  readonly pending: boolean
+  readonly error: unknown
+  readonly onClose: () => void
+  readonly onCreate: (input: {
+    subject: LimitSubject
+    limit: AiLimitFormQuantity
+    enabled: boolean
+  }) => void
+  readonly onUpdate: (
+    policyId: string,
+    input: { limit: AiLimitFormQuantity; enabled: boolean }
+  ) => void
+}) {
+  const [subject, setSubject] = useState<LimitSubject>(policy?.subject ?? { type: "project" })
+  const [meter, setMeter] = useState<AiLimitFormMeter>(
+    policy?.limit.meter ?? "cost.catalogEstimated"
+  )
+  const [amount, setAmount] = useState(policy ? aiLimitAmountInput(policy.limit) : "")
+  const currency =
+    policy?.limit.meter === "cost.catalogEstimated" ? policy.limit.amount.currency : "USD"
+  const [enabled, setEnabled] = useState(policy?.enabled ?? true)
+  const [validationError, setValidationError] = useState<string>()
+  const subjectChoices = limitSubjectFormChoices(subjectOptions, policy?.subject)
+  const directoryError =
+    policy === undefined && subject.type !== "project" ? subjectOptionsError : undefined
+
+  const submit = (event: SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const parsed = parseAiLimitFormQuantity(meter, amount, currency)
+    if (!parsed.ok) {
+      setValidationError(parsed.error)
+      return
+    }
+    if (policy) {
+      onUpdate(policy.id, { limit: parsed.quantity, enabled })
+      return
+    }
+    onCreate({ subject, limit: parsed.quantity, enabled: true })
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => (open ? undefined : onClose())}>
+      <DialogContent className="sm:max-w-lg">
+        <form onSubmit={submit} className="space-y-5">
+          <DialogHeader>
+            <DialogTitle>{policy ? "Edit AI usage limit" : "Add AI usage limit"}</DialogTitle>
+            <DialogDescription>
+              Limits apply to every matching subject and reset on the UTC calendar month.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="ai-limit-subject">Applies to</Label>
+              <Combobox
+                id="ai-limit-subject"
+                value={limitSubjectFormValue(subject)}
+                options={subjectChoices}
+                onValueChange={(value) => {
+                  setSubject(parseLimitSubjectFormValue(value))
+                  setValidationError(undefined)
+                }}
+                disabled={policy !== undefined}
+                placeholder={
+                  subjectOptionsLoading ? "Loading project subjects…" : "Select a subject"
+                }
+                searchPlaceholder="Search projects, groups, users, or service accounts…"
+                emptyLabel="No matching project subject found."
+                className="bg-white dark:bg-input/30"
+              />
+              <p className="text-xs text-muted-foreground">
+                Choose the project, group, user, or service account this limit controls.
+              </p>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Meter</Label>
+                <ToggleGroup
+                  type="single"
+                  value={meter}
+                  onValueChange={(value) => {
+                    if (!value || policy !== undefined) return
+                    setMeter(value as AiLimitFormMeter)
+                    setAmount("")
+                    setValidationError(undefined)
+                  }}
+                  variant="outline"
+                  spacing={0}
+                  className="w-full bg-white dark:bg-input/30"
+                >
+                  <ToggleGroupItem
+                    value="cost.catalogEstimated"
+                    disabled={policy !== undefined}
+                    className="flex-1"
+                  >
+                    Cost
+                  </ToggleGroupItem>
+                  <ToggleGroupItem
+                    value="tokens.total"
+                    disabled={policy !== undefined}
+                    className="flex-1"
+                  >
+                    Tokens
+                  </ToggleGroupItem>
+                </ToggleGroup>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="ai-limit-amount">
+                  {meter === "cost.catalogEstimated"
+                    ? `Monthly cost limit (${currency})`
+                    : "Monthly token limit"}
+                </Label>
+                <div className="flex gap-2">
+                  {meter === "cost.catalogEstimated" ? (
+                    <div className="flex h-9 w-20 shrink-0 items-center rounded-md border bg-white px-3 text-sm dark:bg-input/30">
+                      {currency}
+                    </div>
+                  ) : null}
+                  <Input
+                    id="ai-limit-amount"
+                    className="bg-white dark:bg-input/30"
+                    inputMode={meter === "tokens.total" ? "numeric" : "decimal"}
+                    placeholder={meter === "tokens.total" ? "1000000" : "100.00"}
+                    value={amount}
+                    onChange={(event) => {
+                      setAmount(event.target.value)
+                      setValidationError(undefined)
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {policy ? (
+            <div className="flex items-center justify-between rounded-lg border bg-white p-3 dark:bg-input/20">
+              <div>
+                <Label htmlFor="ai-limit-enabled">Enforce this limit</Label>
+                <p className="text-xs text-muted-foreground">
+                  Disabled limits retain their history.
+                </p>
+              </div>
+              <Switch id="ai-limit-enabled" checked={enabled} onCheckedChange={setEnabled} />
+            </div>
+          ) : null}
+
+          {validationError || error || directoryError ? (
+            <Alert variant="destructive">
+              <TriangleAlert />
+              <AlertDescription>
+                {validationError ??
+                  aiLimitErrorMessage(
+                    error ?? directoryError,
+                    directoryError
+                      ? "Could not load selectable project subjects."
+                      : "Could not save the limit."
+                  )}
+              </AlertDescription>
+            </Alert>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              className="bg-white dark:bg-input/30"
+              disabled={pending}
+              onClick={onClose}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending}>
+              {pending ? <Loader2 className="size-4 animate-spin" /> : null}
+              {policy ? "Save changes" : "Add limit"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function quantityIsPositive(quantity: AiLimitFormQuantity): boolean {
+  return quantity.meter === "tokens.total"
+    ? quantity.amount > 0
+    : BigInt(quantity.amount.amountNanos) > 0n
+}
+
+function committedIsPositive(status: LimitStatus): boolean {
+  return (
+    quantityIsPositive(status.consumption.actual) ||
+    quantityIsPositive(status.consumption.reserved) ||
+    quantityIsPositive(status.consumption.unknown)
+  )
+}
+
+function formatAiLimitPercent(percent: number, hasUsage: boolean): string {
+  if (hasUsage && percent < 0.01) return "<0.01%"
+  return `${percent.toLocaleString(undefined, { maximumFractionDigits: 1 })}%`
+}
+
+function limitSubjectFormChoices(
+  options: LimitSubjectOptions | undefined,
+  selected?: LimitSubject
+) {
+  const choices = [
+    { value: "project", label: "Current project", description: "Project" },
+    ...(["group", "user", "serviceAccount"] as const).flatMap((type) =>
+      aiLimitSubjectChoices(options, type).map((choice) => ({
+        ...choice,
+        value: limitSubjectFormValue({ type, id: choice.value }),
+        description: [subjectTypeLabel(type), choice.description].filter(Boolean).join(" · "),
+      }))
+    ),
+  ]
+  if (selected && !choices.some((choice) => choice.value === limitSubjectFormValue(selected))) {
+    choices.push({
+      value: limitSubjectFormValue(selected),
+      label: aiLimitSubjectLabel(selected, options),
+      description: selected.type === "project" ? "Project" : subjectTypeLabel(selected.type),
+    })
+  }
+  return choices
+}
+
+function limitSubjectFormValue(subject: LimitSubject): string {
+  return subject.type === "project" ? "project" : `${subject.type}:${subject.id}`
+}
+
+function parseLimitSubjectFormValue(value: string): LimitSubject {
+  if (value === "project") return { type: "project" }
+  const separator = value.indexOf(":")
+  const type = value.slice(0, separator)
+  const id = value.slice(separator + 1)
+  if (id && (type === "group" || type === "user" || type === "serviceAccount")) {
+    return { type, id }
+  }
+  throw new Error(`[SixbAtlas] Invalid AI limit subject selection: ${value}`)
+}
+
+function subjectTypeLabel(subject: Exclude<LimitSubjectType, "project">): string {
+  if (subject === "serviceAccount") return "Service account"
+  return subject === "group" ? "Group" : "User"
+}
+
+function meterLabel(meter: AiLimitFormMeter): string {
+  return meter === "tokens.total" ? "Token limit" : "Cost limit"
+}
+
+function formatLimitPeriod(start: string, end: string): string {
+  const startLabel = new Date(start).toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  })
+  const endLabel = new Date(end).toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  })
+  return `Current period: ${startLabel} – ${endLabel} UTC`
+}
+
+function formatReset(value: string): string {
+  return new Date(value).toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "UTC",
+    timeZoneName: "short",
+  })
+}
+
+function aiLimitErrorMessage(error: unknown, fallback: string): string {
+  if (typeof error === "object" && error !== null && "error" in error) {
+    const message = (error as { error?: unknown }).error
+    if (typeof message === "string" && message.length > 0) return message
+  }
+  return error instanceof Error && error.message ? error.message : fallback
+}

--- a/packages/atlas/src/components/UsageBar.tsx
+++ b/packages/atlas/src/components/UsageBar.tsx
@@ -6,6 +6,8 @@ interface UsageBarProps {
   color?: "blue" | "green" | "amber" | "red" | "auto"
   showLabel?: boolean
   size?: "sm" | "md"
+  ariaLabel?: string
+  valueText?: string
 }
 
 function getAutoColor(percentage: number): string {
@@ -27,6 +29,8 @@ export function UsageBar({
   color = "auto",
   showLabel = false,
   size = "sm",
+  ariaLabel,
+  valueText,
 }: UsageBarProps) {
   const percentage = Math.min(100, Math.max(0, (value / max) * 100))
   const barColor = color === "auto" ? getAutoColor(percentage) : colorMap[color]
@@ -34,14 +38,22 @@ export function UsageBar({
 
   return (
     <div className="w-full">
-      <div className={cn("w-full rounded-full overflow-hidden bg-muted", heightClass)}>
+      <div
+        className={cn("w-full overflow-hidden rounded-full bg-muted", heightClass)}
+        role="progressbar"
+        aria-label={ariaLabel}
+        aria-valuemin={0}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        aria-valuetext={valueText}
+      >
         <div
           className={cn(
             "rounded-full transition-all duration-500 shadow-[inset_0_-1px_0_rgba(255,255,255,0.2)]",
             heightClass,
             barColor
           )}
-          style={{ width: `${percentage}%` }}
+          style={{ width: `${percentage}%`, minWidth: percentage > 0 ? "2px" : undefined }}
         />
       </div>
       {showLabel && (

--- a/packages/atlas/src/lib/aiLimits.ts
+++ b/packages/atlas/src/lib/aiLimits.ts
@@ -1,0 +1,164 @@
+import type { GetAiLimitSubjectOptionsResponse } from "@sixb/client"
+import { humanizeIdentifier } from "./labels"
+
+export type AiLimitFormMeter = "tokens.total" | "cost.catalogEstimated"
+export type AiLimitSelectableSubjectType = "group" | "user" | "serviceAccount"
+export type AiLimitSubjectOptions = GetAiLimitSubjectOptionsResponse
+
+export interface AiLimitSubjectChoice {
+  readonly value: string
+  readonly label: string
+  readonly description?: string
+}
+
+export type AiLimitFormQuantity =
+  | { readonly meter: "tokens.total"; readonly amount: number }
+  | {
+      readonly meter: "cost.catalogEstimated"
+      readonly amount: { readonly currency: "USD"; readonly amountNanos: string }
+    }
+
+export type AiLimitFormParseResult =
+  | { readonly ok: true; readonly quantity: AiLimitFormQuantity }
+  | { readonly ok: false; readonly error: string }
+
+export function parseAiLimitFormQuantity(
+  meter: AiLimitFormMeter,
+  amountInput: string,
+  currencyInput = "USD"
+): AiLimitFormParseResult {
+  const amount = amountInput.trim().replaceAll(",", "")
+  if (meter === "tokens.total") {
+    if (!/^\d+$/.test(amount)) {
+      return { ok: false, error: "Enter a whole, non-negative token amount." }
+    }
+    const tokens = Number(amount)
+    if (!Number.isSafeInteger(tokens)) {
+      return { ok: false, error: "Token amount is too large." }
+    }
+    return { ok: true, quantity: { meter, amount: tokens } }
+  }
+
+  const currency = currencyInput.trim().toUpperCase()
+  if (currency !== "USD") {
+    return { ok: false, error: "Catalog-estimated limits use USD." }
+  }
+  const match = /^(\d+)(?:\.(\d{0,9}))?$/.exec(amount)
+  if (!match) {
+    return { ok: false, error: "Enter a non-negative amount with at most nine decimal places." }
+  }
+  const whole = BigInt(match[1])
+  const fraction = BigInt((match[2] ?? "").padEnd(9, "0"))
+  const amountNanos = whole * 1_000_000_000n + fraction
+  if (amountNanos > 9_223_372_036_854_775_807n) {
+    return { ok: false, error: "Cost amount is too large." }
+  }
+  return {
+    ok: true,
+    quantity: {
+      meter,
+      amount: { currency: "USD", amountNanos: amountNanos.toString() },
+    },
+  }
+}
+
+export function aiLimitAmountInput(quantity: AiLimitFormQuantity): string {
+  if (quantity.meter === "tokens.total") return quantity.amount.toString()
+  const nanos = BigInt(quantity.amount.amountNanos)
+  const whole = nanos / 1_000_000_000n
+  const fraction = (nanos % 1_000_000_000n).toString().padStart(9, "0").replace(/0+$/, "")
+  return fraction ? `${whole}.${fraction}` : whole.toString()
+}
+
+export function formatAiLimitQuantity(quantity: AiLimitFormQuantity): string {
+  if (quantity.meter === "tokens.total") {
+    return `${quantity.amount.toLocaleString()} tokens`
+  }
+  const nanos = BigInt(quantity.amount.amountNanos)
+  if (nanos > 0n && nanos < 1_000n) return `${quantity.amount.currency} <0.000001`
+  const value = Number(nanos) / 1_000_000_000
+  const maximumFractionDigits = value === 0 ? 2 : value < 0.01 ? 6 : value < 1 ? 4 : 2
+  return `${quantity.amount.currency} ${value.toLocaleString(undefined, {
+    minimumFractionDigits: value === 0 || value >= 1 ? 2 : 0,
+    maximumFractionDigits,
+  })}`
+}
+
+export function formatAiLimitQuantityExact(quantity: AiLimitFormQuantity): string {
+  if (quantity.meter === "tokens.total") {
+    return `${quantity.amount.toLocaleString()} tokens`
+  }
+  const nanos = BigInt(quantity.amount.amountNanos)
+  const whole = nanos / 1_000_000_000n
+  const fraction = (nanos % 1_000_000_000n).toString().padStart(9, "0").replace(/0+$/, "")
+  return `${quantity.amount.currency} ${whole.toLocaleString("en-US")}${fraction ? `.${fraction}` : ".00"}`
+}
+
+export function aiLimitUsagePercent(input: {
+  readonly limit: AiLimitFormQuantity
+  readonly actual: AiLimitFormQuantity
+  readonly reserved: AiLimitFormQuantity
+  readonly unknown: AiLimitFormQuantity
+}): number {
+  const limit = quantityAmount(input.limit)
+  if (limit === 0n) return 100
+  const committed =
+    quantityAmount(input.actual) + quantityAmount(input.reserved) + quantityAmount(input.unknown)
+  const millionthsOfPercent = (committed * 100_000_000n) / limit
+  return Math.min(100, Number(millionthsOfPercent) / 1_000_000)
+}
+
+export function aiLimitSubjectChoices(
+  options: AiLimitSubjectOptions | undefined,
+  type: AiLimitSelectableSubjectType
+): readonly AiLimitSubjectChoice[] {
+  if (!options) return []
+  if (type === "group") {
+    return options.groups.map((group) => ({
+      value: group.id,
+      label: group.label ?? humanizeIdentifier(group.id),
+      ...(group.description === undefined ? {} : { description: group.description }),
+    }))
+  }
+  if (type === "user") {
+    return options.users.map((user) => ({
+      value: user.id,
+      label: user.displayName?.trim() || user.email,
+      description: [user.displayName?.trim() ? user.email : undefined, statusLabel(user.status)]
+        .filter(Boolean)
+        .join(" · "),
+    }))
+  }
+  return options.serviceAccounts.map((serviceAccount) => ({
+    value: serviceAccount.id,
+    label: serviceAccount.name,
+    description: [serviceAccount.description, statusLabel(serviceAccount.status)]
+      .filter(Boolean)
+      .join(" · "),
+  }))
+}
+
+export function aiLimitSubjectLabel(
+  subject:
+    | { readonly type: "project" }
+    | { readonly type: AiLimitSelectableSubjectType; readonly id: string },
+  options?: AiLimitSubjectOptions
+): string {
+  if (subject.type === "project") return "Current project"
+  const choice = aiLimitSubjectChoices(options, subject.type).find(
+    (option) => option.value === subject.id
+  )
+  if (choice) return choice.label
+  if (subject.type === "serviceAccount") return `Service account · ${subject.id}`
+  return `${subject.type === "group" ? "Group" : "User"} · ${subject.id}`
+}
+
+function quantityAmount(quantity: AiLimitFormQuantity): bigint {
+  return quantity.meter === "tokens.total"
+    ? BigInt(quantity.amount)
+    : BigInt(quantity.amount.amountNanos)
+}
+
+function statusLabel(status: "active" | "suspended"): string {
+  return status === "active" ? "Active" : "Suspended"
+}

--- a/packages/atlas/src/lib/aiLimits.ts
+++ b/packages/atlas/src/lib/aiLimits.ts
@@ -27,7 +27,13 @@ export function parseAiLimitFormQuantity(
   amountInput: string,
   currencyInput = "USD"
 ): AiLimitFormParseResult {
-  const amount = amountInput.trim().replaceAll(",", "")
+  const amount = amountInput.trim()
+  if (/[,\s]/.test(amount)) {
+    return {
+      ok: false,
+      error: "Use a dot for decimals and no thousands separators (for example, 1234.50).",
+    }
+  }
   if (meter === "tokens.total") {
     if (!/^\d+$/.test(amount)) {
       return { ok: false, error: "Enter a whole, non-negative token amount." }

--- a/packages/atlas/src/pages/AiUsagePage.tsx
+++ b/packages/atlas/src/pages/AiUsagePage.tsx
@@ -1,5 +1,9 @@
 import type { GetAiAccountingOverviewResponse, ListAiModelCallsResponse } from "@sixb/client"
-import { getAiAccountingOverviewOptions, listAiModelCallsOptions } from "@sixb/client/hooks"
+import {
+  getAiAccountingOverviewOptions,
+  getAiLimitStatusQueryKey,
+  listAiModelCallsOptions,
+} from "@sixb/client/hooks"
 import {
   Button,
   Card,
@@ -20,7 +24,7 @@ import {
   TableHeader,
   TableRow,
 } from "@sixb/ui/components"
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   Bot,
   CircleDollarSign,
@@ -32,6 +36,7 @@ import {
 } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { Link } from "react-router-dom"
+import { AI_LIMIT_STATUS_QUERY, AiLimitPanel } from "../components/AiLimitPanel"
 import { AiUsageBreakdown, AiUsageMetricCard, AiUsageTimeSeries } from "../components/AiUsageCharts"
 import { AiUsageDateRangeControl } from "../components/AiUsageDateRangeControl"
 import { utcAccountingRangeForCalendarDays } from "../lib/aiUsageDateRange"
@@ -57,6 +62,7 @@ const RANGE_OPTIONS: readonly { value: RangePreset; label: string; milliseconds:
 ]
 
 export function AiUsagePage() {
+  const queryClient = useQueryClient()
   const [rangeSelection, setRangeSelection] = useState<RangeSelection>(() => ({
     kind: "preset",
     preset: "7d",
@@ -101,6 +107,9 @@ export function AiUsagePage() {
   }, [currencies, currency])
 
   const refresh = () => {
+    void queryClient.invalidateQueries({
+      queryKey: getAiLimitStatusQueryKey(AI_LIMIT_STATUS_QUERY),
+    })
     if (rangeSelection.kind === "preset") {
       setRangeSelection({ ...rangeSelection, end: new Date() })
       return
@@ -112,15 +121,28 @@ export function AiUsagePage() {
   const loading = unfilteredQuery.isLoading || (hasFilters && overviewQuery.isLoading)
   const error = unfilteredQuery.error ?? overviewQuery.error
 
-  if (loading) return <AiUsageLoading />
+  if (loading) {
+    return (
+      <div className="space-y-5">
+        <AiLimitPanel />
+        <AiUsageLoading />
+      </div>
+    )
+  }
   if (error || !overview) {
     return (
-      <EmptyState
-        icon={<TriangleAlert />}
-        title="AI accounting is unavailable"
-        description="Atlas could not load project token usage and pricing analytics. Check that AI accounting storage is configured and migrated."
-        action={<Button onClick={refresh}>Retry</Button>}
-      />
+      <div className="space-y-5">
+        <AiLimitPanel />
+        <EmptyState
+          icon={<TriangleAlert />}
+          title="AI accounting is unavailable"
+          description={aiUsageErrorMessage(
+            error,
+            "Atlas could not load project token usage and pricing analytics. Check that AI accounting storage is configured and migrated."
+          )}
+          action={<Button onClick={refresh}>Retry</Button>}
+        />
+      </div>
     )
   }
 
@@ -234,6 +256,15 @@ export function AiUsagePage() {
           </Button>
         </div>
       </header>
+
+      <AiLimitPanel />
+
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold">Usage analytics</h2>
+        <p className="text-sm text-muted-foreground">
+          Historical model activity for the selected date range and filters.
+        </p>
+      </div>
 
       <div className="flex flex-wrap gap-2">
         <AccountingSelect
@@ -462,6 +493,14 @@ export function AiUsagePage() {
       />
     </div>
   )
+}
+
+function aiUsageErrorMessage(error: unknown, fallback: string): string {
+  if (error && typeof error === "object") {
+    if ("error" in error && typeof error.error === "string") return error.error
+    if ("message" in error && typeof error.message === "string") return error.message
+  }
+  return fallback
 }
 
 function ModelCallsTable({
@@ -932,10 +971,16 @@ function nanosToChartValue(amountNanos: string | undefined): number {
 }
 
 function formatMoney(money: { currency: string; amountNanos: string }): string {
-  const nanos = BigInt(money.amountNanos)
-  const whole = nanos / 1_000_000_000n
-  const fraction = (nanos % 1_000_000_000n).toString().padStart(9, "0").replace(/0+$/, "")
-  return `${money.currency} ${whole.toLocaleString("en-US")}${fraction ? `.${fraction.padEnd(2, "0")}` : ".00"}`
+  const value = Number(BigInt(money.amountNanos)) / 1_000_000_000
+  const maximumFractionDigits = value === 0 ? 2 : value < 0.01 ? 6 : value < 1 ? 4 : 2
+  const formatter = new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: money.currency,
+    minimumFractionDigits: value === 0 || value >= 1 ? 2 : 0,
+    maximumFractionDigits,
+  })
+  if (value > 0 && value < 0.000001) return `<${formatter.format(0.000001)}`
+  return formatter.format(value)
 }
 
 function formatChartMoney(value: number, currency: string | undefined): string {

--- a/packages/atlas/tests/aiLimits.test.ts
+++ b/packages/atlas/tests/aiLimits.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test"
+import {
+  aiLimitAmountInput,
+  aiLimitSubjectChoices,
+  aiLimitSubjectLabel,
+  aiLimitUsagePercent,
+  formatAiLimitQuantity,
+  formatAiLimitQuantityExact,
+  parseAiLimitFormQuantity,
+} from "../src/lib/aiLimits"
+
+describe("AI limit presentation", () => {
+  test("parses token limits without accepting fractional or unsafe values", () => {
+    expect(parseAiLimitFormQuantity("tokens.total", "12,500")).toEqual({
+      ok: true,
+      quantity: { meter: "tokens.total", amount: 12_500 },
+    })
+    expect(parseAiLimitFormQuantity("tokens.total", "1.5").ok).toBe(false)
+    expect(parseAiLimitFormQuantity("tokens.total", "9007199254740992").ok).toBe(false)
+  })
+
+  test("converts decimal cost input to exact nanounits", () => {
+    const parsed = parseAiLimitFormQuantity("cost.catalogEstimated", "1,234.000000009", "usd")
+    expect(parsed).toEqual({
+      ok: true,
+      quantity: {
+        meter: "cost.catalogEstimated",
+        amount: { currency: "USD", amountNanos: "1234000000009" },
+      },
+    })
+    if (!parsed.ok) throw new Error("expected a parsed cost limit")
+    expect(aiLimitAmountInput(parsed.quantity)).toBe("1234.000000009")
+    expect(formatAiLimitQuantity(parsed.quantity)).toBe("USD 1,234.00")
+    expect(formatAiLimitQuantityExact(parsed.quantity)).toBe("USD 1,234.000000009")
+    expect(parseAiLimitFormQuantity("cost.catalogEstimated", "1", "EUR")).toEqual({
+      ok: false,
+      error: "Catalog-estimated limits use USD.",
+    })
+    expect(parseAiLimitFormQuantity("cost.catalogEstimated", "1.0000000001").ok).toBe(false)
+    expect(parseAiLimitFormQuantity("cost.catalogEstimated", "9223372036.854775808").ok).toBe(false)
+  })
+
+  test("includes actual, reserved, and unknown capacity in the usage bar", () => {
+    expect(
+      aiLimitUsagePercent({
+        limit: { meter: "tokens.total", amount: 1_000 },
+        actual: { meter: "tokens.total", amount: 400 },
+        reserved: { meter: "tokens.total", amount: 100 },
+        unknown: { meter: "tokens.total", amount: 50 },
+      })
+    ).toBe(55)
+
+    expect(
+      aiLimitUsagePercent({
+        limit: {
+          meter: "cost.catalogEstimated",
+          amount: { currency: "USD", amountNanos: "100000000000" },
+        },
+        actual: {
+          meter: "cost.catalogEstimated",
+          amount: { currency: "USD", amountNanos: "82096" },
+        },
+        reserved: {
+          meter: "cost.catalogEstimated",
+          amount: { currency: "USD", amountNanos: "0" },
+        },
+        unknown: {
+          meter: "cost.catalogEstimated",
+          amount: { currency: "USD", amountNanos: "0" },
+        },
+      })
+    ).toBe(0.000082)
+  })
+
+  test("builds friendly selectable subjects without requiring typed ids", () => {
+    const directory = {
+      groups: [{ id: "customer-success", label: "Customer success" }],
+      users: [
+        {
+          id: "usr_1",
+          email: "ada@example.com",
+          displayName: "Ada Lovelace",
+          status: "active" as const,
+        },
+      ],
+      serviceAccounts: [
+        {
+          id: "svc_1",
+          name: "Billing automation",
+          status: "suspended" as const,
+        },
+      ],
+    }
+
+    expect(aiLimitSubjectChoices(directory, "group")).toEqual([
+      { value: "customer-success", label: "Customer success" },
+    ])
+    expect(aiLimitSubjectChoices(directory, "user")).toEqual([
+      {
+        value: "usr_1",
+        label: "Ada Lovelace",
+        description: "ada@example.com · Active",
+      },
+    ])
+    expect(aiLimitSubjectChoices(directory, "serviceAccount")).toEqual([
+      {
+        value: "svc_1",
+        label: "Billing automation",
+        description: "Suspended",
+      },
+    ])
+    expect(aiLimitSubjectLabel({ type: "user", id: "usr_1" }, directory)).toBe("Ada Lovelace")
+  })
+})

--- a/packages/atlas/tests/aiLimits.test.ts
+++ b/packages/atlas/tests/aiLimits.test.ts
@@ -11,7 +11,7 @@ import {
 
 describe("AI limit presentation", () => {
   test("parses token limits without accepting fractional or unsafe values", () => {
-    expect(parseAiLimitFormQuantity("tokens.total", "12,500")).toEqual({
+    expect(parseAiLimitFormQuantity("tokens.total", "12500")).toEqual({
       ok: true,
       quantity: { meter: "tokens.total", amount: 12_500 },
     })
@@ -20,7 +20,7 @@ describe("AI limit presentation", () => {
   })
 
   test("converts decimal cost input to exact nanounits", () => {
-    const parsed = parseAiLimitFormQuantity("cost.catalogEstimated", "1,234.000000009", "usd")
+    const parsed = parseAiLimitFormQuantity("cost.catalogEstimated", "1234.000000009", "usd")
     expect(parsed).toEqual({
       ok: true,
       quantity: {
@@ -38,6 +38,19 @@ describe("AI limit presentation", () => {
     })
     expect(parseAiLimitFormQuantity("cost.catalogEstimated", "1.0000000001").ok).toBe(false)
     expect(parseAiLimitFormQuantity("cost.catalogEstimated", "9223372036.854775808").ok).toBe(false)
+  })
+
+  // Regression check: restoring replaceAll(",", "") in the parser turns 1,50 into 150.
+  test("rejects ambiguous decimal and grouping separators without changing the budget", () => {
+    for (const amount of ["1,50", "1,234", "1,234.56", "1.234,56", "1 234", "1\u202f234"]) {
+      for (const meter of ["tokens.total", "cost.catalogEstimated"] as const) {
+        expect(parseAiLimitFormQuantity(meter, amount).ok).toBe(false)
+      }
+    }
+    expect(parseAiLimitFormQuantity("cost.catalogEstimated", " 1.50 ")).toMatchObject({
+      ok: true,
+      quantity: { amount: { amountNanos: "1500000000" } },
+    })
   })
 
   test("includes actual, reserved, and unknown capacity in the usage bar", () => {


### PR DESCRIPTION

## Summary

Add monthly AI usage-limit visibility and management to Atlas, and document the guarantees and
operational caveats of the first enforcement release.

The AI Usage page now presents current-month policies independently from its historical analytics
filters. Authorized managers can create, edit, enable, disable, and delete project, group, user, and
service-account policies. Observers retain a read-only status experience, while callers without the
required grants receive a clear unavailable state.

## What changes

- Add an AI limit panel to the existing AI Usage page.
- Show policy limit, actual usage, active reservations, unknown capacity, remaining capacity, reset
  period, accounting quality, enabled state, and orphaned subjects.
- Add create and edit dialogs for token and catalog-estimated USD cost policies.
- Populate searchable subject selectors from the authorized group/user/service-account endpoint;
  operators do not need to enter raw IDs.
- Hide all mutation controls when the API reports that the caller cannot manage policies.
- Add enable/disable and destructive delete flows with cache invalidation and user feedback.
- Improve `UsageBar` progressbar semantics and small nonzero-value rendering.
- Use exact parsing for policy inputs and readable formatting for very small catalog-estimated
  amounts.
- Document authorization, API shapes, reservation/reconciliation behavior, fail-closed cases, and
  the distinction between catalog estimates and provider invoices.

## UX decisions

- Limit status always represents the current UTC calendar month and is not affected by analytics
  date, provider, model, group, or execution filters.
- `unknown` capacity remains visibly committed because releasing it could permit an overrun after a
  provider attempt with ambiguous billing.
- Orphaned groups remain identifiable and editable instead of being hidden.
- Reservations use local cost estimates; recorded consumption follows the runtime's selected valuation.
  Documentation distinguishes this accounting from provider-invoice reconciliation.
- Empty, loading, unauthorized, unavailable, exhausted, disabled, and orphaned states are handled
  explicitly.

## Reviewer guide

Suggested review order:

1. `packages/atlas/src/lib/aiLimits.ts` and its tests for exact parsing and formatting.
2. `AiLimitPanel.tsx` for query ownership, capability handling, and mutations.
3. `AiUsagePage.tsx` and `UsageBar.tsx` for page integration and accessibility.
4. `docs/agents/usage-limits.md` and the authorization docs for public guarantees.

The panel intentionally consumes only generated client operations from PR 4; it does not reach
into storage or duplicate authorization decisions in the browser.

## Validation performed

- `bun run typecheck` — passed across the repository, including Atlas and docs.
- `bun --filter @sixb/atlas build` — passed.
- `bun run test:ci` — 4,843 passed, 7 environment-dependent tests skipped, 0 failed.
- `bun run check` and `git diff --check` — passed.

The rebase preserves the regression coverage rejecting decimal commas and ambiguous separators
in policy amounts, and the accounting-repair documentation. Documentation now reflects model
reservation estimators, Anthropic cache rates, and the existing per-call output-token settings.

## Not in this PR

- New backend policy semantics, meters, periods, or enforcement paths.
- Output-token ceilings configured through usage-limit policies.
- Execution-root or per-execution budgets.
- Provider invoice reconciliation or an operator workflow for manually releasing unknown capacity.

## Stack

This is PR 5 of 5 in GitHub stack #514. It is rebased onto main, which now includes
#509, #510, #511, and #512, and completes the first aggregate AI usage-limit release.
