### PR TITLE
agents: expose typed commands on live component context

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -150,7 +150,7 @@
     },
     "connectors/google": {
       "name": "@sixb/connector-google",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@sixb/connector-rest": "workspace:^",
         "google-auth-library": "^10.9.1",
@@ -481,7 +481,7 @@
     },
     "packages/action-worker": {
       "name": "@sixb/action-worker",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "devDependencies": {
         "@sixb/core": "workspace:*",
         "@types/bun": "latest",
@@ -522,7 +522,7 @@
     },
     "packages/agent-worker": {
       "name": "@sixb/agent-worker",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "ai": "^7.0.4",
       },
@@ -591,7 +591,7 @@
     },
     "packages/cli": {
       "name": "@sixb/cli",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "bin": {
         "sixb": "./src/index.tsx",
       },
@@ -622,7 +622,7 @@
     },
     "packages/client": {
       "name": "@sixb/client",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@sixb/core": "workspace:^",
       },
@@ -649,7 +649,7 @@
     },
     "packages/core": {
       "name": "@sixb/core",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.0",
       },
@@ -676,7 +676,7 @@
     },
     "packages/orchestrator": {
       "name": "@sixb/orchestrator",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "devDependencies": {
         "@sixb/core": "workspace:*",
         "@types/bun": "latest",
@@ -688,7 +688,7 @@
     },
     "packages/pipeline-worker": {
       "name": "@sixb/pipeline-worker",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "devDependencies": {
         "@sixb/core": "workspace:*",
         "@types/bun": "latest",
@@ -700,7 +700,7 @@
     },
     "packages/projection-worker": {
       "name": "@sixb/projection-worker",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "devDependencies": {
         "@sixb/core": "workspace:*",
         "@types/bun": "latest",
@@ -712,7 +712,7 @@
     },
     "packages/rules-worker": {
       "name": "@sixb/rules-worker",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "devDependencies": {
         "@sixb/core": "workspace:*",
         "@types/bun": "latest",
@@ -724,7 +724,7 @@
     },
     "packages/server": {
       "name": "@sixb/server",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@elysiajs/cors": "^1.2.0",
         "@elysiajs/openapi": "^1.4.0",
@@ -746,7 +746,7 @@
     },
     "packages/sync-worker": {
       "name": "@sixb/sync-worker",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "devDependencies": {
         "@sixb/core": "workspace:*",
         "@sixb/lake-local": "workspace:*",
@@ -804,7 +804,7 @@
     },
     "packages/workflow-worker": {
       "name": "@sixb/workflow-worker",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "devDependencies": {
         "@sixb/core": "workspace:*",
         "@types/bun": "latest",
@@ -941,7 +941,7 @@
     },
     "storage/pg": {
       "name": "@sixb/pg",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "postgres": "^3.4.5",
       },
@@ -956,7 +956,7 @@
     },
     "storage/sqlite": {
       "name": "@sixb/sqlite",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "devDependencies": {
         "@sixb/core": "workspace:*",
         "@types/bun": "latest",

--- a/examples/northline/README.md
+++ b/examples/northline/README.md
@@ -47,6 +47,12 @@ assistant turns are unavailable. To customize the assistant, edit
 `gateway()` and the `instructions` prompt. Agent commands run through the local sandbox provider by
 default.
 
+On Dispatch, try **“Show only available technicians in List view.”** The page registers its view
+state and `setSchedule` command through `useAgentContext(context, { commands })`. The assistant
+inspects that live registration and changes the same state as the List/Timeline and availability
+buttons. Manually changing either control is reflected in the next inspection. Removing the
+**Dispatch** context chip excludes those commands for that turn.
+
 To exercise an agent inside a workflow, open **Workflows → Agent service assessment** in Atlas and
 request a run with these values:
 

--- a/examples/northline/agents/operations-assistant.ts
+++ b/examples/northline/agents/operations-assistant.ts
@@ -68,7 +68,7 @@ const compactionDemoContext =
 export const operationsAssistant = defineAgent("operations-assistant", {
   name: "Operations Assistant",
   description: "A demo agent showing how to add an AI assistant to a Sixb app.",
-  model: gateway("deepseek/deepseek-v4-flash-vision-exp"),
+  model: gateway("poolside/laguna-s-2.1-free"),
   reasoning: "medium",
   instructions: [
     "This is a demo agent for the Northline example.",

--- a/examples/northline/app/dispatch/page.tsx
+++ b/examples/northline/app/dispatch/page.tsx
@@ -1,3 +1,4 @@
+import { agentContext, useAgentContext } from "@sixb/app/agents"
 import type {
   ListWorkflowInterventionsResponse,
   SubmitWorkflowInterventionData,
@@ -9,6 +10,7 @@ import {
   useObjectsQuery,
 } from "@sixb/client/hooks"
 import { objects } from "@sixb/client/query"
+import { stringEnum } from "@sixb/core/ontology"
 import { Button } from "@sixb/ui/components"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { ArrowRight, Check, ChevronLeft, ChevronRight, Filter, LoaderCircle } from "lucide-react"
@@ -69,6 +71,34 @@ export default function DispatchPage() {
   const [selectedDate, setSelectedDate] = useState(() => startOfDay(new Date()))
   const [scheduleView, setScheduleView] = useState<"timeline" | "list">("timeline")
   const [showAvailableOnly, setShowAvailableOnly] = useState(false)
+  const updateSchedule = (input: {
+    readonly view: "timeline" | "list"
+    readonly availableOnly: boolean
+  }) => {
+    setScheduleView(input.view)
+    setShowAvailableOnly(input.availableOnly)
+  }
+  useAgentContext(
+    agentContext.appState("northline-dispatch", {
+      label: "Dispatch",
+      description: "The selected schedule date, presentation, and technician availability filter.",
+      value: {
+        selectedDate: selectedDate.toISOString(),
+        scheduleView,
+        showAvailableOnly,
+      },
+    }),
+    {
+      commands: {
+        setSchedule: {
+          description:
+            "Switch between the timeline and list and optionally show only available technicians.",
+          input: { view: stringEnum(["timeline", "list"]), availableOnly: "boolean" },
+          run: updateSchedule,
+        },
+      },
+    }
+  )
   const [reviewingId, setReviewingId] = useState<string>()
   const [submittingId, setSubmittingId] = useState<string>()
   const didChooseInitialDate = useRef(false)
@@ -243,7 +273,9 @@ export default function DispatchPage() {
                     ? "h-9 bg-primary px-4 text-xs font-semibold text-primary-foreground"
                     : "h-9 px-4 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                 }
-                onClick={() => setScheduleView("timeline")}
+                onClick={() =>
+                  updateSchedule({ view: "timeline", availableOnly: showAvailableOnly })
+                }
               >
                 Timeline
               </button>
@@ -255,7 +287,7 @@ export default function DispatchPage() {
                     ? "h-9 border-l border-border bg-primary px-4 text-xs font-semibold text-primary-foreground"
                     : "h-9 border-l border-border px-4 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                 }
-                onClick={() => setScheduleView("list")}
+                onClick={() => updateSchedule({ view: "list", availableOnly: showAvailableOnly })}
               >
                 List
               </button>
@@ -270,7 +302,9 @@ export default function DispatchPage() {
                   ? "grid size-9 place-items-center rounded-md border border-primary bg-primary text-primary-foreground"
                   : "grid size-9 place-items-center rounded-md border border-border bg-background text-muted-foreground transition-colors hover:border-primary/45 hover:text-primary"
               }
-              onClick={() => setShowAvailableOnly((current) => !current)}
+              onClick={() =>
+                updateSchedule({ view: scheduleView, availableOnly: !showAvailableOnly })
+              }
             >
               <Filter className="size-4" strokeWidth={1.8} />
             </button>

--- a/packages/agent-ui/README.md
+++ b/packages/agent-ui/README.md
@@ -117,6 +117,77 @@ function ProjectPage({ project }: { project: ObjectRef }) {
 Registration follows mount and unmount, so context tracks what the user is actually looking at. Pass
 `null` to contribute nothing. Panels that receive their own `context` prop ignore the ambient list.
 
+### Commands on live context
+
+Pass an optional second argument to `useAgentContext` to expose operations on the mounted view:
+
+```tsx
+import { useAgentContext } from "@sixb/agent-ui"
+import { agentContext } from "@sixb/core/agents/context"
+import { stringEnum } from "@sixb/core/ontology"
+import { useState } from "react"
+
+function DispatchPage() {
+  const [view, setView] = useState<"timeline" | "list">("timeline")
+  const [availableOnly, setAvailableOnly] = useState(false)
+
+  const updateSchedule = (input: {
+    readonly view: "timeline" | "list"
+    readonly availableOnly: boolean
+  }) => {
+    setView(input.view)
+    setAvailableOnly(input.availableOnly)
+  }
+
+  useAgentContext(
+    agentContext.appState("dispatch", {
+      label: "Dispatch",
+      description: "Current schedule view and availability filter.",
+      value: { view, availableOnly },
+    }),
+    {
+      commands: {
+        setSchedule: {
+          description: "Change the schedule view and availability filter.",
+          input: {
+            view: stringEnum(["timeline", "list"]),
+            availableOnly: "boolean",
+          },
+          run: updateSchedule,
+        },
+      },
+    }
+  )
+
+  return <Schedule value={{ view, availableOnly }} onChange={updateSchedule} />
+}
+```
+
+Inputs use the same inline Sixb schema syntax as `defineAgentTool`; inline `run` callbacks infer
+their input types automatically. Named value-type references require a server ontology catalog
+and are not supported by browser view commands. Command names are local to their context
+registration, so different components can each declare `setView`.
+
+The context value remains plain serializable data. Commands are live browser bindings: handlers
+and command definitions are never added to the durable user-message context. The host advertises
+their descriptions and input schemas through live inspection. `modelValue`, when supplied, also
+controls what that inspection reveals.
+
+Handlers always read the latest committed React props/state. They may return `void` or a promise
+of `void`, and receive `{ signal }` as a second argument for asynchronous work. Unmounting, changing
+the context identity, or shadowing it with another registration cancels pending handlers; handlers
+must honor the signal before making delayed changes. A remounted view receives a new binding, so
+old command references cannot target its replacement. Ordinary context updates keep the binding.
+
+In a custom app, `sixb dev` automatically connects these registrations to `inspect_app`,
+`navigate_app`, and `invoke_app_command`. After a command, the host returns the updated view context.
+Removing a context chip excludes its live context and commands for that turn. Removing the app
+route context disables the tab's host tools entirely. Standalone panels retain context behavior;
+remote command execution requires the custom-app browser-control host.
+
+Use view commands for filters, selections, tabs, and opening existing review surfaces. Execute
+business changes through the existing Sixb actions and workflow interventions.
+
 ## Full page, with routing
 
 The `/react-router` subpath adds `AgentChatPage`, which wires the conversation to real URLs —

--- a/packages/agent-ui/package.json
+++ b/packages/agent-ui/package.json
@@ -35,6 +35,12 @@
       "import": "./dist/react-router.js",
       "default": "./dist/react-router.js"
     },
+    "./internal/context": {
+      "types": "./dist/internal/context.d.ts",
+      "bun": "./src/internal/context.ts",
+      "import": "./dist/internal/context.js",
+      "default": "./dist/internal/context.js"
+    },
     "./globals.css": "./src/globals.css"
   },
   "scripts": {

--- a/packages/agent-ui/src/AgentContextProvider.tsx
+++ b/packages/agent-ui/src/AgentContextProvider.tsx
@@ -1,92 +1,82 @@
-import {
-  type AgentContextInput,
-  agentContextFingerprint,
-  agentContextIdentity,
-} from "@sixb/core/agents/context"
+import type { AgentToolInputSchema } from "@sixb/core"
+import { type AgentContextInput, agentContextFingerprint } from "@sixb/core/agents/context"
 import {
   createContext,
   type ReactNode,
-  useCallback,
   useContext,
-  useEffect,
-  useMemo,
+  useLayoutEffect,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react"
-
-type RegistrationToken = symbol
-
-interface AgentContextRegistry {
-  readonly context: readonly AgentContextInput[]
-  readonly register: (token: RegistrationToken, context: AgentContextInput) => void
-  readonly unregister: (token: RegistrationToken) => void
-}
+import {
+  type AgentContextOptions,
+  AgentContextRegistry,
+  registerContextCommands,
+} from "./context-commands"
 
 const RegistryContext = createContext<AgentContextRegistry | null>(null)
+const emptyContext: readonly AgentContextInput[] = []
+const emptySnapshot = () => emptyContext
+const emptySubscribe = () => () => {}
 
 export function AgentContextProvider({ children }: { readonly children: ReactNode }) {
-  const [registrations, setRegistrations] = useState(
-    () => new Map<RegistrationToken, AgentContextInput>()
-  )
-
-  const register = useCallback((token: RegistrationToken, context: AgentContextInput) => {
-    setRegistrations((current) => {
-      const next = new Map(current)
-      next.set(token, context)
-      return next
-    })
-  }, [])
-
-  const unregister = useCallback((token: RegistrationToken) => {
-    setRegistrations((current) => {
-      if (!current.has(token)) return current
-      const next = new Map(current)
-      next.delete(token)
-      return next
-    })
-  }, [])
-
-  const context = useMemo(() => {
-    // Later registrations win while mounted. If they unmount, the previous value for that identity
-    // naturally becomes active again; this makes nested page components compose without stale data.
-    const byIdentity = new Map<string, AgentContextInput>()
-    for (const value of registrations.values()) {
-      byIdentity.set(agentContextIdentity(value), value)
-    }
-    return [...byIdentity.values()]
-  }, [registrations])
-
-  const value = useMemo(() => ({ context, register, unregister }), [context, register, unregister])
-  return <RegistryContext.Provider value={value}>{children}</RegistryContext.Provider>
+  const [registry] = useState(() => new AgentContextRegistry())
+  return <RegistryContext.Provider value={registry}>{children}</RegistryContext.Provider>
 }
 
-/** Register ambient page context for every descendant AgentPanel that is not context-controlled. */
-export function useAgentContext(context: AgentContextInput | null | undefined): void {
+/** Register ambient context and optional live view commands for this component's lifetime. */
+export function useAgentContext<
+  const TCommands extends Readonly<Record<string, AgentToolInputSchema>>,
+>(context: AgentContextInput | null | undefined, options?: AgentContextOptions<TCommands>): void {
   const registry = useContext(RegistryContext)
-  const tokenRef = useRef<RegistrationToken>(Symbol("agent-context"))
+  const tokenRef = useRef(Symbol("agent-context"))
+  const optionsRef = useRef(options)
   const contextRef = useRef(context)
-  contextRef.current = context
-  const register = registry?.register
-  const unregister = registry?.unregister
-  const contextKey =
-    context === null || context === undefined ? null : agentContextFingerprint(context)
-
-  useEffect(() => {
-    if (contextKey === null) return
-    if (!register || !unregister) {
+  useLayoutEffect(() => {
+    optionsRef.current = options
+    contextRef.current = context
+  })
+  const contextKey = context == null ? null : agentContextFingerprint(context)
+  // Handler identity is deliberately excluded: inline callbacks read committed props through refs.
+  const commandsKey = JSON.stringify(
+    Object.entries(options?.commands ?? {}).map(([name, command]) => ({
+      name,
+      description: command.description,
+      input: command.input,
+    }))
+  )
+  useLayoutEffect(() => {
+    if (contextKey !== null && !registry) {
       throw new Error("[Sixb] useAgentContext() must be used inside AgentContextProvider.")
     }
+    if (!registry) return
+    const commands =
+      optionsRef.current && commandsKey !== "[]"
+        ? registerContextCommands(optionsRef.current, () => optionsRef.current)
+        : undefined
+    if (contextRef.current == null) registry.unregister(tokenRef.current)
+    else registry.register(tokenRef.current, contextRef.current, commands)
+  }, [registry, contextKey, commandsKey])
 
-    // Read through the ref so structurally identical inline helper values do not re-register after
-    // every provider-driven render; contextKey remains the semantic effect dependency.
-    const currentContext = contextRef.current
-    if (!currentContext) return
+  useLayoutEffect(() => {
     const token = tokenRef.current
-    register(token, currentContext)
-    return () => unregister(token)
-  }, [contextKey, register, unregister])
+    return () => registry?.unregister(token)
+  }, [registry])
 }
 
 export function useRegisteredAgentContext(): readonly AgentContextInput[] {
-  return useContext(RegistryContext)?.context ?? []
+  const registry = useContext(RegistryContext)
+  return useSyncExternalStore(
+    registry?.subscribe ?? emptySubscribe,
+    registry?.getContext ?? emptySnapshot,
+    emptySnapshot
+  )
+}
+
+/** Host integration for the tab-local browser command bridge. */
+export function useAgentContextRegistry(): AgentContextRegistry {
+  const registry = useContext(RegistryContext)
+  if (!registry) throw new Error("[Sixb] The app bridge requires AgentContextProvider.")
+  return registry
 }

--- a/packages/agent-ui/src/context-commands.ts
+++ b/packages/agent-ui/src/context-commands.ts
@@ -1,0 +1,210 @@
+import type { AgentToolInputSchema, InferAgentToolInputSchema } from "@sixb/core"
+import {
+  type AgentContextInput,
+  agentContextIdentity,
+  compileAgentContextCommandInput,
+  normalizeAgentContextEntries,
+} from "@sixb/core/agents/context"
+
+export interface AgentContextCommand<TInput extends AgentToolInputSchema = AgentToolInputSchema> {
+  readonly description: string
+  readonly input: TInput
+  /** Update the current view. Business changes belong to Sixb actions and workflows. */
+  readonly run: (
+    input: InferAgentToolInputSchema<TInput>,
+    context: { readonly signal: AbortSignal }
+  ) => void | Promise<void>
+}
+
+export interface AgentContextOptions<
+  TCommands extends Readonly<Record<string, AgentToolInputSchema>> = Readonly<
+    Record<string, AgentToolInputSchema>
+  >,
+> {
+  readonly commands: {
+    readonly [K in keyof TCommands]: AgentContextCommand<TCommands[K]>
+  }
+}
+
+interface CommandDescriptor {
+  readonly name: string
+  readonly description: string
+  readonly inputSchema: Readonly<Record<string, unknown>>
+}
+
+export interface RegisteredContextCommands {
+  readonly descriptors: readonly CommandDescriptor[]
+  readonly invoke: (name: string, input: unknown, signal: AbortSignal) => Promise<void>
+}
+
+export interface AgentContextInspection {
+  readonly registrationId: string
+  readonly identity: string
+  readonly context: AgentContextInput
+  readonly commands: readonly CommandDescriptor[]
+}
+
+interface Registration {
+  readonly id: string
+  readonly context: AgentContextInput
+  readonly commands?: RegisteredContextCommands
+  readonly pending: Set<AbortController>
+}
+
+/** Live component bindings. Only context snapshots, never callbacks, leave the browser. */
+export class AgentContextRegistry {
+  readonly #registrations = new Map<symbol, Registration>()
+  readonly #listeners = new Set<() => void>()
+  #context: readonly AgentContextInput[] = []
+
+  readonly subscribe = (listener: () => void) => {
+    this.#listeners.add(listener)
+    return () => this.#listeners.delete(listener)
+  }
+
+  readonly getContext = () => this.#context
+
+  register(token: symbol, context: AgentContextInput, commands?: RegisteredContextCommands): void {
+    const snapshot = normalizeAgentContextEntries([{ context, origin: "ambient" }])[0]?.context
+    if (!snapshot) throw new Error("[Sixb] Agent context is missing.")
+    const previous = this.#registrations.get(token)
+    const sameIdentity =
+      previous && agentContextIdentity(previous.context) === agentContextIdentity(snapshot)
+    if (previous && !sameIdentity) this.#abort(previous)
+    this.#registrations.set(token, {
+      id: sameIdentity ? previous.id : crypto.randomUUID(),
+      context: snapshot,
+      commands,
+      pending: sameIdentity ? previous.pending : new Set(),
+    })
+    this.#changed()
+  }
+
+  unregister(token: symbol): void {
+    const registration = this.#registrations.get(token)
+    if (!registration) return
+    this.#abort(registration)
+    this.#registrations.delete(token)
+    this.#changed()
+  }
+
+  inspect(excluded: readonly string[] = []): readonly AgentContextInspection[] {
+    return this.#active()
+      .filter((entry) => !excluded.includes(agentContextIdentity(entry.context)))
+      .map((entry) => ({
+        registrationId: entry.id,
+        identity: agentContextIdentity(entry.context),
+        context:
+          entry.context.kind === "app-state"
+            ? {
+                kind: "app-state",
+                id: entry.context.id,
+                label: entry.context.label,
+                description: entry.context.description,
+                value:
+                  entry.context.modelValue === undefined
+                    ? entry.context.value
+                    : entry.context.modelValue,
+              }
+            : entry.context,
+        commands: entry.commands?.descriptors ?? [],
+      }))
+  }
+
+  async invoke(input: {
+    readonly registrationId: string
+    readonly command: string
+    readonly input: unknown
+    readonly excluded: readonly string[]
+    readonly signal: AbortSignal
+  }): Promise<void> {
+    input.signal.throwIfAborted()
+    const entry = this.#active().find((candidate) => candidate.id === input.registrationId)
+    if (!entry?.commands || input.excluded.includes(agentContextIdentity(entry.context))) {
+      throw new Error(
+        "[Sixb] That view is no longer available. Inspect the current app and try again."
+      )
+    }
+    const controller = new AbortController()
+    const abort = () => controller.abort(input.signal.reason)
+    input.signal.addEventListener("abort", abort, { once: true })
+    entry.pending.add(controller)
+    let onAbort: (() => void) | undefined
+    try {
+      const cancelled = new Promise<never>((_resolve, reject) => {
+        onAbort = () => reject(controller.signal.reason)
+        controller.signal.addEventListener("abort", onAbort, { once: true })
+      })
+      await Promise.race([
+        entry.commands.invoke(input.command, input.input, controller.signal),
+        cancelled,
+      ])
+      controller.signal.throwIfAborted()
+    } finally {
+      entry.pending.delete(controller)
+      input.signal.removeEventListener("abort", abort)
+      if (onAbort) controller.signal.removeEventListener("abort", onAbort)
+    }
+  }
+
+  #active(): Registration[] {
+    const active = new Map<string, Registration>()
+    for (const entry of this.#registrations.values()) {
+      active.set(agentContextIdentity(entry.context), entry)
+    }
+    return [...active.values()]
+  }
+
+  #abort(entry: Registration): void {
+    for (const controller of entry.pending) {
+      controller.abort(new Error("[Sixb] The view was unmounted or replaced."))
+    }
+  }
+
+  #changed(): void {
+    const active = this.#active()
+    for (const entry of this.#registrations.values()) {
+      if (!active.includes(entry)) this.#abort(entry)
+    }
+    this.#context = active.map((entry) => entry.context)
+    for (const listener of this.#listeners) listener()
+  }
+}
+
+/** Compile serializable descriptors, but always call the latest committed React handler. */
+export function registerContextCommands<
+  const TCommands extends Readonly<Record<string, AgentToolInputSchema>>,
+>(
+  options: AgentContextOptions<TCommands>,
+  current: () => AgentContextOptions<TCommands> | undefined
+): RegisteredContextCommands {
+  const schemas = new Map<string, ReturnType<typeof compileAgentContextCommandInput>>()
+  const descriptors = Object.entries(options.commands).map(([name, command]) => {
+    if (!/^[A-Za-z_][A-Za-z0-9_-]{0,63}$/.test(name) || !command.description.trim()) {
+      throw new Error("[Sixb] View commands need a valid name and a non-empty description.")
+    }
+    const schema = compileAgentContextCommandInput(name, command.input)
+    schemas.set(name, schema)
+    return {
+      name,
+      description: command.description,
+      inputSchema: schema.inputSchema,
+    }
+  })
+  return {
+    descriptors,
+    async invoke(name, input, signal) {
+      const schema = schemas.get(name)
+      const commands = current()?.commands
+      if (!schema || !commands || !Object.hasOwn(commands, name)) {
+        throw new Error(`[Sixb] View command '${name}' is no longer available.`)
+      }
+      const command = commands[name]
+      if (!command) throw new Error(`[Sixb] View command '${name}' is no longer available.`)
+      const validated = schema.parse(input)
+      signal.throwIfAborted()
+      // The same Sixb schema supplies inference and runtime normalization at this boundary.
+      await command.run(validated as InferAgentToolInputSchema<TCommands[string]>, { signal })
+    },
+  }
+}

--- a/packages/agent-ui/src/index.ts
+++ b/packages/agent-ui/src/index.ts
@@ -1,3 +1,4 @@
+export type { AgentToolInputSchema, InferAgentToolInputSchema } from "@sixb/core"
 export {
   AgentContextProvider,
   useAgentContext,
@@ -17,3 +18,4 @@ export {
   type AgentSurfaceProps,
 } from "./AgentSurface"
 export { handoffAgentSurfaceThread, setAgentSurfaceMode } from "./agent-surface-state"
+export type { AgentContextCommand, AgentContextOptions } from "./context-commands"

--- a/packages/agent-ui/src/internal/context.ts
+++ b/packages/agent-ui/src/internal/context.ts
@@ -1,0 +1,1 @@
+export { useAgentContextRegistry, useRegisteredAgentContext } from "../AgentContextProvider"

--- a/packages/agent-ui/tests/context-commands.test.ts
+++ b/packages/agent-ui/tests/context-commands.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test"
+import { stringEnum } from "@sixb/core"
+import { agentContext } from "@sixb/core/agents/context"
+import { AgentContextRegistry, registerContextCommands } from "../src/context-commands"
+
+const view = (mode = "timeline") =>
+  agentContext.appState("dispatch", {
+    label: "Dispatch",
+    description: "Current schedule",
+    value: { mode },
+  })
+
+function fixture() {
+  const registry = new AgentContextRegistry()
+  const token = Symbol("dispatch")
+  const calls: string[] = []
+  const options = {
+    commands: {
+      setView: {
+        description: "Set the schedule view",
+        input: { view: stringEnum(["timeline", "list"]) },
+        run: (input: { readonly view: "timeline" | "list" }) => {
+          calls.push(input.view)
+        },
+      },
+    },
+  }
+  const commands = registerContextCommands(options, () => options)
+  registry.register(token, view(), commands)
+  const registrationId = registry.inspect()[0]!.registrationId
+  const invoke = (input: unknown, excluded: readonly string[] = []) =>
+    registry.invoke({
+      registrationId,
+      command: "setView",
+      input,
+      excluded,
+      signal: new AbortController().signal,
+    })
+  return { registry, token, calls, commands, registrationId, invoke }
+}
+
+describe("live context commands", () => {
+  test("uses Sixb schemas to validate inputs before running a view operation", async () => {
+    const { registry, invoke, calls } = fixture()
+    expect(registry.inspect()[0]?.commands[0]?.inputSchema).toMatchObject({
+      type: "object",
+      properties: { view: { enum: ["timeline", "list"] } },
+      required: ["view"],
+      additionalProperties: false,
+    })
+    await expect(invoke({ view: "grid" })).rejects.toThrow("must be one of")
+    await expect(invoke({ view: "list", unexpected: true })).rejects.toThrow()
+    expect(calls).toEqual([])
+    await invoke({ view: "list" })
+    expect(calls).toEqual(["list"])
+  })
+
+  test("keeps persisted context as data and only inspects its model-safe projection", () => {
+    const { registry, token, commands } = fixture()
+    const context = agentContext.appState("dispatch", {
+      label: "Dispatch",
+      description: "Current view",
+      value: { secret: "host-only" },
+      modelValue: null,
+    })
+    registry.register(token, context, commands)
+    expect(registry.getContext()).toEqual([context])
+    expect(JSON.stringify(registry.getContext())).not.toContain("setView")
+    expect(JSON.stringify(registry.inspect())).not.toContain("host-only")
+    expect(registry.inspect()[0]?.context).toMatchObject({ value: null })
+  })
+
+  test("updates state without replacing the component's binding", async () => {
+    const { registry, token, commands, registrationId, invoke } = fixture()
+    registry.register(token, view("list"), commands)
+    expect(registry.inspect()[0]).toMatchObject({
+      registrationId,
+      context: { value: { mode: "list" } },
+    })
+    await invoke({ view: "timeline" })
+  })
+
+  test("a removed composer context cannot be inspected or invoked", async () => {
+    const { registry, invoke, calls } = fixture()
+    expect(registry.inspect(["app-state:dispatch"])).toEqual([])
+    // Guard check: remove the excluded identity check in AgentContextRegistry.invoke.
+    await expect(invoke({ view: "list" }, ["app-state:dispatch"])).rejects.toThrow(
+      "no longer available"
+    )
+    expect(calls).toEqual([])
+  })
+
+  test("unmount/remount cannot resurrect an old command binding", async () => {
+    const { registry, token, commands, registrationId, invoke, calls } = fixture()
+    registry.unregister(token)
+    registry.register(Symbol("new dispatch"), view(), commands)
+    expect(registry.inspect()[0]?.registrationId).not.toBe(registrationId)
+    await expect(invoke({ view: "list" })).rejects.toThrow("no longer available")
+    expect(calls).toEqual([])
+  })
+
+  test("nested context overrides shadow commands and restore the parent on unmount", async () => {
+    const { registry, commands, invoke, calls } = fixture()
+    const nested = Symbol("nested")
+    registry.register(nested, view("list"), commands)
+    await expect(invoke({ view: "list" })).rejects.toThrow("no longer available")
+    registry.unregister(nested)
+    await invoke({ view: "list" })
+    expect(calls).toEqual(["list"])
+  })
+
+  test("changing the subject invalidates the old binding even when the component stays mounted", async () => {
+    const { registry, token, commands, invoke } = fixture()
+    registry.register(token, agentContext.object({ id: "ServiceCase" }, "SC-1042"), commands)
+    await expect(invoke({ view: "list" })).rejects.toThrow("no longer available")
+  })
+
+  test("unknown commands cannot reach inherited object properties", async () => {
+    const { registry, registrationId } = fixture()
+    await expect(
+      registry.invoke({
+        registrationId,
+        command: "toString",
+        input: {},
+        excluded: [],
+        signal: new AbortController().signal,
+      })
+    ).rejects.toThrow("no longer available")
+  })
+
+  test("unmount cancels an in-flight handler and releases the bridge even if it ignores cancellation", async () => {
+    const registry = new AgentContextRegistry()
+    const token = Symbol("view")
+    let handlerSignal: AbortSignal | undefined
+    const options = {
+      commands: {
+        pending: {
+          description: "Wait for the view",
+          input: {},
+          run: (_input: object, { signal }: { signal: AbortSignal }) => {
+            handlerSignal = signal
+            return new Promise<void>(() => {})
+          },
+        },
+      },
+    }
+    registry.register(
+      token,
+      view(),
+      registerContextCommands(options, () => options)
+    )
+    const pending = registry.invoke({
+      registrationId: registry.inspect()[0]!.registrationId,
+      command: "pending",
+      input: {},
+      excluded: [],
+      signal: new AbortController().signal,
+    })
+    registry.unregister(token)
+    await expect(pending).rejects.toThrow("unmounted")
+    expect(handlerSignal?.aborted).toBe(true)
+  })
+})

--- a/packages/agent-worker/src/agent-prompt.ts
+++ b/packages/agent-worker/src/agent-prompt.ts
@@ -29,6 +29,7 @@ const APPLICATION_SURFACE_RULES = [
   "Use live project data—not a tour of application pages—to research broad questions. Navigate when a specific destination will help the user see or continue the work; do not leave an active workspace merely to inspect a launcher or home screen.",
   "An application navigation changes the user's visible workspace. Keep the active conversation continuous, briefly orient the user when the destination is useful, and avoid navigation that does not advance their goal.",
   "Inspect the visible interface only to answer a visual question, resolve ambiguity, or verify an outcome. Do not inspect repeatedly or narrate screenshots by default.",
+  "Live application inspection can expose mounted context and typed view commands. Use those commands for filters, tabs, and selections instead of giving click-by-click instructions. Use the resulting state to verify the change. Historical message context describes where the user was at send time; it does not override the current workspace. A departed view's commands are no longer available. View commands do not replace declared business actions or workflow interventions.",
   "After changing the visible interface, state briefly what is now open and anything important the user should notice. Do not mention routes, session ids, browser controls, screenshots, or tool calls.",
   "Treat user-facing files as shared working artifacts. Identify them by name and purpose and continue collaborating on them; do not describe them primarily as downloads unless the user asks.",
 ].join("\n")

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -152,14 +152,34 @@ generated shell automatically adds a `sixb-custom-app-route` context entry conta
 location, matching route pattern, complete generated route catalog, and a short-lived capability
 for that tab. An embedded `AgentPanel` receives it without app-authored route plumbing.
 
-The co-hosted development runtime automatically provides `inspect_app` and `navigate_app` only for
+The co-hosted development runtime automatically provides `inspect_app`, `navigate_app`, and
+`invoke_app_command` only for
 a conversational turn triggered by a currently connected custom-app tab. Agents do not declare
 these host capabilities in their `tools` list, workflows and direct API requests do not receive
 them, and the tab session id is excluded from model context and model-facing tool input. Navigation is restricted
-to the generated same-origin route catalog. Provisioning either tool also activates the worker's
+to the generated same-origin route catalog. Provisioning the tools also activates the worker's
 application-surface rules, so project prompts can stay focused on the agent's role and business
 judgment instead of explaining route context, browser mechanics, navigation responses, or file
 preview behavior.
+
+`useAgentContext(context, { commands })` associates typed view operations with the same component
+registration that contributes ambient context. Import it from `@sixb/app/agents`; existing
+single-argument registrations continue to work. See the
+[context command example](../agent-ui/README.md#commands-on-live-context) for the full API.
+
+Inspection and navigation results include the current context values and available command
+descriptors. The agent invokes a command using its live registration id, local command name, and
+JSON-encoded input. The browser validates that input against the declared Sixb schema, invokes the
+latest React handler, and returns the resulting context after the UI update. This lets an agent
+navigate to Dispatch and change its view in the same turn, without a separate agent tool definition
+for every component.
+
+The route context stores offered context identities as host-only metadata. At send time, omitted
+context chips are excluded from subsequent live inspection and invocation for that turn. New
+contexts mounted by navigation become discoverable, while departed or replaced component instances
+cannot be invoked through their old registration ids. Commands remain scoped to the originating
+browser tab and expire after 30 seconds; cancellation also removes commands still waiting in its
+queue. Async view handlers receive an abort signal when their view disappears or execution expires.
 
 This first slice intentionally runs only in the co-hosted `sixb dev` process. It proves the tab and
 tool protocol without turning the public app server into a remote-control plane. A production

--- a/packages/app/src/agent-tools.ts
+++ b/packages/app/src/agent-tools.ts
@@ -7,8 +7,13 @@ import {
   type JsonValue,
   type ReadonlyJsonValue,
 } from "@sixb/core"
+import { agentContextIdentity } from "@sixb/core/agents/context"
 import type { AgentMessageRecord } from "@sixb/core/storage"
-import { AppBrowserControlError, AppBrowserControlHub } from "./browser-control-server"
+import {
+  type AppBrowserCommandInput,
+  AppBrowserControlError,
+  AppBrowserControlHub,
+} from "./browser-control-server"
 
 export interface AppBrowserControlRuntime {
   readonly hub: AppBrowserControlHub
@@ -17,15 +22,21 @@ export interface AppBrowserControlRuntime {
 
 function createBoundAppBrowserAgentTools(
   hub: AppBrowserControlHub,
-  sessionId: string
+  sessionId: string,
+  excludedContext: readonly string[]
 ): readonly AgentToolDefinition[] {
   const inspectApp = defineAgentTool("inspect_app")
     .description(
-      "Inspect the exact current page, matching route, complete route catalog, title, and viewport of the connected custom-app browser tab."
+      "Inspect the current page, route catalog, and live component context of the connected app tab. Context entries describe view state and available commands with their registrationId, name, and JSON input schema. Inspect before invoking a view command; historical context is not the current workspace."
     )
     .input({})
     .run(async ({ signal }) => {
-      return await dispatchBrowserCommand(hub, sessionId, { kind: "inspect" }, signal)
+      return await dispatchBrowserCommand(
+        hub,
+        sessionId,
+        { kind: "inspect", excludedContext },
+        signal
+      )
     })
 
   const navigateApp = defineAgentTool("navigate_app")
@@ -37,12 +48,38 @@ function createBoundAppBrowserAgentTools(
       return await dispatchBrowserCommand(
         hub,
         sessionId,
-        { kind: "navigate", path: input.path },
+        { kind: "navigate", path: input.path, excludedContext },
         signal
       )
     })
 
-  return Object.freeze([inspectApp, navigateApp])
+  const invokeAppCommand = defineAgentTool("invoke_app_command")
+    .description(
+      "Operate a mounted app view using a command returned by inspect_app or navigate_app. Pass its exact registrationId and command name, and a JSON-encoded input object matching its inputSchema. Use this for view changes such as filters, tabs, and selections. The result contains the updated app state. If the view is no longer available, inspect again. Business changes still use declared Sixb actions or workflow interventions."
+    )
+    .input({ registrationId: "string", command: "string", inputJson: "string" })
+    .run(async ({ input, signal }) => {
+      let value: unknown
+      try {
+        value = JSON.parse(input.inputJson)
+      } catch {
+        throw new AgentToolPublicError("[SixbApp] View command inputJson must contain valid JSON.")
+      }
+      return await dispatchBrowserCommand(
+        hub,
+        sessionId,
+        {
+          kind: "invoke",
+          registrationId: input.registrationId,
+          command: input.command,
+          input: value,
+          excludedContext,
+        },
+        signal
+      )
+    })
+
+  return Object.freeze([inspectApp, navigateApp, invokeAppCommand])
 }
 
 /**
@@ -61,7 +98,11 @@ export function createAppBrowserAgentToolProvider(hub: AppBrowserControlHub): (i
       return { tools: [], capabilities: [] }
     }
     return {
-      tools: createBoundAppBrowserAgentTools(hub, sessionId),
+      tools: createBoundAppBrowserAgentTools(
+        hub,
+        sessionId,
+        excludedAppContext(input.triggerMessage)
+      ),
       capabilities: ["application-surface"],
     }
   }
@@ -99,10 +140,35 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
+/** Omitted composer chips stay omitted from inspection and command execution for this turn. */
+function excludedAppContext(message: AgentMessageRecord): readonly string[] {
+  const included = new Set(
+    message.parts.flatMap((part) =>
+      part.type === "context" ? [agentContextIdentity(part.context)] : []
+    )
+  )
+  for (const part of message.parts) {
+    if (
+      part.type !== "context" ||
+      part.context.kind !== "app-state" ||
+      part.context.id !== "sixb-custom-app-route" ||
+      !isRecord(part.context.value) ||
+      !isRecord(part.context.value.browser)
+    )
+      continue
+    const offered = part.context.value.browser.offeredContext
+    if (!Array.isArray(offered)) return []
+    return offered.filter(
+      (identity): identity is string => typeof identity === "string" && !included.has(identity)
+    )
+  }
+  return []
+}
+
 async function dispatchBrowserCommand(
   hub: AppBrowserControlHub,
   sessionId: string,
-  input: { readonly kind: "inspect" } | { readonly kind: "navigate"; readonly path: string },
+  input: AppBrowserCommandInput,
   signal: AbortSignal
 ): Promise<JsonValue> {
   try {

--- a/packages/app/src/agents.ts
+++ b/packages/app/src/agents.ts
@@ -2,13 +2,17 @@ import { AgentChatPage, type AgentChatPageProps } from "@sixb/agent-ui/react-rou
 import { createElement } from "react"
 
 export {
+  type AgentContextCommand,
+  type AgentContextOptions,
   AgentContextProvider,
   AgentPanel,
   type AgentPanelProps,
   AgentSurface,
   type AgentSurfaceMode,
   type AgentSurfaceProps,
+  type AgentToolInputSchema,
   handoffAgentSurfaceThread,
+  type InferAgentToolInputSchema,
   setAgentSurfaceMode,
   useAgentContext,
 } from "@sixb/agent-ui"

--- a/packages/app/src/browser-control-protocol.ts
+++ b/packages/app/src/browser-control-protocol.ts
@@ -1,16 +1,26 @@
 export const appBrowserControlPath = "/__sixb/browser-control"
 export const appBrowserControlSecretHeader = "x-sixb-browser-secret"
 
-export type AppBrowserCommand =
+export type AppBrowserOperation = (
   | {
-      readonly id: string
       readonly kind: "inspect"
     }
   | {
-      readonly id: string
       readonly kind: "navigate"
       readonly path: string
     }
+  | {
+      readonly kind: "invoke"
+      readonly registrationId: string
+      readonly command: string
+      readonly input: unknown
+    }
+) & { readonly excludedContext?: readonly string[] }
+
+export type AppBrowserCommand = AppBrowserOperation & {
+  readonly id: string
+  readonly expiresAt: number
+}
 
 export interface AppBrowserCommandResult {
   readonly commandId: string

--- a/packages/app/src/browser-control-react.ts
+++ b/packages/app/src/browser-control-react.ts
@@ -1,5 +1,6 @@
 import { AgentContextProvider, useAgentContext } from "@sixb/agent-ui"
-import { agentContext } from "@sixb/core/agents/context"
+import { useAgentContextRegistry, useRegisteredAgentContext } from "@sixb/agent-ui/internal/context"
+import { agentContext, agentContextIdentity } from "@sixb/core/agents/context"
 import { createElement, type ReactNode, useEffect, useMemo, useRef } from "react"
 import { matchPath, useLocation, useNavigate } from "react-router-dom"
 import {
@@ -27,6 +28,8 @@ function AppAgentContextRegistrar({
 }: AppAgentContextProviderProps) {
   const location = useLocation()
   const navigate = useNavigate()
+  const contextRegistry = useAgentContextRegistry()
+  const registeredContext = useRegisteredAgentContext()
   // Intentionally memory-only: duplicated tabs can inherit sessionStorage from their opener, but
   // every mounted tab must be a distinct control target and conversation surface.
   const identity = useMemo(createBrowserIdentity, [])
@@ -40,6 +43,7 @@ function AppAgentContextRegistrar({
 
     void runBrowserControlLoop({
       identity,
+      contextRegistry,
       routePaths: currentRoutePaths,
       navigate: (path) =>
         navigateRef.current(path, {
@@ -52,7 +56,7 @@ function AppAgentContextRegistrar({
     })
 
     return () => controller.abort()
-  }, [browserControl, identity, routePaths])
+  }, [browserControl, identity, routePaths, contextRegistry])
 
   const matchedRoute =
     routePaths.find((path) => matchPath({ path, end: true }, location.pathname)) ?? null
@@ -72,6 +76,12 @@ function AppAgentContextRegistrar({
         ? {
             sessionId: identity.sessionId,
             navigate: true,
+            offeredContext: registeredContext
+              .filter(
+                (context) => context.kind !== "app-state" || context.id !== "sixb-custom-app-route"
+              )
+              .map(agentContextIdentity)
+              .sort(),
           }
         : { navigate: false },
     },
@@ -111,6 +121,7 @@ async function runBrowserControlLoop(input: {
   readonly routePaths: readonly string[]
   readonly navigate: (path: string) => void
   readonly signal: AbortSignal
+  readonly contextRegistry: ReturnType<typeof useAgentContextRegistry>
 }): Promise<void> {
   const headers = {
     "content-type": "application/json",
@@ -135,6 +146,7 @@ async function runConnectedBrowserControlLoop(
     readonly routePaths: readonly string[]
     readonly navigate: (path: string) => void
     readonly signal: AbortSignal
+    readonly contextRegistry: ReturnType<typeof useAgentContextRegistry>
   },
   headers: Record<string, string>
 ): Promise<void> {
@@ -176,12 +188,17 @@ async function browserCommandResult(
   input: {
     readonly routePaths: readonly string[]
     readonly navigate: (path: string) => void
+    readonly contextRegistry: ReturnType<typeof useAgentContextRegistry>
+    readonly signal: AbortSignal
   }
 ): Promise<
   { readonly ok: true; readonly value: unknown } | { readonly ok: false; readonly error: string }
 > {
   try {
-    return { ok: true, value: await executeBrowserCommand(command, input) }
+    const remaining = command.expiresAt - Date.now()
+    if (remaining <= 0) throw new Error("The browser command has expired.")
+    const signal = AbortSignal.any([input.signal, AbortSignal.timeout(remaining)])
+    return { ok: true, value: await executeBrowserCommand(command, { ...input, signal }) }
   } catch (error) {
     return { ok: false, error: error instanceof Error ? error.message : String(error) }
   }
@@ -204,9 +221,28 @@ async function executeBrowserCommand(
   input: {
     readonly routePaths: readonly string[]
     readonly navigate: (path: string) => void
+    readonly contextRegistry: ReturnType<typeof useAgentContextRegistry>
+    readonly signal: AbortSignal
   }
 ): Promise<unknown> {
-  if (command.kind === "inspect") return browserInspection(input.routePaths)
+  input.signal.throwIfAborted()
+  const inspect = () => ({
+    ...browserInspection(input.routePaths),
+    contexts: input.contextRegistry.inspect(command.excludedContext),
+  })
+  if (command.kind === "inspect") return inspect()
+  if (command.kind === "invoke") {
+    await input.contextRegistry.invoke({
+      registrationId: command.registrationId,
+      command: command.command,
+      input: command.input,
+      excluded: command.excludedContext ?? [],
+      signal: input.signal,
+    })
+    await nextBrowserPaint(input.signal)
+    input.signal.throwIfAborted()
+    return inspect()
+  }
   if (command.kind === "navigate") {
     const url = new URL(command.path, window.location.href)
     if (url.origin !== window.location.origin) {
@@ -216,8 +252,9 @@ async function executeBrowserCommand(
       throw new Error(`No custom-app route matches '${url.pathname}'.`)
     }
     input.navigate(url.pathname + url.search + url.hash)
-    await nextBrowserPaint()
-    return browserInspection(input.routePaths)
+    await nextBrowserPaint(input.signal)
+    input.signal.throwIfAborted()
+    return inspect()
   }
 }
 
@@ -238,10 +275,28 @@ function browserInspection(routePaths: readonly string[]) {
   }
 }
 
-async function nextBrowserPaint(): Promise<void> {
-  await new Promise<void>((resolve) =>
-    requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
-  )
+async function nextBrowserPaint(signal: AbortSignal): Promise<void> {
+  signal.throwIfAborted()
+  await new Promise<void>((resolve, reject) => {
+    let frame = 0
+    const finish = () => {
+      cancelAnimationFrame(frame)
+      clearTimeout(timer)
+      signal.removeEventListener("abort", abort)
+      resolve()
+    }
+    const abort = () => {
+      finish()
+      reject(signal.reason)
+    }
+    // Hidden tabs may suspend animation frames. Give React a task boundary there as well.
+    const timer = setTimeout(finish, 100)
+    frame = requestAnimationFrame(() => {
+      frame = requestAnimationFrame(finish)
+    })
+    signal.addEventListener("abort", abort, { once: true })
+  })
+  signal.throwIfAborted()
 }
 
 async function requireBrowserResponse(response: Response): Promise<void> {

--- a/packages/app/src/browser-control-server.ts
+++ b/packages/app/src/browser-control-server.ts
@@ -1,6 +1,7 @@
 import {
   type AppBrowserCommand,
   type AppBrowserCommandResult,
+  type AppBrowserOperation,
   appBrowserControlPath,
   appBrowserControlSecretHeader,
 } from "./browser-control-protocol"
@@ -32,9 +33,7 @@ interface PendingBrowserCommand {
   readonly dispose: () => void
 }
 
-export type AppBrowserCommandInput =
-  | { readonly kind: "inspect" }
-  | { readonly kind: "navigate"; readonly path: string }
+export type AppBrowserCommandInput = AppBrowserOperation
 
 export class AppBrowserControlError extends Error {
   readonly name = "AppBrowserControlError"
@@ -149,7 +148,11 @@ export class AppBrowserControlHub {
   ): Promise<unknown> {
     this.#pruneStaleSessions()
     const session = this.#activeSession(sessionId)
-    const command = { id: crypto.randomUUID(), ...input } as AppBrowserCommand
+    const command: AppBrowserCommand = {
+      id: crypto.randomUUID(),
+      expiresAt: this.now() + browserCommandTimeoutMs,
+      ...input,
+    }
 
     return await new Promise<unknown>((resolve, reject) => {
       let settled = false
@@ -157,6 +160,8 @@ export class AppBrowserControlHub {
         if (settled) return
         settled = true
         this.#pending.delete(command.id)
+        const queuedIndex = session.commands.findIndex((entry) => entry.id === command.id)
+        if (queuedIndex !== -1) session.commands.splice(queuedIndex, 1)
         dispose()
         reject(error)
       }

--- a/packages/app/tests/agents-context.types.ts
+++ b/packages/app/tests/agents-context.types.ts
@@ -1,5 +1,6 @@
 import type { AgentContextInput } from "@sixb/core"
-import { agentContext } from "../src/agents"
+import { stringEnum } from "@sixb/core"
+import { agentContext, useAgentContext } from "../src/agents"
 
 const Invoice = { id: "Invoice" } as const
 const invoiceContext = agentContext.object(Invoice, "inv-123")
@@ -19,3 +20,25 @@ type Equal<TLeft, TRight> =
 type Expect<TValue extends true> = TValue
 
 type _ObjectTypeAutocomplete = Expect<Equal<typeof invoiceContext.ref.objectTypeId, "Invoice">>
+
+export function ViewCommandsTypecheck() {
+  useAgentContext(viewContext, {
+    commands: {
+      setSchedule: {
+        description: "Change the schedule",
+        input: { view: stringEnum(["timeline", "list"]), availableOnly: "boolean" },
+        run(input) {
+          const view: "timeline" | "list" = input.view
+          const availableOnly: boolean = input.availableOnly
+          // @ts-expect-error Command input must retain its inferred enum.
+          const invalid: "grid" = input.view
+          // @ts-expect-error Command input is not an arbitrary record.
+          input.missing
+          void view
+          void availableOnly
+          void invalid
+        },
+      },
+    },
+  })
+}

--- a/packages/app/tests/browser-control.test.ts
+++ b/packages/app/tests/browser-control.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { noopLogger } from "@sixb/core"
 import type { AgentMessageRecord } from "@sixb/core/storage"
 import { createAppBrowserAgentToolProvider } from "../src/agent-tools"
 import {
@@ -58,7 +59,11 @@ describe("AppBrowserControlHub", () => {
     const provision = provideTools({ triggerMessage: message })
     const tools = provision.tools
     expect(provision.capabilities).toEqual(["application-surface"])
-    expect(tools.map((tool) => tool.name)).toEqual(["inspect_app", "navigate_app"])
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "inspect_app",
+      "navigate_app",
+      "invoke_app_command",
+    ])
     expect(tools[0]?.input).toEqual({})
     expect(tools[1]?.input).toEqual({ path: "string" })
   })
@@ -157,6 +162,95 @@ describe("AppBrowserControlHub", () => {
     await expect(hub.poll(sessionId, "different_secret_123456")).rejects.toMatchObject({
       status: 401,
     })
+  })
+
+  test("does not execute a queued command after its caller cancels", async () => {
+    const hub = new AppBrowserControlHub()
+    hub.register(sessionId, sessionSecret)
+    const controller = new AbortController()
+    const pending = hub.dispatch(
+      sessionId,
+      {
+        kind: "invoke",
+        registrationId: "old-view",
+        command: "setView",
+        input: { view: "list" },
+      },
+      controller.signal
+    )
+    controller.abort()
+    await expect(pending).rejects.toMatchObject({ status: 499 })
+    // Guard check: remove the queuedIndex splice in dispatch's finishWithError.
+    const pollAbort = new AbortController()
+    pollAbort.abort()
+    expect(await hub.poll(sessionId, sessionSecret, pollAbort.signal)).toBeNull()
+  })
+
+  test("forwards live commands and excludes omitted composer contexts from every app operation", async () => {
+    const hub = new AppBrowserControlHub()
+    hub.register(sessionId, sessionSecret)
+    const base = triggerMessage({ sessionId, navigate: true })
+    const message: AgentMessageRecord = {
+      ...base,
+      parts: [
+        {
+          type: "context",
+          origin: "ambient",
+          context: {
+            kind: "app-state",
+            id: "sixb-custom-app-route",
+            label: "App",
+            description: "Current app",
+            value: {
+              browser: { sessionId, navigate: true, offeredContext: ["app-state:dispatch"] },
+            },
+          },
+        },
+      ],
+    }
+    const provision = createAppBrowserAgentToolProvider(hub)({ triggerMessage: message })
+    const cases = [
+      { tool: "inspect_app", input: {}, kind: "inspect" },
+      { tool: "navigate_app", input: { path: "/dispatch" }, kind: "navigate" },
+      {
+        tool: "invoke_app_command",
+        input: {
+          registrationId: "view-instance",
+          command: "setView",
+          inputJson: '{"view":"list"}',
+        },
+        kind: "invoke",
+      },
+    ]
+    for (const entry of cases) {
+      const tool = provision.tools.find((tool) => tool.name === entry.tool)
+      if (!tool) throw new Error("Expected host tool")
+      const result = tool.handler({
+        input: entry.input,
+        signal: new AbortController().signal,
+        toolCallId: "call-1",
+        run: { id: "run-1", agentId: "assistant" },
+        connector: async () => {
+          throw new Error("Unexpected connector")
+        },
+        logger: noopLogger,
+        artifacts: {
+          put: async () => {
+            throw new Error("Unexpected artifact")
+          },
+        },
+      })
+      const command = await hub.poll(sessionId, sessionSecret)
+      expect(command).toMatchObject({ kind: entry.kind, excludedContext: ["app-state:dispatch"] })
+      if (!command) throw new Error("Expected command")
+      if (command.kind === "invoke") expect(command.input).toEqual({ view: "list" })
+      hub.submit(sessionId, sessionSecret, {
+        commandId: command.id,
+        ok: true,
+        value: { contexts: [] },
+      })
+      await expect(result).resolves.toEqual({ contexts: [] })
+    }
   })
 
   test("prunes stale browser tabs and rejects their pending commands", async () => {

--- a/packages/app/tests/context-commands-react.test.tsx
+++ b/packages/app/tests/context-commands-react.test.tsx
@@ -1,0 +1,253 @@
+import { afterAll, afterEach, beforeAll, describe, expect, spyOn, test } from "bun:test"
+import { AgentContextProvider, useAgentContext } from "@sixb/agent-ui"
+import { useAgentContextRegistry, useRegisteredAgentContext } from "@sixb/agent-ui/internal/context"
+import { type AgentContextInput, agentContext, noopLogger, stringEnum } from "@sixb/core"
+import type { AgentMessageRecord } from "@sixb/core/storage"
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react"
+import { Window } from "happy-dom"
+import { StrictMode, useState } from "react"
+import { MemoryRouter } from "react-router-dom"
+import { createAppBrowserAgentToolProvider } from "../src/agent-tools"
+import { AppAgentContextProvider } from "../src/browser-control-react"
+import { AppBrowserControlHub, handleAppBrowserControlRequest } from "../src/browser-control-server"
+
+const browser = new Window({ url: "https://app.sixb.test/" })
+const globals = [
+  "window",
+  "document",
+  "navigator",
+  "HTMLElement",
+  "Node",
+  "MutationObserver",
+  "requestAnimationFrame",
+  "cancelAnimationFrame",
+  "IS_REACT_ACT_ENVIRONMENT",
+] as const
+const previous = new Map<string, PropertyDescriptor | undefined>()
+
+beforeAll(() => {
+  for (const key of globals) {
+    previous.set(key, Object.getOwnPropertyDescriptor(globalThis, key))
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      writable: true,
+      value:
+        key === "window"
+          ? browser
+          : key === "IS_REACT_ACT_ENVIRONMENT"
+            ? true
+            : Reflect.get(browser, key),
+    })
+  }
+})
+afterEach(cleanup)
+afterAll(() => {
+  for (const key of globals) {
+    const descriptor = previous.get(key)
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor)
+    else Reflect.deleteProperty(globalThis, key)
+  }
+  browser.close()
+})
+
+describe("component-owned agent commands", () => {
+  test("host tools operate the rendered view through browser polling and return its committed state", async () => {
+    const hub = new AppBrowserControlHub()
+    const request = spyOn(globalThis, "fetch").mockImplementation(
+      Object.assign(
+        async (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+          if (typeof url !== "string") throw new Error("Expected a browser-control URL")
+          return handleAppBrowserControlRequest(
+            new Request(new URL(url, browser.location.href), init),
+            hub
+          )
+        },
+        { preconnect: fetch.preconnect }
+      )
+    )
+    let contexts: readonly AgentContextInput[] = []
+    function Bridge() {
+      contexts = useRegisteredAgentContext()
+      return null
+    }
+    function View() {
+      const [availableOnly, setAvailableOnly] = useState(false)
+      useAgentContext(
+        agentContext.appState("dispatch", {
+          label: "Dispatch",
+          description: "Schedule filter",
+          value: { availableOnly },
+        }),
+        {
+          commands: {
+            filter: {
+              description: "Filter available technicians",
+              input: { availableOnly: "boolean" },
+              run: (input) => setAvailableOnly(input.availableOnly),
+            },
+          },
+        }
+      )
+      return <output data-testid="filter">{String(availableOnly)}</output>
+    }
+    try {
+      const page = render(
+        <MemoryRouter>
+          <AppAgentContextProvider browserControl routePaths={["/"]}>
+            <Bridge />
+            <View />
+          </AppAgentContextProvider>
+        </MemoryRouter>
+      )
+      const message = (): AgentMessageRecord => ({
+        id: "message",
+        projectId: "project",
+        threadId: "thread",
+        runId: null,
+        role: "user",
+        seq: 1,
+        contentVersion: 1,
+        createdAt: new Date("2026-09-05T12:00:00Z"),
+        parts: contexts.map((context) => ({ type: "context", origin: "ambient", context })),
+      })
+      const provide = createAppBrowserAgentToolProvider(hub)
+      await waitFor(() => expect(provide({ triggerMessage: message() }).tools).toHaveLength(3))
+      const route = contexts.find(
+        (context) => context.kind === "app-state" && context.id === "sixb-custom-app-route"
+      )
+      expect(route).toMatchObject({
+        value: { browser: { offeredContext: ["app-state:dispatch"] } },
+      })
+      const tools = provide({ triggerMessage: message() }).tools
+      const call = (name: string, input: Record<string, unknown>) => {
+        const tool = tools.find((tool) => tool.name === name)
+        if (!tool) throw new Error("Expected a host tool")
+        return tool.handler({
+          input,
+          signal: new AbortController().signal,
+          toolCallId: "call",
+          run: { id: "run", agentId: "assistant" },
+          logger: noopLogger,
+          connector: async () => {
+            throw new Error("Unexpected connector")
+          },
+          artifacts: {
+            put: async () => {
+              throw new Error("Unexpected artifact")
+            },
+          },
+        })
+      }
+      const inspected = await call("inspect_app", {})
+      // This crosses the real JSON transport; narrow just the fields needed for the next command.
+      const entries = Reflect.get(inspected as object, "contexts") as {
+        registrationId: string
+        identity: string
+      }[]
+      const dispatch = entries.find((entry) => entry.identity === "app-state:dispatch")
+      if (!dispatch) throw new Error("Expected mounted Dispatch context")
+      const pending = call("invoke_app_command", {
+        registrationId: dispatch.registrationId,
+        command: "filter",
+        inputJson: '{"availableOnly":true}',
+      })
+      await waitFor(() => expect(page.getByTestId("filter").textContent).toBe("true"))
+      const result = await pending
+      expect(result).toMatchObject({
+        contexts: expect.arrayContaining([
+          expect.objectContaining({
+            identity: "app-state:dispatch",
+            context: expect.objectContaining({ value: { availableOnly: true } }),
+          }),
+        ]),
+      })
+    } finally {
+      cleanup()
+      await Bun.sleep(0)
+      request.mockRestore()
+    }
+  })
+
+  test("manual and agent changes share state, handlers see current props, and unmount revokes the binding", async () => {
+    let registry: ReturnType<typeof useAgentContextRegistry> | undefined
+    function Bridge() {
+      registry = useAgentContextRegistry()
+      const context = useRegisteredAgentContext()
+      return <output data-testid="context">{JSON.stringify(context)}</output>
+    }
+    function View({ suffix }: { suffix: string }) {
+      const [view, setView] = useState("timeline")
+      const [lastLabel, setLastLabel] = useState("")
+      useAgentContext(
+        agentContext.appState("dispatch", {
+          label: "Dispatch",
+          description: "Current schedule",
+          value: { view },
+        }),
+        {
+          commands: {
+            setView: {
+              description: "Set the view",
+              input: { view: stringEnum(["timeline", "list"]) },
+              run(input) {
+                setView(input.view)
+                setLastLabel(`${input.view}:${suffix}`)
+              },
+            },
+          },
+        }
+      )
+      return (
+        <>
+          <button type="button" onClick={() => setView("list")}>
+            List
+          </button>
+          <output data-testid="view">{view}</output>
+          <output data-testid="label">{lastLabel}</output>
+        </>
+      )
+    }
+    const tree = (suffix: string, mounted = true) => (
+      <StrictMode>
+        <AgentContextProvider>
+          <Bridge />
+          {mounted && <View suffix={suffix} />}
+        </AgentContextProvider>
+      </StrictMode>
+    )
+    const page = render(tree("first"))
+    if (!registry) throw new Error("Expected a context registry")
+    const live = registry
+    const registrationId = live.inspect()[0]!.registrationId
+    fireEvent.click(page.getByText("List"))
+    expect(live.inspect()[0]?.context).toMatchObject({ value: { view: "list" } })
+    expect(live.inspect()[0]?.registrationId).toBe(registrationId)
+
+    // Guard check: capture the initial handler instead of reading optionsRef.current in the hook.
+    page.rerender(tree("updated"))
+    await act(async () => {
+      await live.invoke({
+        registrationId,
+        command: "setView",
+        input: { view: "timeline" },
+        excluded: [],
+        signal: new AbortController().signal,
+      })
+    })
+    expect(page.getByTestId("view").textContent).toBe("timeline")
+    expect(page.getByTestId("label").textContent).toBe("timeline:updated")
+    expect(page.getByTestId("context").textContent).not.toContain("commands")
+
+    page.rerender(tree("updated", false))
+    expect(live.inspect()).toEqual([])
+    await expect(
+      live.invoke({
+        registrationId,
+        command: "setView",
+        input: { view: "list" },
+        excluded: [],
+        signal: new AbortController().signal,
+      })
+    ).rejects.toThrow("no longer available")
+  })
+})

--- a/packages/core/src/agents/context-command-input.ts
+++ b/packages/core/src/agents/context-command-input.ts
@@ -1,0 +1,28 @@
+import { schemaRecordToJsonSchema } from "../ontology/json-schema"
+import type { AgentToolInputSchema, InferAgentToolInputSchema } from "./types"
+import { validateAndNormalizeAgentToolInput, validateAndSnapshotAgentToolInput } from "./validation"
+
+export interface AgentContextCommandInput<TInput extends AgentToolInputSchema> {
+  readonly inputSchema: Readonly<Record<string, unknown>>
+  readonly parse: (input: unknown) => InferAgentToolInputSchema<TInput>
+}
+
+/** Compile an inline Sixb input schema for a browser-owned context command. */
+export function compileAgentContextCommandInput<const TInput extends AgentToolInputSchema>(
+  name: string,
+  input: TInput
+): AgentContextCommandInput<TInput> {
+  const shape = validateAndSnapshotAgentToolInput(name, input)
+  return {
+    inputSchema: schemaRecordToJsonSchema({ shape, valueTypesById: new Map() }),
+    parse(value) {
+      // The same schema supplies both type inference and runtime normalization.
+      return validateAndNormalizeAgentToolInput(
+        name,
+        shape,
+        value,
+        new Map()
+      ) as InferAgentToolInputSchema<TInput>
+    },
+  }
+}

--- a/packages/core/src/agents/context.ts
+++ b/packages/core/src/agents/context.ts
@@ -3,6 +3,12 @@ import { cloneJsonValue, getInvalidJsonValueReason, stableJsonStringify } from "
 import type { ObjectRef } from "../ontology/refs"
 import { AgentRequestError } from "./errors"
 
+export {
+  type AgentContextCommandInput,
+  compileAgentContextCommandInput,
+} from "./context-command-input"
+export type { AgentToolInputSchema, InferAgentToolInputSchema } from "./types"
+
 export type AgentContextInput =
   | { readonly kind: "object"; readonly ref: ObjectRef }
   | {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "paths": {
       "@sixb/action-worker": ["./packages/action-worker/src/index.ts"],
       "@sixb/agent-ui": ["./packages/agent-ui/src/index.ts"],
+      "@sixb/agent-ui/internal/context": ["./packages/agent-ui/src/internal/context.ts"],
       "@sixb/agent-ui/react-router": ["./packages/agent-ui/src/react-router.tsx"],
       "@sixb/agent-worker": ["./packages/agent-worker/src/index.ts"],
       "@sixb/app": ["./packages/app/src/index.ts"],


### PR DESCRIPTION
## Summary

Application components can expose typed view commands alongside their ambient agent context.
An agent can inspect the mounted view and change its filters, tabs, or selections through the same
React state handlers used by the interface.

```text
useAgentContext(context, { commands })
  live component registration
  current serializable view state
  typed input schema + current React handler
       |
       v
inspect_app / navigate_app
  model-facing state + command descriptors + registration ID
       |
       v
invoke_app_command
  resolve live registration
  validate input
  call the latest committed handler
  return updated application context
```

## Authoring

```tsx
import { agentContext, useAgentContext } from "@sixb/app/agents"
import { stringEnum } from "@sixb/core/ontology"
import { useState } from "react"

export function DispatchPage() {
  const [view, setView] = useState<"timeline" | "list">("timeline")
  const [availableOnly, setAvailableOnly] = useState(false)

  const updateSchedule = (input: {
    readonly view: "timeline" | "list"
    readonly availableOnly: boolean
  }) => {
    setView(input.view)
    setAvailableOnly(input.availableOnly)
  }

  useAgentContext(
    agentContext.appState("dispatch", {
      label: "Dispatch",
      description: "Current schedule view and availability filter.",
      value: { view, availableOnly },
    }),
    {
      commands: {
        setSchedule: {
          description: "Change the schedule view and availability filter.",
          input: {
            view: stringEnum(["timeline", "list"]),
            availableOnly: "boolean",
          },
          run: updateSchedule,
        },
      },
    }
  )

  return <Schedule value={{ view, availableOnly }} onChange={updateSchedule} />
}
```

Inputs use the same inline Sixb schema syntax as `defineAgentTool`. Inline `run` callbacks infer
their input automatically; named handlers can declare the matching type, as above. The same schema
produces the model-facing JSON Schema and validates/normalizes input before invoking the handler.
Named value-type references require a server ontology catalog and are not supported here.

Command names are local to a context registration, so unrelated components can each expose
`setSchedule` or `setView`. Existing single-argument `useAgentContext(context)` calls continue to work.

## Live inspection and invocation

Inspection now includes mounted context entries and their available operations:

```ts
{
  registrationId: "<live-binding-id>",
  identity: "app-state:dispatch",
  context: {
    kind: "app-state",
    id: "dispatch",
    label: "Dispatch",
    description: "Current schedule view and availability filter.",
    value: { view: "timeline", availableOnly: false },
  },
  commands: [{
    name: "setSchedule",
    description: "Change the schedule view and availability filter.",
    inputSchema: {
      type: "object",
      properties: {
        view: { type: "string", enum: ["timeline", "list"] },
        availableOnly: { type: "boolean" },
      },
      required: ["view", "availableOnly"],
      additionalProperties: false,
    },
  }],
}
```

The agent invokes the exact binding returned by inspection:

```ts
invoke_app_command({
  registrationId: "<live-binding-id>",
  command: "setSchedule",
  inputJson: '{"view":"list","availableOnly":true}',
})
```

The host parses the JSON and sends the request to the originating tab. The browser resolves the
registration, validates the command input, runs its handler, waits for the UI update boundary, and
returns current page information and mounted context. A user can navigate to Dispatch and change
its view in one conversation turn without an agent tool definition for each component.

## Context and handler lifetime

Durable user messages retain plain context snapshots. Command callbacks and definitions remain
browser-owned bindings and are advertised through live inspection. When context supplies
`modelValue`, inspection uses that projection too.

```text
state or props change       retain binding; read latest committed handler
context identity changes    revoke old binding and cancel pending work
component unmounts          revoke binding and cancel pending work
component remounts          create a new binding
duplicate context identity latest registration is active
```

The registry replaces the provider's previous context map and is exposed to the app bridge through
`@sixb/agent-ui/internal/context`. Commands read handler refs updated during React's commit phase,
so inline callback identity does not create a new registration on every render. A nested registration
shadows the previous one; removing it restores the still-mounted parent's context.

Handlers return `void` or `Promise<void>` and receive `{ signal }` as their second argument.
Unmounting, replacement, shadowing, and execution cancellation abort pending work. Asynchronous
handlers must honor the signal before delayed state changes. The bridge releases a cancelled
invocation even if its handler never settles.

## Composer exclusions and command expiry

The route context records the identities offered to the composer as host metadata. For the
triggering user message, offered context chips that were removed are excluded from subsequent live
inspection and invocation. Newly mounted context after navigation remains discoverable. Removing
the route context itself prevents that message from receiving the tab's host tools.

Browser commands now carry an expiry timestamp. Cancellation and timeout also remove commands
still waiting in the tab's queue, and the browser checks expiry before executing them. Old or
excluded registrations fail with an actionable request to inspect the current view again.

The framework prompt directs agents to inspect before invoking a view command and to use the
resulting state to verify it. View commands operate interface state; business changes continue
through declared Sixb actions and workflow interventions.

## Northline

On Dispatch, ask:

> Show only available technicians in List view.

The page contributes its selected date, presentation, and availability filter, and exposes
`setSchedule`. That command updates the same state as the List/Timeline and availability controls.
Manual changes appear in the next inspection. Removing the Dispatch context chip excludes its live
context and commands for that turn.

Two small independent commits also preserve the original branch's demo-model switch to
`poolside/laguna-s-2.1-free` and workspace-version synchronization in `bun.lock`.

## Stack

1. #536: assistant surfaces, Northline, and Atlas — base `main`.
2. #537: browser context and navigation — base `agent-surface-ux`.
3. **#538 (this PR):** typed operations on mounted views — base `agent-browser-navigation`.

Merge bottom-up. This PR's diff contains the view-command layer and the two independent commits
noted above.

## Verification

Local checks at this branch's head (`0f8aae60`):

```text
targeted context-command, React bridge, browser-control,
agent-prompt, and core context tests   36 passed

bun run typecheck                     passed
bun run check                         passed
bun run build                         passed
bun run test:ci                       4,679 passed; 2 skipped; 0 failed
bun run test:publish                  verified 52 publishable packages
```

The React integration test drives the host tools through browser polling into a rendered component
and verifies the returned committed state. Additional tests cover input validation, latest props,
manual/agent state parity, exclusions, stale bindings, nested registrations, and cancellation.

Client generation was verified on the preceding browser layer; this PR leaves those generated
artifacts unchanged. The complete stacked tree matches the original pre-split snapshot. Live
model/browser dogfooding and the separate E2E suite were not run locally. GitHub Actions results
are reported separately on the PR.
