### PR TITLE
files: keep object file URLs fresh after replacement

### DIFF
--- a/docs/client/overview.md
+++ b/docs/client/overview.md
@@ -84,6 +84,38 @@ Failed and cancelled terminal runs reject with `ActionRunFailedError`; timeouts
 reject with `ActionRunTimeoutError`. Keep the generated `requestAction()` when
 you only need enqueue acknowledgement.
 
+### Rendering object files
+
+Use `objectFileContentUrl` for an object property's image source or download link:
+
+```tsx
+import { objectFileContentUrl } from "@sixb/client"
+
+const logoUrl = objectFileContentUrl({
+  objectTypeId: "Organization",
+  objectId: organization.primaryId,
+  pathSegments: ["logo"],
+  fileRef: organization.properties.logo,
+  disposition: "inline",
+})
+
+<img src={logoUrl} alt="Organization logo" />
+```
+
+Call it with the current `FileRef` when rendering. After saving a replacement and
+refetching the object, its URL changes, so the browser loads the new image. Unchanged
+references produce the same URL. Filename, media type, and logical path changes also
+change the URL. Use `disposition: "attachment"` for download links.
+
+`pathSegments` starts at the property name; the helper adds `/properties` and escapes
+JSON pointer segments. It uses the shared client's base URL, or a supplied `client`
+override, and supports relative URLs for same-origin apps and SSR.
+
+The generated `v` query value is an opaque cache key, not a historical-file selector.
+The endpoint always resolves the current property and revalidates privately cached
+content. Native images and links use browser credentials; a URL cannot carry the
+client's bearer headers. Bearer-only callers should fetch content through the SDK.
+
 ## /query: typed object queries
 
 `@sixb/client/query` exposes `objects(Type).query()` — the same fluent query

