### PR TITLE
storage: fence cardinality-many link scopes correctly

### DIFF
--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -422,6 +422,7 @@ export type {
   MaterializationClassificationWorkRecord,
   MaterializationEventWorkRecord,
   MaterializationIncidentObjectWorkRecord,
+  MaterializationLinkScopeRevision,
   MaterializationLinkScopeState,
   MaterializationLinkState,
   MaterializationObjectExistence,

--- a/packages/core/src/storage/ontology/in-memory/materializations.ts
+++ b/packages/core/src/storage/ontology/in-memory/materializations.ts
@@ -38,6 +38,7 @@ import type {
   FinalizeMaterializationInput,
   MaterializationCardinalityOccupantWorkRecord,
   MaterializationEventWorkRecord,
+  MaterializationLinkScopeRevision,
   MaterializationLinkScopeState,
   MaterializationLinkState,
   MaterializationObjectExistence,
@@ -134,7 +135,7 @@ export interface SessionState {
   readonly workStreams: Record<StreamMaterializationWorkInput["order"], WorkStreamState>
   workSealed: boolean
   incidentLinksByObject: Map<string, readonly OntologyLinkRef[]> | null
-  linkScopeStates: Map<string, MaterializationLinkScopeState> | null
+  linkSlotStates: Map<string, MaterializationLinkScopeState> | null
   readonly objectExistence: Map<string, MaterializationObjectExistenceWorkRecord>
   replacement: ReplacementSessionState | null
 }
@@ -209,13 +210,13 @@ export class InMemoryOntologyMaterializationStorage implements OntologyMateriali
       await this.assertObject(expected, input.commit.projectId)
     for (const expected of input.expected.links)
       await this.assertLink(expected, input.commit.projectId)
-    const expectedScopeStates = new Map<string, MaterializationLinkScopeState>()
+    const expectedScopeRevisions = new Map<string, MaterializationLinkScopeRevision>()
     for (const expected of input.expected.linkScopes) {
       const key = linkScopeSortKey(expected.source, expected.linkId)
       const current =
-        expectedScopeStates.get(key) ??
-        this.computeLinkScopeState(input.commit.projectId, expected.source, expected.linkId)
-      expectedScopeStates.set(key, current)
+        expectedScopeRevisions.get(key) ??
+        this.computeEffectiveLinkScope(input.commit.projectId, expected.source, expected.linkId)
+      expectedScopeRevisions.set(key, current)
       if (current.fingerprint !== expected.fingerprint) {
         throw new MaterializationConflictError(
           "effective-state",
@@ -247,7 +248,7 @@ export class InMemoryOntologyMaterializationStorage implements OntologyMateriali
       },
       workSealed: false,
       incidentLinksByObject: null,
-      linkScopeStates: expectedScopeStates,
+      linkSlotStates: new Map(),
       objectExistence: new Map<string, MaterializationObjectExistenceWorkRecord>(),
       replacement: null,
     }
@@ -275,7 +276,7 @@ export class InMemoryOntologyMaterializationStorage implements OntologyMateriali
     session.appliedPlanItems.length = 0
     session.outboxEnvelopes.clear()
     session.incidentLinksByObject = null
-    session.linkScopeStates = null
+    session.linkSlotStates = null
     session.objectExistence.clear()
     session.replacement = null
     this.liveSessions.delete(session)
@@ -329,7 +330,7 @@ export class InMemoryOntologyMaterializationStorage implements OntologyMateriali
         linkScopeSortKey(value.source, value.linkId)
       )) {
         this.requireSession(input.session)
-        const value = this.linkScopeState(session, scope.source, scope.linkId)
+        const value = this.linkSlotState(session, scope.source, scope.linkId)
         // Scope rows are currently only requested for cardinality-one links, so the complete member
         // set is bounded by the ontology invariant. Replacement scope enumeration is flattened in
         // its dedicated stream and never uses this shape.
@@ -1136,25 +1137,44 @@ export class InMemoryOntologyMaterializationStorage implements OntologyMateriali
     }
   }
 
