### PR TITLE
atlas: preserve encoded object identifiers in routes

### DIFF
--- a/packages/atlas/src/lib/objectRoutes.ts
+++ b/packages/atlas/src/lib/objectRoutes.ts
@@ -1,0 +1,13 @@
+export function objectDetailPath(objectId: string): string {
+  // encodeObjectId escapes the identity components. Escape the composite once more for transport
+  // as a route segment; React Router removes this outer layer before decodeObjectId sees it.
+  return `/${encodeURIComponent(objectId)}`
+}
+
+export function objectIdFromPathSegment(pathSegment: string): string {
+  try {
+    return decodeURIComponent(pathSegment)
+  } catch {
+    return pathSegment
+  }
+}

--- a/packages/atlas/src/pages/ObjectDetailPage.tsx
+++ b/packages/atlas/src/pages/ObjectDetailPage.tsx
@@ -42,6 +42,7 @@ import { useObjectTelemetryUpdates } from "../features/objects/hooks/useObjectTe
 import { classifyFileValue, type FileValueContext } from "../lib/files"
 import { formatValue } from "../lib/formatValue"
 import { humanizeIdentifier } from "../lib/labels"
+import { objectDetailPath } from "../lib/objectRoutes"
 import { getHistoryBounds, isSampleInBounds } from "../lib/telemetryHistory"
 import { formatRelativeTime } from "../lib/time"
 
@@ -798,7 +799,7 @@ export function ObjectDetailPage({ projectName, objectLookup }: ObjectDetailPage
             outgoing={outgoing}
             incoming={incoming}
             objectLookup={objectLookup}
-            onSelectObject={(id) => navigate(`/${id}`)}
+            onSelectObject={(id) => navigate(objectDetailPath(id))}
           />
         </Section>
       ) : null}
