### PR TITLE
datasets: expose shared ingestion to webhook handlers

### DIFF
--- a/docs/data/connectors.md
+++ b/docs/data/connectors.md
@@ -469,6 +469,52 @@ export const acmeErpConnector = defineConnector("acme-erp", {
 (it gives `body` its `type`, `invoiceId`, and `deliveryId` fields). Bare `.json()` is also valid
 when you do not need a typed body. Verification and idempotency resolution run before admission; only the handler receives an execution-bound `sixb` and run logger.
 
+### Webhooks updating source datasets
+
+Use [`sixb.datasets.ingest`](./datasets.md#ingest-source-changes) to update the same source rows as a
+sync. These examples use the sequenced [`people` dataset](./datasets.md#source-ordering).
+
+**Webhook handler:** fetch the current record and submit a complete row.
+
+```ts
+.handle(async ({ body, client, sixb, request }) => {
+  const crm = await client()
+  const person = await crm.getPerson(body.personId)
+  await sixb.datasets.ingest(people, {
+    changes: [change.upsert({
+      id: String(person.id),
+      name: person.name,
+      updatedAt: person.updatedAt,
+    })],
+    signal: request.signal,
+  })
+})
+```
+
+**Snapshot sync:** use the same row mapping and source timestamp.
+
+```ts
+export const syncPeople = defineSync("crm-people")
+  .from(crmConnector)
+  .read(async (crm) => (await crm.listPeople()).map((person) => ({
+    id: String(person.id),
+    name: person.name,
+    updatedAt: person.updatedAt,
+  })))
+  .intoDataset(people)
+```
+
+**Downstream pipeline:** attach a dataset-update schedule with `.when(peopleUpdated)`.
+
+```ts
+export const peopleUpdated = defineSchedule("crm-people-updated")
+  .on(events.dataset(people).updated())
+```
+
+- Equal source revisions must map to identical rows. Use source time, never fetch time.
+- Missing snapshot rows stay. Delete explicitly with `change.delete(key, { sequence })`.
+- Delivery deduplication runs before the handler. See [recovery limits](./datasets.md#ingestion-recovery).
+
 ## Discovery and registration
 
 Put connector definitions in `connectors/` and export them. `createSixb()` discovers them

--- a/docs/data/datasets.md
+++ b/docs/data/datasets.md
@@ -164,6 +164,64 @@ restored.
 
 ## Use a dataset
 
+### Ingest source changes
+
+Webhook handlers and other trusted backend executions can update a registered, keyed dataset:
+
+```ts
+const result = await sixb.datasets.ingest(people, {
+  changes: [
+    change.upsert({ id: "42", name: "Sam", updatedAt: "2026-09-09T10:00:00.123Z" }),
+    change.delete({ id: "9" }, { sequence: "2026-09-09T10:01:00.000Z" }),
+  ],
+})
+```
+
+| Contract | Behavior |
+| --- | --- |
+| Input | Iterable or async iterable of complete-row upserts and primary-key deletes |
+| Cancellation | Optional `signal: AbortSignal` |
+| Validation | Registered schema, primary key, source sequence, and referenced blobs |
+| Result | `{ outcome: "created" \| "unchanged", version, rowsRead }`; `version` can be `null` for an initial no-op |
+| Downstream work | New versions emit `dataset.version.committed`; pipelines/projections run asynchronously |
+| Authority | Trusted backend executions, or explicitly disabled authorization; dataset-view grants do not permit ingestion |
+
+Use [`sequenceBy`](#source-ordering) when [webhooks and syncs share a dataset](./connectors.md#webhooks-updating-source-datasets).
+
+| Dataset | Concurrent writes | Snapshot sync |
+| --- | --- | --- |
+| With `sequenceBy` | Newer source values win; concurrency conflicts retry | Ordered upserts; omitted rows stay |
+| Without `sequenceBy` | A concurrent version change fails ingestion | Replaces rows |
+
+**Existing unkeyed dataset?** Create a new keyed dataset → backfill → repoint consumers.
+Stored primary keys and `sequenceBy` are immutable.
+
+#### Objects and relationships
+
+Ingestion updates source data. Existing pipelines and projections determine the object result:
+
+| Change | Downstream behavior |
+| --- | --- |
+| Source record updated | Pipeline recalculates merged data; projection updates its properties and links |
+| Application edit | Projection's [conflict policy](./projections.md#source-and-managed-edit-conflict-resolution) still applies |
+| Source row removed | Projection withdraws its claims; the ontology object is not automatically deleted |
+| Foreign-key target missing | Properties can materialize, but no edge is created; the old source-owned link is withdrawn |
+
+#### Ingestion recovery
+
+> Commits and notifications are separate. A crash can leave committed data without its notification
+> or completed run record. Durable receipts and automatic notification recovery are deferred.
+
+- Notification failures are reported through `onError`.
+- Identical sequenced retries are no-ops; they do not resend notifications.
+- Rerun the downstream pipeline after missed notifications or pipeline failures:
+
+```ts
+await sixb.pipelines.request({ pipelineId: "merge-contacts" })
+```
+
+### Syncs, pipelines, and projections
+
 A dataset on its own is just a shape. The pieces that produce and consume rows reference it.
 
 A [sync](./syncs.md) reads from a [connector](./connectors.md) and writes into one dataset. It does not repeat the schema; it points at the definition:

--- a/packages/cli/tests/webhook-ingestion.test.ts
+++ b/packages/cli/tests/webhook-ingestion.test.ts
@@ -22,6 +22,7 @@ import {
   prop,
   SixbHost,
 } from "@sixb/core"
+import { writeDataset } from "@sixb/core/internal/datasets"
 import { createTestSixb } from "@sixb/core/testing"
 import { createSixbApi, SixbServer } from "../../server/src/server"
 import { startSixbRuntime } from "../src/lib/runtime"
@@ -190,12 +191,17 @@ test("verified webhooks and snapshots feed merged contacts through orchestration
     })
   const pipeline = definePipeline("contacts").when(pdUpdated).when(docUpdated).then(merge)
   const lakeStorage = new InMemoryLakeStorage()
-  // Both pipeline inputs must have a first source version before either triggers the merge.
+  // A first empty snapshot is a real pipeline input; no fake source rows or deletions are needed.
+  // Regression proof: remove createInitialVersion from the writer; the first contact never appears.
   for (const dataset of [pipedrive, pandadoc]) {
-    await lakeStorage.createDataset(dataset)
-    const session = await lakeStorage.beginMerge({ dataset })
-    await session.writeChanges([change.delete({ id: "seed" }, { sequence: 0 })])
-    await session.commit()
+    await writeDataset({
+      lakeStorage,
+      blobStorage: new InMemoryBlobStorage(),
+      dataset,
+      mode: "snapshot",
+      signal: new AbortController().signal,
+      readValues: async () => [],
+    })
   }
   const host = new SixbHost({
     id: "webhook-ingestion",

--- a/packages/cli/tests/webhook-ingestion.test.ts
+++ b/packages/cli/tests/webhook-ingestion.test.ts
@@ -1,0 +1,344 @@
+import { expect, test } from "bun:test"
+import {
+  change,
+  col,
+  defineConnector,
+  defineDataset,
+  defineObjectType,
+  definePipeline,
+  definePipelineStep,
+  defineProjection,
+  defineSchedule,
+  defineSync,
+  defineWebhook,
+  events,
+  fromForeignKey,
+  InMemoryBlobStorage,
+  InMemoryBroker,
+  InMemoryLakeStorage,
+  InMemoryQueues,
+  InMemoryStorage,
+  link,
+  prop,
+  SixbHost,
+} from "@sixb/core"
+import { createTestSixb } from "@sixb/core/testing"
+import { createSixbApi, SixbServer } from "../../server/src/server"
+import { startSixbRuntime } from "../src/lib/runtime"
+
+interface PersonRow {
+  id: string
+  revision: number
+  email: string
+  name: string
+  phone: string | null
+  org: string | null
+}
+const schema = [
+  col("id", "string"),
+  col("revision", "int64"),
+  col("email", "string"),
+  col("name", "string"),
+  col("phone", "string", { nullable: true }),
+  col("org", "string", { nullable: true }),
+]
+const pipedrive = defineDataset("source.pipedrive", {
+  schema,
+  primaryKey: "id",
+  sequenceBy: "revision",
+})
+const pandadoc = defineDataset("source.pandadoc", {
+  schema,
+  primaryKey: "id",
+  sequenceBy: "revision",
+})
+const contacts = defineDataset("merged.contacts", {
+  schema: schema.filter((column) => column.name !== "revision"),
+})
+const Organization = defineObjectType({
+  id: "Organization",
+  name: "Organization",
+  properties: [prop("id", "string", { primary: true, required: true })],
+})
+const Contact = defineObjectType({
+  id: "Contact",
+  name: "Contact",
+  properties: [
+    prop("id", "string", { primary: true, required: true }),
+    prop("email", "string"),
+    prop("name", "string"),
+    prop("phone", "string"),
+  ],
+  links: [link("organization", Organization, { cardinality: "one" })],
+})
+const projection = defineProjection("contacts", Contact)
+  .fromDataset(contacts)
+  .properties({ id: "id", email: "email", name: "name", phone: "phone" })
+  .withLinks({
+    organization: fromForeignKey({
+      link: Contact.l.organization,
+      sourceField: "org",
+      target: Organization,
+    }),
+  })
+
+async function waitFor<T>(read: () => Promise<T>, ready: (value: T) => boolean): Promise<T> {
+  const deadline = Date.now() + 5_000
+  while (Date.now() < deadline) {
+    const value = await read()
+    if (ready(value)) return value
+    await Bun.sleep(10)
+  }
+  throw new Error("Timed out waiting for ingestion downstream work")
+}
+
+test("verified webhooks and snapshots feed merged contacts through orchestration and projections", async () => {
+  // Regression proof: remove ingest's dataset.version.committed emission; the contact wait times out.
+  let failPipeline = false
+  let handled = 0
+  let snapshotRows: PersonRow[] = []
+  const toRow = (person: PersonRow) => ({ ...person, email: person.email.trim().toLowerCase() })
+  const connector = defineConnector("crm", {
+    type: "test",
+    connect: () => ({}),
+    webhooks: [
+      defineWebhook("person")
+        .post()
+        .json({
+          parse(value: unknown) {
+            if (
+              typeof value !== "object" ||
+              value === null ||
+              !("source" in value) ||
+              !("person" in value)
+            )
+              throw new Error("invalid person event")
+            if (value.source !== "pipedrive" && value.source !== "pandadoc")
+              throw new Error("invalid source")
+            const person = value.person
+            if (
+              typeof person !== "object" ||
+              person === null ||
+              !("id" in person) ||
+              typeof person.id !== "string" ||
+              !("revision" in person) ||
+              typeof person.revision !== "number" ||
+              !("email" in person) ||
+              typeof person.email !== "string" ||
+              !("name" in person) ||
+              typeof person.name !== "string" ||
+              !("phone" in person) ||
+              (person.phone !== null && typeof person.phone !== "string") ||
+              !("org" in person) ||
+              (person.org !== null && typeof person.org !== "string")
+            )
+              throw new Error("invalid person")
+            return {
+              source: value.source,
+              person: {
+                id: person.id,
+                revision: person.revision,
+                email: person.email,
+                name: person.name,
+                phone: person.phone,
+                org: person.org,
+              },
+            }
+          },
+        })
+        .verify(({ request }) => {
+          if (request.headers.get("x-secret") !== "test-secret")
+            throw new Error("invalid signature")
+        })
+        .idempotencyKey(({ request }) => request.headers.get("x-delivery"))
+        .handle(async ({ sixb, body }) => {
+          handled += 1
+          const result = await sixb.datasets.ingest(
+            body.source === "pipedrive" ? pipedrive : pandadoc,
+            { changes: [change.upsert(toRow(body.person))] }
+          )
+          return { status: 200, body: { outcome: result.outcome } }
+        }),
+    ],
+  })
+  const sync = defineSync("pipedrive-snapshot")
+    .from(connector)
+    .read(() => snapshotRows.map(toRow))
+    .intoDataset(pipedrive)
+  const pdUpdated = defineSchedule("pipedrive-updated").on(events.dataset(pipedrive).updated())
+  const docUpdated = defineSchedule("pandadoc-updated").on(events.dataset(pandadoc).updated())
+  const merge = definePipelineStep("merge-contacts")
+    .inputs({ pipedrive, pandadoc })
+    .output(contacts)
+    .run(async ({ inputs, output }) => {
+      if (failPipeline) throw new Error("contact pipeline unavailable")
+      const groups = new Map<string, Record<string, unknown>>()
+      // Fallback first, preferred source second. Recompute the complete view, including old email groups.
+      for (const source of [inputs.pandadoc, inputs.pipedrive])
+        for await (const row of source.readRows()) {
+          const email = String(row.email)
+          const prior = groups.get(email)
+          groups.set(email, {
+            id: email,
+            email,
+            name: row.name,
+            phone: row.phone ?? prior?.phone ?? null,
+            org: row.org ?? prior?.org ?? null,
+          })
+        }
+      await output.writeRows(groups.values())
+    })
+  const pipeline = definePipeline("contacts").when(pdUpdated).when(docUpdated).then(merge)
+  const lakeStorage = new InMemoryLakeStorage()
+  // Both pipeline inputs must have a first source version before either triggers the merge.
+  for (const dataset of [pipedrive, pandadoc]) {
+    await lakeStorage.createDataset(dataset)
+    const session = await lakeStorage.beginMerge({ dataset })
+    await session.writeChanges([change.delete({ id: "seed" }, { sequence: 0 })])
+    await session.commit()
+  }
+  const host = new SixbHost({
+    id: "webhook-ingestion",
+    ontology: [Contact, Organization],
+    datasets: [pipedrive, pandadoc, contacts],
+    connectors: [connector],
+    syncs: [sync],
+    schedules: [pdUpdated, docUpdated],
+    pipelines: [pipeline],
+    projections: [projection],
+    lakeStorage,
+    storage: new InMemoryStorage(),
+    queues: new InMemoryQueues(),
+    broker: new InMemoryBroker(),
+    blobStorage: new InMemoryBlobStorage(),
+    onError: () => {},
+  })
+  const sixb = createTestSixb(host)
+  const app = createSixbApi(
+    new SixbServer({
+      host,
+      browser: {
+        publicOrigin: "http://localhost",
+        allowedOrigins: [{ origin: "http://localhost", audience: "atlas" }],
+      },
+    })
+  )
+  const runtime = await startSixbRuntime(host, { cohostWorkers: true })
+  const person: PersonRow = {
+    id: "42",
+    revision: 8,
+    email: " Sam@Example.com ",
+    name: "Preferred",
+    phone: null,
+    org: "org-1",
+  }
+  const send = (source: string, person: PersonRow, delivery: string, secret = "test-secret") =>
+    app.fetch(
+      new Request("http://localhost/api/webhooks/crm/person", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-secret": secret, "x-delivery": delivery },
+        body: JSON.stringify({ source, person }),
+      })
+    )
+  const contact = (id = "sam@example.com") => sixb.objects(Contact).get(id)
+  try {
+    await sixb.objects(Organization).upsert({ properties: { id: "org-1" } })
+    await sixb.objects(Organization).upsert({ properties: { id: "org-2" } })
+    expect((await send("pipedrive", person, "invalid", "wrong")).status).not.toBe(200)
+    expect(handled).toBe(0)
+    expect(
+      (
+        await send(
+          "pandadoc",
+          { ...person, id: "9", revision: 1, name: "Fallback", phone: "555", org: null },
+          "doc-1"
+        )
+      ).status
+    ).toBe(200)
+    await waitFor(contact, (value) => value?.properties.name === "Fallback")
+    expect((await send("pipedrive", person, "pd-1")).status).toBe(200)
+    const merged = await waitFor(contact, (value) => value?.properties.name === "Preferred")
+    expect(merged?.properties.phone).toBe("555")
+    expect((await send("pipedrive", person, "pd-1")).status).toBe(202)
+    expect(handled).toBe(2)
+
+    snapshotRows = [{ ...person, revision: 7, name: "Stale snapshot" }]
+    const syncRun = await sixb.syncs.request({ syncId: sync.id })
+    await waitFor(
+      () => host.storage.syncRuns!.getById({ projectId: host.id, id: syncRun.runId }),
+      (run) => run?.status === "succeeded"
+    )
+    expect((await contact())?.properties.name).toBe("Preferred")
+
+    expect(
+      (
+        await send(
+          "pipedrive",
+          { ...person, revision: 9, email: "new@example.com", org: "org-2" },
+          "pd-2"
+        )
+      ).status
+    ).toBe(200)
+    await waitFor(
+      () => contact("new@example.com"),
+      (value) => value?.properties.name === "Preferred"
+    )
+    expect((await contact())?.properties).toMatchObject({ name: "Fallback", phone: "555" })
+    const links = await sixb.objects(Contact).byId("new@example.com").listLinks()
+    expect(links).toMatchObject([{ targetId: "org-2" }])
+
+    await sixb
+      .objects(Contact)
+      .upsert({ properties: { id: "new@example.com", name: "Application edit" } })
+    failPipeline = true
+    expect(
+      (
+        await send(
+          "pipedrive",
+          {
+            ...person,
+            revision: 10,
+            email: "new@example.com",
+            name: "Source changed",
+            org: "org-1",
+          },
+          "pd-3"
+        )
+      ).status
+    ).toBe(200)
+    await waitFor(
+      () => host.storage.pipelineRuns!.list({ projectId: host.id, pipelineId: pipeline.id }),
+      (runs) => runs.runs.some((run) => run.status === "failed")
+    )
+    failPipeline = false
+    const retry = await sixb.pipelines.request({ pipelineId: pipeline.id })
+    await waitFor(
+      () => host.storage.pipelineRuns!.getById({ projectId: host.id, id: retry.runId }),
+      (run) => run?.status === "succeeded"
+    )
+    await waitFor(
+      () => sixb.objects(Contact).byId("new@example.com").listLinks(),
+      (rows) => rows.some((row) => row.targetId === "org-1")
+    )
+    expect((await contact("new@example.com"))?.properties.name).toBe("Application edit")
+    expect(handled).toBe(4)
+
+    expect(
+      (
+        await send(
+          "pipedrive",
+          { ...person, revision: 11, email: "new@example.com", phone: "999", org: "missing-org" },
+          "pd-4"
+        )
+      ).status
+    ).toBe(200)
+    await waitFor(
+      () => contact("new@example.com"),
+      (value) => value?.properties.phone === "999"
+    )
+    expect(await sixb.objects(Contact).byId("new@example.com").listLinks()).toEqual([])
+  } finally {
+    await runtime.stop()
+    await host.closeBroker()
+  }
+}, 25_000)

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -13172,7 +13172,7 @@
                             "properties": {
                               "kind": {
                                 "type": "string",
-                                "enum": ["sync", "pipeline"]
+                                "enum": ["sync", "pipeline", "ingest"]
                               },
                               "id": {
                                 "type": "string"
@@ -13354,7 +13354,7 @@
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["sync", "pipeline"]
+                          "enum": ["sync", "pipeline", "ingest"]
                         },
                         "id": {
                           "type": "string"
@@ -13560,7 +13560,7 @@
                           "properties": {
                             "kind": {
                               "type": "string",
-                              "enum": ["sync", "pipeline"]
+                              "enum": ["sync", "pipeline", "ingest"]
                             },
                             "id": {
                               "type": "string"

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4304,7 +4304,7 @@ export type ListDatasetVersionsResponses = {
         }>
       }
       producer?: {
-        kind: "sync" | "pipeline"
+        kind: "sync" | "pipeline" | "ingest"
         id?: string
         runId?: string
       }
@@ -4380,7 +4380,7 @@ export type GetDatasetVersionResponses = {
       }>
     }
     producer?: {
-      kind: "sync" | "pipeline"
+      kind: "sync" | "pipeline" | "ingest"
       id?: string
       runId?: string
     }
@@ -4460,7 +4460,7 @@ export type ListDatasetRowsResponses = {
         }>
       }
       producer?: {
-        kind: "sync" | "pipeline"
+        kind: "sync" | "pipeline" | "ingest"
         id?: string
         runId?: string
       }

--- a/packages/core/src/datasets/execution.ts
+++ b/packages/core/src/datasets/execution.ts
@@ -1,15 +1,36 @@
-import { isAllowed } from "../authorization"
+import { assertPrivileged, isAllowed } from "../authorization"
+import type { BlobStorage } from "../blob-storage"
+import type { ExecutionContext } from "../execution"
+import type { DatasetMergeCommitResult } from "../lake-storage/merge"
+import { getDatasetPrimaryKeyColumns } from "../lake-storage/merge-validation"
+import type { DatasetRow, LakeStorage } from "../lake-storage/types"
 import type { SixbRuntimeContext } from "../runtime/types"
+import type { MergeChange } from "./changes"
 import type { DatasetDefinition } from "./types"
+import { writeDataset } from "./write"
+
+export interface DatasetIngestInput {
+  readonly changes:
+    | Iterable<MergeChange<DatasetRow, DatasetRow>>
+    | AsyncIterable<MergeChange<DatasetRow, DatasetRow>>
+  readonly signal?: AbortSignal
+}
+
+/** Source commit result; downstream pipelines and projections run asynchronously. */
+export type DatasetIngestResult = DatasetMergeCommitResult & { readonly rowsRead: number }
 
 export interface DatasetsRuntime {
   list(): readonly DatasetDefinition[]
   getById(datasetId: string): DatasetDefinition | null
+  ingest(dataset: DatasetDefinition, input: DatasetIngestInput): Promise<DatasetIngestResult>
 }
 
 export function createDatasetsRuntime(
-  runtime: Pick<SixbRuntimeContext, "authorization">,
-  source: Pick<DatasetsRuntime, "list" | "getById">
+  runtime: SixbRuntimeContext,
+  execution: ExecutionContext,
+  source: Pick<DatasetsRuntime, "list" | "getById">,
+  lakeStorage: LakeStorage,
+  blobStorage: Pick<BlobStorage, "stat">
 ): DatasetsRuntime {
   const allowed = (datasetId: string) =>
     isAllowed(runtime.authorization, { kind: "dataset.view", datasetId })
@@ -19,6 +40,50 @@ export function createDatasetsRuntime(
     getById: (datasetId) => {
       const dataset = source.getById(datasetId)
       return dataset && allowed(datasetId) ? dataset : null
+    },
+    async ingest(dataset, input) {
+      assertPrivileged(runtime, "datasets.ingest")
+      const registered = source.getById(dataset.id)
+      if (!registered) throw new Error(`[Sixb] Dataset '${dataset.id}' is not registered.`)
+      if (getDatasetPrimaryKeyColumns(registered) === null) {
+        throw new Error(`[Sixb] Dataset '${dataset.id}' must define a primaryKey before ingestion.`)
+      }
+      if (typeof lakeStorage.beginMerge !== "function") {
+        throw new Error("[Sixb] Dataset ingestion requires a lake provider with merge support.")
+      }
+      const producer = { kind: "ingest" as const, id: execution.id }
+      const result = await writeDataset({
+        lakeStorage,
+        blobStorage,
+        dataset: registered,
+        mode: "merge",
+        signal: input.signal ?? new AbortController().signal,
+        producer,
+        readValues: async () =>
+          (async function* () {
+            for await (const value of input.changes) yield { value }
+          })(),
+      })
+      if (result.outcome === "created") {
+        await runtime.events.emit(
+          {
+            events: [
+              {
+                type: "dataset.version.committed",
+                payload: {
+                  datasetId: registered.id,
+                  versionId: result.version.versionId,
+                  createdAt: result.version.createdAt.toISOString(),
+                  producer,
+                },
+              },
+            ],
+            correlationId: execution.correlationId,
+          },
+          { source: "SixbDatasets" }
+        )
+      }
+      return result
     },
   }
 }

--- a/packages/core/src/datasets/index.ts
+++ b/packages/core/src/datasets/index.ts
@@ -2,6 +2,7 @@ export { col, defineDataset } from "./builders"
 export type { MergeChange } from "./changes"
 export { change } from "./changes"
 export { DatasetValidationError } from "./errors"
+export type { DatasetIngestInput, DatasetIngestResult, DatasetsRuntime } from "./execution"
 export type {
   DatasetColumnDefinition,
   DatasetColumnDefinitionOf,

--- a/packages/core/src/events/types/datasets.ts
+++ b/packages/core/src/events/types/datasets.ts
@@ -1,3 +1,4 @@
+import type { DatasetProducer } from "../../lake-storage/types"
 import type { EventEnvelope } from "../envelope"
 
 export interface DatasetVersionCommittedEvent extends EventEnvelope {
@@ -9,12 +10,7 @@ export interface DatasetVersionCommittedEvent extends EventEnvelope {
     versionId: string
     /** Canonical UTC ISO timestamp from the committed immutable dataset version. */
     createdAt: string
-    producer: {
-      kind: "sync" | "pipeline"
-      id?: string
-      runId?: string
-      stepId?: string
-    }
+    producer: DatasetProducer
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -854,7 +854,7 @@ export type {
 } from "./agents/execution"
 export type { BlobsRuntime } from "./blob-storage/execution"
 export type { ConnectorRuntime } from "./connectors/execution"
-export type { DatasetsRuntime } from "./datasets/execution"
+export type { DatasetIngestInput, DatasetIngestResult, DatasetsRuntime } from "./datasets/execution"
 export type {
   SixbActionPhaseFailedContext,
   SixbErrorContext,

--- a/packages/core/src/lake-storage/types.ts
+++ b/packages/core/src/lake-storage/types.ts
@@ -19,7 +19,8 @@ export interface DatasetVersionRef {
 }
 
 export interface DatasetProducer {
-  readonly kind: "sync" | "pipeline"
+  readonly kind: "sync" | "pipeline" | "ingest"
+  /** For ingestion, the bound execution id; otherwise the sync/pipeline definition id. */
   readonly id?: string
   readonly runId?: string
   readonly stepId?: string

--- a/packages/core/src/projections/run-dispatch.ts
+++ b/packages/core/src/projections/run-dispatch.ts
@@ -4,7 +4,7 @@ import { createSixbError, toSixbFailure } from "../errors/internal"
 import type { SixbFailure } from "../errors/types"
 import type { RunDispatcher } from "../execution/dispatch"
 import { createPrimitiveExecutionRecord } from "../execution/durable"
-import type { LakeStorage } from "../lake-storage"
+import type { DatasetProducer, LakeStorage } from "../lake-storage"
 import type { Queues } from "../queues"
 import type { SixbDefinitions } from "../runtime/definitions"
 import type { ExecutionRecord, ProjectionRunRecord, Storage } from "../storage"
@@ -289,14 +289,11 @@ async function assertExistingRun(
 async function resolveProducerExecution(
   storage: Storage,
   projectId: string,
-  producer:
-    | {
-        readonly kind: "sync" | "pipeline"
-        readonly id?: string
-        readonly runId?: string
-      }
-    | undefined
+  producer: DatasetProducer | undefined
 ): Promise<ExecutionRecord | null> {
+  if (producer?.kind === "ingest") {
+    return producer.id ? storage.executions.getById({ projectId, id: producer.id }) : null
+  }
   if (!producer?.runId) return null
   if (producer.kind === "sync") {
     const run = await storage.syncRuns?.getById({ projectId, id: producer.runId })
@@ -342,10 +339,7 @@ async function requireProducerExecution(input: {
   )
 }
 
-function assertProducerId(
-  producer: { readonly kind: "sync" | "pipeline"; readonly id?: string; readonly runId?: string },
-  runOwnerId: string
-): void {
+function assertProducerId(producer: DatasetProducer, runOwnerId: string): void {
   if (producer.id === undefined || producer.id === runOwnerId) return
   throw new ProjectionValidationError(
     `[Sixb] Dataset producer '${producer.kind}:${producer.id}' does not match run '${producer.runId}'.`

--- a/packages/core/src/runtime/host.ts
+++ b/packages/core/src/runtime/host.ts
@@ -318,6 +318,7 @@ export class SixbHost<
         ? {}
         : { connectorConnections: this.connectorService.connectionProcess }),
       blobStorage: this.blobStorage,
+      lakeStorage: this.lakeStorage,
     }
   }
 }

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -11,6 +11,7 @@ import type { ConnectorService } from "../connectors/service"
 import { createDatasetsRuntime, type DatasetsRuntime } from "../datasets/execution"
 import { createEventsRuntime, type EventsRuntime } from "../events/execution"
 import type { ExecutionContext } from "../execution"
+import type { LakeStorage } from "../lake-storage/types"
 import { createLogsRuntime, type LogsRuntime } from "../logging/execution"
 import type { LoggingService } from "../logging/service"
 import { createObjectsRuntime, type ObjectsRuntime } from "../objects/execution"
@@ -54,6 +55,7 @@ export interface SixbDependencies {
   readonly connectorService: ConnectorService
   readonly connectorConnections?: ConnectorConnectionProcess
   readonly blobStorage: BlobStorage
+  readonly lakeStorage: LakeStorage
 }
 
 export function createBoundSixb<TOntologySources extends readonly OntologySource[]>(
@@ -91,7 +93,13 @@ function createExecutionFacades<TOntologySources extends readonly OntologySource
   return {
     objects: createObjectsRuntime<TOntologySources>(runtime, execution),
     actions: createActionsRuntime(runtime, execution),
-    datasets: createDatasetsRuntime(runtime, dependencies.definitions.datasets),
+    datasets: createDatasetsRuntime(
+      runtime,
+      execution,
+      dependencies.definitions.datasets,
+      dependencies.lakeStorage,
+      dependencies.blobStorage
+    ),
     workflows: createWorkflowsRuntime(runtime, execution, dependencies.definitions.workflows),
     syncs: createSyncsRuntime(runtime, execution, dependencies.definitions.syncs),
     pipelines: createPipelinesRuntime(runtime, execution, dependencies.definitions.pipelines),

--- a/packages/core/src/testing/dataset-sequence-contract.ts
+++ b/packages/core/src/testing/dataset-sequence-contract.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import { InMemoryBlobStorage } from "../blob-storage"
+import { InMemoryBroker } from "../broker"
 import { change, col, type DatasetDefinition, defineDataset, type MergeChange } from "../datasets"
 import { writeDataset } from "../datasets/write"
 import type { DatasetMergeCommitResult, DatasetRow, LakeStorage } from "../lake-storage"
+import { InMemoryQueues } from "../queues"
+import { SixbHost } from "../runtime/host"
+import { InMemoryStorage } from "../storage"
+import { createTestSixb } from "./execution"
 import type { LakeMergeStorageContractSuiteOptions } from "./lake-merge-storage-contract"
 
 const dataset = defineDataset("contract.source_order", {
@@ -139,6 +144,37 @@ export function runDatasetSequenceContract<TStorage extends LakeStorage>(
         )
       }))
 
+    test("ingests through the bound SDK and preserves execution provenance", async () => {
+      // Regression proof: remove ingest from DuckLake's producer parser; reopen loses provenance.
+      let storage = await options.createStorage()
+      const broker = new InMemoryBroker()
+      try {
+        const host = new SixbHost({
+          id: "ingest-contract",
+          ontology: [],
+          datasets: [dataset],
+          lakeStorage: storage,
+          broker,
+          storage: new InMemoryStorage(),
+          queues: new InMemoryQueues(),
+          blobStorage: new InMemoryBlobStorage(),
+        })
+        const sixb = createTestSixb(host)
+        const result = await sixb.datasets.ingest(dataset, { changes: [upsert(8)] })
+        expect(result.outcome).toBe("created")
+        if (options.reopen) storage = await options.reopen(storage)
+        expect((await storage.getLatestVersion(dataset.id))?.producer).toEqual({
+          kind: "ingest",
+          id: sixb.execution.id,
+        })
+        expect((await rows(storage)).map((row) => row.name)).toEqual(["Sam"])
+        expect(await host.events.read()).toMatchObject([
+          { type: "dataset.version.committed", payload: { versionId: result.version?.versionId } },
+        ])
+      } finally {
+        await options.teardown?.(storage)
+      }
+    })
     test("rebases retained changes while preserving explicit version guards", () =>
       withStorage(async (storage) => {
         // Regression proof: disable retryOnConflict in retryDatasetMergeCommit; the second commit fails.

--- a/packages/core/tests/dataset-ingest.test.ts
+++ b/packages/core/tests/dataset-ingest.test.ts
@@ -1,0 +1,175 @@
+import { expect, test } from "bun:test"
+import {
+  change,
+  col,
+  defineDataset,
+  InMemoryBlobStorage,
+  InMemoryBroker,
+  InMemoryLakeStorage,
+  InMemoryQueues,
+  InMemoryStorage,
+  SixbHost,
+} from "../src"
+import { emptyGrantIndex } from "../src/authorization"
+import { flushSixbErrors } from "../src/error-reporting/capability"
+import { createPrincipalRequestScope, createTestingScope } from "../src/execution/scopes"
+
+const dataset = defineDataset("source.people", {
+  schema: [col("id", "string"), col("revision", "int64"), col("name", "string")],
+  primaryKey: "id",
+  sequenceBy: "revision",
+})
+
+function setup() {
+  const lakeStorage = new InMemoryLakeStorage()
+  const broker = new InMemoryBroker()
+  const failures: Error[] = []
+  const host = new SixbHost({
+    id: "ingest-test",
+    ontology: [],
+    datasets: [dataset],
+    lakeStorage,
+    broker,
+    storage: new InMemoryStorage(),
+    queues: new InMemoryQueues(),
+    blobStorage: new InMemoryBlobStorage(),
+    onError: (error) => {
+      failures.push(error)
+    },
+  })
+  return {
+    host,
+    lakeStorage,
+    broker,
+    failures,
+    sixb: host.withScope(createTestingScope({ projectId: host.id })),
+  }
+}
+
+test("ingestion validates and orders source changes and only notifies for new versions", async () => {
+  // Regression proof: remove the facade's event emission; the dataset event assertions fail.
+  const { host, lakeStorage, sixb } = setup()
+  const first = await sixb.datasets.ingest(dataset, {
+    changes: [change.upsert({ id: "42", revision: 8, name: "Sam" })],
+  })
+  expect(first).toMatchObject({
+    outcome: "created",
+    rowsRead: 1,
+    version: { mode: "merge", producer: { kind: "ingest", id: sixb.execution.id } },
+  })
+  expect(
+    await sixb.datasets.ingest(dataset, {
+      changes: [change.upsert({ id: "42", revision: 7, name: "Old" })],
+    })
+  ).toMatchObject({ outcome: "unchanged", version: first.version })
+  await expect(
+    sixb.datasets.ingest(dataset, {
+      changes: [
+        change.upsert({ id: "new", revision: 1, name: "Partial" }),
+        change.upsert({ id: "42", revision: 8, name: "Conflict" }),
+      ],
+    })
+  ).rejects.toThrow("conflicting content")
+  expect(await lakeStorage.getLatestVersion(dataset.id)).toEqual(first.version)
+  const events = await host.events.read()
+  expect(events).toHaveLength(1)
+  expect(events[0]).toMatchObject({
+    type: "dataset.version.committed",
+    correlationId: sixb.execution.correlationId,
+    payload: {
+      datasetId: dataset.id,
+      versionId: first.version?.versionId,
+      producer: first.version?.producer,
+    },
+  })
+  expect(
+    await sixb.datasets.ingest(dataset, { changes: [change.delete({ id: "42" }, { sequence: 9 })] })
+  ).toMatchObject({ outcome: "created", version: { rowCount: 0 } })
+})
+
+test("ingestion checks authority and registration before consuming input or creating a dataset", async () => {
+  // Regression proof: remove assertPrivileged from ingestion; the scoped reader writes successfully.
+  const { host, lakeStorage, sixb } = setup()
+  let consumed = false
+  function* changes() {
+    consumed = true
+    yield change.upsert({ id: "42", revision: 1, name: "Sam" })
+  }
+  const scoped = host.withScope(
+    createPrincipalRequestScope({
+      projectId: host.id,
+      requestId: "request",
+      correlationId: "request",
+      context: {
+        principal: { type: "user", id: "reader" },
+        groupIds: [],
+        roleIds: [],
+        grants: { ...emptyGrantIndex(), "view:dataset": new Set([dataset.id]) },
+      },
+    })
+  )
+  expect(scoped.datasets.getById(dataset.id)?.id).toBe(dataset.id)
+  await expect(scoped.datasets.ingest(dataset, { changes: changes() })).rejects.toThrow(
+    "not covered by scoped authorization grants"
+  )
+  await expect(
+    sixb.datasets.ingest({ ...dataset, id: "unregistered" }, { changes: changes() })
+  ).rejects.toThrow("not registered")
+  expect(consumed).toBe(false)
+  expect(await lakeStorage.listDatasets()).toEqual([])
+})
+
+test("ingestion uses the registered schema and cancels one-shot input atomically", async () => {
+  const { lakeStorage, sixb } = setup()
+  await expect(
+    sixb.datasets.ingest(
+      { ...dataset, schema: { columns: [col("id", "string")] } },
+      { changes: [change.upsert({ id: "42" })] }
+    )
+  ).rejects.toThrow()
+  const controller = new AbortController()
+  await expect(
+    sixb.datasets.ingest(dataset, {
+      signal: controller.signal,
+      changes: (async function* () {
+        yield change.upsert({ id: "42", revision: 1, name: "Sam" })
+        controller.abort(new Error("cancelled ingestion"))
+      })(),
+    })
+  ).rejects.toThrow("cancelled ingestion")
+  expect(await lakeStorage.getLatestVersion(dataset.id)).toBeNull()
+})
+
+test("ingestion rejects unkeyed datasets and unsupported providers before mutation", async () => {
+  const unkeyed = defineDataset("unkeyed", { schema: [col("id", "string")] })
+  const lakeStorage = new InMemoryLakeStorage()
+  const host = new SixbHost({
+    id: "ingest-preflight",
+    ontology: [],
+    datasets: [dataset, unkeyed],
+    lakeStorage,
+    broker: new InMemoryBroker(),
+    storage: new InMemoryStorage(),
+    queues: new InMemoryQueues(),
+    blobStorage: new InMemoryBlobStorage(),
+  })
+  const sixb = host.withScope(createTestingScope({ projectId: host.id }))
+  await expect(sixb.datasets.ingest(unkeyed, { changes: [] })).rejects.toThrow("primaryKey")
+  Object.defineProperty(lakeStorage, "beginMerge", { value: undefined })
+  await expect(sixb.datasets.ingest(dataset, { changes: [] })).rejects.toThrow("merge support")
+  expect(await lakeStorage.listDatasets()).toEqual([])
+})
+
+test("notification failure is reported after commit without failing ingestion", async () => {
+  const { host, broker, failures, lakeStorage, sixb } = setup()
+  broker.append = async () => {
+    throw new Error("broker offline")
+  }
+  const result = await sixb.datasets.ingest(dataset, {
+    changes: [change.upsert({ id: "42", revision: 1, name: "Sam" })],
+  })
+  expect(result.outcome).toBe("created")
+  expect(await lakeStorage.getLatestVersion(dataset.id)).toEqual(result.version)
+  await flushSixbErrors(host)
+  expect(failures).toHaveLength(1)
+})

--- a/packages/core/tests/projection-run-dispatch.test.ts
+++ b/packages/core/tests/projection-run-dispatch.test.ts
@@ -14,6 +14,7 @@ import {
   type SixbErrorContext,
   SixbHost,
 } from "../src"
+import type { DatasetProducer } from "../src/lake-storage"
 import { ProjectionRunDispatcher } from "../src/projections/run-dispatch"
 
 const Device = defineObjectType({
@@ -73,7 +74,7 @@ function createDependencies(
 
 async function commitDevicesVersion(
   lakeStorage: InMemoryLakeStorage,
-  producer: { readonly kind: "sync"; readonly id: string; readonly runId: string } = {
+  producer: DatasetProducer = {
     kind: "sync",
     id: "sync-devices",
     runId: "sync-run",
@@ -108,6 +109,30 @@ function dispatchInput(
 }
 
 describe("ProjectionRunDispatcher", () => {
+  test("inherits correlation from the execution that ingested a dataset version", async () => {
+    // Regression proof: remove resolveProducerExecution's ingest branch; correlation falls back.
+    const { host, lakeStorage, storage } = createDependencies()
+    await storage.executions.create({
+      id: "webhook-execution",
+      projectId: host.id,
+      executor: { type: "primitive", kind: "webhook", runId: "delivery" },
+      source: { type: "webhook", deliveryId: "delivery" },
+      correlationId: "webhook-correlation",
+      authorizationRef: {
+        type: "trustedPrimitive",
+        primitive: { kind: "webhook", id: "crm/person", runId: "delivery" },
+      },
+    })
+    const version = await commitDevicesVersion(lakeStorage, {
+      kind: "ingest",
+      id: "webhook-execution",
+    })
+    const dispatched = await new ProjectionRunDispatcher(host).dispatch(dispatchInput(version))
+    const run = await storage.projectionRuns.getById({ projectId: host.id, id: dispatched.runId })
+    expect(
+      await storage.executions.getById({ projectId: host.id, id: run!.executionId })
+    ).toMatchObject({ correlationId: "webhook-correlation" })
+  })
   test("bounds grouped telemetry batches by their maximum mapped point count", async () => {
     const { host, lakeStorage, storage } = createDependencies(groupedTelemetryProjection)
     const version = await commitDevicesVersion(lakeStorage)

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -1215,7 +1215,7 @@ describe("bound Sixb surface", () => {
     expect(Object.keys(scoped.actions).sort()).toEqual(
       ["getById", "list", "listForType", "listGlobal", "request", "requestAndWait", "runs"].sort()
     )
-    expect(Object.keys(scoped.datasets).sort()).toEqual(["getById", "list"])
+    expect(Object.keys(scoped.datasets).sort()).toEqual(["getById", "ingest", "list"])
     expect(Object.keys(scoped.workflows).sort()).toEqual(
       ["getById", "interventions", "list", "request", "requestById", "runs"].sort()
     )

--- a/packages/server/src/schemas/datasets.ts
+++ b/packages/server/src/schemas/datasets.ts
@@ -54,7 +54,7 @@ export const DatasetVersionRefSchema = z.object({
 })
 
 export const DatasetProducerSchema = z.object({
-  kind: z.enum(["sync", "pipeline"]),
+  kind: z.enum(["sync", "pipeline", "ingest"]),
   id: z.string().optional(),
   runId: z.string().optional(),
 })

--- a/storage/ducklake/src/internal/versions.ts
+++ b/storage/ducklake/src/internal/versions.ts
@@ -113,7 +113,7 @@ function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
 function isDatasetProducer(value: unknown): value is NonNullable<DatasetVersion["producer"]> {
   return (
     isRecord(value) &&
-    (value.kind === "sync" || value.kind === "pipeline") &&
+    (value.kind === "sync" || value.kind === "pipeline" || value.kind === "ingest") &&
     optionalString(value.id) &&
     optionalString(value.runId)
   )


### PR DESCRIPTION
## Ingest dataset changes from webhook handlers

Expose the shared writer through the bound SDK, completing the source-write path for #548.

```ts
const result = await sixb.datasets.ingest(people, {
  changes: [
    change.upsert({ id: "42", name: "Sam", revision: 8 }),
    change.delete({ id: "9" }, { sequence: 12 }),
  ],
  signal: request.signal, // optional
})

result.outcome  // "created" | "unchanged"
result.version  // committed/reused version, or null for an initial no-op
result.rowsRead // validated input count
```

### Data flow

```text
Verified webhook ── sixb.datasets.ingest() ─┐
                                          ├─ shared writer → source dataset
Snapshot/merge sync ───────────────────────┘                      │
                                                    new version event
                                                                │
                                                        merge pipeline
                                                                │
                                                          projections
                                                                │
                                                  objects + source-owned links
```

### API contract

| Concern | Behavior |
| --- | --- |
| Authority | Existing privileged backend policy; dataset-view grants cannot ingest |
| Target | Registered dataset with a primary key and provider merge support |
| Input | Iterable/async iterable of complete-row upserts and deletes |
| Validation and ordering | Reuse the shared writer from the preceding PRs |
| Notification | Emit `dataset.version.committed` for new versions only |
| Return | Source commit result; does not wait for pipelines/projections |
| Provenance | `{ kind: "ingest", id: execution.id }`; projections inherit execution correlation |

### End-to-end coverage

| Scenario | Asserted result |
| --- | --- |
| Pipedrive person + PandaDoc contact share an email | Preferred name + fallback phone |
| Source email changes | Both old and new groups recalculate |
| Organization changes | Source-owned link is replaced |
| FK target is missing | Properties materialize; no dangling edge |
| Application edits a projected property | Existing edit-conflict policy still applies |
| Older snapshot follows a webhook | Newer source row survives |
| Duplicate successful webhook delivery | Handler is not rerun |
| Pipeline fails | Visible failed run; pipeline can be rerun without webhook redelivery |

### Review pointers

| File | What to review |
| --- | --- |
| `packages/core/src/datasets/execution.ts` | Thin SDK facade, preflight, and notification |
| `packages/core/src/projections/run-dispatch.ts` | Ingestion execution provenance |
| `packages/core/tests/dataset-ingest.test.ts` | Authority, validation, cancellation, and notification failure |
| `packages/cli/tests/webhook-ingestion.test.ts` | Full webhook → pipeline → projection test |

| Verification | Result |
| --- | --- |
| Targeted tests | 229 passed |
| DuckLake contract E2E | 46 passed |
| Ingestion provenance | InMemory + LocalLake + DuckLake, including durable-provider reopen |
| Build / typecheck / client generation / Biome | Passed |
| Publish verification | 55 packages passed |
| Final docs edits | `git diff --check` passed |

Event, authorization, and provenance regression tests failed with safeguards disabled, then passed after restoration.

> **Agreed scope:** durable receipts and notification recovery are deferred. A crash can leave a committed version without its notification. Identical sequenced retries are no-ops and do not repair that gap.

---
**Stack:** #552 Shared writer → #551 Source ordering → #550 Concurrent snapshots → **#549 Webhook ingestion**

Base: `datasets/concurrent-snapshots`.
