### PR TITLE
workflows: add first-class Agent tasks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -402,6 +402,7 @@
         "@sixb/vercel-ai-gateway": "workspace:*",
         "@tailwindcss/cli": "^4.2.2",
         "@tanstack/react-query": "^5.0.0",
+        "ai": "^7.0.4",
         "lucide-react": "^0.562.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -998,6 +999,12 @@
     "@types/bun": "1.3.14",
   },
   "packages": {
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.75", "", { "dependencies": { "@ai-sdk/provider": "4.0.10", "@ai-sdk/provider-utils": "5.0.36", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HOnhw3oXtBnboBF7kAKipjToCN6+5w6EuukiUKiULcxBitS+vbHRRv9IUBcq+Z1wkXcJjfywKrt5r++I6OYyXg=="],
+
+    "@ai-sdk/provider": ["@ai-sdk/provider@4.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-fX2ENAc7iDpZ+Wp4+Rk06Usn/Ys7dI9uAkGv0jlF6XVrW13NkRWx5Ou+U6lIM2E1fTLkCs16GGrUAaVvroag7A=="],
+
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.36", "", { "dependencies": { "@ai-sdk/provider": "4.0.10", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.29.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MFXBn6XDyf37PNQAge/HTatPJE8Vmg/g/w4WPtjSV53jq8FKAzoaN5+43hsdQa9bqgN+/13jxug9ChvsG+godQ=="],
+
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -1682,6 +1689,8 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
+    "ai": ["ai@7.0.93", "", { "dependencies": { "@ai-sdk/gateway": "4.0.75", "@ai-sdk/provider": "4.0.10", "@ai-sdk/provider-utils": "5.0.36" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CJss6zb9mlltk/mCr8qom20NBnqEQxVawkqwtT62tCwsxilZpXfHNRMRwcS3XRpzdP1kEluVuDBUayYWEEd95g=="],
+
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
@@ -1898,6 +1907,8 @@
 
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
 
+    "eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
+
     "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
@@ -2003,6 +2014,8 @@
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "jsonlines": ["jsonlines@0.1.1", "", {}, "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA=="],
 
@@ -2475,6 +2488,10 @@
     "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@ai-sdk/provider-utils/@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
+
+    "@ai-sdk/provider-utils/undici": ["undici@7.29.1", "", {}, "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q=="],
 
     "@radix-ui/react-accordion/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
 

--- a/docs/agents/authorization.md
+++ b/docs/agents/authorization.md
@@ -28,16 +28,15 @@ When authentication is disabled for the runtime, requests through the Agent API 
 same unrestricted authorization behavior as normal API requests. The group restrictions below
 apply when authentication is enabled.
 
-### Groups gate use and reach
+### Run grants gate use
 
-An agent's `groups` (set on `defineAgent`) do two things:
+A principal can list and run an agent only if their grants cover it (`run:agent`).
+`GET /api/agents` returns only agents the caller may run; running one without the grant is rejected.
 
-- **Who can use it.** A principal can list and run an agent only if their grants cover it
-  (`run:agent`). `GET /api/agents` returns only agents the caller may run; running one without the
-  grant is rejected.
-- **What it can reach.** A run acts under its own identity whose memberships mirror the agent's
-  groups — so it can query the objects, read the telemetry, and request the actions its groups
-  allow, and nothing else. Its instructions can ask for anything; only its permissions get through.
+### Groups gate reach
+
+A run acts under its own identity whose memberships mirror the agent's `groups`. It can only reach
+the objects, telemetry, actions, and other capabilities those groups allow.
 
 ```ts
 import { defineAgent, defineGroup } from "@sixb/core"
@@ -55,6 +54,13 @@ export const invoiceAssistant = defineAgent("invoice-assistant", {
 
 Every referenced group must exist in your security registry (`security/groups/` or
 `createSixb({ groups })`), or startup fails.
+
+## Workflow agent tasks
+
+Starting the workflow is authorized by `run:workflow`; an agent task is not independently runnable
+and needs no `run:agent` grant. Sixb gives each workflow step a stable managed service account whose
+memberships mirror `defineAgentStep({ groups })`. The workflow requester remains the execution's
+original attribution, but the task acts only with its own declared reach.
 
 ## Threads are owner-scoped
 

--- a/docs/agents/overview.md
+++ b/docs/agents/overview.md
@@ -27,8 +27,8 @@ When authentication is enabled, the main agent inherits the requesting user's cu
 
 ## Defined agents
 
-`defineAgent` remains available for existing agent workflow steps during the transition to direct
-workflow agent configuration.
+`defineAgent` remains temporarily available for existing conversational agents. New workflow agent
+tasks are configured directly with `defineAgentStep`; see [Workflows](../workflows/overview.md).
 
 Put each definition in `agents/` and export it.
 
@@ -56,7 +56,7 @@ See [Defining agents](./defining-agents.md) for every config field.
 | Concept | What it is |
 | --- | --- |
 | **Main agent** | The framework-owned conversational entry point, enabled by the project model catalog. |
-| **Defined agent** | An existing `defineAgent` configuration used by current workflow steps. |
+| **Defined agent** | A transitional `defineAgent` configuration for existing conversations. |
 | **Thread** | One conversation with an agent, owned by a principal. |
 | **Run** | One turn. Posting a user message triggers a run. |
 | **Message** | A `system`, `user`, or `assistant` message made of `text`, `reasoning`, `step-start`, and `tool-call` parts. |

--- a/docs/agents/tools-and-gateway.md
+++ b/docs/agents/tools-and-gateway.md
@@ -61,7 +61,8 @@ See [Sandboxes](../sandboxes/overview.md) for factory options and isolation.
 ## Project tools
 
 Project tools run in the agent worker, not the Bash sandbox. Connector credentials stay on the host
-and are not model input. Register them once in `createSixb`; the main agent receives the full list.
+and are not model input. Register them once in `createSixb`; the main agent receives the full list,
+while workflow agent tasks select an explicit subset.
 
 ### Custom tools
 
@@ -90,8 +91,7 @@ export const sixb = createSixb({
 })
 ```
 
-Defined agents continue selecting their own `tools` until workflow agent configuration moves away
-from `defineAgent`.
+Workflow agent tasks select tools directly in `defineAgentStep({ tools })`.
 
 The handler receives inferred input, the provider's `toolCallId`, cancellation, run metadata,
 connector resolution, a run-scoped logger, and an artifact publisher. Ordinary results must be
@@ -168,6 +168,20 @@ attachments. Symbolic links and paths outside the workspace are rejected.
 Complete files moved there are collected as final assistant attachments; it is not used as the live
 tool-result transport.
 
+Tool definitions are not auto-discovered. Register project tools in the project config:
+
+```ts
+tools: [searchKnowledge]
+```
+
+Workflow agent tasks select only what they need:
+
+```ts
+defineAgentStep("research", {
+  instructions: "Research the request using trusted sources.",
+  tools: [searchKnowledge],
+})
+```
 Names must be unique within each list. `bash`, `read`, `view_file`, and `spawn_agent` are reserved
 for framework tools.
 ### Exa web tools

--- a/docs/workflows/overview.md
+++ b/docs/workflows/overview.md
@@ -4,8 +4,8 @@ A workflow runs a business process in a known order. Reach for one when work nee
 steps, typed data flowing between them, an object [action](../actions/overview.md) at the end, and a
 run history you can inspect.
 
-A workflow chains **nodes**: **steps** (typed functions that produce data), **action nodes** (which
-run an object action), and **interventions** (which pause for a human decision — see
+A workflow chains **nodes**: **steps** (typed functions), **agent tasks** (model-driven work with
+structured output), **action nodes**, and **interventions** (human decisions — see
 [Interventions](interventions.md)).
 
 ## When to use a workflow
@@ -58,6 +58,36 @@ const loadInvoiceContext = defineWorkflowStep("load-invoice-context")
 
 A field typed `ref(Invoice)` carries an object reference of the shape `{ objectTypeId, primaryId }`.
 
+## Define agent tasks
+
+An agent task owns its model instructions, permissions, tools, and typed input/output contract.
+
+```ts
+import { defineAgentStep, ref } from "@sixb/core"
+import { finance } from "../security/groups/finance"
+import { searchInvoices } from "../agent-tools/search-invoices"
+
+const composeReminder = defineAgentStep("compose-reminder", {
+  instructions: "Draft a concise reminder grounded in invoice data.",
+  reasoning: "medium",
+  groups: [finance],
+  tools: [searchInvoices],
+})
+  .input({ invoice: ref(Invoice) })
+  .output({ invoice: ref(Invoice), message: "string" })
+  .prompt(({ input }) => `Draft a reminder for invoice '${input.invoice.primaryId}'.`)
+```
+
+| Option | Behavior |
+| --- | --- |
+| `model` | Optional; otherwise uses the first `models.language` entry |
+| `groups` | Permissions of the task's stable, Sixb-managed service account; defaults to none |
+| `tools` | Project tools available to this task; defaults to none |
+
+Tools must also be registered in `createSixb({ tools })`. When a model catalog is configured, an
+explicit model must belong to `models.language`. Sandboxed framework tools such as `read` and
+`bash` are injected separately.
+
 ## Compose the chain
 
 `defineWorkflow(id)` declares the input, then `.then(...)` appends each node in order.
@@ -88,6 +118,7 @@ export const invoiceReminder = defineWorkflow("invoice-reminder")
 | `.input({ invoice })` | Declares the input needed to start a run |
 | `.when(schedule, mapper?)` | Auto-starts from a cron or [event schedule](../schedules/events.md) |
 | `.then(step)` | Runs a step |
+| `.then(agentTask)` | Runs an agent task and waits for its structured output |
 | `.then(action, mapper)` | Runs an object action |
 | `.then(intervention)` | Pauses for a human decision |
 | `steps.composeReminder` | Reads the output of an earlier node |
@@ -245,7 +276,7 @@ A run moves through these statuses, recorded per run and per node so you can ins
 | --- | --- |
 | `queued` | Requested; waiting for a worker |
 | `running` | A node is executing |
-| `waiting` | Suspended at an intervention, awaiting a response |
+| `waiting` | Suspended while an intervention or agent task completes |
 | `succeeded` | All nodes finished |
 | `failed` | A node threw; the run stopped |
 | `cancelled` | The run was cancelled |

--- a/examples/northline/agents/operations-assistant.ts
+++ b/examples/northline/agents/operations-assistant.ts
@@ -1,5 +1,38 @@
-import { defineAgent, defineAgentTool, stringEnum } from "@sixb/core"
+import { type AgentToolResult, defineAgent, defineAgentTool, stringEnum } from "@sixb/core"
 import { vercelGateway } from "@sixb/vercel-ai-gateway"
+import { gateway, generateImage } from "ai"
+
+const IMAGE_MODEL = "xai/grok-imagine-image-2.0"
+
+export const operationsAssistantModel: ReturnType<typeof vercelGateway> = vercelGateway(
+  "deepseek/deepseek-v4-flash-vision-exp"
+)
+
+export const generateImageTool = defineAgentTool("generate_image")
+  .description("Generate an image from a text prompt and return it as an attachment.")
+  .input({ prompt: "string" })
+  .run(async ({ input, artifacts, signal }) => {
+    // Temporary example integration: AI Gateway observes this image call, but Sixb's current usage
+    // ledger records only the worker-owned language-model calls that drive the agent loop.
+    const { image } = await generateImage({
+      model: gateway.image(IMAGE_MODEL),
+      prompt: input.prompt,
+      abortSignal: signal,
+    })
+    const { fileRef } = await artifacts.put({
+      body: image.uint8Array,
+      fileName: `generated-image.${imageFileExtension(image.mediaType)}`,
+      mediaType: image.mediaType,
+    })
+    const result: AgentToolResult = {
+      kind: "agentToolResult",
+      content: [
+        { type: "text", text: "Generated an image." },
+        { type: "file", fileRef },
+      ],
+    }
+    return result
+  })
 
 export const lookupResponsePolicy = defineAgentTool("lookup_response_policy")
   .description(
@@ -40,7 +73,7 @@ const compactionDemoContext =
 export const operationsAssistant = defineAgent("operations-assistant", {
   name: "Operations Assistant",
   description: "A demo agent showing how to add an AI assistant to a Sixb app.",
-  model: vercelGateway("zai/glm-5.3-flash"),
+  model: operationsAssistantModel,
   reasoning: "medium",
   instructions: [
     "This is a demo agent for the Northline example.",

--- a/examples/northline/agents/operations-assistant.ts
+++ b/examples/northline/agents/operations-assistant.ts
@@ -61,6 +61,13 @@ export const lookupResponsePolicy = defineAgentTool("lookup_response_policy")
     }
   })
 
+function imageFileExtension(mediaType: string): string {
+  if (mediaType === "image/jpeg") return "jpg"
+  if (mediaType === "image/webp") return "webp"
+  if (mediaType === "image/gif") return "gif"
+  return "png"
+}
+
 const compactionDemoContext =
   process.env.NORTHLINE_AGENT_COMPACTION_DEMO === "1"
     ? {

--- a/examples/northline/package.json
+++ b/examples/northline/package.json
@@ -14,6 +14,7 @@
     "typecheck": "bun ../../packages/cli/src/index.tsx typegen && tsc --noEmit --paths null"
   },
   "dependencies": {
+    "ai": "^7.0.4",
     "@sixb/app": "workspace:*",
     "@sixb/blob-local": "workspace:*",
     "@sixb/client": "workspace:*",

--- a/examples/northline/sixb.config.ts
+++ b/examples/northline/sixb.config.ts
@@ -5,12 +5,19 @@ import { DuckLakeStorage } from "@sixb/ducklake"
 import { LocalSandboxFactory } from "@sixb/sandboxes-local"
 import { SmolvmSandboxFactory } from "@sixb/sandboxes-smolvm"
 import { SqliteStorage } from "@sixb/sqlite"
+import {
+  generateImageTool,
+  lookupResponsePolicy,
+  operationsAssistantModel,
+} from "./agents/operations-assistant"
 
 const localLakePath = ".sixb/lake"
 mkdirSync(localLakePath, { recursive: true })
 
 export const sixb = createSixb({
   id: "northline",
+  models: { language: [operationsAssistantModel] },
+  tools: [lookupResponsePolicy, generateImageTool],
   broker: new InMemoryBroker(),
   storage: new SqliteStorage({ path: ".sixb" }),
   lakeStorage: new DuckLakeStorage({

--- a/examples/northline/workflows/agent-service-assessment.ts
+++ b/examples/northline/workflows/agent-service-assessment.ts
@@ -1,6 +1,6 @@
 import type { WorkflowDefinition } from "@sixb/core"
 import { defineAgentStep, defineWorkflow, stringEnum } from "@sixb/core"
-import { operationsAssistant } from "../agents/operations-assistant"
+import { lookupResponsePolicy, operationsAssistantModel } from "../agents/operations-assistant"
 
 const serviceAssessmentInput = {
   caseNumber: "string",
@@ -9,7 +9,12 @@ const serviceAssessmentInput = {
   summary: "string",
 } as const
 
-export const assessServiceCase = defineAgentStep("assess-service-case", operationsAssistant)
+export const assessServiceCase = defineAgentStep("assess-service-case", {
+  model: operationsAssistantModel,
+  reasoning: "medium",
+  instructions: "Assess service response urgency using Northline's response policy.",
+  tools: [lookupResponsePolicy],
+})
   .input(serviceAssessmentInput)
   .output({
     priority: stringEnum(["routine", "urgent", "emergency"]),

--- a/packages/agent-worker/src/execution-plan.ts
+++ b/packages/agent-worker/src/execution-plan.ts
@@ -1,6 +1,8 @@
 import type {
   AgentDefinition,
   AgentReasoningLevel,
+  AgentStepDefinition,
+  AgentToolCatalog,
   AgentToolDefinition,
   LanguageModelCatalog,
 } from "@sixb/core"
@@ -46,4 +48,58 @@ export function resolveAgentExecutionPlan(input: {
     ...(agent.reasoning === undefined ? {} : { reasoning: agent.reasoning }),
     ...(agent.loop?.caching === undefined ? {} : { caching: agent.loop.caching }),
   })
+}
+
+/** Resolve a directly configured workflow task into the shared Agent execution contract. */
+export function resolveWorkflowAgentStepExecutionPlan(input: {
+  readonly workflowId: string
+  readonly step: AgentStepDefinition
+  readonly models?: LanguageModelCatalog
+  readonly tools: AgentToolCatalog
+  readonly defaultMaxSteps: number
+}): ResolvedAgentExecutionPlan {
+  const { workflowId, step, models } = input
+  const model = resolveWorkflowAgentStepModel(step, models)
+  if (model === null) {
+    const reference =
+      step.model === undefined
+        ? "the project default language model"
+        : `language model '${step.model.providerId}/${step.model.modelId}'`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbAgentWorker] Workflow '${workflowId}' agent step '${step.id}' cannot resolve ${reference}.`,
+      { details: { workflowId, agentStepId: step.id } }
+    )
+  }
+
+  const tools = step.toolNames.map((name) => {
+    const tool = input.tools.getByName(name)
+    if (tool === null) {
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbAgentWorker] Workflow '${workflowId}' agent step '${step.id}' cannot resolve project tool '${name}'.`,
+        { details: { workflowId, agentStepId: step.id, toolName: name } }
+      )
+    }
+    return tool
+  })
+
+  return Object.freeze({
+    model,
+    instructions: step.instructions,
+    tools: Object.freeze(tools),
+    maxSteps: input.defaultMaxSteps,
+    ...(step.reasoning === undefined ? {} : { reasoning: step.reasoning }),
+  })
+}
+
+function resolveWorkflowAgentStepModel(
+  step: AgentStepDefinition,
+  models: LanguageModelCatalog | undefined
+): AgentDefinition["model"] | null {
+  if (step.model === undefined) return models?.default.model ?? null
+  if (models === undefined) return step.model
+  return (
+    models.getByRef({ provider: step.model.providerId, modelId: step.model.modelId })?.model ?? null
+  )
 }

--- a/packages/agent-worker/src/model-adapters.ts
+++ b/packages/agent-worker/src/model-adapters.ts
@@ -30,11 +30,10 @@ import { AgentToolExecutionError, AgentToolOutputError } from "./errors"
 import { agentModelToolSpecFromDefinition } from "./tools/model-spec"
 import type { AgentToolModelOutput } from "./tools/result-output"
 
-type AgentErrorDetails =
+export type AgentErrorDetails =
   | { readonly agentId: string; readonly runId: string }
-  | { readonly agentId: string; readonly nodeRunId: string }
   | {
-      readonly agentId: string
+      readonly agentStepId: string
       readonly workflowId: string
       readonly workflowRunId: string
       readonly nodeRunId: string

--- a/packages/agent-worker/src/run-environment.ts
+++ b/packages/agent-worker/src/run-environment.ts
@@ -17,7 +17,7 @@ import {
   prepareAgentAttachments,
 } from "./attachments"
 import type { ResolvedAgentExecutionPlan } from "./execution-plan"
-import { modelToolsFromAgentDefinitions } from "./model-adapters"
+import { type AgentErrorDetails, modelToolsFromAgentDefinitions } from "./model-adapters"
 import { prepareAgentSandboxApiContext } from "./sandbox-api-context"
 import { AgentSandboxFileRegistry } from "./sandbox-file-registry"
 import type { AgentSandboxHandle } from "./sandbox-handle"
@@ -57,6 +57,7 @@ export interface CreateConversationAgentEnvironmentInput extends CreateAgentEnvi
 export interface CreateWorkflowAgentNodeEnvironmentInput extends CreateAgentEnvironmentInput {
   readonly run: WorkflowAgentNodeRunRecord
   readonly nodeInput: WorkflowIOSnapshot
+  readonly errorDetails: AgentErrorDetails
 }
 
 /** Prepare conversation history and attachments, then start the shared agent environment. */
@@ -141,6 +142,7 @@ export async function createWorkflowAgentNodeEnvironment(
     }),
     attachmentContext,
     skills,
+    errorDetails: input.errorDetails,
     onDetachedTeardown: input.onDetachedTeardown,
   })
 }
@@ -153,6 +155,7 @@ interface AgentEnvironmentSetup extends CreateAgentEnvironmentInput {
   readonly apiBaseUrl: string
   readonly attachmentContext: PreparedAgentAttachmentContext
   readonly skills: Awaited<AgentWorkerContext["agentSkills"]>
+  readonly errorDetails?: AgentErrorDetails
 }
 
 /**
@@ -199,10 +202,7 @@ function startAgentEnvironment(input: AgentEnvironmentSetup): AgentExecutionEnvi
       logger,
       artifactsForToolCall,
       toolResultToModelOutput: (output) => mediaBridge.toModelOutput(output),
-      errorDetails:
-        mode === "conversation"
-          ? { agentId: agentId, runId }
-          : { agentId: agentId, nodeRunId: runId },
+      errorDetails: input.errorDetails ?? { agentId, runId },
     }),
   ]
 

--- a/packages/agent-worker/src/run-workflow-agent-node.ts
+++ b/packages/agent-worker/src/run-workflow-agent-node.ts
@@ -25,7 +25,7 @@ const WORKFLOW_OUTPUT_FINALIZATION_ATTEMPTS = 2
 
 export interface RunWorkflowAgentNodeInput {
   readonly context: AgentTurnContext
-  readonly agentId: string
+  readonly agentStepId: string
   readonly plan: ResolvedAgentExecutionPlan
   readonly agentStep: AgentStepDefinition
   readonly workflowId: string
@@ -89,7 +89,7 @@ export async function runWorkflowAgentNode(
   const abortSignal = AbortSignal.any([input.signal, timeout.signal, sandboxReadiness.signal])
   const completedSteps: ModelStep[] = []
   const traceDetails = {
-    agentId: input.agentId,
+    agentStepId: input.agentStepId,
     workflowId: input.workflowId,
     workflowRunId: input.workflowRunId,
     nodeRunId: input.nodeRunId,
@@ -131,7 +131,7 @@ export async function runWorkflowAgentNode(
     if (researchText.trim().length === 0) {
       throw createSixbError(
         "agent.execution_failed",
-        `[SixbAgentWorker] Workflow agent '${input.agentId}' produced no final answer to structure.`,
+        `[SixbAgentWorker] Workflow agent step '${input.agentStepId}' produced no final answer to structure.`,
         { details: traceDetails }
       )
     }
@@ -210,7 +210,7 @@ export async function runWorkflowAgentNode(
     if (structuredValue === undefined) {
       throw createSixbError(
         "internal.unexpected",
-        `[SixbAgentWorker] Workflow output finalization for agent '${input.agentId}' ended without a value.`,
+        `[SixbAgentWorker] Workflow output finalization for agent step '${input.agentStepId}' ended without a value.`,
         { details: traceDetails }
       )
     }

--- a/packages/agent-worker/src/types.ts
+++ b/packages/agent-worker/src/types.ts
@@ -50,9 +50,9 @@ export type RecoverAiModelCall = (input: RecoverAiModelCallInput) => Promise<voi
 
 /**
  * The host surface the agent worker is constructed with. `SixbHost` satisfies it structurally, so
- * cohosting passes the host directly. Registered agents provide today's execution configuration;
- * when configured, the model catalog provides the authoritative live model binding. Models are
- * non-serialisable and never sent over the wire.
+ * cohosting passes the host directly. Registered agents and workflow Agent steps provide execution
+ * configuration; when configured, the model catalog provides the authoritative live model binding.
+ * Models are non-serialisable and never sent over the wire.
  */
 export interface AgentWorkerHost extends AgentExecutionHost {
   readonly broker: Broker
@@ -61,7 +61,7 @@ export interface AgentWorkerHost extends AgentExecutionHost {
   readonly queues: Queues
   readonly definitions: Pick<
     SixbDefinitions,
-    "agents" | "workflows" | "ontology" | "security" | "models"
+    "agents" | "workflows" | "ontology" | "security" | "models" | "tools"
   >
   readonly sandboxes?: SandboxFactory
   readonly projectRoot?: string

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -89,7 +89,6 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
   private readonly host: AgentWorkerHost
   private readonly agents: readonly AgentDefinition[]
   private readonly context: AgentWorkerContext | null
-  private readonly idleWithoutAgents: boolean
   private contextBudgets: ReadonlyMap<string, AgentContextBudget> = new Map()
   private models: ReadonlyMap<string, LanguageModel> = new Map()
   /**
@@ -113,8 +112,12 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
 
     this.host = host
     this.agents = host.definitions.agents.list()
-    this.idleWithoutAgents = this.agents.length === 0
-    this.context = this.idleWithoutAgents ? null : buildAgentContext(host, options, turnTimeoutMs)
+    const hasAgentWork =
+      this.agents.length > 0 ||
+      host.definitions.workflows
+        .list()
+        .some((workflow) => workflow.nodes.some((node) => node.type === "agent"))
+    this.context = hasAgentWork ? buildAgentContext(host, options, turnTimeoutMs) : null
   }
 
   override async start(): Promise<void> {
@@ -141,8 +144,8 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
   }
 
   protected override async run(signal: AbortSignal): Promise<void> {
-    if (!this.idleWithoutAgents) {
-      const context = this.requireContext()
+    if (this.context) {
+      const context = this.context
       const stopDispatch = new AbortController()
       const workerSignal = AbortSignal.any([signal, stopDispatch.signal])
       const dispatchLoop = this.runDispatchLoop(context, workerSignal)
@@ -197,7 +200,6 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
         delivery,
         watchForCancel: (runId) => this.watchForCancel(runId),
         onDetachedTeardown: (teardown) => this.trackTeardown(teardown),
-        models: this.models,
       })
       return
     }

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -1,10 +1,4 @@
-import type {
-  AgentDefinition,
-  AgentMessagePart,
-  SixbFailure,
-  ValueType,
-  WorkflowDefinition,
-} from "@sixb/core"
+import type { AgentMessagePart, SixbFailure, ValueType, WorkflowDefinition } from "@sixb/core"
 import {
   createAgentRunExecutionToken,
   resolveAgentExecutionAuthorization,
@@ -19,8 +13,7 @@ import {
 import type { QueueDelivery } from "@sixb/core/internal/workers"
 import { QueueDeliveryLeaseLostError } from "@sixb/core/internal/workers"
 import type { WorkflowAgentNodeDefinition } from "@sixb/core/internal/workflows"
-import { createWorkflowNodeFailure } from "@sixb/core/internal/workflows"
-import type { LanguageModel } from "@sixb/core/models"
+import { createWorkflowNodeFailure, workflowAgentStepActorId } from "@sixb/core/internal/workflows"
 import type {
   AgentQueueJob,
   AgentQueueJobFailureCode,
@@ -38,9 +31,10 @@ import type {
   WorkflowRunStorage,
 } from "@sixb/core/storage"
 import { AGENT_RUN_FAILURE_CODES, WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
+import { prepareAgentModels } from "./context-budget"
 import { AgentUsageRecordingError } from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
-import { resolveAgentExecutionPlan } from "./execution-plan"
+import { resolveWorkflowAgentStepExecutionPlan } from "./execution-plan"
 import { toAgentExecutionFailure } from "./failure"
 import { createAiModelCallLimitController } from "./model-call-limits"
 import { AiModelCallRecorder } from "./model-call-recorder"
@@ -56,7 +50,6 @@ import {
 import type { AgentWorkerContext, AgentWorkerHost } from "./types"
 
 export interface ExecuteWorkflowAgentNodeInput {
-  readonly models?: ReadonlyMap<string, LanguageModel>
   readonly context: AgentWorkerContext
   readonly host: AgentWorkerHost
   readonly job: AgentWorkflowNodeRequestedQueueJob
@@ -76,7 +69,7 @@ interface WorkflowAgentNodeExecutionContext {
   readonly workflowRun: WorkflowRunRecord
   readonly workflow: WorkflowDefinition
   readonly node: WorkflowAgentNodeDefinition
-  readonly agent: AgentDefinition
+  readonly actorId: string
   readonly durableExecution: ExecutionRecord
   readonly valueTypesById: ReadonlyMap<string, ValueType>
 }
@@ -95,19 +88,21 @@ export async function executeWorkflowAgentNode(
     workflowRun,
     workflow,
     node,
-    agent,
+    actorId,
     durableExecution,
     valueTypesById,
   } = loaded
-  const plan = resolveAgentExecutionPlan({
-    agent,
+  const configuredPlan = resolveWorkflowAgentStepExecutionPlan({
+    workflowId: workflow.id,
+    step: node.agentStep,
+    models: input.host.definitions.models?.language,
+    tools: input.host.definitions.tools,
     defaultMaxSteps: context.defaultMaxSteps,
   })
-  // Transitional: workflow steps still use their referenced Agent's managed identity.
   const resolved = await resolveAgentExecutionAuthorization({
     auth: context.storage.auth,
     projectId: context.id,
-    agentId: agent.id,
+    agentId: actorId,
     authorizationRef: durableExecution.authorizationRef,
     security: input.host.definitions.security,
   })
@@ -115,11 +110,17 @@ export async function executeWorkflowAgentNode(
     context,
     host: input.host,
     execution: durableExecution,
-    agentId: agent.id,
+    agentId: actorId,
     runId: nodeRun.id,
     authorization: { type: "principal", context: resolved.context },
     authorPrincipal: resolved.identity.principal,
   })
+  // Tasks pin their selected binding too: research and finalization share its metadata and budget.
+  const prepared = await prepareAgentModels([{ id: actorId, ...configuredPlan }])
+  const model = prepared.models.get(actorId)
+  if (!model)
+    throw new Error("[SixbAgentWorker] Workflow task model preparation returned no model.")
+  const plan = Object.freeze({ ...configuredPlan, model })
   const reserved = await reserveWorkflowAgentNode({
     runs,
     executionRecord,
@@ -132,7 +133,7 @@ export async function executeWorkflowAgentNode(
     throw createSixbError(
       "internal.unexpected",
       `[SixbAgentWorker] Agent workflow node '${nodeRun.id}' has no execution token.`,
-      { details: workflowAgentErrorDetails(agent.id, nodeRun) }
+      { details: workflowAgentErrorDetails(nodeRun) }
     )
   }
   const modelCallLimits = createAiModelCallLimitController({
@@ -177,12 +178,13 @@ export async function executeWorkflowAgentNode(
       plan,
       run: reserved,
       nodeInput: nodeRun.input,
+      errorDetails: workflowAgentErrorDetails(nodeRun),
       signal: turnSignal,
       onDetachedTeardown: input.onDetachedTeardown,
     })
     const result = await runWorkflowAgentNode({
       context: environment.turnContext,
-      agentId: agent.id,
+      agentStepId: node.agentStep.id,
       plan,
       agentStep: node.agentStep,
       workflowId: workflow.id,
@@ -196,7 +198,6 @@ export async function executeWorkflowAgentNode(
     const completedNode = await finishWorkflowAgentNodeSucceeded({
       context,
       nodeRun,
-      agentId: agent.id,
       executionToken,
       result,
     })
@@ -248,7 +249,7 @@ export async function executeWorkflowAgentNode(
     const failed = await finishWorkflowAgentNodeFailed({
       context,
       nodeRun,
-      agentId: agent.id,
+      agentStepId: node.agentStep.id,
       modelId: plan.model.modelId,
       executionToken,
       status,
@@ -318,7 +319,7 @@ async function loadWorkflowAgentNodeExecution(
       error: toSixbFailure(
         createSixbError("runtime.cancelled", message, {
           details: {
-            agentId: executionRecord.agentId,
+            agentStepId: nodeRun.nodeId,
             workflowId: nodeRun.workflowId,
             workflowRunId: nodeRun.workflowRunId,
             nodeRunId: nodeRun.id,
@@ -344,7 +345,7 @@ async function loadWorkflowAgentNodeExecution(
       `[SixbAgentWorker] Agent workflow node '${nodeRun.id}' references missing execution '${executionRecord.executionId}'.`,
       {
         details: {
-          ...workflowAgentErrorDetails(executionRecord.agentId, nodeRun),
+          ...workflowAgentErrorDetails(nodeRun),
           executionId: executionRecord.executionId,
         },
       }
@@ -359,7 +360,7 @@ async function loadWorkflowAgentNodeExecution(
       `[SixbAgentWorker] Agent workflow node '${nodeRun.id}' execution is not linked to workflow run '${workflowRun.id}'.`,
       {
         details: {
-          ...workflowAgentErrorDetails(executionRecord.agentId, nodeRun),
+          ...workflowAgentErrorDetails(nodeRun),
           executionId: executionRecord.executionId,
         },
       }
@@ -372,19 +373,15 @@ async function loadWorkflowAgentNodeExecution(
     throw createSixbError(
       "internal.unexpected",
       `[SixbAgentWorker] Workflow definition for agent node '${job.payload.nodeRunId}' is no longer available.`,
-      { details: workflowAgentErrorDetails(executionRecord.agentId, nodeRun) }
+      { details: workflowAgentErrorDetails(nodeRun) }
     )
   }
-  const registered = host.definitions.agents.getById(executionRecord.agentId)
-  const agent = registered && {
-    ...registered,
-    model: input.models?.get(registered.id) ?? registered.model,
-  }
-  if (!agent || agent.id !== node.agentStep.agent.id) {
+  const actorId = workflowAgentStepActorId(workflow.id, node.agentStep.id)
+  if (executionRecord.agentId !== actorId) {
     throw createSixbError(
       "internal.unexpected",
-      `[SixbAgentWorker] Unknown agent '${executionRecord.agentId}'.`,
-      { details: workflowAgentErrorDetails(executionRecord.agentId, nodeRun) }
+      `[SixbAgentWorker] Workflow agent step '${node.agentStep.id}' execution identity does not match its definition.`,
+      { details: workflowAgentErrorDetails(nodeRun) }
     )
   }
 
@@ -395,7 +392,7 @@ async function loadWorkflowAgentNodeExecution(
     workflowRun,
     workflow,
     node,
-    agent,
+    actorId,
     durableExecution,
     valueTypesById: host.definitions.ontology.getValueTypesById(),
   }
@@ -456,7 +453,6 @@ function confirmQueueOwnership(input: {
 async function finishWorkflowAgentNodeSucceeded(input: {
   readonly context: AgentWorkerContext
   readonly nodeRun: WorkflowNodeRunRecord
-  readonly agentId: string
   readonly executionToken: string
   readonly result: Awaited<ReturnType<typeof runWorkflowAgentNode>>
 }): Promise<WorkflowNodeRunRecord> {
@@ -466,7 +462,7 @@ async function finishWorkflowAgentNodeSucceeded(input: {
       throw createSixbError(
         "internal.unexpected",
         "[SixbAgentWorker] Workflow storage disappeared during finalization.",
-        { details: workflowAgentErrorDetails(input.agentId, input.nodeRun) }
+        { details: workflowAgentErrorDetails(input.nodeRun) }
       )
     }
     await runs.agentNodes.finish({
@@ -490,7 +486,7 @@ async function finishWorkflowAgentNodeSucceeded(input: {
 async function finishWorkflowAgentNodeFailed(input: {
   readonly context: AgentWorkerContext
   readonly nodeRun: WorkflowNodeRunRecord
-  readonly agentId: string
+  readonly agentStepId: string
   readonly modelId: string
   readonly executionToken: string
   readonly status: "failed" | "cancelled"
@@ -505,7 +501,7 @@ async function finishWorkflowAgentNodeFailed(input: {
 }> {
   const at = new Date()
   const agentErrorDetails = {
-    ...workflowAgentErrorDetails(input.agentId, input.nodeRun),
+    ...workflowAgentErrorDetails(input.nodeRun),
     ...(input.failurePhase === undefined ? {} : { failurePhase: input.failurePhase }),
   }
   const agentExecutionError =
@@ -521,7 +517,7 @@ async function finishWorkflowAgentNodeFailed(input: {
             workflowRunId: input.nodeRun.workflowRunId,
             nodeId: input.nodeRun.nodeId,
             nodeRunId: input.nodeRun.id,
-            child: { type: "agent", agentId: input.agentId },
+            child: { type: "agent", agentStepId: input.agentStepId },
           })
       : createSixbError(
           "runtime.cancelled",
@@ -541,7 +537,7 @@ async function finishWorkflowAgentNodeFailed(input: {
       throw createSixbError(
         "internal.unexpected",
         "[SixbAgentWorker] Workflow storage disappeared during finalization.",
-        { details: workflowAgentErrorDetails(input.agentId, input.nodeRun) }
+        { details: workflowAgentErrorDetails(input.nodeRun) }
       )
     }
     await runs.agentNodes.finish({
@@ -760,12 +756,19 @@ function requireFinishedAt(
   return record.finishedAt
 }
 
+interface WorkflowAgentErrorDetails extends Readonly<Record<string, string>> {
+  readonly agentStepId: string
+  readonly workflowId: string
+  readonly workflowRunId: string
+  readonly nodeId: string
+  readonly nodeRunId: string
+}
+
 function workflowAgentErrorDetails(
-  agentId: string,
   nodeRun: Pick<WorkflowNodeRunRecord, "id" | "workflowId" | "workflowRunId" | "nodeId">
-): Readonly<Record<string, string>> {
+): WorkflowAgentErrorDetails {
   return {
-    agentId,
+    agentStepId: nodeRun.nodeId,
     workflowId: nodeRun.workflowId,
     workflowRunId: nodeRun.workflowRunId,
     nodeId: nodeRun.nodeId,

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -32,6 +32,7 @@ import type {
 } from "@sixb/core/storage"
 import { AGENT_RUN_FAILURE_CODES, WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import { prepareAgentModels } from "./context-budget"
+import { shouldRetryAgentPreparation } from "./delivery-policy"
 import { AgentUsageRecordingError } from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
 import { resolveWorkflowAgentStepExecutionPlan } from "./execution-plan"
@@ -62,11 +63,14 @@ export interface ExecuteWorkflowAgentNodeInput {
   readonly onDetachedTeardown: (teardown: Promise<void>) => void
 }
 
-interface WorkflowAgentNodeExecutionContext {
+interface WorkflowAgentNodeRecords {
   readonly runs: WorkflowRunStorage
   readonly executionRecord: WorkflowAgentNodeRunRecord
   readonly nodeRun: WorkflowNodeRunRecord
   readonly workflowRun: WorkflowRunRecord
+}
+
+interface WorkflowAgentNodeExecutionContext extends WorkflowAgentNodeRecords {
   readonly workflow: WorkflowDefinition
   readonly node: WorkflowAgentNodeDefinition
   readonly actorId: string
@@ -81,51 +85,13 @@ export async function executeWorkflowAgentNode(
   if (!loaded) return
 
   const { context, job, signal, delivery } = input
-  const {
-    runs,
-    executionRecord,
-    nodeRun,
-    workflowRun,
-    workflow,
-    node,
-    actorId,
-    durableExecution,
-    valueTypesById,
-  } = loaded
-  const configuredPlan = resolveWorkflowAgentStepExecutionPlan({
-    workflowId: workflow.id,
-    step: node.agentStep,
-    models: input.host.definitions.models?.language,
-    tools: input.host.definitions.tools,
-    defaultMaxSteps: context.defaultMaxSteps,
-  })
-  const resolved = await resolveAgentExecutionAuthorization({
-    auth: context.storage.auth,
-    projectId: context.id,
-    agentId: actorId,
-    authorizationRef: durableExecution.authorizationRef,
-    security: input.host.definitions.security,
-  })
-  const executionContext = createAgentExecutionContext({
-    context,
-    host: input.host,
-    execution: durableExecution,
-    agentId: actorId,
-    runId: nodeRun.id,
-    authorization: { type: "principal", context: resolved.context },
-    authorPrincipal: resolved.identity.principal,
-  })
-  // Tasks pin their selected binding too: research and finalization share its metadata and budget.
-  const prepared = await prepareAgentModels([{ id: actorId, ...configuredPlan }])
-  const model = prepared.models.get(actorId)
-  if (!model)
-    throw new Error("[SixbAgentWorker] Workflow task model preparation returned no model.")
-  const plan = Object.freeze({ ...configuredPlan, model })
+  const { runs, executionRecord, nodeRun, workflowRun } = loaded
+  // Preparation belongs to the owned attempt too, so failures can durably finish the task and
+  // its workflow without claiming a second token in the failure handler.
   const reserved = await reserveWorkflowAgentNode({
     runs,
     executionRecord,
     nodeRun,
-    modelId: plan.model.modelId,
     execution: freshWorkflowExecution(delivery.leaseExpiresAt),
   })
   const executionToken = reserved.execution?.token
@@ -155,6 +121,9 @@ export async function executeWorkflowAgentNode(
   })
 
   let environment: AgentExecutionEnvironment | null = null
+  let modelId = reserved.modelId
+  let totalNodes: number | undefined
+  let preparationComplete = false
   const cancel = await input.watchForCancel(nodeRun.id)
   const turnSignal = AbortSignal.any([signal, cancel.signal])
   const stopOwnershipProjection = projectQueueOwnership({
@@ -173,6 +142,39 @@ export async function executeWorkflowAgentNode(
       executionToken,
       queueLeaseExpiresAt: delivery.leaseExpiresAt,
     })
+    const { workflow, node, actorId, durableExecution, valueTypesById } =
+      await resolveWorkflowAgentNodeExecution(input, loaded)
+    totalNodes = workflow.nodes.length
+    const configuredPlan = resolveWorkflowAgentStepExecutionPlan({
+      workflowId: workflow.id,
+      step: node.agentStep,
+      models: input.host.definitions.models?.language,
+      tools: input.host.definitions.tools,
+      defaultMaxSteps: context.defaultMaxSteps,
+    })
+    modelId = configuredPlan.model.modelId
+    const resolved = await resolveAgentExecutionAuthorization({
+      auth: context.storage.auth,
+      projectId: context.id,
+      agentId: actorId,
+      authorizationRef: durableExecution.authorizationRef,
+      security: input.host.definitions.security,
+    })
+    const executionContext = createAgentExecutionContext({
+      context,
+      host: input.host,
+      execution: durableExecution,
+      agentId: actorId,
+      runId: nodeRun.id,
+      authorization: { type: "principal", context: resolved.context },
+      authorPrincipal: resolved.identity.principal,
+    })
+    const prepared = await prepareAgentModels([{ id: actorId, ...configuredPlan }])
+    const model = prepared.models.get(actorId)
+    if (!model)
+      throw new Error("[SixbAgentWorker] Workflow task model preparation returned no model.")
+    const plan = Object.freeze({ ...configuredPlan, model })
+    preparationComplete = true
     environment = await createWorkflowAgentNodeEnvironment({
       context: executionContext,
       plan,
@@ -235,6 +237,13 @@ export async function executeWorkflowAgentNode(
     }
 
     if (signal.aborted) throw executionError
+    if (
+      !preparationComplete &&
+      !cancel.signal.aborted &&
+      shouldRetryAgentPreparation(executionError, job.attempt)
+    ) {
+      throw executionError
+    }
     if (cancel.signal.aborted && (await isAlreadyCancelled(runs, context.id, nodeRun.id))) {
       // The cancellation endpoint has already made the execution terminal, so it cannot be fenced
       // again. Still surface an accounting failure instead of silently acknowledging it.
@@ -249,8 +258,8 @@ export async function executeWorkflowAgentNode(
     const failed = await finishWorkflowAgentNodeFailed({
       context,
       nodeRun,
-      agentStepId: node.agentStep.id,
-      modelId: plan.model.modelId,
+      agentStepId: nodeRun.nodeId,
+      modelId,
       executionToken,
       status,
       error: executionError,
@@ -270,7 +279,7 @@ export async function executeWorkflowAgentNode(
         failure: failed.failure,
       })
     }
-    await emitNodeAndRunFailed(input.host, failed, workflow.nodes.length, status)
+    await emitNodeAndRunFailed(input.host, failed, totalNodes, status)
   } finally {
     stopOwnershipProjection()
     cancel.stop()
@@ -280,8 +289,8 @@ export async function executeWorkflowAgentNode(
 
 async function loadWorkflowAgentNodeExecution(
   input: ExecuteWorkflowAgentNodeInput
-): Promise<WorkflowAgentNodeExecutionContext | null> {
-  const { context, host, job } = input
+): Promise<WorkflowAgentNodeRecords | null> {
+  const { context, job } = input
   const runs = context.storage.workflowRuns
   if (!runs) {
     throw createSixbError(
@@ -335,6 +344,15 @@ async function loadWorkflowAgentNodeExecution(
     return null
   }
 
+  return { runs, executionRecord, nodeRun, workflowRun }
+}
+
+async function resolveWorkflowAgentNodeExecution(
+  input: ExecuteWorkflowAgentNodeInput,
+  loaded: WorkflowAgentNodeRecords
+): Promise<WorkflowAgentNodeExecutionContext> {
+  const { context, host, job } = input
+  const { runs, executionRecord, nodeRun, workflowRun } = loaded
   const durableExecution = await context.storage.executions.getById({
     projectId: context.id,
     id: executionRecord.executionId,
@@ -402,14 +420,12 @@ async function reserveWorkflowAgentNode(input: {
   readonly runs: WorkflowRunStorage
   readonly executionRecord: WorkflowAgentNodeRunRecord
   readonly nodeRun: WorkflowNodeRunRecord
-  readonly modelId: string
   readonly execution: WorkflowAgentNodeRunExecution
 }): Promise<WorkflowAgentNodeRunRecord> {
   if (input.executionRecord.status === "queued") {
     return input.runs.agentNodes.start({
       projectId: input.executionRecord.projectId,
       nodeRunId: input.nodeRun.id,
-      modelId: input.modelId,
       execution: input.execution,
     })
   }
@@ -487,7 +503,7 @@ async function finishWorkflowAgentNodeFailed(input: {
   readonly context: AgentWorkerContext
   readonly nodeRun: WorkflowNodeRunRecord
   readonly agentStepId: string
-  readonly modelId: string
+  readonly modelId?: string
   readonly executionToken: string
   readonly status: "failed" | "cancelled"
   readonly error: unknown
@@ -616,8 +632,8 @@ async function emitNodeSucceeded(
   node: WorkflowNodeRunRecord,
   totalNodes: number
 ): Promise<void> {
-  await host.events
-    .append({
+  await host.events.emit(
+    {
       events: [
         {
           type: "workflow.run.node.finished",
@@ -635,40 +651,42 @@ async function emitNodeSucceeded(
           },
         },
       ],
-    })
-    .catch((error) => {
-      console.error(
-        `[SixbAgentWorker] Could not emit completion for workflow agent node '${node.id}'.`,
-        error
-      )
-    })
+    },
+    { source: "SixbAgentWorker" }
+  )
 }
 
 async function emitNodeAndRunFailed(
   host: AgentWorkerHost,
   failed: { readonly node: WorkflowNodeRunRecord; readonly run: WorkflowRunRecord },
-  totalNodes: number,
+  totalNodes: number | undefined,
   status: "failed" | "cancelled"
 ): Promise<void> {
-  await host.events
-    .append({
+  await host.events.emit(
+    {
       events: [
-        {
-          type: "workflow.run.node.finished",
-          payload: {
-            workflowId: failed.node.workflowId,
-            runId: failed.node.workflowRunId,
-            nodeRunId: failed.node.id,
-            nodeIndex: failed.node.nodeIndex,
-            totalNodes,
-            nodeType: "agent",
-            nodeId: failed.node.nodeId,
-            nodeKey: failed.node.nodeKey,
-            status,
-            finishedAt: requireFinishedAt(failed.node).toISOString(),
-            ...(failed.node.error ? { error: failed.node.error } : {}),
-          },
-        },
+        // A removed definition has no trustworthy node count; the durable failure and run event
+        // still describe the outcome without inventing workflow metadata.
+        ...(totalNodes === undefined
+          ? []
+          : [
+              {
+                type: "workflow.run.node.finished" as const,
+                payload: {
+                  workflowId: failed.node.workflowId,
+                  runId: failed.node.workflowRunId,
+                  nodeRunId: failed.node.id,
+                  nodeIndex: failed.node.nodeIndex,
+                  totalNodes,
+                  nodeType: "agent" as const,
+                  nodeId: failed.node.nodeId,
+                  nodeKey: failed.node.nodeKey,
+                  status,
+                  finishedAt: requireFinishedAt(failed.node).toISOString(),
+                  ...(failed.node.error ? { error: failed.node.error } : {}),
+                },
+              },
+            ]),
         {
           type: "workflow.run.finished",
           payload: {
@@ -680,13 +698,9 @@ async function emitNodeAndRunFailed(
           },
         },
       ],
-    })
-    .catch((error) => {
-      console.error(
-        `[SixbAgentWorker] Could not emit failure for workflow agent node '${failed.node.id}'.`,
-        error
-      )
-    })
+    },
+    { source: "SixbAgentWorker" }
+  )
 }
 
 export async function enqueueWorkflowAgentNodeResume(

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -102,23 +102,7 @@ export async function executeWorkflowAgentNode(
       { details: workflowAgentErrorDetails(nodeRun) }
     )
   }
-  const modelCallLimits = createAiModelCallLimitController({
-    storage: context.storage,
-    projectId: context.id,
-    requestedBy: durableExecution.requestedBy,
-    requesterGroupIds: workflowRun.requesterGroupIds,
-  })
-  const usageRecorder = new AiModelCallRecorder({
-    storage: context.storage,
-    projectId: context.id,
-    executionId: executionRecord.executionId,
-    attempt: reserved.attempt,
-    requesterGroupIds: workflowRun.requesterGroupIds,
-    beforeModelCall: modelCallLimits.beforeModelCall,
-    markModelCallUnknown: modelCallLimits.markModelCallUnknown,
-    recoverAiModelCall: context.recoverAiModelCall,
-    errorRunId: nodeRun.id,
-  })
+  let usageRecorder: AiModelCallRecorder | undefined
 
   let environment: AgentExecutionEnvironment | null = null
   let modelId = reserved.modelId
@@ -144,6 +128,23 @@ export async function executeWorkflowAgentNode(
     })
     const { workflow, node, actorId, durableExecution, valueTypesById } =
       await resolveWorkflowAgentNodeExecution(input, loaded)
+    const modelCallLimits = createAiModelCallLimitController({
+      storage: context.storage,
+      projectId: context.id,
+      requestedBy: durableExecution.requestedBy,
+      requesterGroupIds: workflowRun.requesterGroupIds,
+    })
+    usageRecorder = new AiModelCallRecorder({
+      storage: context.storage,
+      projectId: context.id,
+      executionId: executionRecord.executionId,
+      attempt: reserved.attempt,
+      requesterGroupIds: workflowRun.requesterGroupIds,
+      beforeModelCall: modelCallLimits.beforeModelCall,
+      markModelCallUnknown: modelCallLimits.markModelCallUnknown,
+      recoverAiModelCall: context.recoverAiModelCall,
+      errorRunId: nodeRun.id,
+    })
     totalNodes = workflow.nodes.length
     const configuredPlan = resolveWorkflowAgentStepExecutionPlan({
       workflowId: workflow.id,
@@ -228,7 +229,7 @@ export async function executeWorkflowAgentNode(
     let executionError = debug?.cause ?? error
     let failurePhase = debug?.phase
     try {
-      usageRecorder.assertHealthy()
+      usageRecorder?.assertHealthy()
     } catch (recordingError) {
       const sameAdmissionFailure =
         isAiUsageLimitFailure(executionError) && isAiUsageLimitFailure(recordingError)

--- a/packages/agent-worker/tests/execution-plan.test.ts
+++ b/packages/agent-worker/tests/execution-plan.test.ts
@@ -1,13 +1,34 @@
 import { describe, expect, test } from "bun:test"
 import {
+  type AgentStepDefinition,
+  type AgentToolCatalog,
+  type AgentToolDefinition,
   defineAgent,
+  defineAgentStep,
   defineAgentTool,
   type LanguageModelCatalog,
   type LanguageModelEntry,
   type LanguageModelRef,
 } from "@sixb/core"
-import { resolveAgentExecutionPlan } from "../src/execution-plan"
+import {
+  resolveAgentExecutionPlan,
+  resolveWorkflowAgentStepExecutionPlan,
+} from "../src/execution-plan"
 import { WorkerTestModel } from "./worker-model-fixture"
+
+function workflowStep(config: Parameters<typeof defineAgentStep>[1]): AgentStepDefinition {
+  return defineAgentStep("review", config)
+    .input({ request: "string" })
+    .output({ answer: "string" })
+    .prompt(({ input }) => input.request)
+}
+
+function toolCatalog(tools: readonly AgentToolDefinition[]): AgentToolCatalog {
+  return {
+    list: () => tools,
+    getByName: (name) => tools.find((tool) => tool.name === name) ?? null,
+  }
+}
 
 describe("resolveAgentExecutionPlan", () => {
   test("maps executable configuration and resolves the worker step default", () => {
@@ -100,5 +121,63 @@ describe("resolveAgentExecutionPlan", () => {
     expect(() => resolveAgentExecutionPlan({ agent, models, defaultMaxSteps: 100 })).toThrow(
       /missing from the runtime catalog/
     )
+  })
+})
+
+describe("resolveWorkflowAgentStepExecutionPlan", () => {
+  test("uses the project default model and grants no project tools by default", () => {
+    const model = new WorkerTestModel({ modelId: "default-model" })
+    const entry: LanguageModelEntry = {
+      provider: model.providerId,
+      modelId: model.modelId,
+      model,
+    }
+    const models: LanguageModelCatalog = {
+      default: entry,
+      list: () => [entry],
+      getByRef: () => entry,
+    }
+
+    const plan = resolveWorkflowAgentStepExecutionPlan({
+      workflowId: "triage",
+      step: workflowStep({ instructions: "Review the request." }),
+      models,
+      tools: toolCatalog([]),
+      defaultMaxSteps: 25,
+    })
+
+    expect(plan.model).toBe(model)
+    expect(plan.instructions).toBe("Review the request.")
+    expect(plan.tools).toEqual([])
+    expect(plan.maxSteps).toBe(25)
+  })
+
+  test("resolves only the tools selected by the workflow step", () => {
+    const model = new WorkerTestModel({ modelId: "task-model" })
+    const selected = defineAgentTool("selected")
+      .description("Selected tool.")
+      .input({ value: "string" })
+      .run(({ input }) => input)
+    const unselected = defineAgentTool("unselected")
+      .description("Unselected tool.")
+      .input({ value: "string" })
+      .run(({ input }) => input)
+
+    const plan = resolveWorkflowAgentStepExecutionPlan({
+      workflowId: "triage",
+      step: workflowStep({
+        model,
+        reasoning: "high",
+        instructions: "Review the request.",
+        tools: [selected],
+      }),
+      tools: toolCatalog([selected, unselected]),
+      defaultMaxSteps: 9,
+    })
+
+    expect(plan.model).toBe(model)
+    expect(plan.reasoning).toBe("high")
+    expect(plan.tools).toEqual([selected])
+    expect(plan.maxSteps).toBe(9)
   })
 })

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -3391,13 +3391,11 @@ describe("AgentWorker", () => {
         throw new Error("A denied workflow Agent call must not reach the provider")
       },
     })
-    const agent = defineAgent("workflow-limit-agent", {
-      name: "Workflow limit agent",
+    const agentStep = defineAgentStep("limited-agent-step", {
       model,
       instructions: "This call is denied before the provider.",
       groups: [AGENT_RUNTIME_GROUP],
     })
-    const agentStep = defineAgentStep("limited-agent-step", agent)
       .input({ query: "string" })
       .output({ answer: "string" })
       .prompt(({ input }) => `Resolve '${input.query}'.`)
@@ -3407,7 +3405,6 @@ describe("AgentWorker", () => {
     const sixb = new SixbHost({
       id: PROJECT_ID,
       ontology: [],
-      agents: [agent],
       workflows: [workflow],
       groups: [AGENT_RUNTIME_GROUP],
       broker: new InMemoryBroker(),
@@ -3427,6 +3424,7 @@ describe("AgentWorker", () => {
     const runs = sixb.storage.workflowRuns!
     const runId = "workflow-agent-limit-run"
     const nodeRunId = `${runId}:node:0`
+    const actorId = workflowAgentStepActorId(workflow.id, agentStep.id)
     const executionId = await createTestWorkflowExecution(sixb.storage.executions, {
       projectId: PROJECT_ID,
       workflowId: workflow.id,
@@ -3454,7 +3452,7 @@ describe("AgentWorker", () => {
     })
     const agentExecutionId = await createTestAgentExecution(sixb.storage, {
       projectId: PROJECT_ID,
-      agentId: agent.id,
+      agentId: actorId,
       runId: nodeRunId,
       sourceExecutionId: executionId,
     })
@@ -3462,7 +3460,7 @@ describe("AgentWorker", () => {
       projectId: PROJECT_ID,
       nodeRunId,
       executionId: agentExecutionId,
-      agentId: agent.id,
+      agentId: actorId,
       prompt: "Resolve 'alpha'.",
     })
     await runs.nodes.wait({ projectId: PROJECT_ID, id: nodeRunId })
@@ -3500,7 +3498,7 @@ describe("AgentWorker", () => {
       expect(execution.error).toMatchObject({
         code: "ai.usage_limit_exceeded",
         details: {
-          agentId: agent.id,
+          agentStepId: agentStep.id,
           workflowId: workflow.id,
           workflowRunId: runId,
           nodeRunId,

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -119,6 +119,12 @@ const COMPACTION_USAGE: ModelUsage = {
 /** Wait for the delivery to finish its error path before stopping the test worker. */
 function observeQueueSettlement<TFailure>(queue: {
   complete(input: { projectId: string; jobId: string; leaseId: string }): Promise<void>
+  retry(input: {
+    projectId: string
+    jobId: string
+    leaseId: string
+    availableAt?: string
+  }): Promise<void>
   fail(input: {
     projectId: string
     jobId: string
@@ -128,6 +134,7 @@ function observeQueueSettlement<TFailure>(queue: {
 }) {
   const complete = queue.complete.bind(queue)
   const fail = queue.fail.bind(queue)
+  const retry = queue.retry.bind(queue)
   let completed = false
   const observer = spyOn(queue, "complete").mockImplementation(async (input) => {
     await complete(input)
@@ -137,11 +144,16 @@ function observeQueueSettlement<TFailure>(queue: {
     await fail(input)
     completed = true
   })
+  const retried = spyOn(queue, "retry").mockImplementation(async (input) => {
+    await retry(input)
+    completed = true
+  })
   return {
     wait: () => waitFor(() => Promise.resolve(completed), { label: "queue delivery completed" }),
     restore: () => {
       observer.mockRestore()
       failed.mockRestore()
+      retried.mockRestore()
     },
   }
 }
@@ -2638,6 +2650,101 @@ describe("AgentWorker", () => {
       expect(catalogCalls).toEqual(["research", "finalize"])
     } finally {
       await worker.stop()
+    }
+  })
+
+  // Regression proof: prepare the model before reserveWorkflowAgentNode; the task stays queued.
+  test.each([
+    "queued",
+    "running",
+    "taken-over",
+    "invalid-budget",
+    "removed-definition",
+  ] as const)("durably handles workflow model preparation failure from %s", async (state) => {
+    const model = trackedStructuredAnswerModel(() => {})
+    let takeoverToken: string | undefined
+    const { sixb, runs, nodeRunId } = await queueWorkflowAgentNode({
+      model,
+      runId: `workflow-preparation-${state}`,
+    })
+    attachSixbErrorReporter(sixb, () => {})
+    if (state === "running" || state === "taken-over") {
+      await runs.agentNodes.start({
+        projectId: PROJECT_ID,
+        nodeRunId,
+        execution: freshTestExecution(),
+      })
+    }
+    const failingModel: LanguageModel = {
+      ...model,
+      providerId: model.providerId,
+      modelId: model.modelId,
+      definition: model.definition,
+      stream: () => {
+        throw new Error("The model must not be called")
+      },
+      resolve: async () => {
+        if (state === "invalid-budget") {
+          return { ...failingModel, definition: { ...model.definition, contextWindow: 1 } }
+        }
+        if (state === "taken-over") {
+          const execution = freshTestExecution()
+          takeoverToken = execution.token
+          await runs.agentNodes.reclaim({ projectId: PROJECT_ID, nodeRunId, execution })
+        }
+        throw createSixbError("internal.unexpected", "Invalid model preparation.")
+      },
+    }
+    // Workflow-only models are prepared per task, not by the project language-catalog preflight.
+    const definition = sixb.definitions.workflows.list()[0]!
+    const definitionNode = definition.nodes[0]!
+    if (definitionNode.type !== "agent") throw new Error("Expected an agent step")
+    const lookup = spyOn(sixb.definitions.workflows, "getById").mockReturnValue(
+      state === "removed-definition"
+        ? null
+        : {
+            ...definition,
+            nodes: [
+              {
+                ...definitionNode,
+                agentStep: { ...definitionNode.agentStep, model: failingModel },
+              },
+            ],
+          }
+    )
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+    const completion = observeQueueSettlement(sixb.queues.agents)
+    await worker.start()
+    try {
+      await waitFor(
+        async () => {
+          const current = await runs.agentNodes.getByNodeRunId({ projectId: PROJECT_ID, nodeRunId })
+          return state === "taken-over" ? takeoverToken : current?.status === "failed"
+        },
+        { label: "workflow preparation failure" }
+      )
+      await completion.wait()
+      await worker.stop()
+      const task = await runs.agentNodes.getByNodeRunId({ projectId: PROJECT_ID, nodeRunId })
+      const node = await runs.nodes.getById({ projectId: PROJECT_ID, id: nodeRunId })
+      const workflow = await runs.getById({
+        projectId: PROJECT_ID,
+        id: `workflow-preparation-${state}`,
+      })
+      if (state === "taken-over") {
+        expect(task).toMatchObject({ status: "running", execution: { token: takeoverToken } })
+        expect(node?.status).toBe("waiting")
+        expect(workflow?.status).toBe("waiting")
+      } else {
+        expect(task).toMatchObject({ status: "failed", attempt: state === "running" ? 2 : 1 })
+        expect(task?.execution).toBeUndefined()
+        expect(node).toMatchObject({ status: "failed", error: { code: "workflow.node_failed" } })
+        expect(workflow).toMatchObject({ status: "failed", error: node?.error })
+      }
+    } finally {
+      await worker.stop()
+      lookup.mockRestore()
+      completion.restore()
     }
   })
 

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -49,6 +49,7 @@ import {
 import { attachSixbErrorReporter } from "@sixb/core/internal/error-reporting"
 import { createSixbError } from "@sixb/core/internal/errors"
 import { bindRequestExecution } from "@sixb/core/internal/request-execution"
+import { workflowAgentStepActorId } from "@sixb/core/internal/workflows"
 import type {
   LanguageModel,
   LanguageModelRequest,
@@ -1168,14 +1169,12 @@ async function queueWorkflowAgentNode(input: {
   readonly requestedByPrincipal?: typeof REQUESTER
   readonly requesterGroupIds?: readonly string[]
 }) {
-  const agent = defineAgent("workflow-usage-agent", {
-    name: "Workflow usage agent",
+  const agentStep = defineAgentStep("workflow-usage-step", {
     model: input.model,
     instructions: "Resolve the best project.",
     groups: [AGENT_RUNTIME_GROUP],
     ...(input.tools === undefined ? {} : { tools: input.tools }),
   })
-  const agentStep = defineAgentStep("workflow-usage-step", agent)
     .input({ query: "string" })
     .output({ answer: "string", confidence: "double" })
     .prompt(({ input: stepInput }) => `Resolve '${stepInput.query}'.`)
@@ -1183,8 +1182,8 @@ async function queueWorkflowAgentNode(input: {
   const sixb = new SixbHost({
     id: PROJECT_ID,
     ontology: [],
-    agents: [agent],
     workflows: [workflow],
+    tools: input.tools ?? [],
     groups: [AGENT_RUNTIME_GROUP],
     broker: new InMemoryBroker(),
     storage: input.storage ?? new InMemoryStorage(),
@@ -1200,6 +1199,7 @@ async function queueWorkflowAgentNode(input: {
   await seedRequesterUser(sixb.storage, requestedBy)
 
   const nodeRunId = `${input.runId}:node:0`
+  const actorId = workflowAgentStepActorId(workflow.id, agentStep.id)
   const executionId = await createTestWorkflowExecution(sixb.storage.executions, {
     projectId: PROJECT_ID,
     workflowId: workflow.id,
@@ -1228,7 +1228,7 @@ async function queueWorkflowAgentNode(input: {
   })
   const agentExecutionId = await createTestAgentExecution(sixb.storage, {
     projectId: PROJECT_ID,
-    agentId: agent.id,
+    agentId: actorId,
     runId: nodeRunId,
     sourceExecutionId: executionId,
   })
@@ -1236,7 +1236,7 @@ async function queueWorkflowAgentNode(input: {
     projectId: PROJECT_ID,
     nodeRunId,
     executionId: agentExecutionId,
-    agentId: agent.id,
+    agentId: actorId,
     prompt: "Resolve 'alpha'.",
   })
   await runs.nodes.wait({ projectId: PROJECT_ID, id: nodeRunId })
@@ -1252,7 +1252,7 @@ async function queueWorkflowAgentNode(input: {
     ],
   })
 
-  return { sixb, runs, workflow, agent, nodeRunId, agentExecutionId }
+  return { sixb, runs, workflow, agentStep, nodeRunId, agentExecutionId }
 }
 
 class FailingRunStreamBroker extends InMemoryBroker {
@@ -2384,8 +2384,7 @@ describe("AgentWorker", () => {
         lookupCalls += 1
         return { project: "Project Alpha", query: input.query, runId: run.id }
       })
-    const agent = defineAgent("workflow-resolver", {
-      name: "Workflow resolver",
+    const agentStep = defineAgentStep("resolve-project", {
       // Regression proof: omit input.models in workflow-node-execution's agent lookup.
       model: {
         providerId: model.providerId,
@@ -2400,7 +2399,6 @@ describe("AgentWorker", () => {
       groups: [AGENT_RUNTIME_GROUP],
       tools: [lookupProject],
     })
-    const agentStep = defineAgentStep("resolve-project", agent)
       .input({ query: "string" })
       .output({ answer: "string", confidence: "double" })
       .prompt(({ input }) => `Resolve '${input.query}'.`)
@@ -2410,8 +2408,8 @@ describe("AgentWorker", () => {
     const sixb = new SixbHost({
       id: PROJECT_ID,
       ontology: [],
-      agents: [agent],
       workflows: [workflow],
+      tools: [lookupProject],
       groups: [AGENT_RUNTIME_GROUP],
       broker: new InMemoryBroker(),
       storage: new InMemoryStorage(),
@@ -2423,6 +2421,7 @@ describe("AgentWorker", () => {
     const runs = sixb.storage.workflowRuns!
     const runId = "workflow-agent-run"
     const nodeRunId = `${runId}:node:0`
+    const actorId = workflowAgentStepActorId(workflow.id, agentStep.id)
     await seedRequesterUser(sixb.storage)
     const executionId = await createTestWorkflowExecution(sixb.storage.executions, {
       projectId: PROJECT_ID,
@@ -2455,7 +2454,7 @@ describe("AgentWorker", () => {
     })
     const agentExecutionId = await createTestAgentExecution(sixb.storage, {
       projectId: PROJECT_ID,
-      agentId: agent.id,
+      agentId: actorId,
       runId: nodeRunId,
       sourceExecutionId: executionId,
     })
@@ -2463,7 +2462,7 @@ describe("AgentWorker", () => {
       projectId: PROJECT_ID,
       nodeRunId,
       executionId: agentExecutionId,
-      agentId: agent.id,
+      agentId: actorId,
       prompt: "Resolve 'alpha'.",
     })
     await runs.nodes.wait({ projectId: PROJECT_ID, id: nodeRunId })
@@ -2503,7 +2502,7 @@ describe("AgentWorker", () => {
       )
       expect(execution).toMatchObject({
         status: "succeeded",
-        agentId: agent.id,
+        agentId: actorId,
         modelId: "mock-model",
         finishReason: "stop",
         attempt: 1,
@@ -2861,7 +2860,7 @@ describe("AgentWorker", () => {
         message: "Agent execution failed.",
         retryable: false,
         details: {
-          agentId: "workflow-usage-agent",
+          agentStepId: "workflow-usage-step",
           workflowId: "workflow-usage-test",
           workflowRunId: "workflow-accounting-failure",
           nodeId: "workflow-usage-step",
@@ -2958,7 +2957,7 @@ describe("AgentWorker", () => {
         message: "Agent execution failed.",
         retryable: false,
         details: {
-          agentId: "workflow-usage-agent",
+          agentStepId: "workflow-usage-step",
           workflowId: "workflow-usage-test",
           workflowRunId: "workflow-final-callback-failure",
           nodeId: "workflow-usage-step",
@@ -3001,7 +3000,7 @@ describe("AgentWorker", () => {
         message: "Agent execution failed.",
         retryable: false,
         details: {
-          agentId: "workflow-usage-agent",
+          agentStepId: "workflow-usage-step",
           workflowId: "workflow-usage-test",
           workflowRunId: "workflow-finalization-failure",
           nodeId: "workflow-usage-step",
@@ -3064,7 +3063,7 @@ describe("AgentWorker", () => {
         retryable: false,
         at: cancelledAt.toISOString(),
         details: {
-          agentId: "workflow-usage-agent",
+          agentStepId: "workflow-usage-step",
           workflowId: "workflow-usage-test",
           workflowRunId: runId,
           nodeRunId,
@@ -3135,13 +3134,11 @@ describe("AgentWorker", () => {
         throw originalError
       },
     })
-    const agent = defineAgent("workflow-failure-agent", {
-      name: "Workflow failure agent",
+    const agentStep = defineAgentStep("resolve-or-fail", {
       model,
       instructions: "Fail for this test.",
       groups: [AGENT_RUNTIME_GROUP],
     })
-    const agentStep = defineAgentStep("resolve-or-fail", agent)
       .input({ query: "string" })
       .output({ answer: "string" })
       .prompt(({ input }) => `Resolve '${input.query}'.`)
@@ -3151,7 +3148,6 @@ describe("AgentWorker", () => {
     const sixb = new SixbHost({
       id: PROJECT_ID,
       ontology: [],
-      agents: [agent],
       workflows: [workflow],
       groups: [AGENT_RUNTIME_GROUP],
       broker: new InMemoryBroker(),
@@ -3168,6 +3164,7 @@ describe("AgentWorker", () => {
     const runs = sixb.storage.workflowRuns!
     const runId = "workflow-agent-failure-run"
     const nodeRunId = `${runId}:node:0`
+    const actorId = workflowAgentStepActorId(workflow.id, agentStep.id)
     const executionId = await createTestWorkflowExecution(sixb.storage.executions, {
       projectId: PROJECT_ID,
       workflowId: workflow.id,
@@ -3195,7 +3192,7 @@ describe("AgentWorker", () => {
     })
     const agentExecutionId = await createTestAgentExecution(sixb.storage, {
       projectId: PROJECT_ID,
-      agentId: agent.id,
+      agentId: actorId,
       runId: nodeRunId,
       sourceExecutionId: executionId,
     })
@@ -3203,7 +3200,7 @@ describe("AgentWorker", () => {
       projectId: PROJECT_ID,
       nodeRunId,
       executionId: agentExecutionId,
-      agentId: agent.id,
+      agentId: actorId,
       prompt: "Resolve 'alpha'.",
     })
     await runs.nodes.wait({ projectId: PROJECT_ID, id: nodeRunId })
@@ -3242,7 +3239,7 @@ describe("AgentWorker", () => {
         message: "Agent execution failed.",
         retryable: false,
         details: {
-          agentId: agent.id,
+          agentStepId: agentStep.id,
           workflowId: workflow.id,
           workflowRunId: runId,
           nodeId: agentStep.id,
@@ -3255,7 +3252,7 @@ describe("AgentWorker", () => {
         message: "Workflow node execution failed.",
         retryable: false,
         details: {
-          agentId: agent.id,
+          agentStepId: agentStep.id,
           workflowId: workflow.id,
           workflowRunId: runId,
           nodeId: agentStep.id,

--- a/packages/atlas/src/features/workflows/components/runs/AgentExecutionPanel.tsx
+++ b/packages/atlas/src/features/workflows/components/runs/AgentExecutionPanel.tsx
@@ -53,7 +53,7 @@ export function AgentExecutionPanel({
       <div className="min-w-0 space-y-2">
         <div className="flex min-w-0 items-start justify-between gap-3">
           <div className="min-w-0">
-            <p className="break-words text-sm font-medium text-foreground">{data.agentId}</p>
+            <p className="break-words text-sm font-medium text-foreground">Agent task</p>
             <p className="mt-0.5 break-all font-mono text-[11px] text-muted-foreground">
               {data.modelId ?? "Model not reported"} · Attempt {data.attempt}
             </p>

--- a/packages/atlas/src/pages/WorkflowDetailPage.tsx
+++ b/packages/atlas/src/pages/WorkflowDetailPage.tsx
@@ -393,7 +393,6 @@ interface AgentNodeData extends BaseNodeData {
   kind: "agent"
   index: number
   label: string
-  agentId: string
   inputCount: number
   outputCount: number
 }
@@ -435,7 +434,6 @@ function toNodeData(node: WorkflowNode, index: number): WorkflowNodeData {
       kind: "agent",
       index,
       label: node.key,
-      agentId: node.agentId,
       inputCount: fieldCount(node.input),
       outputCount: fieldCount(node.output),
     }
@@ -591,8 +589,8 @@ function NodeMetaLine({ data }: { data: WorkflowNodeData }) {
   }
   if (data.kind === "agent") {
     return (
-      <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
-        {data.agentId} · {data.inputCount} in · {data.outputCount} out
+      <p className="mt-0.5 truncate text-[11px] tabular-nums text-muted-foreground">
+        {data.inputCount} in · {data.outputCount} out
       </p>
     )
   }
@@ -1004,7 +1002,7 @@ function nodeHeader(node: WorkflowNode): {
     return {
       title: node.key,
       kind: "agent",
-      description: `Runs agent ${node.agentId} with structured output.`,
+      description: "Runs an agent task with structured output.",
     }
   }
   return { title: node.key, kind: "step", description: "Transforms workflow data." }
@@ -1083,11 +1081,6 @@ function NodePanelSections({ node }: { node: WorkflowNode }) {
   if (node.type === "agent") {
     return (
       <>
-        <PanelBlock label="Agent" icon={<Bot className={SECTION_ICON} />}>
-          <span className="rounded-md bg-muted/60 px-2 py-1 font-mono text-xs text-foreground">
-            {node.agentId}
-          </span>
-        </PanelBlock>
         <PanelBlock
           label="Input"
           count={fieldCount(node.input)}

--- a/packages/atlas/tests/atlas-collection-ui.test.tsx
+++ b/packages/atlas/tests/atlas-collection-ui.test.tsx
@@ -13,7 +13,7 @@ const workflow = {
     { type: "step", id: "one", key: "loadContext", input: {}, output: {} },
     { type: "intervention", id: "two", key: "reviewDispatch", input: {}, response: {} },
     { type: "action", id: "three", key: "dispatchWorkOrder", params: {} },
-    { type: "agent", id: "four", key: "summarizeVisit", agentId: "ops", input: {}, output: {} },
+    { type: "agent", id: "four", key: "summarizeVisit", input: {}, output: {} },
     { type: "step", id: "five", key: "recordOutcome", input: {}, output: {} },
     { type: "step", id: "six", key: "notifyCustomer", input: {}, output: {} },
   ],

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -15457,9 +15457,6 @@
                                 "key": {
                                   "type": "string"
                                 },
-                                "agentId": {
-                                  "type": "string"
-                                },
                                 "input": {
                                   "type": "object",
                                   "additionalProperties": {
@@ -15513,7 +15510,7 @@
                                   }
                                 }
                               },
-                              "required": ["type", "id", "key", "agentId", "input", "output"],
+                              "required": ["type", "id", "key", "input", "output"],
                               "additionalProperties": false
                             }
                           ]
@@ -15923,9 +15920,6 @@
                               "key": {
                                 "type": "string"
                               },
-                              "agentId": {
-                                "type": "string"
-                              },
                               "input": {
                                 "type": "object",
                                 "additionalProperties": {
@@ -15979,7 +15973,7 @@
                                 }
                               }
                             },
-                            "required": ["type", "id", "key", "agentId", "input", "output"],
+                            "required": ["type", "id", "key", "input", "output"],
                             "additionalProperties": false
                           }
                         ]
@@ -17981,9 +17975,6 @@
                           "agentExecution": {
                             "type": "object",
                             "properties": {
-                              "agentId": {
-                                "type": "string"
-                              },
                               "status": {
                                 "type": "string",
                                 "enum": ["queued", "running", "succeeded", "failed", "cancelled"]
@@ -18090,7 +18081,7 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["agentId", "status", "attempt"],
+                            "required": ["status", "attempt"],
                             "additionalProperties": false
                           }
                         },
@@ -18209,9 +18200,6 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "agentId": {
-                      "type": "string"
-                    },
                     "status": {
                       "type": "string",
                       "enum": ["queued", "running", "succeeded", "failed", "cancelled"]
@@ -18879,7 +18867,7 @@
                       "type": "string"
                     }
                   },
-                  "required": ["agentId", "status", "attempt", "nodeRunId", "prompt", "createdAt"],
+                  "required": ["status", "attempt", "nodeRunId", "prompt", "createdAt"],
                   "additionalProperties": false
                 }
               }
@@ -19316,9 +19304,6 @@
                           "agentExecution": {
                             "type": "object",
                             "properties": {
-                              "agentId": {
-                                "type": "string"
-                              },
                               "status": {
                                 "type": "string",
                                 "enum": ["queued", "running", "succeeded", "failed", "cancelled"]
@@ -19425,7 +19410,7 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["agentId", "status", "attempt"],
+                            "required": ["status", "attempt"],
                             "additionalProperties": false
                           }
                         },

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -5199,7 +5199,6 @@ export type ListWorkflowsResponses = {
           type: "agent"
           id: string
           key: string
-          agentId: string
           input: {
             [key: string]:
               | string
@@ -5384,7 +5383,6 @@ export type GetWorkflowResponses = {
           type: "agent"
           id: string
           key: string
-          agentId: string
           input: {
             [key: string]:
               | string
@@ -6115,7 +6113,6 @@ export type GetWorkflowRunResponses = {
         truncated?: true
       }
       agentExecution?: {
-        agentId: string
         status: "queued" | "running" | "succeeded" | "failed" | "cancelled"
         attempt: number
         modelId?: string
@@ -6188,7 +6185,6 @@ export type GetWorkflowAgentNodeExecutionResponses = {
    * Response for status 200
    */
   200: {
-    agentId: string
     status: "queued" | "running" | "succeeded" | "failed" | "cancelled"
     attempt: number
     modelId?: string
@@ -6599,7 +6595,6 @@ export type CancelWorkflowRunResponses = {
         truncated?: true
       }
       agentExecution?: {
-        agentId: string
         status: "queued" | "running" | "succeeded" | "failed" | "cancelled"
         attempt: number
         modelId?: string

--- a/packages/core/src/agents/authority.ts
+++ b/packages/core/src/agents/authority.ts
@@ -1,4 +1,4 @@
-import { SYSTEM_PRINCIPAL } from "../auth"
+import { principalsEqual, SYSTEM_PRINCIPAL } from "../auth"
 import type { AuthorizationContext } from "../authorization"
 import { resolveAuthorizationContext } from "../authorization"
 import { createSixbError } from "../errors/internal"
@@ -45,34 +45,55 @@ export async function ensureAgentExecutionIdentity(input: {
   readonly projectId: string
   readonly agent: AgentDefinition
 }): Promise<AgentExecutionIdentity> {
+  return ensureManagedAgentExecutionIdentity({
+    auth: input.auth,
+    projectId: input.projectId,
+    agentId: input.agent.id,
+    name: input.agent.name,
+    description: `Managed service account for agent '${input.agent.id}'.`,
+    groupIds: input.agent.groupIds,
+  })
+}
+
+/** Ensure a framework-managed Agent actor exists with exactly its declared group memberships. */
+export async function ensureManagedAgentExecutionIdentity(input: {
+  readonly auth: AuthStorage | undefined
+  readonly projectId: string
+  readonly agentId: string
+  readonly name: string
+  readonly description: string
+  readonly groupIds: readonly string[]
+}): Promise<AgentExecutionIdentity> {
   const auth = requireAuthStorage(input.auth)
-  const id = agentServiceAccountId(input.agent.id)
-  const name = input.agent.name
-  const description = `Managed service account for agent '${input.agent.id}'.`
+  const id = agentServiceAccountId(input.agentId)
   const now = new Date()
   const loaded = await loadOrCreateAgentServiceAccount(auth, {
     id,
     projectId: input.projectId,
-    name,
-    description,
+    name: input.name,
+    description: input.description,
     updatedAt: now,
   })
-  assertActiveAgentServiceAccount(input.agent.id, loaded)
+  assertFrameworkManagedAgentServiceAccount(input.agentId, loaded)
+  assertActiveAgentServiceAccount(input.agentId, loaded)
   const serviceAccount = await updateAgentServiceAccountMetadata(auth, {
     existing: loaded,
-    name,
-    description,
+    name: input.name,
+    description: input.description,
     updatedAt: now,
   })
-  assertActiveAgentServiceAccount(input.agent.id, serviceAccount)
+  assertActiveAgentServiceAccount(input.agentId, serviceAccount)
 
-  const groupMemberships = await auth.serviceAccountGroupMemberships.reconcileForServiceAccount({
-    projectId: input.projectId,
-    serviceAccountId: id,
-    groupIds: input.agent.groupIds,
-    source: "agent",
-    updatedAt: now,
-  })
+  const groupMemberships = requireDefinitionOwnedGroupMemberships(
+    input.agentId,
+    await auth.serviceAccountGroupMemberships.reconcileForServiceAccount({
+      projectId: input.projectId,
+      serviceAccountId: id,
+      groupIds: input.groupIds,
+      source: "agent",
+      updatedAt: now,
+    })
+  )
 
   return {
     serviceAccount,
@@ -133,6 +154,39 @@ function assertActiveAgentServiceAccount(
   }
 }
 
+function assertFrameworkManagedAgentServiceAccount(
+  agentId: string,
+  serviceAccount: ServiceAccountRecord
+): void {
+  if (
+    serviceAccount.createdByPrincipal === undefined ||
+    !principalsEqual(serviceAccount.createdByPrincipal, SYSTEM_PRINCIPAL)
+  ) {
+    throw createSixbError(
+      "agent.execution_failed",
+      `[Sixb] Agent '${agentId}' cannot use service account '${serviceAccount.id}' because it is not managed by Sixb.`,
+      { details: { agentId, serviceAccountId: serviceAccount.id } }
+    )
+  }
+}
+
+function requireDefinitionOwnedGroupMemberships(
+  agentId: string,
+  memberships: readonly ServiceAccountGroupMembershipRecord[]
+): readonly ServiceAccountGroupMembershipRecord[] {
+  const externalGroupIds = memberships
+    .filter((membership) => membership.source !== "agent")
+    .map((membership) => membership.groupId)
+  if (externalGroupIds.length > 0) {
+    throw createSixbError(
+      "agent.execution_failed",
+      `[Sixb] Agent '${agentId}' service account has group memberships not managed by its definition: ${externalGroupIds.join(", ")}.`,
+      { details: { agentId, externalGroupIds } }
+    )
+  }
+  return memberships
+}
+
 /** Resolve current grants for the service account referenced by a durable Agent execution. */
 export async function resolveAgentExecutionAuthorization(input: {
   readonly auth: AuthStorage | undefined
@@ -158,11 +212,15 @@ export async function resolveAgentExecutionAuthorization(input: {
   if (!serviceAccount || serviceAccount.status !== "active") {
     throw new Error(`[Sixb] Agent service account '${principal.id}' is not active.`)
   }
+  assertFrameworkManagedAgentServiceAccount(input.agentId, serviceAccount)
 
-  const groupMemberships = await auth.serviceAccountGroupMemberships.listForServiceAccount({
-    projectId: input.projectId,
-    serviceAccountId: principal.id,
-  })
+  const groupMemberships = requireDefinitionOwnedGroupMemberships(
+    input.agentId,
+    await auth.serviceAccountGroupMemberships.listForServiceAccount({
+      projectId: input.projectId,
+      serviceAccountId: principal.id,
+    })
+  )
   const identity: AgentExecutionIdentity = {
     serviceAccount,
     principal: { type: "serviceAccount", id: principal.id },

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -35,6 +35,7 @@ export type { AgentExecutionAuthorization, AgentExecutionIdentity } from "./auth
 export {
   agentServiceAccountId,
   ensureAgentExecutionIdentity,
+  ensureManagedAgentExecutionIdentity,
   resolveAgentExecutionAuthorization,
   resolveInheritedMainAgentExecutionAuthorization,
 } from "./authority"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -765,6 +765,7 @@ export type {
   AgentStepPrompt,
   AgentStepPromptBuilder,
   AgentStepPromptContext,
+  DefineAgentStepConfig,
   InferAgentStepInput,
   InferAgentStepOutput,
   InferInterventionInput,

--- a/packages/core/src/runtime/create.ts
+++ b/packages/core/src/runtime/create.ts
@@ -48,7 +48,7 @@ export interface CreateSixbOptions {
   agents?: readonly AgentDefinition[]
   /** Models this project allows Sixb to use. The first of each kind is the default. */
   models?: ModelCatalogInput
-  /** Project tools available to the built-in main agent. */
+  /** Project tools available to Agent runtimes. */
   tools?: readonly AgentToolDefinition[]
   datasets?: readonly DatasetDefinition[]
   /** Connector definitions to register in addition to auto-discovered `connectors/` exports. */

--- a/packages/core/src/runtime/host.ts
+++ b/packages/core/src/runtime/host.ts
@@ -110,7 +110,7 @@ export interface SixbHostOptions<TOntologySources extends readonly OntologySourc
   workflows?: readonly WorkflowDefinition[]
   agents?: readonly AgentDefinition[]
   models?: ModelCatalogInput
-  /** Project tools available to the built-in main agent. */
+  /** Project tools available to Agent runtimes. */
   tools?: readonly AgentToolDefinition[]
   groups?: readonly GroupDefinition[]
   roles?: readonly RoleDefinition[]

--- a/packages/core/src/runtime/resolve-definitions.ts
+++ b/packages/core/src/runtime/resolve-definitions.ts
@@ -30,7 +30,7 @@ import {
   validateMergeSyncProjectionSafety,
 } from "../syncs/validation"
 import type { WorkflowDefinition } from "../workflows"
-import { validateWorkflowsAtStartup } from "../workflows"
+import { validateWorkflowAgentStepGroupReferences, validateWorkflowsAtStartup } from "../workflows"
 import { createDefinitionCatalog, type SixbDefinitions } from "./definitions"
 import { RuntimeError } from "./errors"
 import type { OntologySource } from "./types"
@@ -151,6 +151,8 @@ export function resolveDefinitions(options: DefinitionOptions): ResolvedDefiniti
     registeredSchedules: schedulesById,
     registeredActionIds,
     registeredAgentIds: new Set(agentsById.keys()),
+    ...(models === undefined ? {} : { models }),
+    tools,
   })
   const workflowsById = indexUniqueDefinitions("workflow", workflows)
 
@@ -169,6 +171,7 @@ export function resolveDefinitions(options: DefinitionOptions): ResolvedDefiniti
     getSubTypes: (objectTypeId) => ontology.listSubTypes(objectTypeId),
   })
   validateAgentGroupReferences(agents, security)
+  validateWorkflowAgentStepGroupReferences(workflows, security)
 
   const projectionRegistry = new ProjectionRegistry({
     projections: options.projections ?? [],

--- a/packages/core/src/testing/agent-execution.ts
+++ b/packages/core/src/testing/agent-execution.ts
@@ -1,4 +1,5 @@
 import { agentServiceAccountId } from "../agents/authority"
+import { SYSTEM_PRINCIPAL } from "../auth"
 import type { AuthStorage } from "../storage/auth"
 import { AuthStorageError } from "../storage/auth"
 import type { ExecutionStorage } from "../storage/executions"
@@ -30,7 +31,7 @@ export async function createTestAgentExecution(
         name: `Test Agent ${input.agentId}`,
         description: `Test service account for Agent '${input.agentId}'.`,
         status: "active",
-        createdByPrincipal: { type: "system", id: "test" },
+        createdByPrincipal: SYSTEM_PRINCIPAL,
         createdAt: now,
         updatedAt: now,
       })

--- a/packages/core/src/workflows/agent-step-identity.ts
+++ b/packages/core/src/workflows/agent-step-identity.ts
@@ -1,0 +1,4 @@
+/** Stable internal actor id for one workflow Agent step. */
+export function workflowAgentStepActorId(workflowId: string, stepId: string): string {
+  return `workflow:${encodeURIComponent(workflowId)}:step:${encodeURIComponent(stepId)}`
+}

--- a/packages/core/src/workflows/builders.ts
+++ b/packages/core/src/workflows/builders.ts
@@ -1,14 +1,16 @@
 import type { ActionDefinition } from "../actions"
 import { isActionDefinition } from "../actions"
-import type { AgentDefinition } from "../agents"
-import { isAgentDefinition } from "../agents"
+import { AGENT_REASONING_LEVELS, isAgentToolDefinition } from "../agents"
+import { isModelReasoning } from "../models/language-model"
 import type { SchemaOrRef } from "../ontology"
 import type { ScheduleDefinition, ScheduleDefinitionForEvent } from "../schedules"
 import { isScheduleDefinition } from "../schedules"
+import { isGroupDefinition } from "../security"
 import { WorkflowDefinitionError } from "./errors"
 import type {
   AgentStepBuilder,
   AgentStepDefinition,
+  DefineAgentStepConfig,
   InterventionBuilder,
   InterventionDefaultsRuntimeHandler,
   InterventionDefinition,
@@ -115,14 +117,25 @@ export function defineWorkflowStep<const TId extends string>(id: TId): StepBuild
   } as unknown as StepBuilder<TId>
 }
 
-export function defineAgentStep<const TId extends string, const TAgent extends AgentDefinition>(
+export function defineAgentStep<const TId extends string>(
   id: TId,
-  agent: TAgent
-): AgentStepBuilder<TId, TAgent> {
+  config: DefineAgentStepConfig
+): AgentStepBuilder<TId> {
   assertNonEmpty(id, "Agent step", "id")
-  if (!isAgentDefinition(agent)) {
-    throw new WorkflowDefinitionError(`Agent step "${id}" references an invalid agent.`)
+  if (!isRecord(config)) {
+    throw new WorkflowDefinitionError(`Agent step "${id}" config must be an object.`)
   }
+  if (typeof config.instructions !== "string" || !config.instructions.trim()) {
+    throw new WorkflowDefinitionError(`Agent step "${id}" instructions must not be empty.`)
+  }
+  if (config.reasoning !== undefined && !isModelReasoning(config.reasoning)) {
+    throw new WorkflowDefinitionError(
+      `Agent step "${id}" reasoning must be one of: ${AGENT_REASONING_LEVELS.join(", ")}, or a nonnegative budgetTokens object.`
+    )
+  }
+  const { model, reasoning, instructions } = config
+  const groupIds = groupIdsFromAgentStepConfig(id, config)
+  const toolNames = toolNamesFromAgentStepConfig(id, config)
 
   return {
     input(input: RuntimeWorkflowInput): unknown {
@@ -133,13 +146,82 @@ export function defineAgentStep<const TId extends string, const TAgent extends A
               if (typeof prompt !== "function") {
                 throw new WorkflowDefinitionError(`Agent step "${id}" prompt must be a function.`)
               }
-              return { kind: "agentStep", id, agent, input, output, prompt }
+              return {
+                kind: "agentStep",
+                id,
+                ...(model === undefined ? {} : { model }),
+                ...(reasoning === undefined ? {} : { reasoning }),
+                instructions,
+                groupIds,
+                toolNames,
+                input,
+                output,
+                prompt,
+              }
             },
           }
         },
       }
     },
-  } as unknown as AgentStepBuilder<TId, TAgent>
+  } as unknown as AgentStepBuilder<TId>
+}
+
+function groupIdsFromAgentStepConfig(
+  stepId: string,
+  config: DefineAgentStepConfig
+): readonly string[] {
+  if (config.groups !== undefined && !Array.isArray(config.groups)) {
+    throw new WorkflowDefinitionError(
+      `Agent step "${stepId}" groups must be an array of group definitions.`
+    )
+  }
+  const groupIds = Array.from(config.groups ?? [], (group) => {
+    if (!isGroupDefinition(group)) {
+      throw new WorkflowDefinitionError(
+        `Agent step "${stepId}" groups must contain only group definitions.`
+      )
+    }
+    return group.id
+  })
+  assertUniqueAgentStepValues(stepId, "group", groupIds)
+  return Object.freeze(groupIds)
+}
+
+function toolNamesFromAgentStepConfig(
+  stepId: string,
+  config: DefineAgentStepConfig
+): readonly string[] {
+  if (config.tools !== undefined && !Array.isArray(config.tools)) {
+    throw new WorkflowDefinitionError(
+      `Agent step "${stepId}" tools must be an array of agent tool definitions.`
+    )
+  }
+  const toolNames = Array.from(config.tools ?? [], (tool) => {
+    if (!isAgentToolDefinition(tool)) {
+      throw new WorkflowDefinitionError(
+        `Agent step "${stepId}" tools must contain only agent tool definitions.`
+      )
+    }
+    return tool.name
+  })
+  assertUniqueAgentStepValues(stepId, "tool", toolNames)
+  return Object.freeze(toolNames)
+}
+
+function assertUniqueAgentStepValues(
+  stepId: string,
+  kind: "group" | "tool",
+  values: readonly string[]
+): void {
+  const seen = new Set<string>()
+  for (const value of values) {
+    if (seen.has(value)) {
+      throw new WorkflowDefinitionError(
+        `Agent step "${stepId}" ${kind}s contains duplicate ${kind} '${value}'.`
+      )
+    }
+    seen.add(value)
+  }
 }
 
 export function defineIntervention<const TId extends string>(
@@ -468,4 +550,8 @@ function isRuntimeWorkflowMapper(value: unknown): value is RuntimeWorkflowMapper
 
 function isRuntimeWorkflowScheduleMapper(value: unknown): value is RuntimeWorkflowScheduleMapper {
   return typeof value === "function"
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }

--- a/packages/core/src/workflows/execution.ts
+++ b/packages/core/src/workflows/execution.ts
@@ -61,7 +61,8 @@ export type ListWorkflowRunNodesInput = Omit<
 >
 
 /** Execution-facing Agent node view derived from its run row and model-call ledger. */
-export interface WorkflowAgentNodeRunView extends Omit<WorkflowAgentNodeRunRecord, "execution"> {
+export interface WorkflowAgentNodeRunView
+  extends Omit<WorkflowAgentNodeRunRecord, "execution" | "agentId"> {
   readonly usage?: AiModelCallUsage
   /** Preferred valuation; omitted when there are no calls or cost storage is unavailable. */
   readonly cost?: AiCostSummary
@@ -274,7 +275,6 @@ function toWorkflowAgentNodeRunView(
     projectId: execution.projectId,
     nodeRunId: execution.nodeRunId,
     executionId: execution.executionId,
-    agentId: execution.agentId,
     status: execution.status,
     prompt: execution.prompt,
     modelId: execution.modelId,

--- a/packages/core/src/workflows/failure.ts
+++ b/packages/core/src/workflows/failure.ts
@@ -15,7 +15,7 @@ export interface WorkflowNodeFailureIdentity extends WorkflowNodeFailureIdentity
         readonly actionId: string
         readonly actionRunId?: string
       }
-    | { readonly type: "agent"; readonly agentId: string }
+    | { readonly type: "agent"; readonly agentStepId: string }
     | { readonly type: "intervention"; readonly interventionId: string }
 }
 
@@ -56,7 +56,7 @@ function workflowNodeFailureDetails(identity: WorkflowNodeFailureIdentity) {
         ...(identity.child.actionRunId ? { actionRunId: identity.child.actionRunId } : {}),
       }
     case "agent":
-      return { ...base, agentId: identity.child.agentId }
+      return { ...base, agentStepId: identity.child.agentStepId }
     case "intervention":
       return { ...base, interventionId: identity.child.interventionId }
   }

--- a/packages/core/src/workflows/index.ts
+++ b/packages/core/src/workflows/index.ts
@@ -1,3 +1,4 @@
+export { workflowAgentStepActorId } from "./agent-step-identity"
 export {
   defineAgentStep,
   defineIntervention,
@@ -39,6 +40,7 @@ export type {
   AgentStepPrompt,
   AgentStepPromptBuilder,
   AgentStepPromptContext,
+  DefineAgentStepConfig,
   DerivedWorkflowNodeKey,
   InferAgentStepInput,
   InferAgentStepOutput,
@@ -90,6 +92,7 @@ export {
   isInterventionDefinition,
   isStepDefinition,
   isWorkflowDefinition,
+  validateWorkflowAgentStepGroupReferences,
   validateWorkflowAgentStepInput,
   validateWorkflowAgentStepOutput,
   validateWorkflowDefinition,

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -6,7 +6,7 @@ import type {
 } from "../actions"
 import type { ActionsRuntime } from "../actions/execution"
 import type { AgentsRuntime } from "../agents/execution"
-import type { AgentDefinition } from "../agents/types"
+import type { AgentReasoningLevel, AgentToolDefinition } from "../agents/types"
 import type { Principal } from "../auth"
 import type { BlobsRuntime } from "../blob-storage/execution"
 import type { ConnectorRuntime } from "../connectors/execution"
@@ -15,6 +15,7 @@ import type { EventsRuntime } from "../events/execution"
 import type { JsonValue } from "../json"
 import type { Logger } from "../logging"
 import type { LogsRuntime } from "../logging/execution"
+import type { LanguageModel } from "../models/language-model"
 import type { ObjectsRuntime } from "../objects/execution"
 import type { InferSchemaOrRef, ObjectRef, OntologySource, SchemaOrRef } from "../ontology"
 import type { PipelinesRuntime } from "../pipelines/execution"
@@ -22,6 +23,7 @@ import type { ProjectionsRuntime } from "../projections/execution"
 import type { RulesRuntime } from "../rules/execution"
 import type { ScheduleDefinition, ScheduleDefinitionForEvent } from "../schedules"
 import type { SchedulesRuntime } from "../schedules/execution"
+import type { GroupDefinition } from "../security"
 import type { SyncsRuntime } from "../syncs/execution"
 import type { WorkflowsRuntime } from "./execution"
 
@@ -133,9 +135,18 @@ export type AgentStepPrompt<TInput extends Record<string, unknown>> = (
   ctx: AgentStepPromptContext<TInput>
 ) => string | Promise<string>
 
+/** Runtime configuration owned directly by a workflow Agent step. */
+export interface DefineAgentStepConfig {
+  readonly model?: LanguageModel
+  readonly reasoning?: AgentReasoningLevel
+  readonly instructions: string
+  readonly groups?: readonly GroupDefinition[]
+  /** Project tools this workflow task may call. Defaults to none. */
+  readonly tools?: readonly AgentToolDefinition[]
+}
+
 export interface AgentStepDefinition<
   TId extends string = string,
-  TAgent extends AgentDefinition = AgentDefinition,
   TInput extends Record<string, unknown> = Record<string, unknown>,
   TOutput extends Record<string, unknown> = Record<string, unknown>,
   TInputValue extends Record<string, unknown> = Record<string, unknown>,
@@ -143,7 +154,11 @@ export interface AgentStepDefinition<
 > {
   readonly kind: "agentStep"
   readonly id: TId
-  readonly agent: TAgent
+  readonly model?: LanguageModel
+  readonly reasoning?: AgentReasoningLevel
+  readonly instructions: string
+  readonly groupIds: readonly string[]
+  readonly toolNames: readonly string[]
   readonly input: TInput
   readonly output: TOutput
   readonly prompt: AgentStepPrompt<Record<string, unknown>>
@@ -153,7 +168,6 @@ export interface AgentStepDefinition<
 
 export interface AgentStepPromptBuilder<
   TId extends string,
-  TAgent extends AgentDefinition,
   TInput extends Record<string, unknown>,
   TOutput extends Record<string, unknown>,
 > {
@@ -161,7 +175,6 @@ export interface AgentStepPromptBuilder<
     prompt: AgentStepPrompt<InferSchemaOrRefRecord<TInput>>
   ): AgentStepDefinition<
     TId,
-    TAgent,
     TInput,
     TOutput,
     InferSchemaOrRefRecord<TInput>,
@@ -171,18 +184,17 @@ export interface AgentStepPromptBuilder<
 
 export interface AgentStepOutputBuilder<
   TId extends string,
-  TAgent extends AgentDefinition,
   TInput extends Record<string, unknown>,
 > {
   output<const TOutput extends Record<string, unknown>>(
     output: TOutput & SchemaOrRefInput<TOutput>
-  ): AgentStepPromptBuilder<TId, TAgent, TInput, TOutput>
+  ): AgentStepPromptBuilder<TId, TInput, TOutput>
 }
 
-export interface AgentStepBuilder<TId extends string, TAgent extends AgentDefinition> {
+export interface AgentStepBuilder<TId extends string> {
   input<const TInput extends Record<string, unknown>>(
     input: TInput & SchemaOrRefInput<TInput>
-  ): AgentStepOutputBuilder<TId, TAgent, TInput>
+  ): AgentStepOutputBuilder<TId, TInput>
 }
 
 export type InferAgentStepInput<TStep extends AgentStepDefinition> = TStep extends {

--- a/packages/core/src/workflows/validation.ts
+++ b/packages/core/src/workflows/validation.ts
@@ -1,8 +1,12 @@
 import { isActionDefinition } from "../actions"
-import { isAgentDefinition } from "../agents"
+import type { AgentToolCatalog } from "../agents"
+import type { ModelCatalog } from "../models"
+import { isModelReasoning } from "../models/language-model"
 import type { SchemaOrRef, ValueType } from "../ontology"
 import { validateSchemaOrRefValue } from "../ontology"
 import type { ScheduleDefinition } from "../schedules"
+import type { SecurityDefinitionCatalog } from "../security"
+import { workflowAgentStepActorId } from "./agent-step-identity"
 import { WorkflowDefinitionError, WorkflowValidationError } from "./errors"
 import type {
   AgentStepDefinition,
@@ -45,7 +49,11 @@ export function isAgentStepDefinition(value: unknown): value is AgentStepDefinit
     isRecord(value) &&
     value.kind === "agentStep" &&
     typeof value.id === "string" &&
-    isAgentDefinition(value.agent) &&
+    (value.model === undefined || isLanguageModel(value.model)) &&
+    (value.reasoning === undefined || isModelReasoning(value.reasoning)) &&
+    typeof value.instructions === "string" &&
+    isStringArray(value.groupIds) &&
+    isStringArray(value.toolNames) &&
     isRecord(value.input) &&
     isRecord(value.output) &&
     typeof value.prompt === "function"
@@ -112,6 +120,8 @@ export function validateWorkflowsAtStartup(options: {
   registeredSchedules: ReadonlyMap<string, ScheduleDefinition>
   registeredActionIds: ReadonlySet<string>
   registeredAgentIds: ReadonlySet<string>
+  models?: ModelCatalog
+  tools: AgentToolCatalog
 }): readonly WorkflowDefinition[] {
   for (const workflow of options.workflows) {
     validateWorkflowDefinition(workflow)
@@ -131,15 +141,65 @@ export function validateWorkflowsAtStartup(options: {
           `Workflow "${workflow.id}" references unknown action "${node.action.id}". Add it to 'actions' in createSixb() or export it from 'actions/'.`
         )
       }
-      if (node.type === "agent" && !options.registeredAgentIds.has(node.agentStep.agent.id)) {
-        throw new WorkflowDefinitionError(
-          `Workflow "${workflow.id}" references unknown agent "${node.agentStep.agent.id}". Add it to 'agents' in createSixb() or export it from 'agents/'.`
-        )
+      if (node.type === "agent") {
+        const actorId = workflowAgentStepActorId(workflow.id, node.agentStep.id)
+        if (options.registeredAgentIds.has(actorId)) {
+          throw new WorkflowDefinitionError(
+            `Workflow "${workflow.id}" agent step "${node.id}" conflicts with registered agent "${actorId}".`
+          )
+        }
+        validateWorkflowAgentStepRuntimeReferences(workflow.id, node.agentStep, options)
       }
     }
   }
 
   return options.workflows
+}
+
+/** Validate workflow task memberships once the security catalog has been composed. */
+export function validateWorkflowAgentStepGroupReferences(
+  workflows: readonly WorkflowDefinition[],
+  security: SecurityDefinitionCatalog
+): void {
+  for (const workflow of workflows) {
+    for (const node of workflow.nodes) {
+      if (node.type !== "agent") continue
+      for (const groupId of node.agentStep.groupIds) {
+        if (!security.getGroupById(groupId)) {
+          throw new WorkflowDefinitionError(
+            `Workflow "${workflow.id}" agent step "${node.id}" references unknown group "${groupId}". Add it to 'security/groups/' or pass it to createSixb({ groups }).`
+          )
+        }
+      }
+    }
+  }
+}
+
+function validateWorkflowAgentStepRuntimeReferences(
+  workflowId: string,
+  step: AgentStepDefinition,
+  options: { readonly models?: ModelCatalog; readonly tools: AgentToolCatalog }
+): void {
+  if (step.model === undefined && options.models === undefined) {
+    throw new WorkflowDefinitionError(
+      `Workflow "${workflowId}" agent step "${step.id}" needs a model. Configure 'models.language' or pass 'model' to defineAgentStep().`
+    )
+  }
+  if (step.model !== undefined && options.models !== undefined) {
+    const ref = { provider: step.model.providerId, modelId: step.model.modelId }
+    if (options.models.language.getByRef(ref) === null) {
+      throw new WorkflowDefinitionError(
+        `Workflow "${workflowId}" agent step "${step.id}" uses unknown language model "${ref.provider}/${ref.modelId}". Add it to 'models.language' in createSixb().`
+      )
+    }
+  }
+  for (const toolName of step.toolNames) {
+    if (options.tools.getByName(toolName) === null) {
+      throw new WorkflowDefinitionError(
+        `Workflow "${workflowId}" agent step "${step.id}" uses unknown project tool "${toolName}". Add it to 'tools' in createSixb().`
+      )
+    }
+  }
 }
 
 export function validateWorkflowInput(params: {
@@ -326,11 +386,52 @@ function validateAgentNodeDefinition(workflowId: string, node: WorkflowAgentNode
       `Workflow "${workflowId}" agent node id "${node.id}" does not match agent step definition id "${node.agentStep.id}".`
     )
   }
+  if (!node.agentStep.instructions.trim()) {
+    throw new WorkflowDefinitionError(
+      `Workflow "${workflowId}" agent step "${node.id}" instructions must not be empty.`
+    )
+  }
+  assertUniqueNonEmptyAgentStepValues(workflowId, node.id, "group", node.agentStep.groupIds)
+  assertUniqueNonEmptyAgentStepValues(workflowId, node.id, "tool", node.agentStep.toolNames)
   if (node.mapper !== undefined && typeof node.mapper !== "function") {
     throw new WorkflowDefinitionError(
       `Workflow "${workflowId}" agent node "${node.id}" mapper must be a function.`
     )
   }
+}
+
+function assertUniqueNonEmptyAgentStepValues(
+  workflowId: string,
+  stepId: string,
+  kind: "group" | "tool",
+  values: readonly string[]
+): void {
+  const seen = new Set<string>()
+  for (const value of values) {
+    if (!value.trim()) {
+      throw new WorkflowDefinitionError(
+        `Workflow "${workflowId}" agent step "${stepId}" has an empty ${kind} id.`
+      )
+    }
+    if (seen.has(value)) {
+      throw new WorkflowDefinitionError(
+        `Workflow "${workflowId}" agent step "${stepId}" has duplicate ${kind} '${value}'.`
+      )
+    }
+    seen.add(value)
+  }
+}
+
+function isLanguageModel(value: unknown): boolean {
+  return (typeof value === "object" || typeof value === "function") && value !== null
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  if (!Array.isArray(value)) return false
+  for (let index = 0; index < value.length; index += 1) {
+    if (!Object.hasOwn(value, index) || typeof value[index] !== "string") return false
+  }
+  return true
 }
 
 export function validateWorkflowAgentStepInput(params: {

--- a/packages/core/tests/agent-authority.test.ts
+++ b/packages/core/tests/agent-authority.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test"
 import { InMemoryStorage } from "../src"
-import { resolveInheritedMainAgentExecutionAuthorization } from "../src/agents/authority"
+import {
+  agentServiceAccountId,
+  ensureManagedAgentExecutionIdentity,
+  resolveAgentExecutionAuthorization,
+  resolveInheritedMainAgentExecutionAuthorization,
+} from "../src/agents/authority"
 import { SecurityRegistry } from "../src/security"
 
 const projectId = "main-agent-authority"
@@ -72,5 +77,62 @@ describe("main agent authority", () => {
         now,
       })
     ).rejects.toMatchObject({ code: "agent.execution_failed" })
+  })
+})
+
+describe("managed agent authority", () => {
+  test("does not adopt a service account created outside the Agent runtime", async () => {
+    const storage = new InMemoryStorage()
+    const agentId = "workflow:billing:step:review"
+    const serviceAccountId = agentServiceAccountId(agentId)
+    await storage.auth.serviceAccounts.create({
+      id: serviceAccountId,
+      projectId,
+      name: "Conflicting account",
+      createdByPrincipal: { type: "user", id: userId },
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    await expect(
+      ensureManagedAgentExecutionIdentity({
+        auth: storage.auth,
+        projectId,
+        agentId,
+        name: "Billing review",
+        description: "Managed workflow Agent task.",
+        groupIds: ["billing"],
+      })
+    ).rejects.toThrow(`service account '${serviceAccountId}' because it is not managed by Sixb`)
+  })
+
+  test("fails closed when a managed Agent receives an external group membership", async () => {
+    const storage = new InMemoryStorage()
+    const agentId = "workflow:billing:step:review"
+    const identity = await ensureManagedAgentExecutionIdentity({
+      auth: storage.auth,
+      projectId,
+      agentId,
+      name: "Billing review",
+      description: "Managed workflow Agent task.",
+      groupIds: ["billing"],
+    })
+    await storage.auth.serviceAccountGroupMemberships.upsert({
+      projectId,
+      serviceAccountId: identity.serviceAccount.id,
+      groupId: "administrators",
+      source: "manual",
+      createdAt: now,
+    })
+
+    await expect(
+      resolveAgentExecutionAuthorization({
+        auth: storage.auth,
+        projectId,
+        agentId,
+        authorizationRef: { type: "principal", principal: identity.principal },
+        security,
+      })
+    ).rejects.toThrow("group memberships not managed by its definition: administrators")
   })
 })

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -114,7 +114,10 @@ const invoiceAgent = defineAgent("invoice-agent", {
   instructions: "Help with invoices.",
 })
 
-const reviewContractWithAgent = defineAgentStep("review-contract-with-agent", contractAgent)
+const reviewContractWithAgent = defineAgentStep("review-contract-with-agent", {
+  model: contractAgent.model,
+  instructions: "Help with contracts.",
+})
   .input({ contract: ref(Contract) })
   .output({ approved: "boolean", reason: "string" })
   .prompt(({ input }) => `Review contract '${input.contract.primaryId}'.`)

--- a/packages/core/tests/workflows.test.ts
+++ b/packages/core/tests/workflows.test.ts
@@ -3,6 +3,8 @@ import {
   defineAction,
   defineAgent,
   defineAgentStep,
+  defineAgentTool,
+  defineGroup,
   defineIntervention,
   defineObjectType,
   defineSchedule,
@@ -15,10 +17,12 @@ import {
   isInterventionDefinition,
   isStepDefinition,
   isWorkflowDefinition,
+  type OntologySource,
   param,
   prop,
   RuntimeError,
   ref,
+  SixbHost,
   stringEnum,
   valueTypeRef,
   type WorkflowDefinition,
@@ -27,7 +31,7 @@ import {
 import type { LanguageModel } from "../src/models"
 import { schemaFieldsToJsonSchema, schemaRecordToJsonSchema } from "../src/ontology/internal"
 import { createTestSixb } from "../src/testing"
-import { validateWorkflowDefinition } from "../src/workflows"
+import { validateWorkflowDefinition, workflowAgentStepActorId } from "../src/workflows"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
 
 const Transaction = defineObjectType({
@@ -42,13 +46,23 @@ const Invoice = defineObjectType({
   properties: [prop("id", "string", { required: true, primary: true })],
 })
 
-const resolverAgent = defineAgent("invoice-resolver", {
-  name: "Invoice resolver",
-  model: {} as LanguageModel,
+function testModel(providerId: string, modelId: string): LanguageModel {
+  return {
+    providerId,
+    modelId,
+    definition: { kind: "language", providerId, modelId, capabilities: {} },
+    async stream() {
+      throw new Error("Definition tests do not run inference.")
+    },
+  }
+}
+
+const workflowModel = testModel("test", "workflow-model")
+
+const resolveInvoice = defineAgentStep("resolve-invoice", {
+  model: workflowModel,
   instructions: "Resolve invoices from transaction evidence.",
 })
-
-const resolveInvoice = defineAgentStep("resolve-invoice", resolverAgent)
   .input({ transaction: ref(Transaction) })
   .output({ invoice: ref(Invoice), confidence: "double", reason: "string" })
   .prompt(({ input }) => `Resolve transaction '${input.transaction.primaryId}'.`)
@@ -156,7 +170,10 @@ describe("defineWorkflowStep", () => {
 describe("defineAgentStep", () => {
   test("builds an inert structured agent step", () => {
     expect(resolveInvoice.kind).toBe("agentStep")
-    expect(resolveInvoice.agent).toBe(resolverAgent)
+    expect(resolveInvoice.model).toBe(workflowModel)
+    expect(resolveInvoice.instructions).toBe("Resolve invoices from transaction evidence.")
+    expect(resolveInvoice.groupIds).toEqual([])
+    expect(resolveInvoice.toolNames).toEqual([])
     expect(resolveInvoice.input).toEqual({
       transaction: { type: "objectRef", objectTypeId: "Transaction" },
     })
@@ -680,26 +697,193 @@ describe("SixbHost workflow registration", () => {
     expect(sixb.workflows.getById("review-match")).toBe(workflow)
   })
 
-  test("requires every workflow agent to be registered", () => {
+  test("registers directly configured workflow agent steps", () => {
     const workflow = defineWorkflow("agent-resolution")
       .input({ transaction: ref(Transaction) })
       .then(resolveInvoice)
 
-    expect(() => {
-      createTestSixb({
-        ontology: [Transaction, Invoice],
-        workflows: [workflow],
-        ...createTestRuntimeDeps(),
-      })
-    }).toThrow('references unknown agent "invoice-resolver"')
-
     const sixb = createTestSixb({
       ontology: [Transaction, Invoice],
-      agents: [resolverAgent],
       workflows: [workflow],
       ...createTestRuntimeDeps(),
     })
     expect(sixb.workflows.getById(workflow.id)).toBe(workflow)
+  })
+
+  test("uses the project default model when an agent step omits its model", () => {
+    const step = defineAgentStep("default-model", {
+      instructions: "Resolve invoices.",
+    })
+      .input({ transaction: ref(Transaction) })
+      .output({ invoice: ref(Invoice) })
+      .prompt(({ input }) => `Resolve '${input.transaction.primaryId}'.`)
+    const workflow: WorkflowDefinition = defineWorkflow("default-model-workflow")
+      .input({ transaction: ref(Transaction) })
+      .then(step)
+
+    const sixb = createTestSixb({
+      ontology: [Transaction, Invoice],
+      models: { language: [workflowModel] },
+      workflows: [workflow],
+      ...createTestRuntimeDeps(),
+    })
+
+    expect(sixb.workflows.getById(workflow.id)).toBe(workflow)
+  })
+
+  test("rejects an agent step without an explicit or project default model", () => {
+    const step = defineAgentStep("missing-model", {
+      instructions: "Resolve invoices.",
+    })
+      .input({ transaction: ref(Transaction) })
+      .output({ invoice: ref(Invoice) })
+      .prompt(({ input }) => `Resolve '${input.transaction.primaryId}'.`)
+    const workflow: WorkflowDefinition = defineWorkflow("missing-model-workflow")
+      .input({ transaction: ref(Transaction) })
+      .then(step)
+
+    expect(
+      () =>
+        new SixbHost<readonly OntologySource[]>({
+          ontology: [Transaction, Invoice],
+          workflows: [workflow],
+          ...createTestRuntimeDeps(),
+        })
+    ).toThrow(/needs a model/)
+  })
+
+  test("rejects an explicit agent-step model outside the project catalog", () => {
+    const unavailableModel = testModel("test", "unavailable-model")
+    const step = defineAgentStep("unknown-model", {
+      model: unavailableModel,
+      instructions: "Resolve invoices.",
+    })
+      .input({ transaction: ref(Transaction) })
+      .output({ invoice: ref(Invoice) })
+      .prompt(({ input }) => `Resolve '${input.transaction.primaryId}'.`)
+    const workflow: WorkflowDefinition = defineWorkflow("unknown-model-workflow")
+      .input({ transaction: ref(Transaction) })
+      .then(step)
+
+    expect(
+      () =>
+        new SixbHost<readonly OntologySource[]>({
+          ontology: [Transaction, Invoice],
+          models: { language: [workflowModel] },
+          workflows: [workflow],
+          ...createTestRuntimeDeps(),
+        })
+    ).toThrow(/uses unknown language model "test\/unavailable-model"/)
+  })
+
+  test("rejects an agent-step tool outside the project catalog", () => {
+    const lookup = defineAgentTool("lookup-invoice")
+      .description("Look up an invoice.")
+      .input({ invoiceId: "string" })
+      .run(({ input }) => input)
+    const step = defineAgentStep("unknown-tool", {
+      model: workflowModel,
+      instructions: "Resolve invoices.",
+      tools: [lookup],
+    })
+      .input({ transaction: ref(Transaction) })
+      .output({ invoice: ref(Invoice) })
+      .prompt(({ input }) => `Resolve '${input.transaction.primaryId}'.`)
+    const workflow: WorkflowDefinition = defineWorkflow("unknown-tool-workflow")
+      .input({ transaction: ref(Transaction) })
+      .then(step)
+
+    expect(
+      () =>
+        new SixbHost<readonly OntologySource[]>({
+          ontology: [Transaction, Invoice],
+          workflows: [workflow],
+          ...createTestRuntimeDeps(),
+        })
+    ).toThrow(/uses unknown project tool "lookup-invoice"/)
+  })
+
+  test("accepts explicitly selected registered tools and groups", () => {
+    const lookup = defineAgentTool("lookup-invoice")
+      .description("Look up an invoice.")
+      .input({ invoiceId: "string" })
+      .run(({ input }) => input)
+    const finance = defineGroup("finance")
+    const step = defineAgentStep("configured-task", {
+      model: workflowModel,
+      instructions: "Resolve invoices.",
+      groups: [finance],
+      tools: [lookup],
+    })
+      .input({ transaction: ref(Transaction) })
+      .output({ invoice: ref(Invoice) })
+      .prompt(({ input }) => `Resolve '${input.transaction.primaryId}'.`)
+    const workflow: WorkflowDefinition = defineWorkflow("configured-task-workflow")
+      .input({ transaction: ref(Transaction) })
+      .then(step)
+
+    const sixb = createTestSixb({
+      ontology: [Transaction, Invoice],
+      tools: [lookup],
+      groups: [finance],
+      workflows: [workflow],
+      ...createTestRuntimeDeps(),
+    })
+
+    expect(sixb.workflows.getById(workflow.id)).toBe(workflow)
+  })
+
+  test("rejects an agent-step group outside the security catalog", () => {
+    const finance = defineGroup("finance")
+    const step = defineAgentStep("unknown-group", {
+      model: workflowModel,
+      instructions: "Resolve invoices.",
+      groups: [finance],
+    })
+      .input({ transaction: ref(Transaction) })
+      .output({ invoice: ref(Invoice) })
+      .prompt(({ input }) => `Resolve '${input.transaction.primaryId}'.`)
+    const workflow: WorkflowDefinition = defineWorkflow("unknown-group-workflow")
+      .input({ transaction: ref(Transaction) })
+      .then(step)
+
+    expect(
+      () =>
+        new SixbHost<readonly OntologySource[]>({
+          ontology: [Transaction, Invoice],
+          workflows: [workflow],
+          ...createTestRuntimeDeps(),
+        })
+    ).toThrow(/references unknown group "finance"/)
+  })
+
+  test("rejects a registered agent that collides with a workflow task identity", () => {
+    const step = defineAgentStep("review", {
+      model: workflowModel,
+      instructions: "Review the invoice.",
+    })
+      .input({ transaction: ref(Transaction) })
+      .output({ invoice: ref(Invoice) })
+      .prompt(({ input }) => `Review '${input.transaction.primaryId}'.`)
+    const workflow: WorkflowDefinition = defineWorkflow("invoice-review")
+      .input({ transaction: ref(Transaction) })
+      .then(step)
+    const actorId = workflowAgentStepActorId(workflow.id, step.id)
+    const collidingAgent = defineAgent(actorId, {
+      name: "Colliding agent",
+      model: workflowModel,
+      instructions: "This identity is reserved by the workflow task.",
+    })
+
+    expect(
+      () =>
+        new SixbHost<readonly OntologySource[]>({
+          ontology: [Transaction, Invoice],
+          agents: [collidingAgent],
+          workflows: [workflow],
+          ...createTestRuntimeDeps(),
+        })
+    ).toThrow(/conflicts with registered agent/)
   })
 
   test("rejects duplicate workflow ids", () => {

--- a/packages/core/tests/workflows.types.ts
+++ b/packages/core/tests/workflows.types.ts
@@ -1,6 +1,5 @@
 import {
   defineAction,
-  defineAgent,
   defineAgentStep,
   defineIntervention,
   defineObjectType,
@@ -34,13 +33,10 @@ const Invoice = defineObjectType({
   properties: [prop("id", "string", { required: true, primary: true })],
 })
 
-const resolverAgent = defineAgent("resolver", {
-  name: "Resolver",
-  model: {} as Parameters<typeof defineAgent>[1]["model"],
+const resolveInvoiceWithAgent = defineAgentStep("resolve-invoice", {
+  model: {} as NonNullable<Parameters<typeof defineAgentStep>[1]["model"]>,
   instructions: "Resolve invoices.",
 })
-
-const resolveInvoiceWithAgent = defineAgentStep("resolve-invoice", resolverAgent)
   .input({ transaction: ref(Transaction) })
   .output({ invoice: ref(Invoice), confidence: "double", reason: "string" })
   .prompt(({ input }) => {

--- a/packages/server/src/routes/workflows.ts
+++ b/packages/server/src/routes/workflows.ts
@@ -139,7 +139,6 @@ function serializePrincipal(principal: Principal) {
 
 function serializeWorkflowAgentExecutionSummary(execution: WorkflowAgentNodeRunView) {
   return {
-    agentId: execution.agentId,
     status: execution.status,
     attempt: execution.attempt,
     modelId: execution.modelId,
@@ -205,7 +204,7 @@ function toWorkflowCancellationFailure(input: {
 function toAgentCancellationFailure(input: {
   readonly message: string
   readonly at: Date
-  readonly agentId: string
+  readonly agentStepId: string
   readonly workflowId: string
   readonly runId: string
   readonly nodeRunId: string
@@ -213,7 +212,7 @@ function toAgentCancellationFailure(input: {
   return toSixbFailure(
     createSixbError("runtime.cancelled", input.message, {
       details: {
-        agentId: input.agentId,
+        agentStepId: input.agentStepId,
         workflowId: input.workflowId,
         workflowRunId: input.runId,
         nodeRunId: input.nodeRunId,
@@ -385,7 +384,6 @@ function serializeWorkflow(
           type: "agent" as const,
           id: node.id,
           key: node.key,
-          agentId: node.agentStep.agent.id,
           input: node.agentStep.input,
           output: node.agentStep.output,
         }
@@ -1132,7 +1130,7 @@ export function registerWorkflowRoutes(app: Elysia, host: SixbHostView) {
                   error: toAgentCancellationFailure({
                     message: cancellationMessage,
                     at: cancelledAt,
-                    agentId: execution.agentId,
+                    agentStepId: active.nodeId,
                     workflowId: run.workflowId,
                     runId: run.id,
                     nodeRunId: active.id,

--- a/packages/server/src/schemas/workflows.ts
+++ b/packages/server/src/schemas/workflows.ts
@@ -119,7 +119,6 @@ const WorkflowNodeSchema = z.union([
     type: z.literal("agent"),
     id: z.string(),
     key: z.string(),
-    agentId: z.string(),
     input: WorkflowIOSnapshotSchema,
     output: WorkflowIOSnapshotSchema,
   }),
@@ -143,7 +142,6 @@ export const WorkflowRunDetailSchema = WorkflowRunSummarySchema.extend({
 })
 
 export const WorkflowAgentNodeExecutionSummarySchema = z.object({
-  agentId: z.string(),
   status: z.enum(["queued", "running", "succeeded", "failed", "cancelled"]),
   attempt: z.number().int().nonnegative(),
   modelId: z.string().optional(),

--- a/packages/server/tests/agent-api-gateway.test.ts
+++ b/packages/server/tests/agent-api-gateway.test.ts
@@ -20,6 +20,7 @@ import {
   type OntologySource,
   prop,
   SixbHost,
+  SYSTEM_PRINCIPAL,
 } from "@sixb/core"
 import { createInheritedMainAgentExecutionRecord } from "@sixb/core/internal/agent-execution"
 import {
@@ -680,6 +681,7 @@ async function createGatewayRuntime(
       projectId: PROJECT_ID,
       name: "Assistant agent",
       status: "active",
+      createdByPrincipal: SYSTEM_PRINCIPAL,
       createdAt: NOW,
       updatedAt: NOW,
     })

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -2098,11 +2098,11 @@ describe("SixbServer HTTP contract", () => {
         nodes: [
           {
             id: `${runId}:node:0`,
-            agentExecution: { agentId: "device-resolver", usage: { inputTokens: 10 } },
+            agentExecution: { usage: { inputTokens: 10 } },
           },
           {
             id: `${runId}:node:1`,
-            agentExecution: { agentId: "device-resolver", usage: { inputTokens: 11 } },
+            agentExecution: { usage: { inputTokens: 11 } },
           },
         ],
       })
@@ -2187,7 +2187,6 @@ describe("SixbServer HTTP contract", () => {
       const detail = (await detailResponse.json()) as Record<string, unknown>
       expect(detail).toMatchObject({
         nodeRunId,
-        agentId: "device-resolver",
         status: "running",
         prompt: "Resolve fan-1.",
         modelId: "test-model",
@@ -2205,6 +2204,7 @@ describe("SixbServer HTTP contract", () => {
           unvaluedCallCount: 1,
         },
       })
+      expect("agentId" in detail).toBe(false)
       expect(JSON.stringify(detail)).not.toContain("secret-execution-token")
 
       Object.defineProperty(sixb.storage, "aiCosts", { value: undefined })
@@ -2225,7 +2225,8 @@ describe("SixbServer HTTP contract", () => {
         body: JSON.stringify({}),
       })
       expect(cancelResponse.status).toBe(200)
-      expect(await cancelResponse.json()).toMatchObject({
+      const cancelled = (await cancelResponse.json()) as Record<string, unknown>
+      expect(cancelled).toMatchObject({
         run: { id: runId, status: "cancelled" },
         nodes: [
           {
@@ -2233,12 +2234,12 @@ describe("SixbServer HTTP contract", () => {
             status: "cancelled",
             agentExecution: {
               status: "cancelled",
-              agentId: "device-resolver",
               usage: { inputTokens: 15, outputTokens: 5 },
             },
           },
         ],
       })
+      expect(JSON.stringify(cancelled)).not.toContain("agentId")
 
       const cancelledExecutionResponse = await fetch(
         `${baseUrl}/api/workflow-runs/${runId}/nodes/resolveDevice/agent-execution`
@@ -2254,7 +2255,7 @@ describe("SixbServer HTTP contract", () => {
           code: "runtime.cancelled",
           message: "Execution was cancelled.",
           details: {
-            agentId: "device-resolver",
+            agentStepId: "resolve-device",
             workflowId: "review-device-health-workflow",
             workflowRunId: runId,
             nodeRunId,

--- a/packages/workflow-worker/src/execution/workflow-node-runner.ts
+++ b/packages/workflow-worker/src/execution/workflow-node-runner.ts
@@ -72,7 +72,7 @@ export class WorkflowNodeRunner {
             `[SixbWorkflowWorker] Workflow '${input.context.workflow.id}' agent node '${input.node.id}' parked a different node run.`,
             {
               details: {
-                agentId: outcome.agentExecution.agentId,
+                agentStepId: input.node.id,
                 workflowId: input.context.workflow.id,
                 workflowRunId: input.context.job.id,
                 nodeId: input.node.id,
@@ -199,7 +199,7 @@ function workflowNodeFailureChild(
         ...(error instanceof ActionRunFailedError ? { actionRunId: error.runId } : {}),
       }
     case "agent":
-      return { type: "agent", agentId: node.agentStep.agent.id }
+      return { type: "agent", agentStepId: node.agentStep.id }
     case "intervention":
       return { type: "intervention", interventionId: node.intervention.id }
   }

--- a/packages/workflow-worker/src/execution/workflow-run-session.ts
+++ b/packages/workflow-worker/src/execution/workflow-run-session.ts
@@ -452,7 +452,7 @@ export class WorkflowRunSession {
             workflowRunId: run.id,
             nodeId: nodeRun.nodeId,
             nodeRunId: nodeRun.id,
-            ...(execution ? { agentId: execution.agentId } : {}),
+            ...(execution ? { agentStepId: nodeRun.nodeId } : {}),
           },
         }
       )
@@ -474,7 +474,7 @@ export class WorkflowRunSession {
         `[SixbWorkflowWorker] Workflow run '${job.id}' and agent node '${nodeRun.id}' must be waiting/succeeded to resume.`,
         {
           details: {
-            agentId: execution.agentId,
+            agentStepId: nodeRun.nodeId,
             workflowId: workflow.id,
             workflowRunId: run.id,
             nodeId: nodeRun.nodeId,
@@ -489,7 +489,7 @@ export class WorkflowRunSession {
         `[SixbWorkflowWorker] Agent execution '${nodeRun.id}' must have a validated output to resume.`,
         {
           details: {
-            agentId: execution.agentId,
+            agentStepId: nodeRun.nodeId,
             workflowId: workflow.id,
             workflowRunId: run.id,
             nodeId: nodeRun.nodeId,

--- a/packages/workflow-worker/src/nodes/agent-node-executor.ts
+++ b/packages/workflow-worker/src/nodes/agent-node-executor.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto"
 import { createAgentExecutionRecord } from "@sixb/core/internal/agent-execution"
 import {
-  ensureAgentExecutionIdentity,
+  ensureManagedAgentExecutionIdentity,
   workflowAgentNodeQueueJobId,
 } from "@sixb/core/internal/agents"
 import { createSixbError } from "@sixb/core/internal/errors"
@@ -9,6 +9,7 @@ import type { WorkflowAgentNodeDefinition } from "@sixb/core/internal/workflows"
 import {
   snapshotWorkflowAgentStepInput,
   validateWorkflowAgentStepInput,
+  workflowAgentStepActorId,
 } from "@sixb/core/internal/workflows"
 import type { WorkflowNodeExecutor } from "../execution/node-executor"
 import { throwIfAborted } from "../normalize"
@@ -67,7 +68,7 @@ export const agentNodeExecutor: WorkflowNodeExecutor<WorkflowAgentNodeDefinition
         `[SixbWorkflowWorker] Workflow '${context.workflow.id}' agent node '${node.id}' prompt must return a non-empty string.`,
         {
           details: {
-            agentId: node.agentStep.agent.id,
+            agentStepId: node.agentStep.id,
             workflowId: context.workflow.id,
             workflowRunId: context.job.id,
             nodeId: node.id,
@@ -77,10 +78,14 @@ export const agentNodeExecutor: WorkflowNodeExecutor<WorkflowAgentNodeDefinition
       )
     }
     throwIfAborted(context.signal)
-    const identity = await ensureAgentExecutionIdentity({
+    const actorId = workflowAgentStepActorId(context.workflow.id, node.agentStep.id)
+    const identity = await ensureManagedAgentExecutionIdentity({
       auth: context.runtime.storage.auth,
       projectId: context.runtime.projectId,
-      agent: node.agentStep.agent,
+      agentId: actorId,
+      name: `Workflow ${context.workflow.id} · ${node.agentStep.id}`,
+      description: `Managed service account for workflow '${context.workflow.id}' agent step '${node.agentStep.id}'.`,
+      groupIds: node.agentStep.groupIds,
     })
     const parentExecution = await context.runtime.storage.executions.getById({
       projectId: context.runtime.projectId,
@@ -92,7 +97,7 @@ export const agentNodeExecutor: WorkflowNodeExecutor<WorkflowAgentNodeDefinition
         `[SixbWorkflowWorker] Workflow run '${context.job.id}' references missing execution '${context.runtime.sixb.execution.id}'.`,
         {
           details: {
-            agentId: node.agentStep.agent.id,
+            agentStepId: node.agentStep.id,
             workflowId: context.workflow.id,
             workflowRunId: context.job.id,
             nodeId: node.id,
@@ -105,7 +110,7 @@ export const agentNodeExecutor: WorkflowNodeExecutor<WorkflowAgentNodeDefinition
     const agentExecution = createAgentExecutionRecord({
       id: `exec_${randomUUID()}`,
       parent: parentExecution,
-      agentId: node.agentStep.agent.id,
+      agentId: actorId,
       runId: nodeRun.id,
       principal: identity.principal,
     })
@@ -118,7 +123,7 @@ export const agentNodeExecutor: WorkflowNodeExecutor<WorkflowAgentNodeDefinition
           `[SixbWorkflowWorker] Workflow '${context.workflow.id}' agent node '${node.id}' requires storage.workflowRuns.`,
           {
             details: {
-              agentId: node.agentStep.agent.id,
+              agentStepId: node.agentStep.id,
               workflowId: context.workflow.id,
               workflowRunId: context.job.id,
               nodeId: node.id,
@@ -132,7 +137,7 @@ export const agentNodeExecutor: WorkflowNodeExecutor<WorkflowAgentNodeDefinition
         projectId: context.runtime.projectId,
         nodeRunId: nodeRun.id,
         executionId: agentExecution.id,
-        agentId: node.agentStep.agent.id,
+        agentId: actorId,
         prompt,
         createdAt: waitingAt,
       })

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, test } from "bun:test"
 import {
   type ActionDefinition,
-  type AgentDefinition,
   type DomainEventLog,
   defineAction,
-  defineAgent,
   defineAgentStep,
+  defineGroup,
   defineIntervention,
   defineObjectType,
   defineWorkflow,
   defineWorkflowStep,
+  type GroupDefinition,
   InMemoryBlobStorage,
   InMemoryBroker,
   InMemoryLakeStorage,
@@ -22,8 +22,9 @@ import {
   type WorkflowDefinition,
   WorkflowValidationError,
 } from "@sixb/core"
+import { agentServiceAccountId } from "@sixb/core/internal/agents"
 import { bindDurablePrimitiveExecution } from "@sixb/core/internal/primitive-execution"
-import { snapshotWorkflowInput } from "@sixb/core/internal/workflows"
+import { snapshotWorkflowInput, workflowAgentStepActorId } from "@sixb/core/internal/workflows"
 import type {
   ActionRunFailure,
   ActionRunPhase,
@@ -77,13 +78,10 @@ const Invoice = defineObjectType({
   properties: [prop("id", "string", { required: true, primary: true })],
 })
 
-const invoiceResolverAgent = defineAgent("invoice-resolver", {
-  name: "Invoice resolver",
-  model: {} as Parameters<typeof defineAgent>[1]["model"],
+const resolveInvoiceWithAgent = defineAgentStep("resolve-invoice-with-agent", {
+  model: {} as NonNullable<Parameters<typeof defineAgentStep>[1]["model"]>,
   instructions: "Resolve the best matching invoice.",
 })
-
-const resolveInvoiceWithAgent = defineAgentStep("resolve-invoice-with-agent", invoiceResolverAgent)
   .input({ transaction: ref(Transaction) })
   .output({ invoice: ref(Invoice), confidence: "double", reason: "string" })
   .prompt(({ input }) => `Resolve transaction '${input.transaction.primaryId}'.`)
@@ -240,7 +238,7 @@ const createInvoiceFromTransaction = defineAction("create-invoice-from-transacti
 function createSixb(options: {
   readonly workflows?: readonly WorkflowDefinition[]
   readonly actions?: readonly ActionDefinition[]
-  readonly agents?: readonly AgentDefinition[]
+  readonly groups?: readonly GroupDefinition[]
 }) {
   return new SixbHost({
     id: "workflow-worker-tests",
@@ -251,7 +249,7 @@ function createSixb(options: {
     blobStorage: new InMemoryBlobStorage(),
     queues: new InMemoryQueues(),
     actions: options.actions ?? [],
-    agents: options.agents ?? [],
+    groups: options.groups ?? [],
     workflows: options.workflows ?? [],
   })
 }
@@ -819,10 +817,19 @@ describe("runWorkflowJob", () => {
   })
 
   test("parks at an agent node and resumes from its validated structured output", async () => {
+    const finance = defineGroup("finance")
+    const configuredStep = defineAgentStep("resolve-invoice-with-agent", {
+      model: {} as NonNullable<Parameters<typeof defineAgentStep>[1]["model"]>,
+      instructions: "Resolve the best matching invoice.",
+      groups: [finance],
+    })
+      .input({ transaction: ref(Transaction) })
+      .output({ invoice: ref(Invoice), confidence: "double", reason: "string" })
+      .prompt(({ input }) => `Resolve transaction '${input.transaction.primaryId}'.`)
     const workflow = defineWorkflow("agent-resolves-invoice")
       .input({ transaction: ref(Transaction) })
-      .then(resolveInvoiceWithAgent)
-    const sixb = createSixb({ workflows: [workflow], agents: [invoiceResolverAgent] })
+      .then(configuredStep)
+    const sixb = createSixb({ workflows: [workflow], groups: [finance] })
     const runtime = createRuntime(sixb)
 
     const waiting = await runWorkflowJob({
@@ -845,10 +852,32 @@ describe("runWorkflowJob", () => {
       nodeRunId: node!.id,
     })
     expect(execution).toMatchObject({
-      agentId: invoiceResolverAgent.id,
+      agentId: workflowAgentStepActorId(workflow.id, configuredStep.id),
       status: "queued",
       prompt: "Resolve transaction 'txn_1'.",
     })
+    const auth = sixb.storage.auth
+    if (!auth) throw new Error("Expected auth storage in test runtime.")
+    const actorId = workflowAgentStepActorId(workflow.id, configuredStep.id)
+    const serviceAccountId = agentServiceAccountId(actorId)
+    expect(
+      await auth.serviceAccounts.getById({ projectId: sixb.id, id: serviceAccountId })
+    ).toMatchObject({
+      id: serviceAccountId,
+      status: "active",
+    })
+    expect(
+      await auth.serviceAccountGroupMemberships.listForServiceAccount({
+        projectId: sixb.id,
+        serviceAccountId,
+      })
+    ).toEqual([
+      expect.objectContaining({
+        serviceAccountId,
+        groupId: finance.id,
+        source: "agent",
+      }),
+    ])
     const waitingEvents = await sixb.events.read({ topics: ["workflows"] })
     expect(waitingEvents.map((event) => event.type)).toEqual([
       "workflow.run.started",
@@ -917,7 +946,7 @@ describe("runWorkflowJob", () => {
     const workflow = defineWorkflow("agent-waiting-observer-fails")
       .input({ transaction: ref(Transaction) })
       .then(resolveInvoiceWithAgent)
-    const sixb = createSixb({ workflows: [workflow], agents: [invoiceResolverAgent] })
+    const sixb = createSixb({ workflows: [workflow] })
     let runWaitingNotified = false
     const observer: WorkflowRunObserver = {
       onRunStarted: async () => undefined,


### PR DESCRIPTION
## Summary

- Add first-class, headless Agent tasks to workflows.
- Configure each task directly instead of referencing a conversational `defineAgent` definition.
- Reuse the Agent Worker for sandboxing, streaming, tool execution, usage, and structured output.
- Give each workflow Agent step a stable, Sixb-managed identity with definition-owned permissions.

## Developer experience

```ts
const composeReminder = defineAgentStep("compose-reminder", {
  instructions: "Draft a concise reminder grounded in invoice data.",
  reasoning: "medium",
  groups: [finance],
  tools: [searchInvoices],
})
  .input({ invoice: ref(Invoice) })
  .output({ invoice: ref(Invoice), message: "string" })
  .prompt(({ input }) => `Draft a reminder for '${input.invoice.primaryId}'.`)
```

| Concern | Behavior |
| --- | --- |
| Model | Uses the project default, or an explicit catalog model |
| Project tools | Explicit allow-list; defaults to none |
| Sixb CLI | Available through the shared sandbox runtime |
| Authority | Stable service account scoped by the step's `groups` |
| Output | Validated against the declared workflow contract |

## Why

- Workflow tasks need their own model, instructions, permissions, tools, and typed contract.
- Conversational Agent definitions are not reusable workflow task specifications.
- Sharing one execution engine keeps Agent behavior and operational guarantees consistent.

## Authorization

```text
run:workflow → workflow execution → managed step identity → declared groups
```

- The workflow grant controls admission.
- The task acts only with its declared groups.
- Conflicting or externally extended managed identities fail closed.

## Validation

- `bun run test:ci`
- `bun run build`
- `bun run typecheck`
- `bun run check`
- `bun run generate:client`
- `bun run test:publish`

Part of #451. Stacked on #521.
