### PR TITLE
core: validate action writeback results at compile time

### DIFF
--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -1171,7 +1171,7 @@ describe("runActionJob", () => {
       .params({})
       .writeback(
         ({ signal }) =>
-          new Promise((_resolve, reject) => {
+          new Promise<never>((_resolve, reject) => {
             enteredWriteback?.()
             signal.addEventListener(
               "abort",

--- a/packages/core/src/actions/types/definitions.ts
+++ b/packages/core/src/actions/types/definitions.ts
@@ -1,3 +1,4 @@
+import type { ReadonlyJsonValue } from "../../json"
 import type { ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
 import type {
   ActionEditsHandler,
@@ -12,6 +13,18 @@ import type {
   GlobalActionWritebackHandler,
 } from "./handlers"
 import type { ActionParamsConfig, InferActionParams } from "./params"
+
+// Validate fields structurally so JSON-shaped interfaces do not need an index signature.
+// Builders infer the original result first, then check it without widening via NoInfer.
+type WritebackJsonValue<T> = T extends ReadonlyJsonValue
+  ? T
+  : T extends (...args: never[]) => unknown
+    ? never
+    : T extends object
+      ? { [K in keyof T]: WritebackJsonValue<T[K]> }
+      : never
+
+type WritebackResult<T> = T extends ReturnType<() => void> ? T : WritebackJsonValue<T>
 
 export interface BaseActionDefinition<
   TId extends string = string,
@@ -136,7 +149,11 @@ export interface GlobalActionPhaseBuilder<TId extends string, TParams extends Ac
     validator: GlobalActionValidator<InferActionParams<TParams>>
   ): GlobalActionPhaseBuilder<TId, TParams>
   writeback<const TResult>(
-    handler: GlobalActionWritebackHandler<InferActionParams<TParams>, TResult>
+    handler: GlobalActionWritebackHandler<InferActionParams<TParams>, TResult> &
+      GlobalActionWritebackHandler<
+        InferActionParams<TParams>,
+        WritebackResult<NoInfer<Awaited<TResult>>>
+      >
   ): GlobalActionAfterWritebackBuilder<TId, TParams, TResult>
   edits<const TResult extends ActionNoResultHandlerResult>(
     handler: GlobalActionEditsHandler<InferActionParams<TParams>, undefined, TResult>
@@ -152,7 +169,12 @@ export interface ObjectActionPhaseBuilder<
     validator: ActionValidator<TObjectType, InferActionParams<TParams>>
   ): ObjectActionPhaseBuilder<TId, TObjectType, TParams>
   writeback<const TResult>(
-    handler: ActionWritebackHandler<TObjectType, InferActionParams<TParams>, TResult>
+    handler: ActionWritebackHandler<TObjectType, InferActionParams<TParams>, TResult> &
+      ActionWritebackHandler<
+        TObjectType,
+        InferActionParams<TParams>,
+        WritebackResult<NoInfer<Awaited<TResult>>>
+      >
   ): ObjectActionAfterWritebackBuilder<TId, TObjectType, TParams, TResult>
   edits<const TResult extends ActionNoResultHandlerResult>(
     handler: ActionEditsHandler<TObjectType, InferActionParams<TParams>, undefined, TResult>

--- a/packages/core/tests/actions.types.ts
+++ b/packages/core/tests/actions.types.ts
@@ -328,6 +328,132 @@ defineAction("writebackOnly")
   .params({})
   .writeback(async () => {})
 
+// Regression check: remove the intersected handler that validates WritebackResult from both builders
+// in actions/types/definitions.ts, then run `bun --filter @sixb/core typecheck`.
+// The non-JSON cases below must fail with unused @ts-expect-error directives.
+const globalWriteback = defineAction("globalWritebackResult").params({})
+const objectWriteback = defineAction("objectWritebackResult").on(Room).params({})
+const writebackDate = new Date("2026-01-01T00:00:00.000Z")
+
+// @ts-expect-error Date must be serialized explicitly
+globalWriteback.writeback(() => writebackDate)
+// @ts-expect-error async results must also be JSON
+globalWriteback.writeback(async () => writebackDate)
+// @ts-expect-error nested Date values are not JSON
+globalWriteback.writeback(() => ({ rows: [{ at: writebackDate }] }))
+// @ts-expect-error nested async Date values are not JSON
+globalWriteback.writeback(async () => ({ rows: [{ at: writebackDate }] }))
+// @ts-expect-error Date must be serialized explicitly
+objectWriteback.writeback(() => writebackDate)
+// @ts-expect-error async results must also be JSON
+objectWriteback.writeback(async () => writebackDate)
+// @ts-expect-error nested Date values are not JSON
+objectWriteback.writeback(() => ({ rows: [{ at: writebackDate }] }))
+// @ts-expect-error nested async Date values are not JSON
+objectWriteback.writeback(async () => ({ rows: [{ at: writebackDate }] }))
+
+// @ts-expect-error bigint is not JSON
+globalWriteback.writeback(() => 1n)
+// @ts-expect-error functions are not JSON
+objectWriteback.writeback(() => () => "result")
+// @ts-expect-error Map is not a JSON object
+globalWriteback.writeback(async () => new Map([["id", "ext_1"]]))
+// @ts-expect-error undefined is only accepted as the entire result
+objectWriteback.writeback(() => ({ at: undefined }))
+
+interface WritebackReceipt {
+  readonly id: string
+  readonly metadata: { readonly at: string }
+  readonly note?: string
+}
+
+const writebackReceipt: WritebackReceipt = {
+  id: "receipt_1",
+  metadata: { at: writebackDate.toISOString() },
+}
+globalWriteback
+  .writeback(() => writebackReceipt)
+  .edits(({ writeback }) => {
+    type _result = Expect<Equal<typeof writeback, WritebackReceipt>>
+  })
+objectWriteback
+  .writeback(async () => ({ receipts: [writebackReceipt] as const }))
+  .edits(({ writeback }) => {
+    type _result = Expect<
+      Equal<typeof writeback, { readonly receipts: readonly [WritebackReceipt] }>
+    >
+  })
+
+interface InvalidWritebackReceipt {
+  readonly at: Date
+}
+const invalidWritebackReceipt: InvalidWritebackReceipt = { at: writebackDate }
+// @ts-expect-error JSON validation also checks fields of interfaces
+globalWriteback.writeback(() => invalidWritebackReceipt)
+// @ts-expect-error nested async interfaces must also have JSON fields
+objectWriteback.writeback(async () => ({ receipts: [invalidWritebackReceipt] }))
+
+const unknownWritebackResult: unknown = writebackReceipt
+// @ts-expect-error unknown external results must be validated before returning them
+globalWriteback.writeback(() => unknownWritebackResult)
+
+globalWriteback
+  .writeback(() => ({
+    at: writebackDate.toISOString(),
+    values: ["paid", 1, true, null] as const,
+  }))
+  .edits(({ writeback }) => {
+    type _result = Expect<
+      Equal<
+        typeof writeback,
+        { readonly at: string; readonly values: readonly ["paid", 1, true, null] }
+      >
+    >
+  })
+  .effects(({ writeback }) => {
+    type _values = Expect<Equal<typeof writeback.values, readonly ["paid", 1, true, null]>>
+  })
+
+objectWriteback
+  .writeback(async () => [writebackDate.toISOString(), { status: "paid" }] as const)
+  .edits(({ writeback }) => {
+    type _result = Expect<Equal<typeof writeback, readonly [string, { readonly status: "paid" }]>>
+  })
+  .effects(({ writeback }) => {
+    type _result = Expect<Equal<typeof writeback, readonly [string, { readonly status: "paid" }]>>
+  })
+
+globalWriteback
+  .writeback(() => {})
+  .edits(({ writeback }) => {
+    type _result = Expect<Equal<typeof writeback, null>>
+  })
+globalWriteback
+  .writeback(async () => {})
+  .edits(({ writeback }) => {
+    type _result = Expect<Equal<typeof writeback, null>>
+  })
+objectWriteback
+  .writeback(() => {})
+  .edits(({ writeback }) => {
+    type _result = Expect<Equal<typeof writeback, null>>
+  })
+objectWriteback
+  .writeback(async () => {})
+  .edits(({ writeback }) => {
+    type _result = Expect<Equal<typeof writeback, null>>
+  })
+globalWriteback
+  .writeback(() => undefined)
+  .edits(({ writeback }) => {
+    type _result = Expect<Equal<typeof writeback, null>>
+  })
+objectWriteback
+  .writeback(async () => null)
+  .edits(({ writeback }) => {
+    type _result = Expect<Equal<typeof writeback, null>>
+  })
+
 defineAction("editsOnly")
   .params({})
   .edits(({ objects }) => {


### PR DESCRIPTION
## Summary

Catch non-JSON `.writeback()` results at compile time, before a worker rejects them after the handler has already run.

```ts
.writeback(() => ({ at: new Date() })) // Type error
.writeback(() => ({ at: new Date().toISOString() })) // Accepted
```

- Covers global and object actions, including async handlers and nested values.
- Preserves inferred results in `edits` and `effects`, readonly containers, and handlers without a return value.

## Typing choices

- Check fields recursively: a direct `JsonValue` constraint also rejects valid interfaces such as `FileRef` because they lack an index signature.
- Use `NoInfer` to validate the inferred result without widening it. Runtime validation remains necessary for cycles and non-finite numbers.

## Validation

- Full typecheck, 62 targeted action/worker tests, and Biome passed; client regeneration produced no diff.
- All 15 negative type cases fail when the validation is removed; restoring it passes.
