### PR TITLE
core: activate delegated SDK with closed auxiliary surfaces

### DIFF
--- a/packages/core/src/agents/execution.ts
+++ b/packages/core/src/agents/execution.ts
@@ -1,6 +1,7 @@
 import { principalsEqual, SYSTEM_PRINCIPAL } from "../auth"
-import { assertAuthorized, isAllowed } from "../authorization"
+import { assertAuthorized, isRuntimeAllowed } from "../authorization"
 import type { AuthorizablePrincipal, ExecutionContext } from "../execution"
+import { resolveRuntimeAuthorizationForProject } from "../execution/authorization"
 import type { ModelCatalog } from "../models"
 import { resolveExecutionCosts } from "../runtime/ai-cost"
 import { resolveExecutionUsage } from "../runtime/ai-usage"
@@ -82,22 +83,25 @@ export function createAgentRuntime(
   execution: ExecutionContext,
   models?: ModelCatalog
 ): AgentRuntime {
-  const principal = runtime.authorization?.principal ?? SYSTEM_PRINCIPAL
-  const allowed = () => isAllowed(runtime.authorization, { kind: "agent.run" })
+  const authority = resolveRuntimeAuthorizationForProject(runtime)
+  const principal = authority.type === "principal" ? authority.context.principal : SYSTEM_PRINCIPAL
+  const allowed = () => isRuntimeAllowed(runtime, { kind: "agent.run" })
 
   const getVisibleThreadRecord = async (threadId: string): Promise<AgentThreadRecord | null> => {
+    if (authority.type === "denied" || authority.type === "delegated") return null
     const thread =
       (await runtime.storage.agents?.threads.getById({
         projectId: runtime.projectId,
         id: threadId,
       })) ?? null
     if (!thread || !allowed()) return null
-    return runtime.authorization && !principalsEqual(principal, thread.ownerPrincipal)
+    return authority.type === "principal" && !principalsEqual(principal, thread.ownerPrincipal)
       ? null
       : thread
   }
 
   const getAgent = (): AgentDescriptor | null => {
+    if (authority.type === "denied" || authority.type === "delegated") return null
     const model = models?.language.default
     if (!model || !allowed()) return null
     return {
@@ -107,6 +111,7 @@ export function createAgentRuntime(
   }
 
   const getVisibleRunRecord = async (runId: string): Promise<ConversationAgentRunRecord | null> => {
+    if (authority.type === "denied" || authority.type === "delegated") return null
     const run =
       (await runtime.storage.agents?.runs.getById({
         projectId: runtime.projectId,
@@ -148,12 +153,15 @@ export function createAgentRuntime(
       getById: getVisibleThreadRecord,
       list: async (input = {}) => {
         assertNoAgentSelector(input)
+        if (authority.type === "denied" || authority.type === "delegated") {
+          return { threads: [], hasMore: false, total: 0 }
+        }
         const storage = runtime.storage.agents
         if (!storage || !allowed()) return { threads: [], hasMore: false, total: 0 }
         return storage.threads.list({
           ...input,
           projectId: runtime.projectId,
-          ownerPrincipal: runtime.authorization ? principal : undefined,
+          ownerPrincipal: authority.type === "principal" ? principal : undefined,
         })
       },
     },

--- a/packages/core/src/ai-usage/execution.ts
+++ b/packages/core/src/ai-usage/execution.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto"
-import { assertAuthorized, assertRuntimeAuthorizationBound, isAllowed } from "../authorization"
+import { assertAuthorized, isRuntimeAllowed } from "../authorization"
 import type { SixbRuntimeContext } from "../runtime/types"
 import type { SecurityDefinitionCatalog } from "../security"
 import type {
@@ -87,11 +87,9 @@ export function createAiUsageRuntime(
   const assertObservable = () => assertAuthorized(runtime, { kind: "aiUsage.observe" })
   const assertManageable = () => assertAuthorized(runtime, { kind: "aiUsage.manage" })
   const assertPolicyReadable = () => {
-    const resolved = assertRuntimeAuthorizationBound(runtime)
     if (
-      resolved.type === "principal" &&
-      !isAllowed(resolved.context, { kind: "aiUsage.observe" }) &&
-      !isAllowed(resolved.context, { kind: "aiUsage.manage" })
+      !isRuntimeAllowed(runtime, { kind: "aiUsage.observe" }) &&
+      !isRuntimeAllowed(runtime, { kind: "aiUsage.manage" })
     ) {
       assertObservable()
     }
@@ -114,12 +112,7 @@ export function createAiUsageRuntime(
     limitsConfigured: runtime.storage.aiLimits !== undefined,
     assertObservable,
     assertManageable,
-    canManageLimits: () => {
-      const resolved = assertRuntimeAuthorizationBound(runtime)
-      return (
-        resolved.type !== "principal" || isAllowed(resolved.context, { kind: "aiUsage.manage" })
-      )
-    },
+    canManageLimits: () => isRuntimeAllowed(runtime, { kind: "aiUsage.manage" }),
     queryOverview: (input) => {
       assertObservable()
       return requireCosts().queryProjectOverview({ ...input, projectId: runtime.projectId })

--- a/packages/core/src/authorization/decision.ts
+++ b/packages/core/src/authorization/decision.ts
@@ -153,6 +153,13 @@ export function assertAuthorized(runtime: AuthorizedRuntime, request: AuthzReque
   )
 }
 
+/** Runtime catalogs never infer unrestricted access from an absent principal context. */
+export function isRuntimeAllowed(runtime: AuthorizedRuntime, request: AuthzRequest): boolean {
+  const authority = resolveRuntimeAuthorizationForProject(runtime)
+  if (authority.type === "denied" || authority.type === "delegated") return false
+  return authority.type === "unrestricted" || isAllowed(authority.context, request)
+}
+
 /** Resolve registered process-local authority before a protected leaf makes a decision. */
 export function assertRuntimeAuthorizationBound(
   runtime: AuthorizedRuntime

--- a/packages/core/src/authorization/index.ts
+++ b/packages/core/src/authorization/index.ts
@@ -10,6 +10,7 @@ export {
   assertRuntimeAuthorizationBound,
   evaluate,
   isAllowed,
+  isRuntimeAllowed,
 } from "./decision"
 export { AuthorizationError } from "./errors"
 export { canViewEvent } from "./event-visibility"

--- a/packages/core/src/datasets/execution.ts
+++ b/packages/core/src/datasets/execution.ts
@@ -1,6 +1,7 @@
-import { assertPrivileged, isAllowed } from "../authorization"
+import { assertPrivileged, isRuntimeAllowed } from "../authorization"
 import type { BlobStorage } from "../blob-storage"
 import type { ExecutionContext } from "../execution"
+import { resolveRuntimeAuthorizationForProject } from "../execution/authorization"
 import type { DatasetMergeCommitResult } from "../lake-storage/merge"
 import { getDatasetPrimaryKeyColumns } from "../lake-storage/merge-validation"
 import type { DatasetRow, LakeStorage } from "../lake-storage/types"
@@ -32,12 +33,17 @@ export function createDatasetsRuntime(
   lakeStorage: LakeStorage,
   blobStorage: Pick<BlobStorage, "stat">
 ): DatasetsRuntime {
+  const authority = resolveRuntimeAuthorizationForProject(runtime)
   const allowed = (datasetId: string) =>
-    isAllowed(runtime.authorization, { kind: "dataset.view", datasetId })
+    isRuntimeAllowed(runtime, { kind: "dataset.view", datasetId })
 
   return {
-    list: () => source.list().filter((dataset) => allowed(dataset.id)),
+    list: () =>
+      authority.type === "denied" || authority.type === "delegated"
+        ? []
+        : source.list().filter((dataset) => allowed(dataset.id)),
     getById: (datasetId) => {
+      if (authority.type === "denied" || authority.type === "delegated") return null
       const dataset = source.getById(datasetId)
       return dataset && allowed(datasetId) ? dataset : null
     },

--- a/packages/core/src/events/execution.ts
+++ b/packages/core/src/events/execution.ts
@@ -1,4 +1,5 @@
 import { assertPrivileged, canViewEvent } from "../authorization"
+import { resolveRuntimeAuthorizationForProject } from "../execution/authorization"
 import type { SixbRuntimeContext } from "../runtime/types"
 import type {
   EventsAppendInput,
@@ -21,8 +22,31 @@ export interface EventsRuntime {
 }
 
 export function createEventsRuntime(runtime: SixbRuntimeContext): EventsRuntime {
+  const authority = resolveRuntimeAuthorizationForProject(runtime)
+  const visibleEvents = (events: readonly StoredDomainEvent[]): readonly StoredDomainEvent[] => {
+    switch (authority.type) {
+      case "denied":
+      case "delegated":
+        return []
+      case "principal":
+        return events.filter((event) => canViewEvent(authority.context, event))
+      case "unrestricted":
+        return [...events]
+    }
+  }
+
   return {
-    canRead: (event) => canViewEvent(runtime.authorization, event),
+    canRead: (event) => {
+      switch (authority.type) {
+        case "denied":
+        case "delegated":
+          return false
+        case "principal":
+          return canViewEvent(authority.context, event)
+        case "unrestricted":
+          return true
+      }
+    },
     append: (input) => {
       assertPrivileged(runtime, "events.append")
       return runtime.events.append(input)
@@ -32,14 +56,40 @@ export function createEventsRuntime(runtime: SixbRuntimeContext): EventsRuntime 
       return runtime.events.emit(input, options)
     },
     read: async (input) => {
+      switch (authority.type) {
+        case "denied":
+        case "delegated":
+          return []
+        case "principal":
+        case "unrestricted":
+          break
+      }
       const events = await runtime.events.read(input)
-      return events.filter((event) => canViewEvent(runtime.authorization, event))
+      return visibleEvents(events)
     },
-    latestCursor: () => runtime.events.latestCursor(),
-    subscribe: (input, handler) =>
-      runtime.events.subscribe(input, (events) => {
-        const visible = events.filter((event) => canViewEvent(runtime.authorization, event))
+    latestCursor: () => {
+      switch (authority.type) {
+        case "denied":
+        case "delegated":
+          return Promise.resolve(undefined)
+        case "principal":
+        case "unrestricted":
+          return runtime.events.latestCursor()
+      }
+    },
+    subscribe: (input, handler) => {
+      switch (authority.type) {
+        case "denied":
+        case "delegated":
+          return Promise.resolve(() => {})
+        case "principal":
+        case "unrestricted":
+          break
+      }
+      return runtime.events.subscribe(input, (events) => {
+        const visible = visibleEvents(events)
         if (visible.length > 0) handler(visible)
-      }),
+      })
+    },
   }
 }

--- a/packages/core/src/pipelines/execution.ts
+++ b/packages/core/src/pipelines/execution.ts
@@ -1,5 +1,6 @@
-import { canViewPipelineRun, isAllowed } from "../authorization"
+import { assertAuthorized, canViewPipelineRun, isRuntimeAllowed } from "../authorization"
 import type { ExecutionContext } from "../execution"
+import { resolveRuntimeAuthorizationForProject } from "../execution/authorization"
 import type { SixbRuntimeContext } from "../runtime/types"
 import type {
   ListLatestPipelineRunsResult,
@@ -41,30 +42,46 @@ export function createPipelinesRuntime(
   execution: ExecutionContext,
   source: Pick<PipelinesRuntime, "list" | "getById">
 ): PipelinesRuntime {
+  const authority = resolveRuntimeAuthorizationForProject(runtime)
   const allowed = (pipelineId: string) =>
-    isAllowed(runtime.authorization, { kind: "pipeline.run", pipelineId })
+    isRuntimeAllowed(runtime, { kind: "pipeline.run", pipelineId })
   const visibleIds = () =>
     source
       .list()
       .filter((pipeline) => allowed(pipeline.id))
       .map((pipeline) => pipeline.id)
+  const historyFilterIds = () =>
+    authority.type === "unrestricted"
+      ? undefined
+      : authority.type === "principal"
+        ? visibleIds()
+        : []
 
   const getRun = async (runId: string) => {
+    if (authority.type === "denied" || authority.type === "delegated") return null
     const run =
       (await runtime.storage.pipelineRuns?.getById({
         projectId: runtime.projectId,
         id: runId,
       })) ?? null
-    return run && canViewPipelineRun(runtime.authorization, run) ? run : null
+    if (!run) return null
+    return authority.type === "unrestricted" || canViewPipelineRun(authority.context, run)
+      ? run
+      : null
   }
 
   return {
-    list: () => source.list().filter((pipeline) => allowed(pipeline.id)),
+    list: () =>
+      authority.type === "denied" || authority.type === "delegated"
+        ? []
+        : source.list().filter((pipeline) => allowed(pipeline.id)),
     getById: (pipelineId) => {
+      if (authority.type === "denied" || authority.type === "delegated") return null
       const pipeline = source.getById(pipelineId)
       return pipeline && allowed(pipelineId) ? pipeline : null
     },
     request: async (input) => {
+      assertAuthorized(runtime, { kind: "pipeline.run", pipelineId: input.pipelineId })
       const pipeline = source.getById(input.pipelineId)
       if (!pipeline) throw new PipelineError(`[Sixb] Unknown pipeline '${input.pipelineId}'`)
       return requestPipelineRun(runtime, execution, pipeline, input)
@@ -72,15 +89,21 @@ export function createPipelinesRuntime(
     runs: {
       getById: getRun,
       list: (input = {}) => {
+        if (authority.type === "denied" || authority.type === "delegated") {
+          return Promise.resolve({ runs: [], hasMore: false, total: 0 })
+        }
         const storage = runtime.storage.pipelineRuns
         if (!storage) return Promise.resolve({ runs: [], hasMore: false, total: 0 })
         return storage.list({
-          projectId: runtime.projectId,
           ...input,
-          pipelineIds: runtime.authorization ? visibleIds() : undefined,
+          pipelineIds: historyFilterIds(),
+          projectId: runtime.projectId,
         })
       },
       listLatest: (pipelineIds) => {
+        if (authority.type === "denied" || authority.type === "delegated") {
+          return Promise.resolve({ runs: [] })
+        }
         const storage = runtime.storage.pipelineRuns
         if (!storage || pipelineIds.length === 0) return Promise.resolve({ runs: [] })
         const allowedIds = pipelineIds.filter(allowed)
@@ -95,9 +118,9 @@ export function createPipelinesRuntime(
         const storage = runtime.storage.pipelineRuns
         if (!storage || !(await getRun(runId))) return null
         return storage.listSteps({
-          projectId: runtime.projectId,
           ...input,
           pipelineRunId: runId,
+          projectId: runtime.projectId,
         })
       },
     },

--- a/packages/core/src/projections/execution.ts
+++ b/packages/core/src/projections/execution.ts
@@ -1,4 +1,5 @@
 import { canViewProjection, canViewProjectionRun } from "../authorization"
+import { resolveRuntimeAuthorizationForProject } from "../execution/authorization"
 import type { SixbRuntimeContext } from "../runtime/types"
 import type {
   ListLatestProjectionRunsResult,
@@ -35,8 +36,31 @@ export function createProjectionsRuntime(
   runtime: SixbRuntimeContext,
   source: ProjectionDefinitionCatalog
 ): ProjectionsRuntime {
-  const visible = (projection: ProjectionDefinition) =>
-    canViewProjection(runtime.authorization, projection)
+  const authority = resolveRuntimeAuthorizationForProject(runtime)
+  const listVisible = <TProjection extends ProjectionDefinition>(
+    list: () => readonly TProjection[]
+  ): readonly TProjection[] => {
+    switch (authority.type) {
+      case "denied":
+      case "delegated":
+        return []
+      case "principal":
+        return list().filter((projection) => canViewProjection(authority.context, projection))
+      case "unrestricted":
+        return [...list()]
+    }
+  }
+  const visible = (projection: ProjectionDefinition) => {
+    switch (authority.type) {
+      case "denied":
+      case "delegated":
+        return false
+      case "principal":
+        return canViewProjection(authority.context, projection)
+      case "unrestricted":
+        return true
+    }
+  }
   const visibleIds = (projectionIds: readonly string[]) =>
     projectionIds.filter((projectionId) => {
       const projection = source.getById(projectionId)
@@ -44,35 +68,72 @@ export function createProjectionsRuntime(
     })
 
   return {
-    list: () => source.list().filter(visible),
-    listObjects: () => source.listObjects().filter(visible),
-    listLinks: () => source.listLinks().filter(visible),
-    listTelemetry: () => source.listTelemetry().filter(visible),
+    list: () => listVisible(() => source.list()),
+    listObjects: () => listVisible(() => source.listObjects()),
+    listLinks: () => listVisible(() => source.listLinks()),
+    listTelemetry: () => listVisible(() => source.listTelemetry()),
     getById: (projectionId) => {
+      switch (authority.type) {
+        case "denied":
+        case "delegated":
+          return null
+        case "principal":
+        case "unrestricted":
+          break
+      }
       const projection = source.getById(projectionId)
       return projection && visible(projection) ? projection : null
     },
     runs: {
       getById: async (runId) => {
+        switch (authority.type) {
+          case "denied":
+          case "delegated":
+            return null
+          case "principal":
+          case "unrestricted":
+            break
+        }
         const run =
           (await runtime.storage.projectionRuns?.getById({
             projectId: runtime.projectId,
             id: runId,
           })) ?? null
-        return run && canViewProjectionRun(runtime.authorization, run.target) ? run : null
+        if (!run) return null
+        return authority.type === "unrestricted" ||
+          canViewProjectionRun(authority.context, run.target)
+          ? run
+          : null
       },
       list: (input = {}) => {
+        switch (authority.type) {
+          case "denied":
+          case "delegated":
+            return Promise.resolve({ runs: [], hasMore: false, total: 0 })
+          case "principal":
+          case "unrestricted":
+            break
+        }
         const storage = runtime.storage.projectionRuns
         if (!storage) return Promise.resolve({ runs: [], hasMore: false, total: 0 })
         return storage.list({
-          projectId: runtime.projectId,
           ...input,
-          objectTypeIds: runtime.authorization
-            ? [...runtime.authorization.grants["view:object"]]
-            : undefined,
+          objectTypeIds:
+            authority.type === "principal"
+              ? [...authority.context.grants["view:object"]]
+              : undefined,
+          projectId: runtime.projectId,
         })
       },
       listLatest: (projectionIds) => {
+        switch (authority.type) {
+          case "denied":
+          case "delegated":
+            return Promise.resolve({ runs: [] })
+          case "principal":
+          case "unrestricted":
+            break
+        }
         const storage = runtime.storage.projectionRuns
         if (!storage || projectionIds.length === 0) return Promise.resolve({ runs: [] })
         const ids = visibleIds(projectionIds)

--- a/packages/core/src/rules/execution.ts
+++ b/packages/core/src/rules/execution.ts
@@ -1,4 +1,5 @@
-import { isAllowed } from "../authorization"
+import { isRuntimeAllowed } from "../authorization"
+import { resolveRuntimeAuthorizationForProject } from "../execution/authorization"
 import type { DefinitionCatalog } from "../runtime/definitions"
 import type { SixbRuntimeContext } from "../runtime/types"
 import type { ListActiveRuleStatesInput, ListActiveRuleStatesResult } from "../storage/rules"
@@ -20,28 +21,39 @@ export function createRulesRuntime(
   runtime: SixbRuntimeContext,
   source: DefinitionCatalog<RuleDefinition>
 ): RulesRuntime {
-  const visible = (rule: RuleDefinition) =>
-    isAllowed(runtime.authorization, {
+  const authority = resolveRuntimeAuthorizationForProject(runtime)
+  const visible = (rule: RuleDefinition) => {
+    if (authority.type === "denied" || authority.type === "delegated") return false
+    return isRuntimeAllowed(runtime, {
       kind: "object.view",
       objectTypeId: rule.subject.objectTypeId,
     })
+  }
 
   return {
-    list: () => source.list().filter(visible),
+    list: () =>
+      authority.type === "denied" || authority.type === "delegated"
+        ? []
+        : source.list().filter(visible),
     getById: (ruleId) => {
+      if (authority.type === "denied" || authority.type === "delegated") return null
       const rule = source.getById(ruleId)
       return rule && visible(rule) ? rule : null
     },
     states: {
       list: (input = {}) => {
+        if (authority.type === "denied" || authority.type === "delegated") {
+          return Promise.resolve({ states: [], hasMore: false, total: 0 })
+        }
         const storage = runtime.storage.rules
         if (!storage) return Promise.resolve({ states: [], hasMore: false, total: 0 })
         return storage.listActive({
-          projectId: runtime.projectId,
           ...input,
-          objectTypeIds: runtime.authorization
-            ? [...runtime.authorization.grants["view:object"]]
-            : undefined,
+          objectTypeIds:
+            authority.type === "principal"
+              ? [...authority.context.grants["view:object"]]
+              : undefined,
+          projectId: runtime.projectId,
         })
       },
     },

--- a/packages/core/src/runtime/host.ts
+++ b/packages/core/src/runtime/host.ts
@@ -245,11 +245,6 @@ export class SixbHost<
   withScope(scope: ExecutionScope): Sixb<TOntologySources> {
     const capturedScope = captureExecutionScope(scope)
     const authorization = resolveExecutionScopeAuthorization(this.projectId, capturedScope)
-    if (authorization.type === "delegated") {
-      throw new Error(
-        "[Sixb] Delegated runtime authorization cannot be bound to the domain SDK until every delegated surface is activated."
-      )
-    }
     if (authorization.type === "unrestricted" && authorization.ref.type === "kernel") {
       throw new Error("[Sixb] Kernel authority cannot be bound to the domain SDK.")
     }

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -119,7 +119,7 @@ function createExecutionFacades<TOntologySources extends readonly OntologySource
     aiUsage: createAiUsageRuntime(runtime, dependencies.definitions.security),
     events: createEventsRuntime(runtime),
     logs: createLogsRuntime(runtime, dependencies.logging),
-    schedules: createSchedulesRuntime(dependencies.definitions.schedules),
+    schedules: createSchedulesRuntime(runtime, dependencies.definitions.schedules),
     connector: createConnectorRuntime(runtime, execution, dependencies.connectorService),
     blobs: createBlobsRuntime(runtime, execution, dependencies.blobStorage),
   }

--- a/packages/core/src/schedules/execution.ts
+++ b/packages/core/src/schedules/execution.ts
@@ -1,14 +1,36 @@
+import { resolveRuntimeAuthorizationForProject } from "../execution/authorization"
 import type { DefinitionCatalog } from "../runtime/definitions"
+import type { SixbRuntimeContext } from "../runtime/types"
 import type { ScheduleDefinition } from "./types"
 
 /** Schedule definitions visible to an execution; process lifecycle remains on the host. */
 export type SchedulesRuntime = DefinitionCatalog<ScheduleDefinition>
 
 export function createSchedulesRuntime(
+  runtime: SixbRuntimeContext,
   schedules: DefinitionCatalog<ScheduleDefinition>
 ): SchedulesRuntime {
+  const authority = resolveRuntimeAuthorizationForProject(runtime)
   return {
-    list: () => schedules.list(),
-    getById: (scheduleId) => schedules.getById(scheduleId),
+    list: () => {
+      switch (authority.type) {
+        case "denied":
+        case "delegated":
+          return []
+        case "principal":
+        case "unrestricted":
+          return schedules.list()
+      }
+    },
+    getById: (scheduleId) => {
+      switch (authority.type) {
+        case "denied":
+        case "delegated":
+          return null
+        case "principal":
+        case "unrestricted":
+          return schedules.getById(scheduleId)
+      }
+    },
   }
 }

--- a/packages/core/src/syncs/execution.ts
+++ b/packages/core/src/syncs/execution.ts
@@ -1,5 +1,6 @@
-import { isAllowed } from "../authorization"
+import { assertAuthorized, isRuntimeAllowed } from "../authorization"
 import type { ExecutionContext } from "../execution"
+import { resolveRuntimeAuthorizationForProject } from "../execution/authorization"
 import type { SixbRuntimeContext } from "../runtime/types"
 import type {
   ListLatestSyncRunsResult,
@@ -29,26 +30,39 @@ export function createSyncsRuntime(
   execution: ExecutionContext,
   source: Pick<SyncsRuntime, "list" | "getById">
 ): SyncsRuntime {
-  const allowed = (syncId: string) => isAllowed(runtime.authorization, { kind: "sync.run", syncId })
+  const authority = resolveRuntimeAuthorizationForProject(runtime)
+  const allowed = (syncId: string) => isRuntimeAllowed(runtime, { kind: "sync.run", syncId })
   const visibleIds = () =>
     source
       .list()
       .filter((sync) => allowed(sync.id))
       .map((sync) => sync.id)
+  const historyFilterIds = () =>
+    authority.type === "unrestricted"
+      ? undefined
+      : authority.type === "principal"
+        ? visibleIds()
+        : []
 
   return {
-    list: () => source.list().filter((sync) => allowed(sync.id)),
+    list: () =>
+      authority.type === "denied" || authority.type === "delegated"
+        ? []
+        : source.list().filter((sync) => allowed(sync.id)),
     getById: (syncId) => {
+      if (authority.type === "denied" || authority.type === "delegated") return null
       const sync = source.getById(syncId)
       return sync && allowed(syncId) ? sync : null
     },
     request: async (input) => {
+      assertAuthorized(runtime, { kind: "sync.run", syncId: input.syncId })
       const sync = source.getById(input.syncId)
       if (!sync) throw new SyncValidationError(`[Sixb] Unknown sync '${input.syncId}'`)
       return requestSyncRun(runtime, execution, sync, input)
     },
     runs: {
       getById: async (runId) => {
+        if (authority.type === "denied" || authority.type === "delegated") return null
         const run =
           (await runtime.storage.syncRuns?.getById({
             projectId: runtime.projectId,
@@ -57,15 +71,21 @@ export function createSyncsRuntime(
         return run && allowed(run.syncId) ? run : null
       },
       list: (input = {}) => {
+        if (authority.type === "denied" || authority.type === "delegated") {
+          return Promise.resolve({ runs: [], hasMore: false, total: 0 })
+        }
         const storage = runtime.storage.syncRuns
         if (!storage) return Promise.resolve({ runs: [], hasMore: false, total: 0 })
         return storage.list({
-          projectId: runtime.projectId,
           ...input,
-          syncIds: runtime.authorization ? visibleIds() : undefined,
+          syncIds: historyFilterIds(),
+          projectId: runtime.projectId,
         })
       },
       listLatest: (syncIds) => {
+        if (authority.type === "denied" || authority.type === "delegated") {
+          return Promise.resolve({ runs: [] })
+        }
         const storage = runtime.storage.syncRuns
         if (!storage || syncIds.length === 0) return Promise.resolve({ runs: [] })
         const allowedIds = syncIds.filter(allowed)

--- a/packages/core/src/workflows/execution.ts
+++ b/packages/core/src/workflows/execution.ts
@@ -1,5 +1,11 @@
-import { canViewWorkflowIntervention, canViewWorkflowRun, isAllowed } from "../authorization"
+import {
+  assertAuthorized,
+  canViewWorkflowIntervention,
+  canViewWorkflowRun,
+  isRuntimeAllowed,
+} from "../authorization"
 import type { AuthorizablePrincipal, ExecutionContext } from "../execution"
+import { resolveRuntimeAuthorizationForProject } from "../execution/authorization"
 import { resolveExecutionCosts } from "../runtime/ai-cost"
 import { resolveExecutionUsage } from "../runtime/ai-usage"
 import type { SixbRuntimeContext } from "../runtime/types"
@@ -101,22 +107,40 @@ export function createWorkflowsRuntime(
   execution: ExecutionContext,
   source: Pick<WorkflowsRuntime, "list" | "getById">
 ): WorkflowsRuntime {
+  const authority = resolveRuntimeAuthorizationForProject(runtime)
   const allowed = (workflowId: string) =>
-    isAllowed(runtime.authorization, { kind: "workflow.run", workflowId })
-  const canAccessHistory = (workflowId: string) =>
-    allowed(workflowId) && (!runtime.authorization || source.getById(workflowId) !== null)
+    isRuntimeAllowed(runtime, { kind: "workflow.run", workflowId })
+  const canAccessHistory = (workflowId: string) => {
+    switch (authority.type) {
+      case "denied":
+      case "delegated":
+        return false
+      case "unrestricted":
+        return true
+      case "principal":
+        return allowed(workflowId) && source.getById(workflowId) !== null
+    }
+  }
   const visibleIds = () =>
     source
       .list()
       .filter((workflow) => allowed(workflow.id))
       .map((workflow) => workflow.id)
+  const historyFilterIds = () =>
+    authority.type === "unrestricted"
+      ? undefined
+      : authority.type === "principal"
+        ? visibleIds()
+        : []
   const getVisibleRunRecord = async (runId: string): Promise<WorkflowRunRecord | null> => {
+    if (authority.type === "denied" || authority.type === "delegated") return null
     const run =
       (await runtime.storage.workflowRuns?.getById({
         projectId: runtime.projectId,
         id: runId,
       })) ?? null
-    return run && canViewWorkflowRun(runtime.authorization, run) && canAccessHistory(run.workflowId)
+    if (!run || !canAccessHistory(run.workflowId)) return null
+    return authority.type === "unrestricted" || canViewWorkflowRun(authority.context, run)
       ? run
       : null
   }
@@ -131,9 +155,9 @@ export function createWorkflowsRuntime(
     const storage = runtime.storage.workflowRuns
     if (!storage || !(await getVisibleRunRecord(runId))) return null
     const result = await storage.nodes.list({
-      projectId: runtime.projectId,
       ...input,
       workflowRunId: runId,
+      projectId: runtime.projectId,
     })
     return {
       ...result,
@@ -142,13 +166,18 @@ export function createWorkflowsRuntime(
   }
 
   return {
-    list: () => source.list().filter((workflow) => allowed(workflow.id)),
+    list: () =>
+      authority.type === "denied" || authority.type === "delegated"
+        ? []
+        : source.list().filter((workflow) => allowed(workflow.id)),
     getById: (workflowId) => {
+      if (authority.type === "denied" || authority.type === "delegated") return null
       const workflow = source.getById(workflowId)
       return workflow && allowed(workflowId) ? workflow : null
     },
     request: (workflow, options) => requestWorkflowRun(runtime, execution, workflow, options),
     requestById: async (input) => {
+      assertAuthorized(runtime, { kind: "workflow.run", workflowId: input.workflowId })
       const workflow = source.getById(input.workflowId)
       if (!workflow) {
         throw new WorkflowValidationError(`[Sixb] Unknown workflow '${input.workflowId}'`)
@@ -158,12 +187,15 @@ export function createWorkflowsRuntime(
     runs: {
       getById: getRun,
       list: async (input = {}) => {
+        if (authority.type === "denied" || authority.type === "delegated") {
+          return { runs: [], hasMore: false, total: 0 }
+        }
         const storage = runtime.storage.workflowRuns
         if (!storage) return { runs: [], hasMore: false, total: 0 }
         const result = await storage.list({
-          projectId: runtime.projectId,
           ...input,
-          workflowIds: runtime.authorization ? visibleIds() : undefined,
+          workflowIds: historyFilterIds(),
+          projectId: runtime.projectId,
         })
         return {
           ...result,
@@ -171,6 +203,9 @@ export function createWorkflowsRuntime(
         }
       },
       listLatest: async (workflowIds) => {
+        if (authority.type === "denied" || authority.type === "delegated") {
+          return { runs: [] }
+        }
         const storage = runtime.storage.workflowRuns
         if (!storage || workflowIds.length === 0) return { runs: [] }
         const allowedIds = workflowIds.filter(canAccessHistory)
@@ -187,24 +222,28 @@ export function createWorkflowsRuntime(
     },
     interventions: {
       getById: async (interventionId) => {
+        if (authority.type === "denied" || authority.type === "delegated") return null
         const intervention =
           (await runtime.storage.workflowInterventions?.getById({
             projectId: runtime.projectId,
             id: interventionId,
           })) ?? null
-        return intervention &&
-          canViewWorkflowIntervention(runtime.authorization, intervention) &&
-          canAccessHistory(intervention.workflowId)
+        if (!intervention || !canAccessHistory(intervention.workflowId)) return null
+        return authority.type === "unrestricted" ||
+          canViewWorkflowIntervention(authority.context, intervention)
           ? intervention
           : null
       },
       list: (input = {}) => {
+        if (authority.type === "denied" || authority.type === "delegated") {
+          return Promise.resolve({ interventions: [], hasMore: false, total: 0 })
+        }
         const storage = runtime.storage.workflowInterventions
         if (!storage) return Promise.resolve({ interventions: [], hasMore: false, total: 0 })
         return storage.list({
-          projectId: runtime.projectId,
           ...input,
-          workflowIds: runtime.authorization ? visibleIds() : undefined,
+          workflowIds: historyFilterIds(),
+          projectId: runtime.projectId,
         })
       },
     },

--- a/packages/core/tests/authorized-object-reader-runtime.test.ts
+++ b/packages/core/tests/authorized-object-reader-runtime.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, test } from "bun:test"
+import { createAgentRuntime } from "../src/agents/execution"
+import { createDatasetsRuntime } from "../src/datasets/execution"
 import { createAuthorizedObjectReader } from "../src/execution/authorized-object-reader"
 import { createDelegatedRequestScope, createTestingScope } from "../src/execution/scopes"
 import { OntologyRegistry } from "../src/ontology"
+import { createPipelinesRuntime } from "../src/pipelines/execution"
+import { createProjectionsRuntime } from "../src/projections/execution"
+import { createRulesRuntime } from "../src/rules/execution"
 import { SixbHost } from "../src/runtime/host"
 import { createBoundSixb, type SixbDependencies } from "../src/runtime/sixb"
 import type { SixbRuntimeContext } from "../src/runtime/types"
+import { createSchedulesRuntime } from "../src/schedules/execution"
 import { InMemoryStorage } from "../src/storage"
+import { createSyncsRuntime } from "../src/syncs/execution"
+import { createWorkflowsRuntime } from "../src/workflows/execution"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
 
 const projectId = "authorized-object-reader-runtime"
@@ -48,7 +56,7 @@ describe("AuthorizedObjectReader runtime binding", () => {
     expect(authorizationReads).toBe(1)
   })
 
-  test("SixbHost keeps delegated authority off the domain SDK until every surface is active", () => {
+  test("SixbHost binds selected reads while delegated non-object surfaces stay closed", async () => {
     const host = new SixbHost({ id: projectId, ontology: [], ...createTestRuntimeDeps() })
     const scope = createDelegatedRequestScope({
       projectId,
@@ -60,9 +68,103 @@ describe("AuthorizedObjectReader runtime binding", () => {
       },
     })
 
-    expect(() => host.withScope(scope)).toThrow(
-      "Delegated runtime authorization cannot be bound to the domain SDK"
-    )
+    const sixb = host.withScope(scope)
+    expect(sixb.objects.listTypes()).toEqual([])
+    // Reverting the authority guard in any facade makes its dependency trap fail this test.
+    const trap = () => {
+      throw new Error("Unscoped dependency access")
+    }
+    const runtime: SixbRuntimeContext = {
+      projectId,
+      runtimeAuthorization: scope.authorization,
+      objectReader: createAuthorizedObjectReader({
+        scope,
+        ontology: host.definitions.ontology as OntologyRegistry,
+        objectStorage: host.storage.objects,
+      }),
+      broker: host.broker,
+      ontology: host.definitions.ontology as OntologyRegistry,
+      actionRegistry: host.definitions.actions,
+      events: host.events,
+      queues: host.queues,
+      get storage() {
+        return trap()
+      },
+    }
+    const source = { list: trap, getById: trap }
+    const catalogs = [
+      createDatasetsRuntime(runtime, scope.execution, source, host.lakeStorage, host.blobStorage),
+      createWorkflowsRuntime(runtime, scope.execution, source),
+      createSyncsRuntime(runtime, scope.execution, source),
+      createPipelinesRuntime(runtime, scope.execution, source),
+      createProjectionsRuntime(runtime, {
+        ...source,
+        listObjects: trap,
+        listLinks: trap,
+        listTelemetry: trap,
+      }),
+      createRulesRuntime(runtime, source),
+      createSchedulesRuntime(runtime, source),
+    ]
+    for (const catalog of catalogs) {
+      expect(catalog.list()).toEqual([])
+      expect(catalog.getById("guessed")).toBeNull()
+    }
+    const agent = createAgentRuntime(runtime, scope.execution)
+    expect(agent.get()).toBeNull()
+    expect(await agent.threads.getById("guessed")).toBeNull()
+    expect(await agent.threads.list()).toEqual({ threads: [], total: 0, hasMore: false })
+    expect(await agent.runs.getById("guessed")).toBeNull()
+    await expect(agent.runs.request({ text: "hello" })).rejects.toMatchObject({
+      code: "agent_not_found",
+    })
+    host.events.read = async () => {
+      throw new Error("Unscoped event read")
+    }
+    host.events.latestCursor = async () => {
+      throw new Error("Unscoped cursor read")
+    }
+    host.events.subscribe = async () => {
+      throw new Error("Unscoped subscription")
+    }
+    expect(await sixb.events.read()).toEqual([])
+    expect(await sixb.events.latestCursor()).toBeUndefined()
+    expect(typeof (await sixb.events.subscribe({}, () => {}))).toBe("function")
+    expect(await sixb.workflows.runs.list()).toEqual({ runs: [], total: 0, hasMore: false })
+    expect(await sixb.syncs.runs.list()).toEqual({ runs: [], total: 0, hasMore: false })
+    expect(await sixb.pipelines.runs.list()).toEqual({ runs: [], total: 0, hasMore: false })
+    expect(await sixb.projections.runs.list()).toEqual({ runs: [], total: 0, hasMore: false })
+    expect(await sixb.agent.threads.list()).toEqual({ threads: [], total: 0, hasMore: false })
+    expect(await sixb.rules.states.list()).toEqual({ states: [], total: 0, hasMore: false })
+    expect(() => sixb.logs.read()).toThrow()
+    expect(() => sixb.blobs.open("guessed")).toThrow()
+    expect(() => sixb.events.append({ events: [] })).toThrow()
+  })
+
+  test("delegated AI usage cannot read limit policies or advertise management", () => {
+    const deps = createTestRuntimeDeps()
+    let policyReads = 0
+    deps.storage.aiLimits.listPolicies = async () => {
+      policyReads += 1
+      return []
+    }
+    const host = new SixbHost({ id: projectId, ontology: [], ...deps })
+    const scope = createDelegatedRequestScope({
+      projectId,
+      requestId: "delegated-ai-usage",
+      correlationId: "delegated-ai-usage",
+      objectRead: {
+        selection: { kind: "selected", roots: [] },
+        limits: { maxTraversalFacts: 10, maxOutputJsonBytes: 1_024 },
+      },
+    })
+    const sixb = host.withScope(scope)
+
+    // Revert the AI usage facade's isRuntimeAllowed guards: policy reads succeed and
+    // canManageLimits incorrectly advertises management for principal-free delegation.
+    expect(() => sixb.aiUsage.listLimitPolicies()).toThrow("not covered by delegated authorization")
+    expect(policyReads).toBe(0)
+    expect(sixb.aiUsage.canManageLimits()).toBe(false)
   })
 
   test("createBoundSixb rejects a reader from another exact authority", () => {


### PR DESCRIPTION
Part of #269 · Stack #547 · Parent: #506 · Next: #481

## What changes

**A delegated execution can now use the ordinary Sixb SDK.** Previous PRs prepared scoped reads and action checks; this PR enables SDK construction and closes the remaining unsupported surfaces.

```typescript
const sixb = host.withScope(delegatedScope)
// Before: throws — delegated SDK binding is disabled.
// After: returns a Sixb instance bound to the delegated authority.
```

## What that instance can access

| Surface | Delegated behavior |
| --- | --- |
| Objects, queries, links and telemetry | Existing scoped readers and limits |
| Object metadata and action catalog | Filtered metadata from #506 |
| Action execution | Only explicitly authorized action/subject targets |
| Datasets, workflows, pipelines, syncs, projections, rules and schedules | Empty catalogs or missing entries; no access to their histories |
| Agent discovery and history | Absent or empty |
| AI usage and limit policies | Denied; management capability is `false` |
| Event reads / subscriptions | Empty results / inactive subscriptions |
| Unsupported writes | Rejected before provider work |

A delegated execution has no ordinary principal context. Each surface checks its actual authority so that this absence cannot accidentally grant unrestricted access.

**Shared grants, sessions and pages arrive in the following PRs.**

## Validation

Tests use throwing dependencies to verify that closed surfaces never read underlying providers. Principal/trusted regressions, typecheck and Biome are covered.