--- a/docs/server/overview.md
+++ b/docs/server/overview.md
@@ -131,6 +131,19 @@ messages — `/api/action-runs/:runId/files/content`, `/api/workflow-runs/:runId
 `.../nodes/:nodeKey/files/content`, and
 `/api/agent-threads/:threadId/messages/:messageId/files/content`.
 
+These contextual URLs resolve the current reference, so responses use
+`Cache-Control: private, no-cache`. Browsers can store the bytes but must revalidate
+before reuse. GET and HEAD support `If-None-Match` and return `304` for an unchanged
+representation after checking access and blob existence. ETags include the content
+identity and effective response metadata. `If-Range` accepts a matching strong ETag;
+other validators cause the full representation to be returned.
+
+For object images and download links, use the client's
+[`objectFileContentUrl`](../client/overview.md#rendering-object-files) helper. Its
+content-aware URL changes when a refetched property changes, prompting an existing
+image element to load the new file. The optional `v` query parameter is only a client
+cache key; it does not select an old blob or enable immutable caching.
+
 > **Pre-0.1 limit — upload sessions are in-memory.** Neither `@sixb/pg` nor `@sixb/sqlite`
 > implements `fileUploadSessions`, so every session opened by `POST /api/files/uploads` lives in
 > the serving process: it does not survive a restart and is not shared across replicas. Route a

--- a/packages/atlas/src/components/objects/FileRefAttachment.tsx
+++ b/packages/atlas/src/components/objects/FileRefAttachment.tsx
@@ -1,4 +1,4 @@
-import { client } from "@sixb/client"
+import { objectFileContentUrl } from "@sixb/client"
 import { type FileRef, fileNameFor } from "@sixb/core/blob-storage"
 import {
   Attachment,
@@ -12,7 +12,7 @@ import {
 } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
 import { Download, Eye, FileIcon, FileImage, FileText } from "lucide-react"
-import { fileMediaLabel, formatFileSize, objectFileContentUrl } from "../../lib/files"
+import { fileMediaLabel, formatFileSize } from "../../lib/files"
 
 export interface FileRefAttachmentProps {
   readonly fileRef: FileRef
@@ -29,10 +29,9 @@ export function FileRefAttachment({
 }: FileRefAttachmentProps) {
   const fileName = fileNameFor(fileRef)
   const mediaLabel = fileMediaLabel(fileRef.mediaType, fileName)
-  const baseUrl = client.getConfig().baseUrl ?? window.location.origin
-  const context = { objectTypeId, primaryId, pathSegments }
-  const inlineUrl = objectFileContentUrl({ baseUrl, context })
-  const downloadUrl = objectFileContentUrl({ baseUrl, context, disposition: "attachment" })
+  const source = { objectTypeId, objectId: primaryId, pathSegments, fileRef }
+  const inlineUrl = objectFileContentUrl(source)
+  const downloadUrl = objectFileContentUrl({ ...source, disposition: "attachment" })
   const { Icon, className } = fileIconPresentation(fileRef.mediaType, fileName)
 
   return (

--- a/packages/atlas/src/lib/files.ts
+++ b/packages/atlas/src/lib/files.ts
@@ -64,21 +64,6 @@ export function formatFileSize(sizeBytes: number): string {
   return `${value.toLocaleString(undefined, { maximumFractionDigits })} ${units[unitIndex]}`
 }
 
-export function objectFileContentUrl(input: {
-  readonly baseUrl: string
-  readonly context: FileValueContext
-  readonly disposition?: "attachment" | "inline"
-}): string {
-  return contextualFileContentUrl({
-    baseUrl: input.baseUrl,
-    routePath: `/api/objects/${encodeURIComponent(input.context.objectTypeId)}/${encodeURIComponent(
-      input.context.primaryId
-    )}/files/content`,
-    jsonPointerPath: ["properties", ...input.context.pathSegments],
-    disposition: input.disposition,
-  })
-}
-
 export function actionRunFileContentUrl(input: {
   readonly baseUrl: string
   readonly runId: string

--- a/packages/atlas/tests/files.test.ts
+++ b/packages/atlas/tests/files.test.ts
@@ -5,7 +5,6 @@ import {
   classifyFileValue,
   fileMediaLabel,
   formatFileSize,
-  objectFileContentUrl,
   workflowNodeFileContentUrl,
   workflowRunFileContentUrl,
 } from "../src/lib/files"
@@ -29,22 +28,6 @@ describe("Atlas file helpers", () => {
     expect(classifyFileValue({ ...fileRef, blobId: "blob_tampered" }).kind).toBe("none")
     // A mixed array is not treated as a file list.
     expect(classifyFileValue([fileRef, "not-a-file"]).kind).toBe("none")
-  })
-
-  test("builds object-bound file content URLs with JSON pointer escaping", () => {
-    const url = objectFileContentUrl({
-      baseUrl: "https://atlas.test/app",
-      context: {
-        objectTypeId: "document type",
-        primaryId: "doc/1",
-        pathSegments: ["attachments", "a/b", "tilde~name"],
-      },
-      disposition: "attachment",
-    })
-
-    expect(url).toBe(
-      "https://atlas.test/api/objects/document%20type/doc%2F1/files/content?path=%2Fproperties%2Fattachments%2Fa%7E1b%2Ftilde%7E0name&disposition=attachment"
-    )
   })
 
   test("builds run-bound file content URLs", () => {

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -64,6 +64,31 @@ const run = await requestActionAndWait({
 })
 ```
 
