### PR TITLE
docs: disable automatic preview deployments

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -4,5 +4,11 @@
   "buildCommand": "bun run build",
   "installCommand": "bun install",
   "ignoreCommand": "bun ../../scripts/docs-vercel-ignore.ts",
+  "git": {
+    "deploymentEnabled": {
+      "**": false,
+      "main": true
+    }
+  },
   "github": { "silent": true }
 }

--- a/scripts/docs-vercel-ignore.ts
+++ b/scripts/docs-vercel-ignore.ts
@@ -1,5 +1,7 @@
 /**
  * Vercel's Ignored Build Step for the docs site: exit 0 to skip the build, non-zero to run it.
+ * Automatic Git deployments are limited to `main` by apps/docs/vercel.json; PR previews are
+ * disabled there before a build is created. This step filters production builds by changed paths.
  *
  * The rule this replaces diffed `HEAD^ HEAD` against `apps/docs` and `packages/ui`, but the site
  * renders `/docs` at the repo root (`apps/docs/src/docs/config.ts`). Every documentation-only


### PR DESCRIPTION
## Summary

Disable automatic Vercel docs deployments for every Git branch except `main`. We do not use the PR previews enough to justify building them on every branch update.

- Set `git.deploymentEnabled` to disable `**` (including slash-separated branch names), with an explicit `main` exception.
- Keep the existing ignored-build script so production deployments can skip merges that do not affect the docs, docs app, shared UI, or lockfile.
- Document the distinction between the branch gate and production changed-path filtering.

## Build usage and charges

Checked the Sixb team's Vercel CLI billing usage, docs deployment history, project settings, and a preview build log on September 8, 2026.

| Docs project | August 2026 | September 1–8, 2026 |
| --- | ---: | ---: |
| Build CPU Minutes usage value | $21.49 | $1.92 |
| Total docs usage value, including hosting | $21.55 | $1.94 |
| Billed docs usage after applicable credits/allowances | $0.00 | $0.00 |
| Preview deployment records | 751 | 161 |
| Production deployment records | 106 | 27 |

Vercel meters builds under **Build CPU Minutes**. The dollar amounts above are the CLI's `effectiveCost`; `billedCost` reports the amount after applicable credits/allowances. These are usage-report figures, not finalized invoices. We are consuming build usage even though it currently produces no billed docs charge.

August had 857 docs deployment records: 765 successful and 92 canceled. About 88% were previews, spanning 179 PRs. Successful deployments had a median build duration of about 38 seconds. The $21.49 covers **all docs builds**, not previews alone; the billing query did not split preview and production costs, so this is not a claim of $21.49/month in cash savings.

The existing ignore step can also build previews without a confirmed docs change: it deliberately builds when the previous deployment's commit is outside Vercel's shallow clone. A sampled preview log confirmed this fallback. Disabling previews at the Git deployment gate avoids those builds as well.

Sources: `vercel usage --scope sixb --group-by project --json` (also queried August with `--from 2026-08-01 --to 2026-08-31`), paginated deployment records via `vercel api`, and `vercel inspect --logs` using CLI 59.11.7.

## Rollout

The branch must contain this configuration for the Git deployment gate to apply. Existing PR branches should pick it up by merging or rebasing onto updated `main`.

## Verification

- `bun test scripts/tests/docs-vercel-ignore.test.ts` — 12 passed.
- `bunx @biomejs/biome@2.4.6 check apps/docs/vercel.json scripts/docs-vercel-ignore.ts` — passed.
- `git diff --check` — passed.
- Checked Vercel's documented branch matching: an explicit `true` match permits `main` despite the catch-all `false` rule.