### PR TITLE
agent-ui: support host document preview renderers

### DIFF
--- a/packages/agent-ui/README.md
+++ b/packages/agent-ui/README.md
@@ -127,5 +127,4 @@ const workbookPreviewRenderer = {
 
 The first matching host renderer handles the document, including formats with a built-in viewer.
 Built-in viewers are the fallback. Keep `supports` synchronous and metadata-only. A renderer
-component may come from a private package; only the host application that registers it needs that
-dependency.
+implementation remains owned and explicitly registered by the host application.

--- a/packages/agent-ui/README.md
+++ b/packages/agent-ui/README.md
@@ -101,3 +101,31 @@ existing open/download behavior.
 
 Preview tabs support Left/Right Arrow, Home, End, Delete, and Backspace. Closing the final document
 returns focus to the attachment that opened the viewer.
+
+### Host-provided document viewers
+
+An application can add viewers for other formats without adding those implementations to this public
+package. `agent-ui` keeps responsibility for the authenticated download, cache, loading and error
+states, size limit, preview shell, and renderer isolation. The supplied component receives the
+durable file metadata and its `Blob`:
+
+```tsx
+import { lazy } from "react"
+import { AgentPanel, type AgentDocumentPreviewRenderer } from "@sixb/agent-ui"
+
+const workbookPreviewRenderer = {
+  id: "workbook-preview",
+  maxFileSizeBytes: 25 * 1024 * 1024,
+  supports: (file) =>
+    file.mediaType === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
+    file.fileName?.toLowerCase().endsWith(".xlsx") === true,
+  component: lazy(() => import("./WorkbookPreview")),
+} satisfies AgentDocumentPreviewRenderer
+
+<AgentPanel agentId="analyst" documentPreviewRenderers={[workbookPreviewRenderer]} />
+```
+
+The first matching host renderer handles the document, including formats with a built-in viewer.
+Built-in viewers are the fallback. Keep `supports` synchronous and metadata-only. A renderer
+component may come from a private package; only the host application that registers it needs that
+dependency.

--- a/packages/agent-ui/src/AgentChat.tsx
+++ b/packages/agent-ui/src/AgentChat.tsx
@@ -15,6 +15,7 @@ import { AgentsHome } from "./components/AgentsHome"
 import { ConversationPanel } from "./components/ConversationPanel"
 import { ThreadSidebar } from "./components/ThreadSidebar"
 import { DocumentPreviewRoot } from "./document-preview/DocumentPreviewRoot"
+import type { AgentDocumentPreviewRenderer } from "./document-preview/types"
 import { useAgentConversation } from "./hooks/useAgentConversation"
 import type { Agent, AgentContextInput } from "./types"
 
@@ -39,6 +40,8 @@ export interface AgentChatProps {
   readonly sidebarFooter?: ReactNode
   /** Desktop workspace sidebar width. Mobile keeps its responsive sheet width. */
   readonly sidebarWidth?: CSSProperties["width"]
+  /** Additional file viewers supplied by the host application. */
+  readonly documentPreviewRenderers?: readonly AgentDocumentPreviewRenderer[]
 }
 
 /** Route-independent conversation view; routing and embedded panels only adapt its callbacks. */
@@ -57,6 +60,7 @@ export function AgentChat({
   sidebarHeader,
   sidebarFooter,
   sidebarWidth,
+  documentPreviewRenderers,
 }: AgentChatProps) {
   const threadId = threadIdInput ?? null
   const conversation = useAgentConversation({
@@ -260,6 +264,7 @@ export function AgentChat({
       compact={compact}
       scopeKey={threadId ?? (draftAgentIdInput ? `draft:${draftAgentIdInput}` : "home")}
       persistenceKey={threadId}
+      documentPreviewRenderers={documentPreviewRenderers}
     >
       <div
         data-agent-panel={compact ? "" : undefined}

--- a/packages/agent-ui/src/AgentPanel.tsx
+++ b/packages/agent-ui/src/AgentPanel.tsx
@@ -3,6 +3,7 @@ import { cn } from "@sixb/ui/lib/utils"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { AgentChat } from "./AgentChat"
 import { useRegisteredAgentContext } from "./AgentContextProvider"
+import type { AgentDocumentPreviewRenderer } from "./document-preview/types"
 
 export interface AgentPanelProps {
   readonly agentId: string
@@ -13,6 +14,8 @@ export interface AgentPanelProps {
   readonly defaultThreadId?: string | null
   readonly onThreadChange?: (threadId: string | null) => void
   readonly className?: string
+  /** Additional file viewers supplied by the host application. */
+  readonly documentPreviewRenderers?: readonly AgentDocumentPreviewRenderer[]
 }
 
 /** Embeddable chat that never reads or changes the host application's route. */
@@ -23,6 +26,7 @@ export function AgentPanel({
   defaultThreadId = null,
   onThreadChange,
   className,
+  documentPreviewRenderers,
 }: AgentPanelProps) {
   const registeredContext = useRegisteredAgentContext()
   const ambientContext = context === undefined ? registeredContext : context
@@ -60,6 +64,7 @@ export function AgentPanel({
       onNavigateHome={() => changeThread(null)}
       onNavigateDraft={() => changeThread(null)}
       onNavigateThread={changeThread}
+      documentPreviewRenderers={documentPreviewRenderers}
       className={cn("min-h-0 overflow-hidden bg-background", className)}
     />
   )

--- a/packages/agent-ui/src/components/FileAttachmentCard.tsx
+++ b/packages/agent-ui/src/components/FileAttachmentCard.tsx
@@ -9,7 +9,7 @@ import {
 import { cn } from "@sixb/ui/lib/utils"
 import { File as FileIcon, FileImage, FileText, Table2 } from "lucide-react"
 import { useDocumentPreview } from "../document-preview/DocumentPreviewRoot"
-import { agentDocumentPreviewRenderer } from "../document-preview/rendering"
+import { formatFileSize } from "../document-preview/file-size"
 import type { AgentDocumentSource } from "../document-preview/types"
 import type { AgentFileRef } from "../types"
 
@@ -24,7 +24,7 @@ export function FileAttachmentCard({
 }) {
   const preview = useDocumentPreview()
   const fileName = fileRef.fileName?.trim() || "File"
-  const previewable = agentDocumentPreviewRenderer(document?.kind ?? null) !== null
+  const previewable = document !== undefined && preview?.canPreview(document) === true
   const mediaLabel = fileMediaLabel(fileRef.mediaType, fileName)
   const { Icon, className: iconClassName } = fileIconPresentation(fileRef.mediaType, fileName)
 
@@ -87,21 +87,6 @@ function fileMediaLabel(mediaType: string | undefined, fileName: string): string
   if (normalized?.startsWith("text/")) return "Document"
   if (normalized) return normalized
   return "File"
-}
-
-function formatFileSize(sizeBytes: number): string {
-  if (!Number.isFinite(sizeBytes) || sizeBytes < 0) return "Unknown size"
-
-  const units = ["B", "KB", "MB", "GB", "TB"] as const
-  let value = sizeBytes
-  let unitIndex = 0
-  while (value >= 1024 && unitIndex < units.length - 1) {
-    value /= 1024
-    unitIndex += 1
-  }
-
-  const maximumFractionDigits = unitIndex === 0 || value >= 10 ? 0 : 1
-  return `${value.toLocaleString(undefined, { maximumFractionDigits })} ${units[unitIndex]}`
 }
 
 function fileIconPresentation(mediaType: string | undefined, fileName: string) {

--- a/packages/agent-ui/src/document-preview/DocumentPreviewRoot.tsx
+++ b/packages/agent-ui/src/document-preview/DocumentPreviewRoot.tsx
@@ -14,10 +14,12 @@ import { useIsMobile } from "@sixb/ui/hooks"
 import { cn } from "@sixb/ui/lib/utils"
 import { Download, ExternalLink, FileWarning, X } from "lucide-react"
 import {
+  Component,
   createContext,
   memo,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
+  Suspense,
   useCallback,
   useContext,
   useEffect,
@@ -27,8 +29,14 @@ import {
   useReducer,
   useRef,
 } from "react"
-import { useDelimitedTextDocument, useHtmlDocument, useMarkdownDocument } from "./content"
+import {
+  useCustomDocument,
+  useDelimitedTextDocument,
+  useHtmlDocument,
+  useMarkdownDocument,
+} from "./content"
 import { DelimitedTextParseError, type DelimitedTextPreview, parseDelimitedText } from "./delimited"
+import { formatFileSize } from "./file-size"
 import { buildSafeHtmlPreviewDocument, HTML_PREVIEW_SANDBOX } from "./html"
 import {
   documentPreviewStorageKey,
@@ -37,7 +45,7 @@ import {
   writeDocumentPreviewState,
 } from "./persistence"
 import { documentPreviewPresentation } from "./presentation"
-import { agentDocumentPreviewRenderer } from "./rendering"
+import { resolveAgentDocumentPreview } from "./rendering"
 import {
   type DocumentPreviewState,
   type DocumentTabNavigationKey,
@@ -45,9 +53,10 @@ import {
   documentTabIdAfterKey,
   EMPTY_DOCUMENT_PREVIEW_STATE,
 } from "./state"
-import type { AgentDocumentSource } from "./types"
+import type { AgentDocumentPreviewRenderer, AgentDocumentSource } from "./types"
 
 interface DocumentPreviewContextValue {
+  readonly canPreview: (document: AgentDocumentSource) => boolean
   readonly openDocument: (document: AgentDocumentSource) => void
 }
 
@@ -57,6 +66,7 @@ interface DocumentViewerProps {
   readonly onSelect: (id: string) => void
   readonly onClose: (id: string) => void
   readonly onCloseAll: () => void
+  readonly renderers: readonly AgentDocumentPreviewRenderer[]
 }
 
 interface PreviewPanelHandle {
@@ -68,12 +78,14 @@ interface PreviewPanelHandle {
 }
 
 const DocumentPreviewContext = createContext<DocumentPreviewContextValue | null>(null)
+const NO_CUSTOM_RENDERERS: readonly AgentDocumentPreviewRenderer[] = []
 
 export function DocumentPreviewRoot({
   children,
   compact = false,
   scopeKey,
   persistenceKey,
+  documentPreviewRenderers = NO_CUSTOM_RENDERERS,
 }: {
   readonly children: ReactNode
   readonly compact?: boolean
@@ -81,6 +93,8 @@ export function DocumentPreviewRoot({
   readonly scopeKey?: string | null
   /** Persist open tabs, the active document, and panel width for a durable thread. */
   readonly persistenceKey?: string | null
+  /** Viewers supplied by the host. The first match overrides the built-in viewer. */
+  readonly documentPreviewRenderers?: readonly AgentDocumentPreviewRenderer[]
 }) {
   const idPrefix = useId()
   const previewScopeKey = persistenceKey ? `thread:${persistenceKey}` : `scope:${scopeKey ?? ""}`
@@ -163,7 +177,15 @@ export function DocumentPreviewRoot({
     (width: number) => dispatch({ type: "set-panel-width", width }),
     []
   )
-  const context = useMemo<DocumentPreviewContextValue>(() => ({ openDocument }), [openDocument])
+  const canPreview = useCallback(
+    (document: AgentDocumentSource) =>
+      resolveAgentDocumentPreview(document, documentPreviewRenderers) !== null,
+    [documentPreviewRenderers]
+  )
+  const context = useMemo<DocumentPreviewContextValue>(
+    () => ({ canPreview, openDocument }),
+    [canPreview, openDocument]
+  )
   const viewerProps = useMemo<DocumentViewerProps>(
     () => ({
       idPrefix,
@@ -171,8 +193,16 @@ export function DocumentPreviewRoot({
       onSelect: selectDocument,
       onClose: closeDocument,
       onCloseAll: closeAllDocuments,
+      renderers: documentPreviewRenderers,
     }),
-    [closeAllDocuments, closeDocument, idPrefix, selectDocument, visibleState]
+    [
+      closeAllDocuments,
+      closeDocument,
+      documentPreviewRenderers,
+      idPrefix,
+      selectDocument,
+      visibleState,
+    ]
   )
 
   return (
@@ -352,6 +382,7 @@ function DocumentViewer({
   onSelect,
   onClose,
   onCloseAll,
+  renderers,
   showActionLabels,
   focusActiveTab,
 }: DocumentViewerProps & {
@@ -381,7 +412,7 @@ function DocumentViewer({
           aria-labelledby={documentTabDomId(idPrefix, activeDocument.id)}
           className="flex min-h-0 flex-1 flex-col"
         >
-          <DocumentContent document={activeDocument} />
+          <DocumentContent document={activeDocument} renderers={renderers} />
         </div>
       ) : null}
     </>
@@ -546,13 +577,24 @@ function DocumentTabs({
   )
 }
 
-function DocumentContent({ document }: { document: AgentDocumentSource }) {
-  const renderer = agentDocumentPreviewRenderer(document.kind)
-  if (renderer === "markdown") return <MarkdownDocument document={document} />
-  if (renderer === "html-static") return <HtmlDocument document={document} />
-  if (renderer === "delimited-text") return <DelimitedTextDocument document={document} />
-  if (renderer === "pdf-native") return <PdfDocument document={document} />
-  if (renderer === "image-native") return <ImageDocument document={document} />
+function DocumentContent({
+  document,
+  renderers,
+}: {
+  readonly document: AgentDocumentSource
+  readonly renderers: readonly AgentDocumentPreviewRenderer[]
+}) {
+  const resolution = resolveAgentDocumentPreview(document, renderers)
+  if (resolution?.type === "custom") {
+    return <CustomDocument document={document} renderer={resolution.renderer} />
+  }
+  if (resolution?.renderer === "markdown") return <MarkdownDocument document={document} />
+  if (resolution?.renderer === "html-static") return <HtmlDocument document={document} />
+  if (resolution?.renderer === "delimited-text") {
+    return <DelimitedTextDocument document={document} />
+  }
+  if (resolution?.renderer === "pdf-native") return <PdfDocument document={document} />
+  if (resolution?.renderer === "image-native") return <ImageDocument document={document} />
 
   return (
     <DocumentNotice
@@ -560,6 +602,73 @@ function DocumentContent({ document }: { document: AgentDocumentSource }) {
       description="This file type is not available in the document viewer yet."
     />
   )
+}
+
+function CustomDocument({
+  document,
+  renderer,
+}: {
+  readonly document: AgentDocumentSource
+  readonly renderer: AgentDocumentPreviewRenderer
+}) {
+  const preview = useCustomDocument(document, renderer.maxFileSizeBytes)
+
+  if (preview.tooLarge) {
+    return (
+      <DocumentNotice
+        title="Document is too large to preview"
+        description={`This viewer accepts files up to ${formatFileSize(renderer.maxFileSizeBytes)}. Download the file to view it elsewhere.`}
+      />
+    )
+  }
+  if (preview.loading) return <DocumentLoading />
+  if (preview.error || !preview.source) {
+    return (
+      <DocumentNotice
+        title="Could not preview document"
+        description={preview.error ?? "The document content was unavailable."}
+      />
+    )
+  }
+
+  const Renderer = renderer.component
+  return (
+    <DocumentRendererBoundary key={`${renderer.id}:${document.id}`} rendererId={renderer.id}>
+      <Suspense fallback={<DocumentLoading />}>
+        <Renderer file={document.fileRef} source={preview.source} />
+      </Suspense>
+    </DocumentRendererBoundary>
+  )
+}
+
+class DocumentRendererBoundary extends Component<
+  { readonly children: ReactNode; readonly rendererId: string },
+  { readonly failed: boolean }
+> {
+  state = { failed: false }
+
+  static getDerivedStateFromError() {
+    return { failed: true }
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error(
+      `[SixbAgentUI] Document preview renderer '${this.props.rendererId}' failed.`,
+      error
+    )
+  }
+
+  render() {
+    if (this.state.failed) {
+      return (
+        <DocumentNotice
+          title="Could not preview document"
+          description="The configured document viewer could not render this file."
+        />
+      )
+    }
+    return this.props.children
+  }
 }
 
 function ImageDocument({ document }: { document: AgentDocumentSource }) {

--- a/packages/agent-ui/src/document-preview/content-policy.ts
+++ b/packages/agent-ui/src/document-preview/content-policy.ts
@@ -16,6 +16,15 @@ export function markdownPreviewTooLarge(source: AgentDocumentSource): boolean {
   return textPreviewTooLarge(source)
 }
 
+export function customPreviewTooLarge(
+  source: AgentDocumentSource,
+  maxFileSizeBytes: number
+): boolean {
+  if (!Number.isFinite(maxFileSizeBytes) || maxFileSizeBytes <= 0) return true
+  if (!Number.isFinite(source.fileRef.sizeBytes) || source.fileRef.sizeBytes < 0) return true
+  return source.fileRef.sizeBytes > maxFileSizeBytes
+}
+
 export function documentLoadError(error: unknown): string {
   if (isSixbApiError(error)) {
     if (error.status === 404) return "This document is no longer available."

--- a/packages/agent-ui/src/document-preview/content.ts
+++ b/packages/agent-ui/src/document-preview/content.ts
@@ -1,6 +1,6 @@
 import { getAgentMessageFileContent } from "@sixb/client"
 import { useQuery } from "@tanstack/react-query"
-import { documentLoadError, textPreviewTooLarge } from "./content-policy"
+import { customPreviewTooLarge, documentLoadError, textPreviewTooLarge } from "./content-policy"
 import type { AgentDocumentSource } from "./types"
 
 export function useMarkdownDocument(source: AgentDocumentSource) {
@@ -24,6 +24,7 @@ function useTextDocument(source: AgentDocumentSource) {
       source.messageId,
       source.partIndex,
       source.fileRef.digest,
+      "text",
     ],
     enabled: !tooLarge,
     staleTime: Number.POSITIVE_INFINITY,
@@ -41,6 +42,39 @@ function useTextDocument(source: AgentDocumentSource) {
 
   return {
     text: query.data,
+    loading: query.isLoading,
+    error: query.error ? documentLoadError(query.error) : null,
+    tooLarge,
+  }
+}
+
+export function useCustomDocument(source: AgentDocumentSource, maxFileSizeBytes: number) {
+  const tooLarge = customPreviewTooLarge(source, maxFileSizeBytes)
+  const query = useQuery({
+    queryKey: [
+      "agent-document-preview",
+      source.threadId,
+      source.messageId,
+      source.partIndex,
+      source.fileRef.digest,
+      "blob",
+    ],
+    enabled: !tooLarge,
+    staleTime: Number.POSITIVE_INFINITY,
+    queryFn: async ({ signal }) => {
+      const response = await getAgentMessageFileContent({
+        path: { threadId: source.threadId, messageId: source.messageId },
+        query: { path: `/parts/${source.partIndex}/fileRef`, disposition: "inline" },
+        parseAs: "blob",
+        throwOnError: true,
+        signal,
+      })
+      return response.data
+    },
+  })
+
+  return {
+    source: query.data,
     loading: query.isLoading,
     error: query.error ? documentLoadError(query.error) : null,
     tooLarge,

--- a/packages/agent-ui/src/document-preview/file-size.ts
+++ b/packages/agent-ui/src/document-preview/file-size.ts
@@ -1,0 +1,14 @@
+export function formatFileSize(sizeBytes: number): string {
+  if (!Number.isFinite(sizeBytes) || sizeBytes < 0) return "Unknown size"
+
+  const units = ["B", "KB", "MB", "GB", "TB"] as const
+  let value = sizeBytes
+  let unitIndex = 0
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+
+  const maximumFractionDigits = unitIndex === 0 || value >= 10 ? 0 : 1
+  return `${value.toLocaleString(undefined, { maximumFractionDigits })} ${units[unitIndex]}`
+}

--- a/packages/agent-ui/src/document-preview/rendering.ts
+++ b/packages/agent-ui/src/document-preview/rendering.ts
@@ -1,20 +1,48 @@
-import type { AgentDocumentKind } from "./types"
+import type {
+  AgentDocumentKind,
+  AgentDocumentSource,
+  AgentDocumentPreviewRenderer as CustomDocumentPreviewRenderer,
+} from "./types"
 
-export type AgentDocumentPreviewRenderer =
+export type BuiltInDocumentPreviewRenderer =
   | "markdown"
   | "html-static"
   | "delimited-text"
   | "pdf-native"
   | "image-native"
 
+export type ResolvedAgentDocumentPreview =
+  | { readonly type: "built-in"; readonly renderer: BuiltInDocumentPreviewRenderer }
+  | { readonly type: "custom"; readonly renderer: CustomDocumentPreviewRenderer }
+
 /** Keep attachment click behavior and viewer dispatch on one supported-format decision. */
 export function agentDocumentPreviewRenderer(
   kind: AgentDocumentKind | null
-): AgentDocumentPreviewRenderer | null {
+): BuiltInDocumentPreviewRenderer | null {
   if (kind === "markdown") return "markdown"
   if (kind === "html") return "html-static"
   if (kind === "csv" || kind === "tsv") return "delimited-text"
   if (kind === "pdf") return "pdf-native"
   if (kind === "image") return "image-native"
   return null
+}
+
+/** The host may override any format; built-ins remain the fallback. */
+export function resolveAgentDocumentPreview(
+  document: AgentDocumentSource,
+  customRenderers: readonly CustomDocumentPreviewRenderer[]
+): ResolvedAgentDocumentPreview | null {
+  for (const renderer of customRenderers) {
+    try {
+      if (renderer.supports(document.fileRef)) return { type: "custom", renderer }
+    } catch (error) {
+      console.error(
+        `[SixbAgentUI] Document preview renderer '${renderer.id}' failed its capability check.`,
+        error
+      )
+    }
+  }
+
+  const builtIn = agentDocumentPreviewRenderer(document.kind)
+  return builtIn ? { type: "built-in", renderer: builtIn } : null
 }

--- a/packages/agent-ui/src/document-preview/types.ts
+++ b/packages/agent-ui/src/document-preview/types.ts
@@ -1,3 +1,4 @@
+import type { ComponentType } from "react"
 import type { AgentFileRef } from "../types"
 
 export type AgentDocumentKind = "markdown" | "html" | "csv" | "tsv" | "pdf" | "image"
@@ -12,4 +13,23 @@ export interface AgentDocumentSource {
   readonly partIndex: number
   readonly inlineUrl: string
   readonly downloadUrl: string
+}
+
+export interface AgentDocumentPreviewRendererProps {
+  /** Serializable metadata for the durable message file. */
+  readonly file: AgentFileRef
+  /** Content loaded through the configured Sixb client after the size policy succeeds. */
+  readonly source: Blob
+}
+
+/** Optional document viewer supplied by the host application. Registered viewers keep priority. */
+export interface AgentDocumentPreviewRenderer {
+  /** Stable diagnostic identity. */
+  readonly id: string
+  /** Maximum declared file size accepted before any content is downloaded. */
+  readonly maxFileSizeBytes: number
+  /** Metadata-only capability check. It must not fetch or parse the document. */
+  readonly supports: (file: AgentFileRef) => boolean
+  /** May be a React.lazy component; the preview surface provides its Suspense boundary. */
+  readonly component: ComponentType<AgentDocumentPreviewRendererProps>
 }

--- a/packages/agent-ui/src/index.ts
+++ b/packages/agent-ui/src/index.ts
@@ -8,3 +8,8 @@ export {
   type AgentExecutionTraceVariant,
 } from "./AgentExecutionTrace"
 export { AgentPanel, type AgentPanelProps } from "./AgentPanel"
+export type {
+  AgentDocumentPreviewRenderer,
+  AgentDocumentPreviewRendererProps,
+} from "./document-preview/types"
+export type { AgentFileRef } from "./types"

--- a/packages/agent-ui/src/react-router.tsx
+++ b/packages/agent-ui/src/react-router.tsx
@@ -3,6 +3,12 @@ import { useCallback } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { AgentChat, type AgentChatProps } from "./AgentChat"
 
+export type {
+  AgentDocumentPreviewRenderer,
+  AgentDocumentPreviewRendererProps,
+} from "./document-preview/types"
+export type { AgentFileRef } from "./types"
+
 export interface AgentChatPageProps
   extends Omit<
     AgentChatProps,

--- a/packages/agent-ui/tests/document-preview.test.ts
+++ b/packages/agent-ui/tests/document-preview.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import { SixbApiError } from "@sixb/client"
 import { agentDocumentKind } from "../src/document-preview/classify"
 import {
+  customPreviewTooLarge,
   documentLoadError,
   MAX_MARKDOWN_PREVIEW_BYTES,
   markdownPreviewTooLarge,
@@ -15,14 +16,20 @@ import {
 import { buildSafeHtmlPreviewDocument, HTML_PREVIEW_SANDBOX } from "../src/document-preview/html"
 import { parseDocumentPreviewState } from "../src/document-preview/persistence"
 import { documentPreviewPresentation } from "../src/document-preview/presentation"
-import { agentDocumentPreviewRenderer } from "../src/document-preview/rendering"
+import {
+  agentDocumentPreviewRenderer,
+  resolveAgentDocumentPreview,
+} from "../src/document-preview/rendering"
 import { createAgentDocumentSource } from "../src/document-preview/source"
 import {
   documentPreviewReducer,
   documentTabIdAfterKey,
   EMPTY_DOCUMENT_PREVIEW_STATE,
 } from "../src/document-preview/state"
-import type { AgentDocumentSource } from "../src/document-preview/types"
+import type {
+  AgentDocumentPreviewRenderer,
+  AgentDocumentSource,
+} from "../src/document-preview/types"
 import type { AgentFileRef } from "../src/types"
 
 const MARKDOWN_FILE: AgentFileRef = {
@@ -94,6 +101,75 @@ describe("document preview rendering", () => {
     expect(agentDocumentPreviewRenderer("tsv")).toBe("delimited-text")
     expect(agentDocumentPreviewRenderer("image")).toBe("image-native")
     expect(agentDocumentPreviewRenderer(null)).toBeNull()
+  })
+
+  test("resolves the first matching host renderer before built-in viewers", () => {
+    const spreadsheet = {
+      ...document("workbook", "forecast.xlsx"),
+      kind: null,
+    } satisfies AgentDocumentSource
+    const renderer: AgentDocumentPreviewRenderer = {
+      id: "test-spreadsheet",
+      maxFileSizeBytes: 10 * 1024 * 1024,
+      supports: (file) => file.fileName?.endsWith(".xlsx") === true,
+      component: () => null,
+    }
+
+    expect(resolveAgentDocumentPreview(spreadsheet, [renderer])).toEqual({
+      type: "custom",
+      renderer,
+    })
+    expect(resolveAgentDocumentPreview(document("markdown", "report.md"), [renderer])).toEqual({
+      type: "built-in",
+      renderer: "markdown",
+    })
+    expect(
+      resolveAgentDocumentPreview(document("markdown", "report.md"), [
+        { ...renderer, supports: () => true },
+      ])
+    ).toMatchObject({ type: "custom" })
+    expect(
+      resolveAgentDocumentPreview(
+        { ...spreadsheet, fileRef: { ...spreadsheet.fileRef, fileName: "archive.zip" } },
+        [renderer]
+      )
+    ).toBeNull()
+  })
+
+  test("isolates a failed capability check and tries the next renderer", () => {
+    const spreadsheet = {
+      ...document("workbook", "forecast.xlsx"),
+      kind: null,
+    } satisfies AgentDocumentSource
+    const failure = new Error("broken capability check")
+    const consoleError = spyOn(console, "error").mockImplementation(() => undefined)
+    const fallback: AgentDocumentPreviewRenderer = {
+      id: "fallback",
+      maxFileSizeBytes: 1024,
+      supports: () => true,
+      component: () => null,
+    }
+
+    try {
+      expect(
+        resolveAgentDocumentPreview(spreadsheet, [
+          {
+            ...fallback,
+            id: "broken",
+            supports: () => {
+              throw failure
+            },
+          },
+          fallback,
+        ])
+      ).toEqual({ type: "custom", renderer: fallback })
+      expect(consoleError).toHaveBeenCalledWith(
+        "[SixbAgentUI] Document preview renderer 'broken' failed its capability check.",
+        failure
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 })
 
@@ -321,6 +397,19 @@ describe("Markdown document loading policy", () => {
         ...document("large", "large.md"),
         fileRef: { ...MARKDOWN_FILE, sizeBytes: MAX_MARKDOWN_PREVIEW_BYTES + 1 },
       })
+    ).toBe(true)
+  })
+
+  test("applies a host renderer's limit before loading binary content", () => {
+    const source = document("binary", "workbook.xlsx")
+    expect(customPreviewTooLarge(source, source.fileRef.sizeBytes)).toBe(false)
+    expect(customPreviewTooLarge(source, source.fileRef.sizeBytes - 1)).toBe(true)
+    expect(customPreviewTooLarge(source, Number.NaN)).toBe(true)
+    expect(
+      customPreviewTooLarge(
+        { ...source, fileRef: { ...source.fileRef, sizeBytes: Number.POSITIVE_INFINITY } },
+        1024
+      )
     ).toBe(true)
   })
 

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -89,6 +89,16 @@ export default function AgentsLayout({ children }: PropsWithChildren) {
 Explicit props passed to a project-owned `AgentsPage` override provider defaults. The custom width
 applies to the persistent desktop rail; the mobile sheet keeps its responsive width.
 
+The provider also accepts `documentPreviewRenderers`. This is the integration point for a private
+document package: the application imports and registers its renderer while `@sixb/app` and
+`@sixb/agent-ui` stay independent of that package.
+
+```tsx
+<AgentWorkspaceProvider documentPreviewRenderers={[workbookPreviewRenderer]}>
+  {children}
+</AgentWorkspaceProvider>
+```
+
 ### Embedded Agent Panel
 
 Embed the same conversation runtime without changing the page route:

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -89,9 +89,8 @@ export default function AgentsLayout({ children }: PropsWithChildren) {
 Explicit props passed to a project-owned `AgentsPage` override provider defaults. The custom width
 applies to the persistent desktop rail; the mobile sheet keeps its responsive width.
 
-The provider also accepts `documentPreviewRenderers`. This is the integration point for a private
-document package: the application imports and registers its renderer while `@sixb/app` and
-`@sixb/agent-ui` stay independent of that package.
+The provider also accepts `documentPreviewRenderers`. Applications can register document viewers
+without coupling `@sixb/app` or `@sixb/agent-ui` to their implementation.
 
 ```tsx
 <AgentWorkspaceProvider documentPreviewRenderers={[workbookPreviewRenderer]}>

--- a/packages/app/src/agents.ts
+++ b/packages/app/src/agents.ts
@@ -3,6 +3,9 @@ import { createContext, createElement, type PropsWithChildren, useContext } from
 
 export {
   AgentContextProvider,
+  type AgentDocumentPreviewRenderer,
+  type AgentDocumentPreviewRendererProps,
+  type AgentFileRef,
   AgentPanel,
   type AgentPanelProps,
   useAgentContext,
@@ -12,34 +15,35 @@ export { agentContext } from "@sixb/core/agents/context"
 
 export type AgentsPageProps = Omit<AgentChatPageProps, "routeBase">
 
-type AgentWorkspaceChrome = Pick<
+type AgentWorkspaceConfiguration = Pick<
   AgentsPageProps,
-  "sidebarHeader" | "sidebarFooter" | "sidebarWidth"
+  "sidebarHeader" | "sidebarFooter" | "sidebarWidth" | "documentPreviewRenderers"
 >
 
-export type AgentWorkspaceProviderProps = PropsWithChildren<AgentWorkspaceChrome>
+export type AgentWorkspaceProviderProps = PropsWithChildren<AgentWorkspaceConfiguration>
 
-const AgentWorkspaceContext = createContext<AgentWorkspaceChrome>({})
+const AgentWorkspaceContext = createContext<AgentWorkspaceConfiguration>({})
 
 /** Configure the framework-owned Agents routes, typically from `app/agents/layout.tsx`. */
 export function AgentWorkspaceProvider({
   sidebarHeader,
   sidebarFooter,
   sidebarWidth,
+  documentPreviewRenderers,
   children,
 }: AgentWorkspaceProviderProps) {
   return createElement(
     AgentWorkspaceContext.Provider,
-    { value: { sidebarHeader, sidebarFooter, sidebarWidth } },
+    { value: { sidebarHeader, sidebarFooter, sidebarWidth, documentPreviewRenderers } },
     children
   )
 }
 
 export default function AgentsPage(props: AgentsPageProps) {
-  const workspaceChrome = useContext(AgentWorkspaceContext)
+  const workspaceConfiguration = useContext(AgentWorkspaceContext)
 
   return createElement(AgentChatPage, {
-    ...workspaceChrome,
+    ...workspaceConfiguration,
     ...props,
     routeBase: "/agents",
   })


### PR DESCRIPTION
## Summary

Adds a public document-renderer extension point to `@sixb/agent-ui`, allowing applications to support additional formats or override built-in previews.

```text
message file → agent-ui fetch/cache/limits → first matching host renderer → built-in fallback
```

## Linked issue

None.

## Scope

- Exposes a minimal renderer contract: file metadata, `Blob`, size limit, capability check, and React component.
- Registers renderers through `AgentPanel`, `AgentChatPage`, and `AgentWorkspaceProvider`.
- Gives host renderers explicit priority, with list order deciding between multiple matches.
- Keeps authentication, downloading, caching, loading states, and errors inside `agent-ui`.
- Supports lazy renderers and isolates extension failures from the conversation UI.
- Keeps renderer implementations outside the `agent-ui` dependency graph.

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run build`
- `bun run test:publish` — 52 publishable packages verified
- `bun run test:ci` — 4,631 passed, 7 external integrations skipped, 0 failed

## Notes

- Built-in viewers remain the fallback and can be intentionally overridden by the host.
- The renderer contract exposes only file metadata and the loaded `Blob`.