-  private linkScopeState(
+  private linkSlotState(
     session: SessionState,
     source: OntologyObjectRef,
     linkId: string
   ): MaterializationLinkScopeState {
-    session.linkScopeStates ??= new Map()
+    session.linkSlotStates ??= new Map()
     const key = linkScopeSortKey(source, linkId)
-    const existing = session.linkScopeStates.get(key)
+    const existing = session.linkSlotStates.get(key)
     if (existing) return structuredClone(existing)
-    const computed = this.computeLinkScopeState(session.header.commit.projectId, source, linkId)
-    session.linkScopeStates.set(key, computed)
+    const computed = this.computeLinkSlotState(session.header.commit.projectId, source, linkId)
+    session.linkSlotStates.set(key, computed)
     return structuredClone(computed)
   }
 
-  private computeLinkScopeState(
+  private computeLinkSlotState(
     projectId: string,
     source: OntologyObjectRef,
     linkId: string
   ): MaterializationLinkScopeState {
+    const value = this.computeEffectiveLinkScope(projectId, source, linkId)
+    return {
+      ...value,
+      sourceAssertion: this.findActiveLinkScopeSource(projectId, source, linkId),
+      override: structuredClone(
+        publicLinkSlotOverride(
+          this.state.linkSlotOverrides.get(
+            projectEntityKey(projectId, linkScopeKey(source, linkId))
+          )
+        )
+      ),
+    }
+  }
+
+  private computeEffectiveLinkScope(
+    projectId: string,
+    source: OntologyObjectRef,
+    linkId: string
+  ): MaterializationLinkScopeRevision & Pick<MaterializationLinkScopeState, "effective"> {
     const rows: ObjectLinkRow[] = []
     getInMemoryObjectMaterializerAdapter(this.objects).visitExactScopeLinks(
       projectId,
@@ -1177,14 +1197,6 @@ export class InMemoryOntologyMaterializationStorage implements OntologyMateriali
     const effective = rows.length === 1 ? linkSnapshot(rows[0]!) : null
     return {
       ...finishScopeAccumulator(accumulator),
-      sourceAssertion: this.findActiveLinkScopeSource(projectId, source, linkId),
-      override: structuredClone(
-        publicLinkSlotOverride(
-          this.state.linkSlotOverrides.get(
-            projectEntityKey(projectId, linkScopeKey(source, linkId))
-          )
-        )
-      ),
       effective,
     }
   }

--- a/packages/core/src/storage/ontology/index.ts
+++ b/packages/core/src/storage/ontology/index.ts
@@ -45,6 +45,7 @@ export type {
   MaterializationClassificationWorkRecord,
   MaterializationEventWorkRecord,
   MaterializationIncidentObjectWorkRecord,
+  MaterializationLinkScopeRevision,
   MaterializationLinkScopeState,
   MaterializationLinkState,
   MaterializationObjectExistence,

--- a/packages/core/src/storage/ontology/materializations.ts
+++ b/packages/core/src/storage/ontology/materializations.ts
@@ -77,17 +77,22 @@ export interface MaterializationLinkState {
   readonly effective: EffectiveLinkSnapshot | null
 }
 
-export interface MaterializationLinkScopeState {
+/** Revision of the complete effective `(source, linkId)` member set, for either cardinality. */
+export interface MaterializationLinkScopeRevision {
   readonly source: OntologyObjectRef
   readonly linkId: string
+  readonly effectiveCount: number
+  readonly fingerprint: string
+}
+
+/** Cardinality-one slot state used while resolving managed and projected authority. */
+export interface MaterializationLinkScopeState extends MaterializationLinkScopeRevision {
   /** Complete active source value for the link slot. */
   readonly sourceAssertion: StoredSourceLinkAssertion | null
   /** Managed slot authority; absence delegates to source authority. */
   readonly override: StoredLinkSlotOverride | null
   /** The single effective edge, if its endpoints are effective. */
   readonly effective: EffectiveLinkSnapshot | null
-  readonly effectiveCount: number
-  readonly fingerprint: string
 }
 
 export interface MaterializationStatePage {

--- a/packages/core/src/storage/ontology/provider.ts
+++ b/packages/core/src/storage/ontology/provider.ts
@@ -14,7 +14,7 @@ import type { OntologyCommitOriginSelector, OntologyCommitWrite } from "./commit
 import type {
   FinalizeMaterializationInput,
   MaterializationEventWorkRecord,
-  MaterializationLinkScopeState,
+  MaterializationLinkScopeRevision,
   MaterializationPlanChunk,
   MaterializationPlanHeader,
   MaterializationPlanWorkItem,
@@ -99,7 +99,7 @@ export function appendScopeSnapshot(
 
 export function finishScopeAccumulator(
   accumulator: LinkScopeAccumulator
-): Pick<MaterializationLinkScopeState, "source" | "linkId" | "effectiveCount" | "fingerprint"> {
+): MaterializationLinkScopeRevision {
   accumulator.hash.update("]")
   return {
     source: accumulator.source,

--- a/packages/core/src/testing/materializer-storage-contract.ts
+++ b/packages/core/src/testing/materializer-storage-contract.ts
@@ -15,6 +15,7 @@ import { restoreTrustedPrimitiveExecutionScope } from "../execution/durable"
 import { createTestingScope } from "../execution/scopes"
 import type { OntologyMaterializer } from "../materializer"
 import {
+  createLinkScopeFingerprint,
   createOntologyMaterializer,
   type OntologyEditOperation,
   ProjectionRegistry,
@@ -42,7 +43,7 @@ const Device = defineObjectType({
     prop("name", "string", { required: true }),
     prop("temperature", "double", { mode: "telemetry" }),
   ],
-  links: [link.self("parent", { cardinality: "one" })],
+  links: [link.self("parent", { cardinality: "one" }), link.self("peers", { cardinality: "many" })],
 })
 
 const devices = defineDataset("storage_contract_devices", {
@@ -54,6 +55,9 @@ const devices = defineDataset("storage_contract_devices", {
 })
 const readings = defineDataset("storage_contract_readings", {
   schema: [col("device_id", "string"), col("at", "timestamp"), col("value", "float64")],
+})
+const devicePeers = defineDataset("storage_contract_device_peers", {
+  schema: [col("source_id", "string"), col("target_id", "string")],
 })
 const ConflictDevice = defineObjectType({
   id: "StorageContractConflictDevice",
@@ -88,6 +92,10 @@ const temperatureProjection = defineProjection(
 )
   .fromDataset(readings)
   .points({ objectId: "device_id", at: "at", value: "value" })
+const devicePeersProjection = defineProjection("storage_contract_device_peers", Device.l.peers)
+  .fromDataset(devicePeers)
+  .sourceField("source_id")
+  .targetField("target_id")
 const conflictDeviceProjection = defineProjection(
   "storage_contract_conflict_devices",
   ConflictDevice
@@ -98,11 +106,17 @@ const conflictDeviceProjection = defineProjection(
 
 const ontology = new OntologyRegistry({ sources: [Device, ConflictDevice] })
 const projections = new ProjectionRegistry({
-  projections: [deviceProjection, temperatureProjection, conflictDeviceProjection],
+  projections: [
+    deviceProjection,
+    temperatureProjection,
+    devicePeersProjection,
+    conflictDeviceProjection,
+  ],
   ontology,
   datasetsById: new Map<string, DatasetDefinition>([
     [devices.id, devices],
     [readings.id, readings],
+    [devicePeers.id, devicePeers],
     [conflictDevices.id, conflictDevices],
   ]),
 })
@@ -557,6 +571,160 @@ export function runMaterializerStorageContractSuite<TStorage extends Storage>(
         ref: linkRef("haverstraw"),
       })
       expect(await targets()).toEqual(["rockland"])
+    } finally {
+      await provider.cleanup?.(createdStorage)
+    }
+  })
+
+  test(`${name} fences projected cardinality-many link scopes by fingerprint`, async () => {
+    const createdStorage = await provider.createStorage()
+    const storage = requireContractStorage(createdStorage)
+    let materializationOrdinal = 0
+    const materializer = createOntologyMaterializer({
+      projectId: "materializer-storage-contract",
+      ontology,
+      projections,
+      storage,
+      dependencies: {
+        batching: { sourceStageRows: 1, statePageRows: 1, planChunkRows: 1 },
+        clock: () => new Date("2026-02-01T12:00:00.000Z"),
+        materializationId: () => `many-scope-contract-candidate-${++materializationOrdinal}`,
+      },
+    })
+    const runtimeMaterializer = materializer.withScope(runtimeScope())
+    const source = { objectTypeId: Device.id, primaryId: "source" }
+    const peer = (primaryId: string) => ({ objectTypeId: Device.id, primaryId })
+    const linkRef = (targetId: string) => ({
+      source,
+      linkId: "peers",
+      target: peer(targetId),
+    })
+
+    try {
+      await runtimeMaterializer.edits.commit({
+        mode: "atomic",
+        source: { kind: "runtime", requestId: "many-scope-endpoints" },
+        operations: ["source", "peer-a", "peer-b", "peer-c"].map((primaryId) => ({
+          id: `create-${primaryId}`,
+          kind: "object.create" as const,
+          ref: peer(primaryId),
+          properties: { name: primaryId },
+        })),
+        expectedObjects: [],
+        expectedLinks: [],
+        expectedLinkScopes: [],
+      })
+
+      const datasetVersion = {
+        datasetId: devicePeers.id,
+        versionId: "many-links-v1",
+        createdAt: "2026-02-01T00:00:00.000Z",
+      }
+      const execution = await claim(storage, {
+        runId: "many-links-v1",
+        projectionId: devicePeersProjection.id,
+        protocol: "replacement",
+        datasetVersion,
+      })
+      const projectedLinks = [linkRef("peer-a"), linkRef("peer-b")]
+      await (
+        await projectionMaterializer(
+          materializer,
+          storage,
+          devicePeersProjection.id,
+          "many-links-v1"
+        )
+      ).projections.replace({
+        source: { projectionId: devicePeersProjection.id },
+        datasetVersion,
+        execution,
+        entries: entries(
+          projectedLinks.map((ref) => ({
+            root: { kind: "link", ref },
+            assertions: [{ kind: "link", ref }],
+          }))
+        ),
+      })
+
+      const observedLinks = await storage.objects.listLinks({
+        projectId: "materializer-storage-contract",
+        objectTypeId: Device.id,
+        objectId: source.primaryId,
+        linkId: "peers",
+      })
+      const fingerprint = createLinkScopeFingerprint(
+        observedLinks.map((row) => {
+          if (row.lastCommitId === undefined) {
+            throw new Error("Projected contract link is missing materializer provenance.")
+          }
+          return {
+            ref: linkRef(row.targetId),
+            createdAt: row.createdAt.toISOString(),
+            updatedAt: row.updatedAt.toISOString(),
+            lastCommitId: row.lastCommitId,
+          }
+        })
+      )
+      const commitObservation = async (runId: string, name: string) => {
+        await queueTestActionRun(storage, {
+          id: runId,
+          projectId: "materializer-storage-contract",
+          actionId: "observePeers",
+          subject: { kind: "object", objectTypeId: Device.id, primaryId: source.primaryId },
+          params: {},
+          idempotencyKey: runId,
+        })
+        await storage.actionRuns.start({ id: runId, projectId: "materializer-storage-contract" })
+        const actionMaterializer = await primitiveMaterializer(materializer, storage, {
+          kind: "action",
+          id: "observePeers",
+          runId,
+        })
+        return actionMaterializer.edits.commit({
+          mode: "atomic",
+          source: { kind: "action", actionId: "observePeers", runId },
+          operations: [
+            {
+              id: `record-${runId}`,
+              kind: "object.patch",
+              ref: source,
+              set: { name },
+              unset: [],
+              reset: [],
+            },
+          ],
+          expectedObjects: [],
+          expectedLinks: [],
+          expectedLinkScopes: [{ source, linkId: "peers", fingerprint }],
+        })
+      }
+
+      // Regression guard for G-021: make begin() hydrate the expected scope through the
+      // cardinality-one slot reader again and this otherwise unrelated Action commit fails before
+      // its already-stable fingerprint can be compared.
+      await expect(commitObservation("many-scope-action", "observed peers")).resolves.toMatchObject(
+        { kind: "edit", created: true }
+      )
+
+      await runtimeMaterializer.edits.commit({
+        mode: "atomic",
+        source: { kind: "runtime", requestId: "many-scope-change" },
+        operations: [{ id: "add-peer", kind: "link.upsert", ref: linkRef("peer-c") }],
+        expectedObjects: [],
+        expectedLinks: [],
+        expectedLinkScopes: [],
+      })
+
+      await expect(commitObservation("stale-many-scope-action", "must not commit")).rejects.toThrow(
+        "Expected link scope changed"
+      )
+      expect(
+        await storage.objects.getByPrimaryId({
+          projectId: "materializer-storage-contract",
+          objectTypeId: Device.id,
+          primaryId: source.primaryId,
+        })
+      ).toMatchObject({ properties: { name: "observed peers" } })
     } finally {
       await provider.cleanup?.(createdStorage)
     }

--- a/storage/pg/src/ontology-storage/materialization-state.ts
+++ b/storage/pg/src/ontology-storage/materialization-state.ts
@@ -22,6 +22,7 @@ import {
   startScopeAccumulator,
 } from "@sixb/core/internal/ontology-storage-provider"
 import type {
+  MaterializationLinkScopeRevision,
   MaterializationLinkScopeState,
   MaterializationLinkState,
   MaterializationObjectState,
@@ -407,7 +408,14 @@ export class PgMaterializationStateReader {
     })
   }
 
-  async linkScopes(
+  async linkScopeRevisions(
+    scopes: readonly { readonly source: OntologyObjectRef; readonly linkId: string }[]
+  ): Promise<readonly MaterializationLinkScopeRevision[]> {
+    if (scopes.length === 0) return []
+    return (await this.readEffectiveLinkScopes(scopes)).revisions
+  }
+
+  async linkSlotStates(
     scopes: readonly { readonly source: OntologyObjectRef; readonly linkId: string }[]
   ): Promise<readonly MaterializationLinkScopeState[]> {
     if (scopes.length === 0) return []
@@ -417,12 +425,6 @@ export class PgMaterializationStateReader {
       source_id: source.primaryId,
       link_id: linkId,
     }))
-    const accumulators = new Map(
-      scopes.map(({ source, linkId }) => {
-        const key = linkScopeSortKey(source, linkId)
-        return [key, startScopeAccumulator(source, linkId)] as const
-      })
-    )
     const requestedParameter = jsonParameter(this.sql, requested)
     const [sourceRows, slotOverrideRows] = await Promise.all([
       this.sql<PgOntologySourceAssertionRow[]>`
@@ -470,6 +472,37 @@ export class PgMaterializationStateReader {
         return [linkScopeSortKey(stored.ref.source, stored.ref.linkId), stored] as const
       })
     )
+    const { revisions, effective } = await this.readEffectiveLinkScopes(scopes)
+    return scopes.map(({ source, linkId }, index) => {
+      const key = linkScopeSortKey(source, linkId)
+      return {
+        ...revisions[index]!,
+        sourceAssertion: sources.get(key) ?? null,
+        override: overrides.get(key) ?? null,
+        effective: effective.get(key) ?? null,
+      }
+    })
+  }
+
+  private async readEffectiveLinkScopes(
+    scopes: readonly { readonly source: OntologyObjectRef; readonly linkId: string }[]
+  ): Promise<{
+    readonly revisions: readonly MaterializationLinkScopeRevision[]
+    readonly effective: ReadonlyMap<string, EffectiveLinkSnapshot | null>
+  }> {
+    const requested = scopes.map(({ source, linkId }) => ({
+      scope_sort_key: linkScopeSortKey(source, linkId),
+      source_type_id: source.objectTypeId,
+      source_id: source.primaryId,
+      link_id: linkId,
+    }))
+    const requestedParameter = jsonParameter(this.sql, requested)
+    const accumulators = new Map(
+      scopes.map(({ source, linkId }) => {
+        const key = linkScopeSortKey(source, linkId)
+        return [key, startScopeAccumulator(source, linkId)] as const
+      })
+    )
     const effective = new Map<string, EffectiveLinkSnapshot | null>()
     let scopeCursor: string | null = null
     let linkCursor: string | null = null
@@ -510,29 +543,12 @@ export class PgMaterializationStateReader {
       scopeCursor = last.scope_sort_key
       linkCursor = last.link_sort_key
     }
-    return scopes.map(({ source, linkId }) => {
-      const key = linkScopeSortKey(source, linkId)
-      return {
-        ...finishScopeAccumulator(accumulators.get(key)!),
-        sourceAssertion: sources.get(key) ?? null,
-        override: overrides.get(key) ?? null,
-        effective: effective.get(key) ?? null,
-      }
-    })
-  }
-
-  async linkScope(
-    source: OntologyObjectRef,
-    linkId: string
-  ): Promise<MaterializationLinkScopeState> {
-    const [scope] = await this.linkScopes([{ source, linkId }])
-    if (!scope) {
-      throw new MaterializationConflictError(
-        "effective-state",
-        "Link scope lookup returned no row."
-      )
+    return {
+      revisions: scopes.map(({ source, linkId }) =>
+        finishScopeAccumulator(accumulators.get(linkScopeSortKey(source, linkId))!)
+      ),
+      effective,
     }
-    return scope
   }
 
   async *incidentLinks(

--- a/storage/pg/src/ontology-storage/materializations.ts
+++ b/storage/pg/src/ontology-storage/materializations.ts
@@ -121,9 +121,9 @@ export class PgOntologyMaterializationStorage implements OntologyMaterialization
       for (const expected of input.expected.links) {
         this.assertLink(linkRevisions.get(linkRefKey(expected.ref)), expected)
       }
-      const linkScopes = await reader.linkScopes(input.expected.linkScopes)
+      const linkScopeRevisions = await reader.linkScopeRevisions(input.expected.linkScopes)
       for (const [index, expected] of input.expected.linkScopes.entries()) {
-        if (linkScopes[index]?.fingerprint !== expected.fingerprint) {
+        if (linkScopeRevisions[index]?.fingerprint !== expected.fingerprint) {
           throw new MaterializationConflictError(
             "effective-state",
             `Expected link scope changed for ${expected.source.objectTypeId}:${expected.source.primaryId}.${expected.linkId}.`
@@ -191,7 +191,7 @@ export class PgOntologyMaterializationStorage implements OntologyMaterialization
         yield {
           objects: [],
           links: [],
-          linkScopes: await reader.linkScopes(scopes.slice(offset, offset + input.pageRows)),
+          linkScopes: await reader.linkSlotStates(scopes.slice(offset, offset + input.pageRows)),
           points: [],
         }
       }

--- a/storage/sqlite/src/ontology-storage/materialization-state.ts
+++ b/storage/sqlite/src/ontology-storage/materialization-state.ts
@@ -22,6 +22,7 @@ import {
   startScopeAccumulator,
 } from "@sixb/core/internal/ontology-storage-provider"
 import type {
+  MaterializationLinkScopeRevision,
   MaterializationLinkScopeState,
   MaterializationLinkState,
   MaterializationObjectState,
@@ -81,6 +82,19 @@ interface TelemetryRow {
 
 interface LinkScopeRow extends EffectiveLinkRow {
   readonly scope_sort_key: string
+}
+
+function linkScopeRequestJson(
+  scopes: readonly { readonly source: OntologyObjectRef; readonly linkId: string }[]
+): string {
+  return canonicalJson(
+    scopes.map(({ source, linkId }) => ({
+      scopeSortKey: linkScopeSortKey(source, linkId),
+      sourceTypeId: source.objectTypeId,
+      sourceId: source.primaryId,
+      linkId,
+    }))
+  )
 }
 
 interface ObjectOverrideRow extends SqliteStoredOverrideRow {
@@ -426,23 +440,18 @@ export class SqliteMaterializationStateReader {
     })
   }
 
-  linkScopes(
+  linkScopeRevisions(
+    scopes: readonly { readonly source: OntologyObjectRef; readonly linkId: string }[]
+  ): readonly MaterializationLinkScopeRevision[] {
+    if (scopes.length === 0) return []
+    return this.readEffectiveLinkScopes(scopes, linkScopeRequestJson(scopes)).revisions
+  }
+
+  linkSlotStates(
     scopes: readonly { readonly source: OntologyObjectRef; readonly linkId: string }[]
   ): readonly MaterializationLinkScopeState[] {
     if (scopes.length === 0) return []
-    const requested = scopes.map(({ source, linkId }) => ({
-      scopeSortKey: linkScopeSortKey(source, linkId),
-      sourceTypeId: source.objectTypeId,
-      sourceId: source.primaryId,
-      linkId,
-    }))
-    const accumulators = new Map(
-      scopes.map(({ source, linkId }) => {
-        const key = linkScopeSortKey(source, linkId)
-        return [key, startScopeAccumulator(source, linkId)] as const
-      })
-    )
-    const requestedJson = canonicalJson(requested)
+    const requestedJson = linkScopeRequestJson(scopes)
     const sourceRows = this.db
       .query(
         `WITH requested AS (
@@ -491,6 +500,31 @@ export class SqliteMaterializationStateReader {
         return [linkScopeSortKey(stored.ref.source, stored.ref.linkId), stored] as const
       })
     )
+    const { revisions, effective } = this.readEffectiveLinkScopes(scopes, requestedJson)
+    return scopes.map(({ source, linkId }, index) => {
+      const key = linkScopeSortKey(source, linkId)
+      return {
+        ...revisions[index]!,
+        sourceAssertion: sources.get(key) ?? null,
+        override: overrides.get(key) ?? null,
+        effective: effective.get(key) ?? null,
+      }
+    })
+  }
+
+  private readEffectiveLinkScopes(
+    scopes: readonly { readonly source: OntologyObjectRef; readonly linkId: string }[],
+    requestedJson: string
+  ): {
+    readonly revisions: readonly MaterializationLinkScopeRevision[]
+    readonly effective: ReadonlyMap<string, EffectiveLinkSnapshot | null>
+  } {
+    const accumulators = new Map(
+      scopes.map(({ source, linkId }) => {
+        const key = linkScopeSortKey(source, linkId)
+        return [key, startScopeAccumulator(source, linkId)] as const
+      })
+    )
     const effective = new Map<string, EffectiveLinkSnapshot | null>()
     const rows = this.db
       .query(
@@ -526,26 +560,12 @@ export class SqliteMaterializationStateReader {
       appendScopeSnapshot(accumulator, snapshot)
       effective.set(row.scope_sort_key, accumulator.effectiveCount === 1 ? snapshot : null)
     }
-    return scopes.map(({ source, linkId }) => {
-      const key = linkScopeSortKey(source, linkId)
-      return {
-        ...finishScopeAccumulator(accumulators.get(key)!),
-        sourceAssertion: sources.get(key) ?? null,
-        override: overrides.get(key) ?? null,
-        effective: effective.get(key) ?? null,
-      }
-    })
-  }
-
-  linkScope(source: OntologyObjectRef, linkId: string): MaterializationLinkScopeState {
-    const [scope] = this.linkScopes([{ source, linkId }])
-    if (!scope) {
-      throw new MaterializationConflictError(
-        "effective-state",
-        "Link scope lookup returned no row."
-      )
+    return {
+      revisions: scopes.map(({ source, linkId }) =>
+        finishScopeAccumulator(accumulators.get(linkScopeSortKey(source, linkId))!)
+      ),
+      effective,
     }
-    return scope
   }
 
   *incidentLinks(

--- a/storage/sqlite/src/ontology-storage/materializations.ts
+++ b/storage/sqlite/src/ontology-storage/materializations.ts
@@ -88,10 +88,9 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
         this.assertSource(expected, input.commit.projectId)
       for (const expected of input.expected.objects) this.assertObject(reader, expected)
       for (const expected of input.expected.links) this.assertLink(reader, expected)
-      for (const expected of input.expected.linkScopes) {
-        if (
-          reader.linkScope(expected.source, expected.linkId).fingerprint !== expected.fingerprint
-        ) {
+      const linkScopeRevisions = reader.linkScopeRevisions(input.expected.linkScopes)
+      for (const [index, expected] of input.expected.linkScopes.entries()) {
+        if (linkScopeRevisions[index]?.fingerprint !== expected.fingerprint) {
           throw new MaterializationConflictError(
             "effective-state",
             `Expected link scope changed for ${expected.source.objectTypeId}:${expected.source.primaryId}.${expected.linkId}.`
@@ -151,7 +150,7 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
         yield {
           objects: [],
           links: [],
-          linkScopes: reader.linkScopes(scopes.slice(offset, offset + input.pageRows)),
+          linkScopes: reader.linkSlotStates(scopes.slice(offset, offset + input.pageRows)),
           points: [],
         }
       }

--- a/storage/sqlite/tests/sqlite-materialization-query-plan.test.ts
+++ b/storage/sqlite/tests/sqlite-materialization-query-plan.test.ts
@@ -105,7 +105,7 @@ describe("SQLite materialization query plans", () => {
     })
   })
 
-  test("point and link-scope batches use their complete lookup keys", () => {
+  test("point and link-scope revision batches use their complete lookup keys", () => {
     withRecordedReader(({ db, reader, recorded }) => {
       reader.exactPoints([
         {
@@ -113,7 +113,7 @@ describe("SQLite materialization query plans", () => {
           at: "2026-08-06T00:00:00.000Z",
         },
       ])
-      reader.linkScopes([{ source: objectRef, linkId: "timecards" }])
+      reader.linkScopeRevisions([{ source: objectRef, linkId: "timecards" }])
 
       expectRequestedFirstLookup(
         db,


### PR DESCRIPTION
## Problem

Actions fence every link scope they read by storing its fingerprint.

```text
Question
└── sources
    ├── Passage A
    ├── Passage B
    └── Passage C
```

In 0.1.4, commit validation loaded this scope through the cardinality-one slot reader:

```text
many edges → one-slot state → false cardinality conflict → commit rejected
```

This resolves framework gap G-021.

## Fix

```text
Before: one state did two jobs

After:
scope revision (one or many) → optimistic commit fence
slot state     (one only)    → authority and override resolution
```

- Add `MaterializationLinkScopeRevision` for count and fingerprint checks.
- Use revision-only readers during Action commit validation.
- Keep the richer slot state restricted to cardinality-one materialization.
- Apply the same separation to in-memory, SQLite, and PostgreSQL storage.

## Guarantees

- An unchanged multi-link scope can commit.
- A real scope change still raises `MaterializationConflictError` before any mutation.
- Cardinality-one authority behavior remains unchanged.

## Validation

- Shared storage contract covers stable and stale cardinality-many scopes.
- 4,630 unit tests passed.
- Typecheck, build, and Biome checks passed.