+### Object file URLs
+
+Use the current `FileRef` to build image sources and download links:
+
+```tsx
+import { objectFileContentUrl } from "@sixb/client"
+
+<img
+  src={objectFileContentUrl({
+    objectTypeId: "Organization",
+    objectId: organization.primaryId,
+    pathSegments: ["logo"],
+    fileRef: organization.properties.logo,
+    disposition: "inline",
+  })}
+  alt="Organization logo"
+/>
+```
+
+The helper uses the configured client base URL (or an optional `client` override).
+After replacing the file and refetching the object, the new reference produces a new
+URL. Unchanged references keep the same URL; content and metadata edits change it.
+Use `disposition: "attachment"` for downloads. The version query is a cache key, not
+a historical-file selector; the server still resolves and authorizes the current property.
+
 ### React Query hooks
 
 ```tsx

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -17512,6 +17512,9 @@
               }
             }
           },
+          "304": {
+            "description": "File representation is unchanged; reuse the privately cached content"
+          },
           "400": {
             "description": "Response for status 400",
             "content": {
@@ -17573,6 +17576,15 @@
             "schema": {
               "type": "string",
               "enum": ["inline", "attachment"]
+            }
+          },
+          {
+            "name": "v",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Client cache key; the route still resolves the current file"
             }
           }
         ]
@@ -17593,6 +17605,9 @@
           "206": {
             "description": "Partial file content headers"
           },
+          "304": {
+            "description": "File representation is unchanged; reuse the privately cached content"
+          },
           "400": {
             "description": "Response for status 400",
             "content": {
@@ -17654,6 +17669,15 @@
             "schema": {
               "type": "string",
               "enum": ["inline", "attachment"]
+            }
+          },
+          {
+            "name": "v",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Client cache key; the route still resolves the current file"
             }
           }
         ]
@@ -17692,6 +17716,9 @@
               }
             }
           },
+          "304": {
+            "description": "File representation is unchanged; reuse the privately cached content"
+          },
           "400": {
             "description": "Response for status 400",
             "content": {
@@ -17762,6 +17789,15 @@
             "schema": {
               "type": "string",
               "enum": ["inline", "attachment"]
+            }
+          },
+          {
+            "name": "v",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Client cache key; the route still resolves the current file"
             }
           }
         ]
@@ -17782,6 +17818,9 @@
           "206": {
             "description": "Partial file content headers"
           },
+          "304": {
+            "description": "File representation is unchanged; reuse the privately cached content"
+          },
           "400": {
             "description": "Response for status 400",
             "content": {
@@ -17852,6 +17891,15 @@
             "schema": {
               "type": "string",
               "enum": ["inline", "attachment"]
+            }
+          },
+          {
+            "name": "v",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Client cache key; the route still resolves the current file"
             }
           }
         ]
@@ -20566,6 +20614,9 @@
               }
             }
           },
+          "304": {
+            "description": "File representation is unchanged; reuse the privately cached content"
+          },
           "400": {
             "description": "Response for status 400",
             "content": {
@@ -20625,6 +20676,15 @@
             "schema": {
               "type": "string",
               "enum": ["inline", "attachment"]
+            }
+          },
+          {
+            "name": "v",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Client cache key; the route still resolves the current file"
             }
           }
         ]
@@ -20645,6 +20705,9 @@
           "206": {
             "description": "Partial file content headers"
           },
+          "304": {
+            "description": "File representation is unchanged; reuse the privately cached content"
+          },
           "400": {
             "description": "Response for status 400",
             "content": {
@@ -20704,6 +20767,15 @@
             "schema": {
               "type": "string",
               "enum": ["inline", "attachment"]
+            }
+          },
+          {
+            "name": "v",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Client cache key; the route still resolves the current file"
             }
           }
         ]
@@ -23055,6 +23127,9 @@
               }
             }
           },
+          "304": {
+            "description": "File representation is unchanged; reuse the privately cached content"
+          },
           "400": {
             "description": "Response for status 400",
             "content": {
@@ -23116,6 +23191,15 @@
             "schema": {
               "type": "string",
               "enum": ["inline", "attachment"]
+            }
+          },
+          {
+            "name": "v",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Client cache key; the route still resolves the current file"
             }
           }
         ]
@@ -23136,6 +23220,9 @@
           "206": {
             "description": "Partial file content headers"
           },
+          "304": {
+            "description": "File representation is unchanged; reuse the privately cached content"
+          },
           "400": {
             "description": "Response for status 400",
             "content": {
@@ -23197,6 +23284,15 @@
             "schema": {
               "type": "string",
               "enum": ["inline", "attachment"]
+            }
+          },
+          {
+            "name": "v",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Client cache key; the route still resolves the current file"
             }
           }
         ]
@@ -25555,6 +25651,9 @@
               }
             }
           },
+          "304": {
+            "description": "File representation is unchanged; reuse the privately cached content"
+          },
           "400": {
             "description": "Response for status 400",
             "content": {
@@ -25624,6 +25723,15 @@
             "schema": {
               "type": "string",
               "enum": ["inline", "attachment"]
+            }
+          },
+          {
+            "name": "v",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Client cache key; the route still resolves the current file"
             }
           }
         ]
@@ -25644,6 +25752,9 @@
           "206": {
             "description": "Partial file content headers"
           },
+          "304": {
+            "description": "File representation is unchanged; reuse the privately cached content"
+          },
           "400": {
             "description": "Response for status 400",
             "content": {
@@ -25713,6 +25824,15 @@
             "schema": {
               "type": "string",
               "enum": ["inline", "attachment"]
+            }
+          },
+          {
+            "name": "v",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Client cache key; the route still resolves the current file"
             }
           }
         ]

--- a/packages/client/src/file.ts
+++ b/packages/client/src/file.ts
@@ -1,6 +1,7 @@
 import type { FileRef } from "@sixb/core"
 import { DEFAULT_SIMPLE_FILE_UPLOAD_BYTES } from "@sixb/core/blob-storage"
 import { isSixbApiError, type SixbClient } from "./api"
+import { client as sharedClient } from "./generated/client.gen"
 import {
   abortFileUpload,
   completeFileUpload,
@@ -10,6 +11,41 @@ import {
   uploadFileRaw,
 } from "./generated/sdk.gen"
 import { computeStreamingBlobDigest } from "./sha256"
+
+export interface ObjectFileContentUrlInput {
+  readonly objectTypeId: string
+  readonly objectId: string
+  /** Property path segments, without the leading `properties` segment. */
+  readonly pathSegments: readonly string[]
+  readonly fileRef: FileRef
+  readonly disposition?: "inline" | "attachment"
+  readonly client?: SixbClient
+}
+
+/** Build a rendering/download URL that changes with the file's content or metadata. */
+export function objectFileContentUrl(input: ObjectFileContentUrlInput): string {
+  if (!input.objectTypeId || !input.objectId || input.pathSegments.length === 0) {
+    throw new Error("[SixbClient] File content URLs require an object type, ID, and property path.")
+  }
+  const client = input.client ?? sharedClient
+  const { digest, fileName, mediaType, logicalPath } = input.fileRef
+  return client.buildUrl({
+    baseUrl: client.getConfig().baseUrl,
+    url: "/api/objects/{objectTypeId}/{objectId}/files/content",
+    path: { objectTypeId: input.objectTypeId, objectId: input.objectId },
+    query: {
+      path: `/properties/${input.pathSegments
+        .map((segment) => segment.replaceAll("~", "~0").replaceAll("/", "~1"))
+        .join("/")}`,
+      disposition: input.disposition,
+      // Opaque cache key, not a historical-file selector. Include per-reference metadata.
+      // Encode each field so Elysia won't interpret commas in filenames as an array.
+      v: [digest, fileName ?? "", mediaType ?? "", logicalPath ?? ""]
+        .map(encodeURIComponent)
+        .join(":"),
+    },
+  })
+}
 
 export type SixbFileUploadStage =
   | "hash"

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -6058,6 +6058,10 @@ export type GetWorkflowRunFileContentData = {
   query: {
     path: string
     disposition?: "inline" | "attachment"
+    /**
+     * Client cache key; the route still resolves the current file
+     */
+    v?: string
   }
   url: "/api/workflow-runs/{runId}/files/content"
 }
@@ -6106,6 +6110,10 @@ export type HeadWorkflowRunFileContentData = {
   query: {
     path: string
     disposition?: "inline" | "attachment"
+    /**
+     * Client cache key; the route still resolves the current file
+     */
+    v?: string
   }
   url: "/api/workflow-runs/{runId}/files/content"
 }
@@ -6152,6 +6160,10 @@ export type GetWorkflowNodeRunFileContentData = {
   query: {
     path: string
     disposition?: "inline" | "attachment"
+    /**
+     * Client cache key; the route still resolves the current file
+     */
+    v?: string
   }
   url: "/api/workflow-runs/{runId}/nodes/{nodeKey}/files/content"
 }
@@ -6201,6 +6213,10 @@ export type HeadWorkflowNodeRunFileContentData = {
   query: {
     path: string
     disposition?: "inline" | "attachment"
+    /**
+     * Client cache key; the route still resolves the current file
+     */
+    v?: string
   }
   url: "/api/workflow-runs/{runId}/nodes/{nodeKey}/files/content"
 }
@@ -7103,6 +7119,10 @@ export type GetObjectFileContentData = {
   query: {
     path: string
     disposition?: "inline" | "attachment"
+    /**
+     * Client cache key; the route still resolves the current file
+     */
+    v?: string
   }
   url: "/api/objects/{objectTypeId}/{objectId}/files/content"
 }
@@ -7147,6 +7167,10 @@ export type HeadObjectFileContentData = {
   query: {
     path: string
     disposition?: "inline" | "attachment"
+    /**
+     * Client cache key; the route still resolves the current file
+     */
+    v?: string
   }
   url: "/api/objects/{objectTypeId}/{objectId}/files/content"
 }
@@ -7997,6 +8021,10 @@ export type GetActionRunFileContentData = {
   query: {
     path: string
     disposition?: "inline" | "attachment"
+    /**
+     * Client cache key; the route still resolves the current file
+     */
+    v?: string
   }
   url: "/api/action-runs/{runId}/files/content"
 }
@@ -8045,6 +8073,10 @@ export type HeadActionRunFileContentData = {
   query: {
     path: string
     disposition?: "inline" | "attachment"
+    /**
+     * Client cache key; the route still resolves the current file
+     */
+    v?: string
   }
   url: "/api/action-runs/{runId}/files/content"
 }
@@ -8826,6 +8858,10 @@ export type GetAgentMessageFileContentData = {
   query: {
     path: string
     disposition?: "inline" | "attachment"
+    /**
+     * Client cache key; the route still resolves the current file
+     */
+    v?: string
   }
   url: "/api/agent-threads/{threadId}/messages/{messageId}/files/content"
 }
@@ -8875,6 +8911,10 @@ export type HeadAgentMessageFileContentData = {
   query: {
     path: string
     disposition?: "inline" | "attachment"
+    /**
+     * Client cache key; the route still resolves the current file
+     */
+    v?: string
   }
   url: "/api/agent-threads/{threadId}/messages/{messageId}/files/content"
 }

--- a/packages/client/tests/file-content-url.test.ts
+++ b/packages/client/tests/file-content-url.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import type { FileRef } from "@sixb/core"
+import { createSixbClient, objectFileContentUrl, client as sharedClient } from "../src"
+
+const fileRef: FileRef = {
+  blobId: `blob_${"a".repeat(64)}`,
+  digest: `sha256:${"a".repeat(64)}`,
+  sizeBytes: 12,
+  fileName: "logo, final.png",
+  mediaType: "image/png",
+}
+const input = {
+  objectTypeId: "document type",
+  objectId: "doc/1",
+  pathSegments: ["attachments", "a/b", "tilde~name"],
+  fileRef,
+}
+
+describe("objectFileContentUrl", () => {
+  test("defaults to the shared client configuration", () => {
+    const config = sharedClient.getConfig()
+    try {
+      sharedClient.setConfig({ baseUrl: "https://shared.test" })
+      expect(objectFileContentUrl(input).startsWith("https://shared.test/api/objects/")).toBe(true)
+    } finally {
+      sharedClient.setConfig(config)
+    }
+  })
+
+  test("uses the client base path and encodes object IDs and JSON pointers", () => {
+    const client = createSixbClient({ baseUrl: "https://sixb.test/prefix/api" })
+    const url = new URL(objectFileContentUrl({ ...input, client, disposition: "attachment" }))
+    expect(url.origin).toBe("https://sixb.test")
+    expect(url.pathname).toBe("/prefix/api/objects/document%20type/doc%2F1/files/content")
+    expect(url.searchParams.get("path")).toBe("/properties/attachments/a~1b/tilde~0name")
+    expect(url.searchParams.get("disposition")).toBe("attachment")
+    // Elysia 1.4 parses comma-delimited query values into arrays before validation.
+    // Replacing the scalar key with JSON.stringify([...]) reproduces a route 422.
+    expect(url.searchParams.get("v")).not.toContain(",")
+  })
+
+  // Regression for #527: removing `v` from the helper must fail the replacement assertions.
+  test("keeps identical references stable and changes the URL for content or metadata edits", () => {
+    const client = createSixbClient()
+    const original = objectFileContentUrl({ ...input, client })
+    expect(original.startsWith("/api/objects/")).toBe(true)
+    expect(objectFileContentUrl({ ...input, client, fileRef: { ...fileRef } })).toBe(original)
+    for (const replacement of [
+      { ...fileRef, digest: `sha256:${"b".repeat(64)}` as const, blobId: `blob_${"b".repeat(64)}` },
+      { ...fileRef, fileName: "new-name.png" },
+      { ...fileRef, mediaType: "image/jpeg" },
+      { ...fileRef, logicalPath: "images/logo.png" },
+    ]) {
+      expect(objectFileContentUrl({ ...input, client, fileRef: replacement })).not.toBe(original)
+    }
+  })
+
+  test("supports relative deployment prefixes and rejects missing context", () => {
+    const client = createSixbClient({ baseUrl: "/prefix/api" })
+    expect(objectFileContentUrl({ ...input, client }).startsWith("/prefix/api/objects/")).toBe(true)
+    for (const invalid of [{ objectId: "" }, { objectTypeId: "" }, { pathSegments: [] }]) {
+      expect(() => objectFileContentUrl({ ...input, ...invalid })).toThrow("[SixbClient]")
+    }
+  })
+})

--- a/packages/server/src/files/content.ts
+++ b/packages/server/src/files/content.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { type BlobInfo, type BlobStorage, type FileRef, isFileRef } from "@sixb/core"
 import { BlobStorageError, supportsRangeRead } from "@sixb/core/blob-storage/server"
 import { ZodError } from "zod"
@@ -10,6 +11,8 @@ export interface FileContentResponseInput {
   readonly disposition?: FileContentDisposition
   readonly head?: boolean
   readonly rangeHeader?: string | null
+  readonly ifNoneMatchHeader?: string | null
+  readonly ifRangeHeader?: string | null
 }
 
 export interface FileContentQuery {
@@ -82,6 +85,9 @@ export function fileContentGetResponses(options: FileContentResponsesOptions = {
         },
       },
     },
+    304: {
+      description: "File representation is unchanged; reuse the privately cached content",
+    },
     400: {
       description: "Response for status 400",
       content: {
@@ -112,6 +118,9 @@ export function fileContentHeadResponses(options: FileContentResponsesOptions = 
     },
     206: {
       description: "Partial file content headers",
+    },
+    304: {
+      description: "File representation is unchanged; reuse the privately cached content",
     },
     400: {
       description: "Response for status 400",
@@ -146,7 +155,18 @@ export async function createFileContentResponse(
 
   const canReadRange = supportsRangeRead(input.blobStorage)
   const headers = fileContentHeaders(input.fileRef, stat, input.disposition, canReadRange)
-  if (canReadRange && input.rangeHeader) {
+  const etag = headers.get("etag")!
+  if (matchesIfNoneMatch(input.ifNoneMatchHeader, etag)) {
+    headers.delete("content-length")
+    return new Response(null, { status: 304, headers })
+  }
+
+  // Date validators are unsupported: only a strong ETag can validate a range.
+  if (
+    canReadRange &&
+    input.rangeHeader &&
+    (input.ifRangeHeader == null || input.ifRangeHeader.trim() === etag)
+  ) {
     const range = parseSingleByteRange(input.rangeHeader, stat.sizeBytes)
     if (!range) {
       return rangeNotSatisfiableResponse(stat.sizeBytes)
@@ -213,6 +233,8 @@ export async function createContextualFileContentResponse<TQuery extends FileCon
       disposition: parsed.disposition,
       head: input.head,
       rangeHeader: input.request.headers.get("range"),
+      ifNoneMatchHeader: input.request.headers.get("if-none-match"),
+      ifRangeHeader: input.request.headers.get("if-range"),
     })
     if (!response) {
       return fileContentNotFound(input.set, missingMessage)
@@ -251,6 +273,13 @@ function blobMatchesFileRef(stat: BlobInfo, fileRef: FileRef): boolean {
     stat.blobId === fileRef.blobId &&
     stat.digest === fileRef.digest &&
     stat.sizeBytes === fileRef.sizeBytes
+  )
+}
+
+function matchesIfNoneMatch(header: string | null | undefined, etag: string): boolean {
+  return (
+    header?.trim() === "*" ||
+    (header?.split(",").some((value) => value.trim().replace(/^W\//, "") === etag) ?? false)
   )
 }
 
@@ -307,12 +336,16 @@ function fileContentHeaders(
   headers.set("content-type", mediaType)
   headers.set("content-length", stat.sizeBytes.toString())
   headers.set("content-disposition", contentDispositionHeader(disposition, fileNameFor(fileRef)))
-  headers.set("etag", `"${fileRef.digest}"`)
+  // Metadata belongs to the reference, not the blob; changing it must also invalidate caches.
+  const representation = JSON.stringify([
+    fileRef.digest,
+    mediaType,
+    headers.get("content-disposition"),
+  ])
+  headers.set("etag", `"sha256:${createHash("sha256").update(representation).digest("hex")}"`)
   headers.set("x-content-type-options", "nosniff")
-  // Blobs are content-addressed and immutable, so responses can be cached
-  // aggressively — but only privately: reads are grant-enforced and must never
-  // land in a shared cache.
-  headers.set("cache-control", "private, max-age=31536000, immutable")
+  // The containing record is mutable even though its referenced blob is immutable.
+  headers.set("cache-control", "private, no-cache")
   if (canReadRange) {
     headers.set("accept-ranges", "bytes")
   }

--- a/packages/server/src/schemas/files.ts
+++ b/packages/server/src/schemas/files.ts
@@ -79,4 +79,5 @@ export const CompleteFileUploadBodySchema = z.object({
 export const FileContentQuerySchema = z.object({
   path: z.string().min(1),
   disposition: z.enum(["inline", "attachment"]).optional(),
+  v: z.string().optional().describe("Client cache key; the route still resolves the current file"),
 })

--- a/packages/server/tests/object-file-content-routes.test.ts
+++ b/packages/server/tests/object-file-content-routes.test.ts
@@ -91,6 +91,8 @@ async function createObjectFileApi(options: { readonly auth?: boolean } = {}) {
       new SixbServer({ host: sixb, quiet: true, browser: createTestBrowserPolicy() })
     ),
     storage,
+    blobStorage,
+    setup,
   }
 }
 
@@ -134,6 +136,101 @@ function contentRequest(
 }
 
 describe("object file content routes", () => {
+  // Regression for #527: restoring the immutable cache policy or removing conditional
+  // handling in src/files/content.ts must make these cache tests fail.
+  test("revalidates cached content against the current property", async () => {
+    const { app, setup, blobStorage } = await createObjectFileApi()
+    const path = "/api/objects/document/doc-1/files/content?path=/properties/pdf"
+    const initial = await app.fetch(contentRequest(path))
+    expect(initial.headers.get("cache-control")).toBe("private, no-cache")
+    const etag = initial.headers.get("etag")!
+    await initial.text()
+
+    for (const method of ["GET", "HEAD"]) {
+      for (const validator of [etag, `"other", W/${etag}`, "*"]) {
+        const response = await app.fetch(
+          contentRequest(path, {
+            method,
+            headers: { "if-none-match": validator, range: "bytes=0-3" },
+          })
+        )
+        expect(response.status).toBe(304)
+        expect(response.headers.get("etag")).toBe(etag)
+        expect(response.headers.get("cache-control")).toBe("private, no-cache")
+        expect(response.headers.get("content-range")).toBeNull()
+        expect(await response.text()).toBe("")
+      }
+    }
+
+    const replacement = await blobStorage.put({
+      body: new TextEncoder().encode("replacement pdf"),
+      mediaType: "application/pdf",
+    })
+    await setup.objects.upsert("document", { id: "doc-1", pdf: replacement })
+    const updated = await app.fetch(contentRequest(path, { headers: { "if-none-match": etag } }))
+    expect(updated.status).toBe(200)
+    expect(updated.headers.get("etag")).not.toBe(etag)
+    expect(await updated.text()).toBe("replacement pdf")
+
+    await setup.objects.upsert("document", {
+      id: "doc-1",
+      pdf: { ...replacement, fileName: "renamed.txt", mediaType: "text/plain" },
+    })
+    const renamed = await app.fetch(
+      contentRequest(path, { headers: { "if-none-match": updated.headers.get("etag")! } })
+    )
+    expect(renamed.status).toBe(200)
+    expect(renamed.headers.get("content-type")).toBe("text/plain")
+    expect(renamed.headers.get("content-disposition")).toContain("renamed.txt")
+    expect(await renamed.text()).toBe("replacement pdf")
+  })
+
+  test("honors ranges only when If-Range strongly matches the current representation", async () => {
+    const { app } = await createObjectFileApi()
+    const path = "/api/objects/document/doc-1/files/content?path=/properties/pdf"
+    const initial = await app.fetch(contentRequest(path))
+    const etag = initial.headers.get("etag")!
+    await initial.text()
+
+    for (const validator of [etag, `W/${etag}`, '"old-file"', "Wed, 01 Jul 2026 00:00:00 GMT"]) {
+      const response = await app.fetch(
+        contentRequest(path, { headers: { range: "bytes=0-3", "if-range": validator } })
+      )
+      expect(response.status).toBe(validator === etag ? 206 : 200)
+      expect(response.headers.get("cache-control")).toBe("private, no-cache")
+      expect(await response.text()).toBe(validator === etag ? "%PDF" : "%PDF test")
+    }
+  })
+
+  test("treats version queries as cache keys, not historical file selectors", async () => {
+    const { app } = await createObjectFileApi()
+    const query = new URLSearchParams({
+      path: "/properties/pdf",
+      v: `sha256%3A${"0".repeat(64)}:old%2Cname.pdf:application%2Fpdf:`,
+    })
+    const response = await app.fetch(
+      contentRequest(`/api/objects/document/doc-1/files/content?${query}`)
+    )
+    expect(response.status).toBe(200)
+    expect(response.headers.get("cache-control")).toBe("private, no-cache")
+    expect(await response.text()).toBe("%PDF test")
+  })
+
+  test("checks visibility and existence before conditional responses", async () => {
+    const { app, storage } = await createObjectFileApi({ auth: true })
+    const viewer = await seedSession(storage, ["document-viewers"])
+    for (const path of [
+      "/api/objects/invoice/inv-1/files/content?path=/properties/pdf",
+      "/api/objects/document/missing/files/content?path=/properties/pdf",
+      "/api/objects/document/doc-1/files/content?path=/properties/missing",
+    ]) {
+      const response = await app.fetch(
+        contentRequest(path, { headers: { ...viewer, "if-none-match": "*" } })
+      )
+      expect(response.status).toBe(404)
+    }
+  })
+
   test("streams object-bound FileRef content with browser viewer headers", async () => {
     const { app } = await createObjectFileApi()
 

--- a/packages/server/tests/openapi-docs.test.ts
+++ b/packages/server/tests/openapi-docs.test.ts
@@ -205,7 +205,7 @@ describe("OpenAPI docs", () => {
           | Record<string, { content?: Record<string, { schema?: unknown }> }>
           | undefined
         expect(responses, `${method.toUpperCase()} ${path}`).toBeDefined()
-        for (const status of ["200", "206", "400", "404", "416"]) {
+        for (const status of ["200", "206", "304", "400", "404", "416"]) {
           expect(responses, `${method.toUpperCase()} ${path}`).toHaveProperty(status)
         }
       }


### PR DESCRIPTION
Closes #527.

Replacing a `FileRef` could leave the previous image visible: its URL stayed the same, and the server allowed a year of immutable caching.

## Content-aware URLs

Use the current `FileRef` when rendering:

```tsx
import { objectFileContentUrl } from "@sixb/client"

