### PR TITLE
auth: optionally reveal invitation links

### DIFF
--- a/auth/magic-link/src/strategy.ts
+++ b/auth/magic-link/src/strategy.ts
@@ -12,6 +12,8 @@ import type {
   MagicLinkPeekResult,
   MagicLinkRequestInput,
   MagicLinkRequestResult,
+  MagicLinkRequestStatus,
+  RevealedInvitationLink,
 } from "@sixb/core/auth/strategy"
 import type { AuthStorage } from "@sixb/core/storage"
 import { createMagicLinkEmail, type SendMagicLinkInput } from "./email"
@@ -56,6 +58,10 @@ export function magicLink(options: MagicLinkOptions): MagicLinkAuthStrategy {
   return new MagicLinkAuthStrategyImpl(options)
 }
 
+type MagicLinkIssueResult =
+  | { readonly status: Exclude<MagicLinkRequestStatus, "sent"> }
+  | { readonly status: "sent"; readonly link: RevealedInvitationLink }
+
 class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
   readonly kind = "magicLink"
   readonly id: string
@@ -85,6 +91,30 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
   }
 
   async requestMagicLink(input: MagicLinkRequestInput): Promise<MagicLinkRequestResult> {
+    const result = await this.issueMagicLink(input)
+    // A public sign-in request must never receive its credential in the response.
+    return { status: result.status }
+  }
+
+  async deliverInvitation(input: InvitationDeliveryInput): Promise<InviteDeliveryResult> {
+    const result = await this.issueMagicLink({
+      projectId: input.projectId,
+      authStorage: input.authStorage,
+      email: input.invitation.email,
+      audience: input.audience,
+      returnTo: input.returnTo,
+      requestOrigin: input.requestOrigin,
+      now: input.now,
+    })
+
+    if (result.status !== "sent" || !input.revealLink) {
+      return { status: result.status }
+    }
+
+    return result
+  }
+
+  private async issueMagicLink(input: MagicLinkRequestInput): Promise<MagicLinkIssueResult> {
     const now = input.now ? new Date(input.now) : new Date()
     const email = normalizeEmail(input.email)
     if (!email || !this.isAllowedEmail(email)) {
@@ -107,6 +137,7 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
 
     const credential = createMagicLinkCredential()
     const magicLinkId = `ml_${randomUUID()}`
+    const expiresAt = new Date(now.getTime() + this.magicLinkTtlMs)
     await input.authStorage.magicLinks.create({
       id: magicLinkId,
       projectId: input.projectId,
@@ -116,7 +147,7 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
       tokenHash: credential.tokenHash,
       returnTo: input.returnTo,
       createdAt: now,
-      expiresAt: new Date(now.getTime() + this.magicLinkTtlMs),
+      expiresAt,
     })
 
     const link = this.createCallbackUrl({
@@ -145,19 +176,13 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
       throw error
     }
 
-    return { status: "sent" }
-  }
-
-  async deliverInvitation(input: InvitationDeliveryInput): Promise<InviteDeliveryResult> {
-    return this.requestMagicLink({
-      projectId: input.projectId,
-      authStorage: input.authStorage,
-      email: input.invitation.email,
-      audience: input.audience,
-      returnTo: input.returnTo,
-      requestOrigin: input.requestOrigin,
-      now: input.now,
-    })
+    return {
+      status: "sent",
+      link: {
+        url: link,
+        expiresAt,
+      },
+    }
   }
 
   async validateInvitationRecipient(

--- a/auth/magic-link/tests/magic-link.test.ts
+++ b/auth/magic-link/tests/magic-link.test.ts
@@ -333,6 +333,46 @@ describe("magicLink", () => {
     expect(messages).toHaveLength(1)
   })
 
+  test("reveals invitation links without exposing public sign-in links", async () => {
+    const storage = new InMemoryAuthStorage()
+    const { messages, sendMagicLink } = createSender()
+    const strategy = magicLink({
+      allowedDomains: ["acme.com"],
+      sendMagicLink,
+    })
+    const invitation = await storage.invitations.createOrUpdateActive({
+      id: "inv_1",
+      projectId,
+      email: "invited@acme.com",
+      createdAt: at("2026-05-16T09:00:00.000Z"),
+      expiresAt: at("2026-05-23T09:00:00.000Z"),
+    })
+
+    const delivery = await strategy.deliverInvitation({
+      projectId,
+      authStorage: storage,
+      invitation,
+      audience: "atlas",
+      returnTo: "/dashboard",
+      requestOrigin,
+      revealLink: true,
+      now: at("2026-05-16T10:00:00.000Z"),
+    })
+
+    expect(delivery.status).toBe("sent")
+    expect(delivery.link?.url).toBe(messages[0]?.url)
+    expect(delivery.link?.expiresAt).toEqual(at("2026-05-16T10:15:00.000Z"))
+
+    const publicRequest = await requestMagicLink({
+      storage,
+      strategy,
+      email: "invited@acme.com",
+      now: at("2026-05-16T10:01:00.000Z"),
+    })
+    expect(publicRequest).toEqual({ status: "sent" })
+    expect("link" in publicRequest).toBe(false)
+  })
+
   test("allows bootstrap requests even after active users exist", async () => {
     const storage = new InMemoryAuthStorage()
     const { messages, sendMagicLink } = createSender()

--- a/auth/oidc/src/strategy.ts
+++ b/auth/oidc/src/strategy.ts
@@ -253,24 +253,36 @@ class OidcAuthStrategyImpl implements OidcAuthStrategy {
   }
 
   async deliverInvitation(input: InvitationDeliveryInput): Promise<InviteDeliveryResult> {
+    const url = this.createSignInUrl({
+      audience: input.audience,
+      requestOrigin: input.requestOrigin,
+      returnTo: input.returnTo,
+    })
+    const revealed = input.revealLink
+      ? {
+          link: {
+            url,
+            // For a new user, the non-secret OIDC entry link stops provisioning access when the
+            // invitation expires. Existing users may continue to use the same sign-in page.
+            expiresAt: input.invitation.expiresAt,
+          },
+        }
+      : {}
+
     if (!this.sendInvitation) {
-      return { status: "not_supported" }
+      return { status: "not_supported", ...revealed }
     }
 
     await this.sendInvitation(
       createOidcInvitationEmail({
         email: input.invitation.email,
         from: this.from,
-        url: this.createSignInUrl({
-          audience: input.audience,
-          requestOrigin: input.requestOrigin,
-          returnTo: input.returnTo,
-        }),
+        url,
         subject: this.subject,
       })
     )
 
-    return { status: "sent" }
+    return { status: "sent", ...revealed }
   }
 
   private async getConfiguration(): Promise<unknown> {

--- a/docs/auth/authentication.md
+++ b/docs/auth/authentication.md
@@ -179,8 +179,26 @@ const { invitation, delivery } = await sixb.auth.invite(request, {
 ```
 
 `invite(request, input, options)` takes an `input` of `email` plus optional `groups` / `groupIds`,
-`expiresAt`, and `returnTo`. The companion methods are `listInvitations`, `revokeInvitation`, and
-`getInvitationOptions`.
+`expiresAt`, `returnTo`, and `revealLink`. The companion methods are `listInvitations`,
+`revokeInvitation`, and `getInvitationOptions`.
+
+Set `revealLink: true` only for an explicit manual-delivery fallback. The delivered link is returned
+once on `delivery.link`, remains hash-only in storage, and is never included when invitations are
+listed:
+
+```ts
+const { delivery } = await sixb.auth.invite(request, {
+  email: "newhire@acme-corp.com",
+  groups: [teamMembers],
+  revealLink: true,
+})
+
+const linkToShowOnce = delivery.link?.url
+```
+
+The HTTP API accepts the same `revealLink` boolean. Anyone holding a revealed magic link can sign in
+as its recipient, so expose this option only to trusted inviters and verify the recipient through a
+separate channel before sharing it. A normal sign-in request never returns its magic link.
 
 In Atlas, the invite form also offers every browser application configured on the API. Selecting
 **Custom app** sends a link with the `app` session audience and returns the recipient to the custom

--- a/packages/atlas/src/components/SettingsMembersPage.tsx
+++ b/packages/atlas/src/components/SettingsMembersPage.tsx
@@ -1,4 +1,5 @@
 import type {
+  CreateAuthInvitationResponse,
   GetAuthInvitationOptionsResponse,
   ListAuthInvitationsResponse,
   ListAuthMembersResponse,
@@ -31,6 +32,7 @@ import {
   AlertDialogTitle,
   Badge,
   Button,
+  Checkbox,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -58,8 +60,10 @@ import { cn } from "@sixb/ui/lib/utils"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   Ban,
+  Check,
   CheckCircle2,
   Clock3,
+  Copy,
   Loader2,
   Mail,
   MoreHorizontal,
@@ -67,6 +71,7 @@ import {
   Pencil,
   RotateCcw,
   Search,
+  TriangleAlert,
   UsersRound,
   XCircle,
 } from "lucide-react"
@@ -91,6 +96,9 @@ type Invitation = ListAuthInvitationsResponse["invitations"][number]
 type InvitationCreateCapability =
   GetAuthInvitationOptionsResponse["capabilities"]["createInvitation"]
 type InvitationDestination = GetAuthInvitationOptionsResponse["destinations"][number]
+type RevealedInvitationLink = NonNullable<CreateAuthInvitationResponse["delivery"]["link"]> & {
+  readonly email: string
+}
 type MemberAction = "suspend" | "reactivate"
 
 const memberListOptions = {
@@ -115,6 +123,15 @@ const STATUS_FILTERS: readonly { readonly id: StatusFilter; readonly label: stri
 
 function displayName(user: MemberUser): string {
   return user.displayName?.trim() || user.email
+}
+
+function formatDateTime(timestamp: string): string {
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return "at an unknown time"
+  return date.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  })
 }
 
 function initials(user: MemberUser): string {
@@ -263,6 +280,8 @@ function InviteMembersCard({
   onDestinationChange,
   selectedGroupIds,
   onGroupsChange,
+  revealLink,
+  onRevealLinkChange,
   onSubmit,
   isSubmitting,
   errorMessage,
@@ -277,10 +296,13 @@ function InviteMembersCard({
   readonly onDestinationChange: (destinationId: string) => void
   readonly selectedGroupIds: readonly string[]
   readonly onGroupsChange: (groupIds: string[]) => void
+  readonly revealLink: boolean
+  readonly onRevealLinkChange: (revealLink: boolean) => void
   readonly onSubmit: (body: {
     email: string
     groupIds: string[]
     destinationId?: "atlas" | "app"
+    revealLink?: boolean
   }) => void
   readonly isSubmitting: boolean
   readonly errorMessage: string | null
@@ -300,6 +322,7 @@ function InviteMembersCard({
       email: email.trim(),
       groupIds: [...selectedGroupIds],
       ...(destinationId === "atlas" || destinationId === "app" ? { destinationId } : {}),
+      ...(revealLink ? { revealLink: true } : {}),
     })
   }
 
@@ -387,6 +410,25 @@ function InviteMembersCard({
               disabled={disabled || isSubmitting}
               emptyMessage="You have no groups available to assign."
             />
+
+            <div className="mt-4 flex items-start gap-3 rounded-lg border border-border/60 bg-muted/20 p-3.5">
+              <Checkbox
+                id="invite-reveal-link"
+                checked={revealLink}
+                onCheckedChange={(checked) => onRevealLinkChange(checked === true)}
+                disabled={disabled || isSubmitting}
+                className="mt-0.5"
+              />
+              <div className="min-w-0">
+                <label htmlFor="invite-reveal-link" className="text-sm font-medium text-foreground">
+                  Show a copyable invitation link
+                </label>
+                <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                  Use only as a fallback. With magic-link authentication, the link signs in as this
+                  recipient.
+                </p>
+              </div>
+            </div>
           </div>
 
           {errorMessage && (
@@ -404,6 +446,79 @@ function InviteMembersCard({
         </div>
       </form>
     </section>
+  )
+}
+
+function InvitationLinkReveal({
+  link,
+  onDone,
+}: {
+  readonly link: RevealedInvitationLink
+  readonly onDone: () => void
+}) {
+  const [copied, setCopied] = useState(false)
+  const [copyFailed, setCopyFailed] = useState(false)
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(link.url)
+      setCopied(true)
+      setCopyFailed(false)
+    } catch {
+      setCopied(false)
+      setCopyFailed(true)
+    }
+  }
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Copy the invitation link</DialogTitle>
+        <DialogDescription>
+          A link was created for {link.email}. It is shown only for this request.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4">
+        <div className="flex items-stretch overflow-hidden rounded-lg border border-border/60 bg-background">
+          <code className="min-w-0 flex-1 break-all px-3 py-2.5 font-mono text-xs leading-relaxed text-foreground">
+            {link.url}
+          </code>
+          <button
+            type="button"
+            onClick={copy}
+            className={cn(
+              "flex shrink-0 items-center gap-1.5 border-l border-border/60 bg-card px-3.5 text-xs font-medium transition-colors hover:bg-accent",
+              copied ? "text-emerald-700 dark:text-emerald-300" : "text-foreground"
+            )}
+          >
+            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
+
+        <div className="flex items-start gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5">
+          <TriangleAlert className="mt-px h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+          <p className="text-xs text-amber-700 dark:text-amber-300">
+            Treat this link as sensitive and verify the recipient through another trusted channel.
+            Magic links can be used once
+            {link.expiresAt ? ` and expire ${formatDateTime(link.expiresAt)}` : ""}.
+          </p>
+        </div>
+
+        {copyFailed ? (
+          <p className="text-xs text-muted-foreground">
+            Clipboard access failed. Select the link above and copy it manually.
+          </p>
+        ) : null}
+      </div>
+
+      <DialogFooter>
+        <Button type="button" onClick={onDone}>
+          Done
+        </Button>
+      </DialogFooter>
+    </>
   )
 }
 
@@ -495,6 +610,8 @@ export function SettingsMembersPage() {
   const [inviteEmail, setInviteEmail] = useState("")
   const [inviteDestinationId, setInviteDestinationId] = useState("")
   const [inviteGroupIds, setInviteGroupIds] = useState<string[]>([])
+  const [revealInviteLink, setRevealInviteLink] = useState(false)
+  const [revealedInviteLink, setRevealedInviteLink] = useState<RevealedInvitationLink | null>(null)
   const [revokingInvitationId, setRevokingInvitationId] = useState<string | null>(null)
   const [showPastInvitations, setShowPastInvitations] = useState(false)
 
@@ -641,6 +758,12 @@ export function SettingsMembersPage() {
   const createInvitation = useMutation({
     ...createAuthInvitationMutation(),
     onSuccess: async (result) => {
+      if (result.delivery.link) {
+        setRevealedInviteLink({
+          ...result.delivery.link,
+          email: result.invitation.email,
+        })
+      }
       toast.success(
         result.delivery.status === "sent"
           ? `Invitation sent to ${result.invitation.email}.`
@@ -648,6 +771,7 @@ export function SettingsMembersPage() {
       )
       setInviteEmail("")
       setInviteGroupIds([])
+      setRevealInviteLink(false)
       // Land on the invitations tab so the new invite is visible immediately.
       setActiveTab("invitations")
       await refreshInvitations()
@@ -767,12 +891,15 @@ export function SettingsMembersPage() {
         onDestinationChange={setInviteDestinationId}
         selectedGroupIds={inviteGroupIds}
         onGroupsChange={setInviteGroupIds}
+        revealLink={revealInviteLink}
+        onRevealLinkChange={setRevealInviteLink}
         onSubmit={(body) =>
           createInvitation.mutate({
             body: {
               email: body.email,
               ...(body.groupIds.length > 0 ? { groupIds: body.groupIds } : {}),
               ...(body.destinationId ? { destinationId: body.destinationId } : {}),
+              ...(body.revealLink ? { revealLink: true } : {}),
             },
           })
         }
@@ -1251,6 +1378,28 @@ export function SettingsMembersPage() {
                 </Button>
               </DialogFooter>
             </>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={revealedInviteLink !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRevealedInviteLink(null)
+            createInvitation.reset()
+          }
+        }}
+      >
+        <DialogContent>
+          {revealedInviteLink ? (
+            <InvitationLinkReveal
+              link={revealedInviteLink}
+              onDone={() => {
+                setRevealedInviteLink(null)
+                createInvitation.reset()
+              }}
+            />
           ) : null}
         </DialogContent>
       </Dialog>

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -3168,6 +3168,9 @@
                   },
                   "returnTo": {
                     "type": "string"
+                  },
+                  "revealLink": {
+                    "type": "boolean"
                   }
                 },
                 "required": ["email"],
@@ -3198,6 +3201,9 @@
                   },
                   "returnTo": {
                     "type": "string"
+                  },
+                  "revealLink": {
+                    "type": "boolean"
                   }
                 },
                 "required": ["email"],
@@ -3228,6 +3234,9 @@
                   },
                   "returnTo": {
                     "type": "string"
+                  },
+                  "revealLink": {
+                    "type": "boolean"
                   }
                 },
                 "required": ["email"],
@@ -3296,6 +3305,20 @@
                         "status": {
                           "type": "string",
                           "enum": ["sent", "skipped", "rate_limited", "not_supported"]
+                        },
+                        "link": {
+                          "type": "object",
+                          "properties": {
+                            "url": {
+                              "type": "string",
+                              "format": "uri"
+                            },
+                            "expiresAt": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["url"],
+                          "additionalProperties": false
                         }
                       },
                       "required": ["status"],

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -1140,6 +1140,7 @@ export type CreateAuthInvitationData = {
     destinationId?: "atlas" | "app"
     expiresAt?: string
     returnTo?: string
+    revealLink?: boolean
   }
   path?: never
   query?: never
@@ -1205,6 +1206,10 @@ export type CreateAuthInvitationResponses = {
     }
     delivery: {
       status: "sent" | "skipped" | "rate_limited" | "not_supported"
+      link?: {
+        url: string
+        expiresAt?: string
+      }
     }
   }
 }

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -127,6 +127,7 @@ export type {
   ReactivateMemberInput,
   ReactivateMemberResult,
   ResolvedAuthConfig,
+  RevealedInvitationLink,
   RevokeAccessTokenResult,
   RevokeInvitationInput,
   RevokeInvitationResult,

--- a/packages/core/src/auth/runtime.ts
+++ b/packages/core/src/auth/runtime.ts
@@ -1242,11 +1242,19 @@ export class AuthRuntime {
         audience: deliveryAudience,
         returnTo: options.delivery?.returnTo ?? sanitizeReturnTo(input.returnTo),
         requestOrigin: options.delivery?.requestOrigin ?? new URL(request.url).origin,
+        revealLink: input.revealLink,
         now,
       })
     } catch (error) {
       await this.revokeInvitationAfterDeliveryFailure(authStorage, invitation, now)
       throw error
+    }
+
+    // The runtime owns the disclosure boundary even for third-party strategies. A strategy that
+    // accidentally returns a link must not expose it unless the caller opted in explicitly.
+    delivery = {
+      status: delivery.status,
+      ...(input.revealLink && delivery.link ? { link: delivery.link } : {}),
     }
 
     if (delivery.status === "not_supported") {

--- a/packages/core/src/auth/strategy.ts
+++ b/packages/core/src/auth/strategy.ts
@@ -38,6 +38,7 @@ export type {
   OidcCallbackResult,
   OidcStartSignInInput,
   OidcStartSignInResult,
+  RevealedInvitationLink,
 } from "./types"
 export {
   isInvitationDeliveryAuthStrategy,

--- a/packages/core/src/auth/types.ts
+++ b/packages/core/src/auth/types.ts
@@ -73,6 +73,8 @@ export interface InvitationDeliveryInput {
   readonly audience: AuthSessionAudience
   readonly returnTo: string
   readonly requestOrigin: string
+  /** Return the delivered link once so the inviter can copy it through an approved channel. */
+  readonly revealLink?: boolean
   readonly now?: Date
 }
 
@@ -80,8 +82,18 @@ export type AuthEmailDeliveryStatus = "sent" | "skipped" | "rate_limited"
 
 export type InviteDeliveryStatus = AuthEmailDeliveryStatus | "not_supported"
 
+export interface RevealedInvitationLink {
+  readonly url: string
+  readonly expiresAt?: Date
+}
+
 export interface InviteDeliveryResult {
   readonly status: InviteDeliveryStatus
+  /**
+   * Present only when the caller explicitly requests `revealLink`. Treat this as a credential:
+   * never persist it or include it in list responses, logs, or analytics.
+   */
+  readonly link?: RevealedInvitationLink
 }
 
 export interface InvitationDeliveryAuthStrategy extends AuthStrategy {
@@ -214,6 +226,8 @@ export interface InviteUserInput {
   readonly groupIds?: readonly string[]
   readonly expiresAt?: Date
   readonly returnTo?: string
+  /** Reveal the delivered link once in the result. Defaults to false. */
+  readonly revealLink?: boolean
 }
 
 export interface InviteUserResult {

--- a/packages/core/tests/auth-runtime.test.ts
+++ b/packages/core/tests/auth-runtime.test.ts
@@ -658,6 +658,47 @@ describe("SixbHost auth runtime", () => {
     })
   })
 
+  test("reveals invitation links only when the caller opts in", async () => {
+    const strategy: MagicLinkAuthStrategy = {
+      id: "magic-link",
+      kind: "magicLink" as const,
+      async requestMagicLink() {
+        return { status: "sent" as const }
+      },
+      async deliverInvitation() {
+        return {
+          status: "sent" as const,
+          link: {
+            url: "https://api.example/auth/callback?token=secret",
+            expiresAt: new Date("2099-05-16T10:15:00.000Z"),
+          },
+        }
+      },
+      async completeMagicLinkSignIn(): Promise<never> {
+        throw new Error("unused")
+      },
+    }
+    const { deps, sixb } = createInviteRuntime({ strategy })
+    const request = await seedAuthenticatedUser(sixb, deps, {
+      userId: "usr_admin",
+      email: "admin@acme.com",
+      groupIds: ["security-admins"],
+    })
+
+    const concealed = await sixb.auth.invite(request, {
+      email: "ava@acme.com",
+      groups: [commercial],
+    })
+    expect(concealed.delivery).toEqual({ status: "sent" })
+
+    const revealed = await sixb.auth.invite(request, {
+      email: "ava@acme.com",
+      groups: [commercial],
+      revealLink: true,
+    })
+    expect(revealed.delivery.link?.url).toContain("token=secret")
+  })
+
   test("rejects undeliverable invitations before writing", async () => {
     const strategy: MagicLinkAuthStrategy = {
       id: "magic-link",

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -11,6 +11,7 @@ import {
   createSessionCredential,
   generateCsrfToken,
   getCookie,
+  type InviteDeliveryResult,
   isMagicLinkAuthStrategy,
   isOidcAuthStrategy,
   type MagicLinkAuthStrategy,
@@ -901,6 +902,7 @@ export function registerAuthRoutes(app: Elysia, host: SixbHostView, options: Aut
               groupIds: parsed.groupIds,
               expiresAt: parseDate(parsed.expiresAt),
               returnTo: deliveryContext.returnTo,
+              revealLink: parsed.revealLink,
             },
             {
               ...authOptions,
@@ -915,7 +917,7 @@ export function registerAuthRoutes(app: Elysia, host: SixbHostView, options: Aut
           return jsonResponse(
             {
               invitation: serializeInvitation(result.invitation),
-              delivery: result.delivery,
+              delivery: serializeInvitationDelivery(result.delivery),
             },
             201
           )
@@ -2274,6 +2276,20 @@ function serializeInvitation(invitation: InvitationRecord) {
     expiresAt: toIsoString(invitation.expiresAt),
     acceptedAt: invitation.acceptedAt ? toIsoString(invitation.acceptedAt) : undefined,
     revokedAt: invitation.revokedAt ? toIsoString(invitation.revokedAt) : undefined,
+  }
+}
+
+function serializeInvitationDelivery(delivery: InviteDeliveryResult) {
+  return {
+    status: delivery.status,
+    ...(delivery.link
+      ? {
+          link: {
+            url: delivery.link.url,
+            expiresAt: delivery.link.expiresAt ? toIsoString(delivery.link.expiresAt) : undefined,
+          },
+        }
+      : {}),
   }
 }
 

--- a/packages/server/src/schemas/auth.ts
+++ b/packages/server/src/schemas/auth.ts
@@ -22,6 +22,12 @@ export const AuthInvitationSchema = z.object({
 
 export const AuthInvitationDeliverySchema = z.object({
   status: z.enum(["sent", "skipped", "rate_limited", "not_supported"]),
+  link: z
+    .object({
+      url: z.string().url(),
+      expiresAt: z.string().optional(),
+    })
+    .optional(),
 })
 
 export const AuthInvitationGroupOptionSchema = AuthGroupOptionSchema
@@ -230,6 +236,7 @@ export const CreateAuthInvitationBodySchema = z.object({
   destinationId: z.enum(["atlas", "app"]).optional(),
   expiresAt: z.string().optional(),
   returnTo: z.string().optional(),
+  revealLink: z.boolean().optional(),
 })
 
 export const CreateAuthInvitationResponseSchema = z.object({

--- a/packages/server/tests/invitations-auth-routes.test.ts
+++ b/packages/server/tests/invitations-auth-routes.test.ts
@@ -210,6 +210,48 @@ describe("auth invitation routes", () => {
     expect(messages[0]?.email).toBe("ava@acme.com")
   })
 
+  test("reveals the delivered link once when explicitly requested", async () => {
+    const { app, messages, storage } = createRuntime()
+    const admin = await seedAdminSession(storage)
+
+    const response = await app.fetch(
+      new Request("http://localhost/api/auth/invitations", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          cookie: admin.cookie,
+          ...admin.csrfHeader,
+        },
+        body: JSON.stringify({
+          email: "ava@acme.com",
+          groupIds: ["commercial"],
+          destinationId: "atlas",
+          revealLink: true,
+        }),
+      })
+    )
+    const body = (await response.json()) as {
+      readonly delivery: {
+        readonly link?: { readonly url: string; readonly expiresAt?: string }
+      }
+    }
+
+    expect(response.status).toBe(201)
+    expect(response.headers.get("cache-control")).toBe("no-store")
+    expect(body.delivery.link?.url).toBe(messages[0]?.url)
+    expect(body.delivery.link?.expiresAt).toBeString()
+
+    const list = await app.fetch(
+      new Request("http://localhost/api/auth/invitations", {
+        headers: { cookie: admin.cookie },
+      })
+    )
+    const listed = await list.text()
+
+    expect(listed).not.toContain(messages[0]?.url ?? "unreachable")
+    expect(listed).not.toContain("token")
+  })
+
   test("creates invitations on the browser origin audience", async () => {
     const { sixb, storage } = createRuntime()
     const app = createSixbApi(
@@ -465,6 +507,7 @@ describe("auth invitation routes", () => {
           email: "oidc-user@acme.com",
           groupIds: ["commercial"],
           destinationId: "app",
+          revealLink: true,
         }),
       })
     )
@@ -479,6 +522,9 @@ describe("auth invitation routes", () => {
       },
       delivery: {
         status: "sent",
+        link: {
+          url: messages[0]?.url,
+        },
       },
     })
     expect(messages).toHaveLength(1)


### PR DESCRIPTION
## Pourquoi

- Certains emails marqués `delivered` sont ensuite filtrés et n'atteignent pas le destinataire.
- Le seul contournement actuel impose d'extraire manuellement le lien chez le prestataire email.

## Ce qui change

- Ajoute `revealLink: true` à la création d'une invitation.
- Retourne le lien dans `delivery.link` uniquement dans cette réponse.
- Ajoute dans Atlas une option désactivée par défaut et une modale de copie.
- Aligne les stratégies Magic Link et OIDC sur le même contrat.
- Met à jour la documentation, l'OpenAPI et le client généré.

## Contrat

```text
revealLink absent/false  -> aucun lien retourné
revealLink true          -> delivery.link dans la réponse de création
liste des invitations    -> aucun lien retourné
```

## Sécurité

- Aucun token en clair n'est persisté ; aucune migration de base n'est nécessaire.
- Le runtime supprime tout lien sans opt-in explicite, y compris pour une stratégie tierce.
- Les contrôles administrateur, la protection CSRF, `Cache-Control: no-store` et l'expiration restent inchangés.
- Atlas efface le lien et l'état de la mutation à la fermeture de la modale.

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run test:ci` — 4 628 tests réussis, 7 ignorés
- `bun run build`
- `bun run test:publish` — 52 packages vérifiés