@@ -1031,7 +1032,7 @@ function RelatedObjectLink({
 }) {
   return (
     <Link
-      to={`/${objectId}`}
+      to={objectDetailPath(objectId)}
       onClick={(event) => {
         event.preventDefault()
         onSelect(objectId)

--- a/packages/atlas/src/pages/ProjectWorkspace.tsx
+++ b/packages/atlas/src/pages/ProjectWorkspace.tsx
@@ -40,6 +40,7 @@ import {
 import { SidebarDataContext } from "../components/layout/sidebarData"
 import { KNOWN_VIEWS } from "../components/layout/viewMode"
 import { SettingsAccessGate } from "../components/SettingsAccessGate"
+import { objectDetailPath, objectIdFromPathSegment } from "../lib/objectRoutes"
 import {
   getObjectSortPreference,
   type ObjectSortPreference,
@@ -82,7 +83,8 @@ export function ProjectWorkspace() {
   const location = useLocation()
   const pathSegments = location.pathname.split("/").filter(Boolean)
   const firstSegment = pathSegments[0]
-  const objectIdFromUrl = firstSegment && !KNOWN_VIEWS.has(firstSegment) ? firstSegment : null
+  const objectIdFromUrl =
+    firstSegment && !KNOWN_VIEWS.has(firstSegment) ? objectIdFromPathSegment(firstSegment) : null
   const { setSidebarData } = useContext(SidebarDataContext)
 
   const [objectSortBy, setObjectSortBy] = useState<ObjectSortPreference>(getObjectSortPreference)
@@ -347,8 +349,6 @@ export function ProjectWorkspace() {
     [objectTypePreviewSections]
   )
 
-  const toProjectPath = (suffix: string) => `/${suffix}`
-
   const handleObjectSortByChange = (sortBy: ObjectSortPreference) => {
     setObjectSortBy(sortBy)
     setObjectSortPreference(sortBy)
@@ -435,7 +435,7 @@ export function ProjectWorkspace() {
                     selectedObjectId={selectedObjectIdForSidebar}
                     onSortByChange={handleObjectSortByChange}
                     onClassFilterChange={setClassFilter}
-                    onSelectObject={(objectId) => navigate(toProjectPath(objectId))}
+                    onSelectObject={(objectId) => navigate(objectDetailPath(objectId))}
                   />
                 }
               />
@@ -495,7 +495,7 @@ export function ProjectWorkspace() {
                     onSelectedTypeChange={setSelectedOntologyTypeId}
                     onOpenType={openOntologyTypeDetails}
                     onViewObjects={(typeId) => {
-                      navigate(toProjectPath(`?class=${encodeURIComponent(typeId)}`))
+                      navigate(`/?class=${encodeURIComponent(typeId)}`)
                     }}
                   />
                 }

--- a/packages/atlas/src/pages/RulesPage.tsx
+++ b/packages/atlas/src/pages/RulesPage.tsx
@@ -34,6 +34,7 @@ import {
 import { useRuleLiveUpdates } from "../features/rules/hooks/useRuleLiveUpdates"
 import { formatValue } from "../lib/formatValue"
 import { humanizeIdentifier } from "../lib/labels"
+import { objectDetailPath } from "../lib/objectRoutes"
 import { formatRelativeTime } from "../lib/time"
 import { getCollectionViewStyle, setCollectionViewStyle } from "../lib/userPreferences"
 
@@ -732,7 +733,7 @@ export function RuleDetailPage() {
   const states = statesQuery.data?.states ?? []
 
   const handleSelectObject = (state: RuleState) => {
-    navigate(`/${encodeObjectId(state.subject.objectTypeId, state.subject.primaryId)}`)
+    navigate(objectDetailPath(encodeObjectId(state.subject.objectTypeId, state.subject.primaryId)))
   }
 
   if (ruleQuery.isLoading) {

--- a/packages/atlas/tests/object-routes.test.ts
+++ b/packages/atlas/tests/object-routes.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import { decodeObjectId, encodeObjectId } from "@sixb/client"
+import { matchRoutes } from "react-router-dom"
+import { objectDetailPath, objectIdFromPathSegment } from "../src/lib/objectRoutes"
+
+describe("object routes", () => {
+  test("preserves already encoded primary ids through the router decoding boundary", () => {
+    // Regression proof: returning `/${objectId}` from objectDetailPath makes React Router turn the
+    // literal `%2F` in this primary id into `/`, so this test fails.
+    const primaryId = "site%2Fnorth%2Fdevice%2F100"
+    const objectId = encodeObjectId("point", primaryId)
+    const path = objectDetailPath(objectId)
+
+    expect(path).toBe("/point~site%25252Fnorth%25252Fdevice%25252F100")
+
+    const routeParam = matchRoutes([{ path: "/:objectId" }], path)?.[0]?.params.objectId
+    expect(routeParam).toBe(objectId)
+    expect(decodeObjectId(routeParam ?? "")).toEqual({ objectTypeId: "point", primaryId })
+    expect(objectIdFromPathSegment(path.slice(1))).toBe(objectId)
+  })
+
+  test("preserves reserved and unicode characters in object ids", () => {
+    const primaryId = "north/Paris #1?température=20%"
+    const objectId = encodeObjectId("sensor/type", primaryId)
+    const routeParam = objectIdFromPathSegment(objectDetailPath(objectId).slice(1))
+
+    expect(decodeObjectId(routeParam)).toEqual({ objectTypeId: "sensor/type", primaryId })
+  })
+})


### PR DESCRIPTION
## Summary

- Preserve exact object identifiers containing encoded sequences such as `%2F` or `%25`.
- Encode composite object IDs as opaque URL path segments before Atlas navigation.
- Apply the shared route helper to object lists, relationships, and rule states.
- Keep sidebar selection aligned with the canonical object ID.

## Why

React Router decodes route parameters before Atlas calls `decodeObjectId`. An already encoded primary ID could therefore change before the API request:

```text
site%2Fnorth → site/north
```

Atlas then queried a different identity even though the API could retrieve the original object.

## Implementation choice

The extra encoding is limited to the URL transport layer. This preserves the existing object ID and API contracts and requires no dependency change.

## Validation

- Object-route regression tests, including encoded, reserved, and Unicode characters
- Atlas typecheck
- Atlas build
- Biome checks on touched files