<img
  src={objectFileContentUrl({
    objectTypeId: "Organization",
    objectId: organization.primaryId,
    pathSegments: ["logo"],
    fileRef: organization.properties.logo,
    disposition: "inline",
  })}
  alt="Organization logo"
/>
```

```text
Same file                 → same URL
Replaced file + refetch    → new URL → image reloads
Changed file metadata     → new URL
```

The helper uses the configured client base URL and handles URL/JSON pointer escaping. Use `disposition: "attachment"` for downloads. Atlas now uses this helper too.

## Correct cache behavior

```http
# Before
Cache-Control: private, max-age=31536000, immutable

# After
Cache-Control: private, no-cache
ETag: "sha256:<content-and-metadata-hash>"
```

- Matching `If-None-Match` → `304`, after access and blob checks.
- Changed content or metadata → fresh response.
- Matching strong `If-Range` → partial content; otherwise, full content.
- The `v` query is a cache key; the endpoint always resolves the current property.

Docs, OpenAPI, and generated client types are updated.

## Verified

- [x] Unit suite and final targeted regression tests
- [x] Typecheck, build, and Biome checks
- [x] Client regeneration
- [x] Regression tests fail when the fixes are removed
- [x] Chromium: replacement changed rendered pixels; unchanged refetch kept the URL; subsequent requests returned `304`
