### PR TITLE
datasets: reconcile sequenced snapshots and retry concurrent merges

### DIFF
--- a/docs/data/datasets.md
+++ b/docs/data/datasets.md
@@ -116,7 +116,9 @@ absent keys; new deletion state creates a version without requiring a visible ro
 
 #### V1 constraints
 
-- **Merge writes only.** Snapshot, append, and SQL-transform writes to sequenced datasets are rejected.
+- **Snapshot syncs reconcile.** Returned rows become ordered upserts; omitted keys stay. Deletion requires a sequenced delete.
+- **Bounded retries.** Sequenced writes retry known concurrency conflicts up to 3 total attempts, reusing staged changes without re-fetching. Explicit version guards stay strict.
+- **Provider writes use merges.** Direct snapshot/append sessions and SQL-transform writes to sequenced datasets are rejected.
 - **Immutable configuration.** Create a new dataset and backfill to adopt or change `sequenceBy`.
 - **Explicit derivation.** Derived datasets must declare their own `sequenceBy` and primary key.
 

--- a/docs/data/datasets.md
+++ b/docs/data/datasets.md
@@ -117,6 +117,8 @@ absent keys; new deletion state creates a version without requiring a visible ro
 #### V1 constraints
 
 - **Snapshot syncs reconcile.** Returned rows become ordered upserts; omitted keys stay. Deletion requires a sequenced delete.
+- **Empty snapshots initialize.** A first successful snapshot creates an addressable version even
+  with no rows. Later empty snapshots reuse the existing version and retain its rows.
 - **Bounded retries.** Sequenced writes retry known concurrency conflicts up to 3 total attempts, reusing staged changes without re-fetching. Explicit version guards stay strict.
 - **Provider writes use merges.** Direct snapshot/append sessions and SQL-transform writes to sequenced datasets are rejected.
 - **Immutable configuration.** Create a new dataset and backfill to adopt or change `sequenceBy`.

--- a/docs/data/pipelines.md
+++ b/docs/data/pipelines.md
@@ -235,6 +235,14 @@ sixb worker-group sync pipeline projection
 
 See [deployment](../deployment/overview.md) for running workers in production.
 
+## Concurrent runs
+
+Each step captures its output version before pinning inputs, including when no version exists.
+
+If the output changes before commit, the step fails. Start a new run to recompute; there is no automatic retry.
+
+New input versions create an output version and update event even when rows are unchanged, protecting against older runs. Identical inputs and rows remain a no-op.
+
 ## Notes
 
 - Steps write `snapshot` output by default; use `{ mode: "append" }` when you mean to add rows.

--- a/docs/data/syncs.md
+++ b/docs/data/syncs.md
@@ -240,17 +240,20 @@ never received a row, that run does not create a dataset version, so dataset-upd
 not fire. This lets incremental readers advance an initial cursor without inventing placeholder
 rows.
 
-Without `sequenceBy`, a snapshot is the complete source state, including when that state is empty. A first snapshot that
-returns no rows therefore commits an addressable empty dataset version. Pipelines and projections
+A first successful snapshot, with or without `sequenceBy`, makes its result addressable even
+when it returns no rows. Pipelines and projections
 can consume that version normally, and later empty snapshots reuse it until the visible contents
 change. The initial version emits the normal dataset-version event, so dataset-updated schedules can
-run against the known-empty state. An empty snapshot after a non-empty version still commits a new
-empty version so projections can withdraw source-owned objects that disappeared upstream.
+run against the known-empty state. Without `sequenceBy`, an empty snapshot after a non-empty
+version commits a new empty version so projections can withdraw source-owned objects that
+disappeared upstream. With `sequenceBy`, it retains existing rows and reuses their version instead.
+That also applies when another writer initializes the dataset while an empty sequenced snapshot
+is being read: the snapshot reuses the concurrent writer's version.
 
 A merge run may also succeed and advance its checkpoint without creating a version. This happens
 when an unsequenced initial run only deletes absent keys, or when every staged change leaves the
 current source state unchanged. Later no-op runs continue to reference the existing dataset version.
-Sequenced snapshots follow these merge rules; an empty result retains existing rows and creates no
+Sequenced snapshots follow these merge rules except that a first empty snapshot creates an
 initial version. New deletion sequences create a version even for absent keys.
 
 ## Read context

--- a/docs/data/syncs.md
+++ b/docs/data/syncs.md
@@ -139,6 +139,13 @@ The sync mode controls how each run writes to the target dataset.
 | `"append"` | Adds new rows to the dataset | Audit logs, webhook deliveries, invoice events |
 | `"merge"` | Upserts and deletes rows by primary key | Ordered source change logs |
 
+For datasets with [`sequenceBy`](./datasets.md#source-ordering), snapshot syncs **reconcile instead of replace**:
+
+- Newer source rows win, even if a webhook-style write commits during the fetch.
+- Missing rows stay; removal requires an explicit sequenced delete.
+- Known concurrency conflicts retry up to 3 total commit attempts using the same staged data.
+- The sync run keeps mode `snapshot`; its dataset version has mode `merge`.
+
 Snapshot is the default — omit `mode` for it. Use append when the source is event-like:
 
 ```ts
@@ -178,7 +185,7 @@ export const syncErpInvoices = defineSync("sync-erp-invoices", { mode: "merge" }
   .intoDataset(erpInvoicesDataset)
 ```
 
-Each upsert is a complete row, not a patch. Deletes provide exactly the primary-key fields. The
+For datasets without `sequenceBy`, each upsert is a complete row, not a patch. Deletes provide exactly the primary-key fields. The
 final change for a repeated key wins, identical upserts and deletes of absent keys are no-ops, and
 no dataset version is created when the visible rows do not change. V1 requires non-null string
 keys, ordered changes, immutable keys, and one registered writer per keyed dataset. Object and link
@@ -187,7 +194,7 @@ datasets are not supported yet.
 
 ### Merge source requirements
 
-Use merge only when the source provides a durable, ordered change log. Each source event needs a
+Without `sequenceBy`, use merge only when the source provides a durable, ordered change log. Each source event needs a
 stable cursor, a complete row for an upsert or the exact key for a delete, and deterministic replay.
 Set the next checkpoint after yielding each event as shown above. Sixb stores the latest checkpoint
 only after the entire merge commits, so retrying a failed run safely replays its changes.
@@ -233,7 +240,7 @@ never received a row, that run does not create a dataset version, so dataset-upd
 not fire. This lets incremental readers advance an initial cursor without inventing placeholder
 rows.
 
-A snapshot is the complete source state, including when that state is empty. A first snapshot that
+Without `sequenceBy`, a snapshot is the complete source state, including when that state is empty. A first snapshot that
 returns no rows therefore commits an addressable empty dataset version. Pipelines and projections
 can consume that version normally, and later empty snapshots reuse it until the visible contents
 change. The initial version emits the normal dataset-version event, so dataset-updated schedules can
@@ -241,8 +248,10 @@ run against the known-empty state. An empty snapshot after a non-empty version s
 empty version so projections can withdraw source-owned objects that disappeared upstream.
 
 A merge run may also succeed and advance its checkpoint without creating a version. This happens
-when an initial run only deletes absent keys, or when every staged change leaves the current rows
-unchanged. Later no-op runs continue to reference the existing dataset version.
+when an unsequenced initial run only deletes absent keys, or when every staged change leaves the
+current source state unchanged. Later no-op runs continue to reference the existing dataset version.
+Sequenced snapshots follow these merge rules; an empty result retains existing rows and creates no
+initial version. New deletion sequences create a version even for absent keys.
 
 ## Read context
 

--- a/packages/core/src/datasets/write.ts
+++ b/packages/core/src/datasets/write.ts
@@ -60,7 +60,8 @@ export async function writeDataset<TValue extends DatasetWriteValue>(
   await lakeStorage.createDataset(dataset)
   try {
     throwIfAborted(signal)
-    if (input.mode === "merge") {
+    const reconcileSnapshot = dataset.sequenceBy !== undefined && input.mode === "snapshot"
+    if (input.mode === "merge" || reconcileSnapshot) {
       const session = await lakeStorage.beginMerge({
         dataset,
         expectedLatestVersionId: input.expectedLatestVersionId,
@@ -74,12 +75,19 @@ export async function writeDataset<TValue extends DatasetWriteValue>(
         validatedValues(
           input,
           values,
-          (value, itemIndex) => validateMergeChange(value, input, itemIndex),
+          async (value, itemIndex) =>
+            reconcileSnapshot
+              ? { kind: "upsert" as const, row: await validateRow(value, input, itemIndex) }
+              : validateMergeChange(value, input, itemIndex),
           onRead
         )
       )
       throwIfAborted(signal)
-      const result = await session.commit({ commitMessage: input.commitMessage })
+      const result = await session.commit({
+        commitMessage: input.commitMessage,
+        retryOnConflict: dataset.sequenceBy !== undefined,
+        signal,
+      })
       return { ...result, rowsRead }
     }
 

--- a/packages/core/src/datasets/write.ts
+++ b/packages/core/src/datasets/write.ts
@@ -85,6 +85,7 @@ export async function writeDataset<TValue extends DatasetWriteValue>(
       throwIfAborted(signal)
       const result = await session.commit({
         commitMessage: input.commitMessage,
+        createInitialVersion: reconcileSnapshot,
         retryOnConflict: dataset.sequenceBy !== undefined,
         signal,
       })

--- a/packages/core/src/lake-storage/errors.ts
+++ b/packages/core/src/lake-storage/errors.ts
@@ -2,5 +2,10 @@
  * Error for lake-storage invariants and invalid lake operations.
  */
 export class LakeStorageError extends Error {
-  readonly name = "LakeStorageError"
+  readonly name: string = "LakeStorageError"
+}
+
+/** A known, uncommitted version/transaction conflict; safe to retry staged changes. */
+export class LakeConcurrencyError extends LakeStorageError {
+  override readonly name = "LakeConcurrencyError"
 }

--- a/packages/core/src/lake-storage/in-memory.ts
+++ b/packages/core/src/lake-storage/in-memory.ts
@@ -2,13 +2,14 @@ import { randomUUID } from "node:crypto"
 import type { DatasetDefinition, DatasetSchema, MergeChange } from "../datasets"
 import { getDatasetRowValidationError } from "../datasets/validation"
 import { mergeStrictDatasetDefinition } from "./definition-updates"
-import { LakeStorageError } from "./errors"
+import { LakeConcurrencyError, LakeStorageError } from "./errors"
 import type {
   BeginDatasetMergeInput,
   CommitDatasetMergeInput,
   DatasetMergeCommitResult,
   LakeMergeSession,
 } from "./merge"
+import { retryDatasetMergeCommit } from "./merge"
 import {
   cloneDatasetMergeChange,
   encodeDatasetPrimaryKey,
@@ -183,12 +184,16 @@ class InMemoryLakeMergeSession implements LakeMergeSession {
   async commit(input?: CommitDatasetMergeInput): Promise<DatasetMergeCommitResult> {
     this.assertOpen()
     this.closed = true
-    return this.storage.commitMerge({
-      merge: this.input,
-      baseVersionId: this.baseVersionId,
-      changes: this.changes,
-      commit: input,
-    })
+    return retryDatasetMergeCommit(this.input, input, async (rebase) =>
+      this.storage.commitMerge({
+        merge: this.input,
+        baseVersionId: rebase
+          ? ((await this.storage.getLatestVersion(this.input.dataset.id))?.versionId ?? null)
+          : this.baseVersionId,
+        changes: this.changes,
+        commit: input,
+      })
+    )
   }
 
   async abort(): Promise<void> {
@@ -326,7 +331,7 @@ export class InMemoryLakeStorage implements LakeStorage {
       input.expectedLatestVersionId !== undefined &&
       latestVersion?.versionId !== input.expectedLatestVersionId
     ) {
-      throw new LakeStorageError(
+      throw new LakeConcurrencyError(
         `[LakeStorage] Optimistic merge start failed for dataset '${definition.id}': expected latest version '${input.expectedLatestVersionId}', found '${latestVersion?.versionId ?? "none"}'`
       )
     }
@@ -406,9 +411,10 @@ export class InMemoryLakeStorage implements LakeStorage {
       }
 
       const latestVersion = await this.getLatestVersion(options.merge.dataset.id)
+      options.commit?.signal?.throwIfAborted()
       const actualVersionId = latestVersion?.versionId ?? null
       if (actualVersionId !== options.baseVersionId) {
-        throw new LakeStorageError(
+        throw new LakeConcurrencyError(
           `[LakeStorage] Optimistic merge commit failed for dataset '${options.merge.dataset.id}': expected latest version '${options.baseVersionId ?? "none"}', found '${actualVersionId ?? "none"}'`
         )
       }

--- a/packages/core/src/lake-storage/in-memory.ts
+++ b/packages/core/src/lake-storage/in-memory.ts
@@ -34,6 +34,7 @@ import type {
   LakeWriteSession,
   ReadDatasetRowsInput,
 } from "./types"
+import { hasDatasetInputChanges } from "./version-inputs"
 
 function cloneDatasetDefinition(definition: DatasetDefinition): DatasetDefinition {
   return structuredClone(definition)
@@ -448,10 +449,12 @@ export class InMemoryLakeStorage implements LakeStorage {
         }
       }
 
+      const createInitialVersion = options.commit?.createInitialVersion && latestVersion === null
       if (
-        ordered
+        !createInitialVersion &&
+        (ordered
           ? ordered.accepted.size === 0
-          : this.sameKeyedRowContent(previousByKey, nextByKey, definition.schema)
+          : this.sameKeyedRowContent(previousByKey, nextByKey, definition.schema))
       ) {
         return {
           outcome: "unchanged",
@@ -505,10 +508,10 @@ export class InMemoryLakeStorage implements LakeStorage {
     const latestVersion = await this.getLatestVersion(options.write.dataset.id)
 
     if (options.commit?.expectedLatestVersionId !== undefined) {
-      const actual = latestVersion?.versionId
+      const actual = latestVersion?.versionId ?? null
       if (actual !== options.commit.expectedLatestVersionId) {
-        throw new LakeStorageError(
-          `[LakeStorage] Optimistic commit failed for dataset '${options.write.dataset.id}': expected latest version '${options.commit.expectedLatestVersionId}', found '${actual ?? "none"}'`
+        throw new LakeConcurrencyError(
+          `[LakeStorage] Optimistic commit failed for dataset '${options.write.dataset.id}': expected latest version '${options.commit.expectedLatestVersionId ?? "none"}', found '${actual ?? "none"}'`
         )
       }
     }
@@ -516,9 +519,10 @@ export class InMemoryLakeStorage implements LakeStorage {
     this.assertKeyedWriteIsUnique(mode, options.rows, latestVersion, definition)
 
     // Content-identical snapshots and empty appends reuse the latest version
-    // instead of creating a new one.
+    // unless explicitly supplied input lineage has changed.
     if (
       latestVersion &&
+      !hasDatasetInputChanges(latestVersion.inputs, options.write.inputs) &&
       this.isUnchangedWrite(mode, latestVersion, options.rows, definition.schema)
     ) {
       return { ...latestVersion, outcome: "unchanged" }

--- a/packages/core/src/lake-storage/index.ts
+++ b/packages/core/src/lake-storage/index.ts
@@ -18,7 +18,7 @@ export {
   mergeStrictDatasetDefinition,
   planDatasetDefinitionUpdate,
 } from "./definition-updates"
-export { LakeStorageError } from "./errors"
+export { LakeConcurrencyError, LakeStorageError } from "./errors"
 export { InMemoryLakeStorage } from "./in-memory"
 export type {
   BeginDatasetMergeInput,
@@ -26,6 +26,7 @@ export type {
   DatasetMergeCommitResult,
   LakeMergeSession,
 } from "./merge"
+export { retryDatasetMergeCommit } from "./merge"
 export {
   cloneDatasetMergeChange,
   encodeDatasetPrimaryKey,

--- a/packages/core/src/lake-storage/index.ts
+++ b/packages/core/src/lake-storage/index.ts
@@ -68,3 +68,4 @@ export type {
   LakeWriteSession,
   ReadDatasetRowsInput,
 } from "./types"
+export { hasDatasetInputChanges } from "./version-inputs"

--- a/packages/core/src/lake-storage/merge.ts
+++ b/packages/core/src/lake-storage/merge.ts
@@ -13,6 +13,8 @@ export interface BeginDatasetMergeInput {
 
 export interface CommitDatasetMergeInput {
   readonly commitMessage?: string
+  /** Create an addressable first version even without changes; reuse an existing version on no-op. */
+  readonly createInitialVersion?: boolean
   /** Retry sequenced merges up to three times total; ignored when an explicit version guard is set. */
   readonly retryOnConflict?: boolean
   /** Checked before each attempt; a durable commit is never cancelled retroactively. */

--- a/packages/core/src/lake-storage/merge.ts
+++ b/packages/core/src/lake-storage/merge.ts
@@ -1,4 +1,5 @@
 import type { DatasetDefinition, MergeChange } from "../datasets"
+import { LakeConcurrencyError } from "./errors"
 import type { DatasetProducer, DatasetRow, DatasetVersion, DatasetVersionRef } from "./types"
 
 export interface BeginDatasetMergeInput {
@@ -12,6 +13,38 @@ export interface BeginDatasetMergeInput {
 
 export interface CommitDatasetMergeInput {
   readonly commitMessage?: string
+  /** Retry sequenced merges up to three times total; ignored when an explicit version guard is set. */
+  readonly retryOnConflict?: boolean
+  /** Checked before each attempt; a durable commit is never cancelled retroactively. */
+  readonly signal?: AbortSignal
+}
+
+/** Providers retain their staging session throughout this bounded commit loop. */
+export async function retryDatasetMergeCommit(
+  merge: BeginDatasetMergeInput,
+  commit: CommitDatasetMergeInput | undefined,
+  run: (rebase: boolean) => Promise<DatasetMergeCommitResult>
+): Promise<DatasetMergeCommitResult> {
+  const attempts =
+    commit?.retryOnConflict &&
+    merge.dataset.sequenceBy !== undefined &&
+    merge.expectedLatestVersionId === undefined
+      ? 3
+      : 1
+  for (let attempt = 0; ; attempt += 1) {
+    commit?.signal?.throwIfAborted()
+    try {
+      return await run(attempt > 0)
+    } catch (error) {
+      if (!(error instanceof LakeConcurrencyError) || attempts === 1) throw error
+      if (attempt + 1 === attempts) {
+        throw new LakeConcurrencyError(
+          `[SixbLake] Dataset '${merge.dataset.id}' merge exhausted ${attempts} concurrency attempts. No changes from this operation were committed.`,
+          { cause: error }
+        )
+      }
+    }
+  }
 }
 
 /**
@@ -32,7 +65,7 @@ export interface LakeMergeSession {
       | Iterable<MergeChange<DatasetRow, DatasetRow>>
       | AsyncIterable<MergeChange<DatasetRow, DatasetRow>>
   ): Promise<void>
-  /** Commit only if the latest version still matches the version captured when the session began. */
+  /** Commit against the captured version; opt-in retries rebase sequenced changes on a fresh head. */
   commit(input?: CommitDatasetMergeInput): Promise<DatasetMergeCommitResult>
   abort(): Promise<void>
 }

--- a/packages/core/src/lake-storage/sql-transforms.ts
+++ b/packages/core/src/lake-storage/sql-transforms.ts
@@ -39,7 +39,8 @@ export interface ExecuteSqlTransformInput<TSqlDialect extends SqlDialect = SqlDi
   readonly target: DatasetDefinition
   readonly mode: DatasetWriteMode
   readonly producer?: DatasetProducer
-  readonly expectedLatestVersionId?: string
+  /** Atomic target version guard; null requires that no version exists. */
+  readonly expectedLatestVersionId?: string | null
   readonly commitMessage?: string
 }
 

--- a/packages/core/src/lake-storage/types.ts
+++ b/packages/core/src/lake-storage/types.ts
@@ -73,7 +73,8 @@ export interface ReadDatasetRowsInput {
 }
 
 export interface CommitDatasetWriteInput {
-  readonly expectedLatestVersionId?: string
+  /** Atomic version guard; null requires that no version exists, undefined leaves it unguarded. */
+  readonly expectedLatestVersionId?: string | null
   readonly commitMessage?: string
 }
 
@@ -81,11 +82,14 @@ export interface DatasetWriteCommitResult extends DatasetVersion {
   /**
    * Whether this operation created the returned version or reused the
    * unchanged latest version. When a latest version exists, providers must
-   * report `unchanged` and reuse it for commits that cannot change visible
-   * dataset content: a snapshot whose rows equal the latest visible rows
+   * report `unchanged` and reuse it for commits that change neither visible
+   * dataset content nor explicitly supplied input lineage: a snapshot whose
+   * rows equal the latest visible rows
    * (order-insensitive, with equal duplicate counts), or an append of zero
    * rows. Without a latest version, an empty snapshot or append still creates
-   * the first addressable dataset version.
+   * the first addressable dataset version. New input versions create a version
+   * even for identical rows, so a newer pipeline calculation fences concurrent
+   * work based on older inputs.
    */
   readonly outcome: "created" | "unchanged"
 }

--- a/packages/core/src/lake-storage/version-inputs.ts
+++ b/packages/core/src/lake-storage/version-inputs.ts
@@ -1,0 +1,14 @@
+import type { DatasetVersionRef } from "./types"
+
+/** Input lineage participates in write identity when the caller supplies it. */
+export function hasDatasetInputChanges(
+  previous: readonly DatasetVersionRef[] | undefined,
+  next: readonly DatasetVersionRef[] | undefined
+): boolean {
+  if (next === undefined) return false
+  const keys = (refs: readonly DatasetVersionRef[]) =>
+    new Set(refs.map((ref) => JSON.stringify([ref.datasetId, ref.versionId])))
+  const before = keys(previous ?? [])
+  const after = keys(next)
+  return before.size !== after.size || [...after].some((key) => !before.has(key))
+}

--- a/packages/core/src/testing/dataset-sequence-contract.ts
+++ b/packages/core/src/testing/dataset-sequence-contract.ts
@@ -84,6 +84,32 @@ export function runDatasetSequenceContract<TStorage extends LakeStorage>(
         )
       }))
 
+    test("rebases retained changes while preserving explicit version guards", () =>
+      withStorage(async (storage) => {
+        // Regression proof: disable retryOnConflict in retryDatasetMergeCommit; the second commit fails.
+        const first = await storage.beginMerge({ dataset })
+        const second = await storage.beginMerge({ dataset })
+        await first.writeChanges([upsert(8)])
+        await second.writeChanges([upsert(7, "stale"), upsert(1, "other", "other")])
+        const initial = await first.commit({ retryOnConflict: true })
+        await second.commit({ retryOnConflict: true })
+        expect((await rows(storage)).map((row) => row.name).sort()).toEqual(["Sam", "other"])
+        const guarded = await storage.beginMerge({
+          dataset,
+          expectedLatestVersionId: (await storage.getLatestVersion(dataset.id))?.versionId,
+        })
+        await guarded.writeChanges([upsert(10)])
+        await merge(storage, [change.delete({ id: "42" }, { sequence: 9 })])
+        await expect(guarded.commit({ retryOnConflict: true })).rejects.toThrow("Optimistic")
+        await guarded.abort()
+        const staleDelete = await storage.beginMerge({ dataset })
+        await staleDelete.writeChanges([change.delete({ id: "42" }, { sequence: 9 })])
+        await merge(storage, [upsert(10)])
+        expect((await staleDelete.commit({ retryOnConflict: true })).outcome).toBe("unchanged")
+        expect((await storage.getLatestVersion(dataset.id))?.versionId).not.toBe(
+          initial.version?.versionId
+        )
+      }))
     // Regression proof: bypass reconcileDatasetSequences at the provider commit boundary.
     // The stale-write, conflict, and deletion assertions below must then fail.
     test("orders repeated keys exactly and conflicts atomically", () =>

--- a/packages/core/src/testing/dataset-sequence-contract.ts
+++ b/packages/core/src/testing/dataset-sequence-contract.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
+import { InMemoryBlobStorage } from "../blob-storage"
 import { change, col, type DatasetDefinition, defineDataset, type MergeChange } from "../datasets"
-import type { DatasetRow, LakeStorage } from "../lake-storage"
+import { writeDataset } from "../datasets/write"
+import type { DatasetMergeCommitResult, DatasetRow, LakeStorage } from "../lake-storage"
 import type { LakeMergeStorageContractSuiteOptions } from "./lake-merge-storage-contract"
 
 const dataset = defineDataset("contract.source_order", {
@@ -31,7 +33,7 @@ async function merge(
   }
 }
 
-async function rows(storage: LakeStorage, definition = dataset) {
+async function rows(storage: LakeStorage, definition: DatasetDefinition = dataset) {
   const result: DatasetRow[] = []
   for await (const row of storage.readRows({ datasetId: definition.id })) result.push(row)
   return result
@@ -51,6 +53,59 @@ export function runDatasetSequenceContract<TStorage extends LakeStorage>(
   }
 
   describe("source ordering", () => {
+    test("initializes empty snapshots and preserves versions across retries and reopen", async () => {
+      // Regression proof: remove createInitialVersion from the writer or provider; the first
+      // snapshot has no version. Ignore the rebased head and the concurrent-write assertion fails.
+      let storage = await options.createStorage()
+      const snapshot = () =>
+        writeDataset({
+          lakeStorage: storage,
+          blobStorage: new InMemoryBlobStorage(),
+          dataset,
+          mode: "snapshot",
+          signal: new AbortController().signal,
+          readValues: async () => [],
+        })
+      try {
+        await storage.createDataset(dataset)
+        expect(await merge(storage, [])).toEqual({ outcome: "unchanged", version: null })
+        const initialized = await Promise.all([snapshot(), snapshot()])
+        expect(initialized.map((result) => result.outcome).sort()).toEqual(["created", "unchanged"])
+        const initial = initialized.find((result) => result.outcome === "created")!
+        expect(initialized[0]?.version).toEqual(initialized[1]?.version)
+        expect(initial).toMatchObject({
+          outcome: "created",
+          version: { rowCount: 0, mode: "merge" },
+        })
+        expect(await rows(storage)).toEqual([])
+        if (options.reopen) storage = await options.reopen(storage)
+        expect(await storage.getLatestVersion(dataset.id)).toEqual(initial.version)
+        expect(await snapshot()).toMatchObject({ outcome: "unchanged", version: initial.version })
+
+        const concurrent = defineDataset("contract.empty_race", {
+          schema: dataset.schema.columns,
+          primaryKey: "id",
+          sequenceBy: "revision",
+        })
+        let committed: DatasetMergeCommitResult | undefined
+        const rebased = await writeDataset({
+          lakeStorage: storage,
+          blobStorage: new InMemoryBlobStorage(),
+          dataset: concurrent,
+          mode: "snapshot",
+          signal: new AbortController().signal,
+          readValues: async () => {
+            committed = await merge(storage, [upsert(8)], concurrent)
+            return []
+          },
+        })
+        expect(rebased).toMatchObject({ outcome: "unchanged", version: committed?.version })
+        expect(await rows(storage, concurrent)).toHaveLength(1)
+      } finally {
+        await options.teardown?.(storage)
+      }
+    })
+
     test("rejects lossy timestamps outside the ordering column before changing source state", () =>
       withStorage(async (storage) => {
         // Regression proof: remove the sequenced timestamp check in getColumnValidationError;

--- a/packages/core/src/testing/lake-storage-contract.ts
+++ b/packages/core/src/testing/lake-storage-contract.ts
@@ -471,6 +471,64 @@ export function runLakeStorageContractSuite<TStorage extends LakeStorage>(
         })
       })
 
+      test("guards initial and existing versions before accepting even an unchanged write", () =>
+        withStorage(async (storage) => {
+          // Regression proof: treat null like undefined or move the version guard after no-op
+          // detection. An old writer then succeeds after a competing version has committed.
+          await storage.createDataset(writeDataset)
+          const first = await storage.beginWrite({ dataset: writeDataset })
+          const stale = await storage.beginWrite({ dataset: writeDataset })
+          const initial = await first.commit({ expectedLatestVersionId: null })
+          await expect(stale.commit({ expectedLatestVersionId: null })).rejects.toThrow(
+            "Optimistic"
+          )
+          await stale.abort()
+          const replacement = await storage.beginWrite({ dataset: writeDataset })
+          await replacement.writeRows([{ orderId: "ord_1", customerName: "Ada" }])
+          const next = await replacement.commit({ expectedLatestVersionId: initial.versionId })
+          const identical = await storage.beginWrite({ dataset: writeDataset })
+          await identical.writeRows([{ orderId: "ord_1", customerName: "Ada" }])
+          await expect(
+            identical.commit({ expectedLatestVersionId: initial.versionId })
+          ).rejects.toThrow("Optimistic")
+          await identical.abort()
+          expect((await storage.getLatestVersion(writeDataset.id))?.versionId).toBe(next.versionId)
+        }))
+
+      test("versions changed input lineage even when output rows are identical", () =>
+        withStorage(async (storage) => {
+          // Regression proof: omit hasDatasetInputChanges in the provider's no-op branch.
+          // The updated input reference is lost and the stale writer is no longer fenced.
+          await storage.createDataset(writeDataset)
+          await storage.createDataset(definitionDataset)
+          const sourceWrite = await storage.beginWrite({ dataset: definitionDataset })
+          const source1 = await sourceWrite.commit()
+          const rows = [{ orderId: "ord_1", customerName: "Ada" }]
+          const ref1 = { datasetId: definitionDataset.id, versionId: source1.versionId }
+          const first = await storage.beginWrite({ dataset: writeDataset, inputs: [ref1] })
+          await first.writeRows(rows)
+          const initial = await first.commit({ expectedLatestVersionId: null })
+          const stale = await storage.beginWrite({ dataset: writeDataset, inputs: [ref1] })
+          await stale.writeRows([{ orderId: "ord_1", customerName: "Stale" }])
+          const sourceUpdate = await storage.beginWrite({ dataset: definitionDataset })
+          await sourceUpdate.writeRows([{ orderId: "source", customerName: "Changed" }])
+          const source2 = await sourceUpdate.commit()
+          const ref2 = { datasetId: definitionDataset.id, versionId: source2.versionId }
+          const update = await storage.beginWrite({ dataset: writeDataset, inputs: [ref2] })
+          await update.writeRows(rows)
+          const newer = await update.commit({ expectedLatestVersionId: initial.versionId })
+          expect(newer).toMatchObject({ outcome: "created", inputs: [ref2] })
+          await expect(
+            stale.commit({ expectedLatestVersionId: initial.versionId })
+          ).rejects.toThrow("Optimistic")
+          await stale.abort()
+          const same = await storage.beginWrite({ dataset: writeDataset, inputs: [ref2] })
+          await same.writeRows(rows)
+          const unchanged = await same.commit({ expectedLatestVersionId: newer.versionId })
+          expect(unchanged).toMatchObject({ outcome: "unchanged", versionId: newer.versionId })
+          expect(await collectRows(storage.readRows({ datasetId: writeDataset.id }))).toEqual(rows)
+        }))
+
       test("creates an initial empty append version", async () => {
         await withStorage(async (storage) => {
           await storage.createDataset(writeDataset)

--- a/packages/core/tests/lake-merge-retry.test.ts
+++ b/packages/core/tests/lake-merge-retry.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test"
+import { col, defineDataset } from "../src/datasets"
+import {
+  LakeConcurrencyError,
+  LakeStorageError,
+  retryDatasetMergeCommit,
+} from "../src/lake-storage"
+
+const dataset = defineDataset("retry", {
+  schema: [col("id", "string"), col("revision", "int64")],
+  primaryKey: "id",
+  sequenceBy: "revision",
+})
+
+test("merge retries are bounded and preserve the last concurrency failure", async () => {
+  // Regression proof: remove the attempt bound; use a fourth-attempt sentinel to avoid a hung test.
+  const failure = new LakeConcurrencyError("stale dataset")
+  const rebases: boolean[] = []
+  await expect(
+    retryDatasetMergeCommit({ dataset }, { retryOnConflict: true }, async (rebase) => {
+      rebases.push(rebase)
+      if (rebases.length > 3) throw new Error("retry bound exceeded")
+      throw failure
+    })
+  ).rejects.toMatchObject({
+    name: "LakeConcurrencyError",
+    message: expect.stringContaining("exhausted 3"),
+    cause: failure,
+  })
+  expect(rebases).toEqual([false, true, true])
+})
+
+test("merge retries exclude validation, source-content, and ambiguous provider failures", async () => {
+  for (const failure of [
+    new LakeStorageError("conflicting source content"),
+    new Error("validation failed"),
+    new Error("connection lost after COMMIT"),
+  ]) {
+    let attempts = 0
+    await expect(
+      retryDatasetMergeCommit({ dataset }, { retryOnConflict: true }, async () => {
+        attempts += 1
+        throw failure
+      })
+    ).rejects.toBe(failure)
+    expect(attempts).toBe(1)
+  }
+})
+
+test("cancellation prevents another commit attempt", async () => {
+  const controller = new AbortController()
+  const cancelled = new Error("delivery cancelled")
+  let attempts = 0
+  await expect(
+    retryDatasetMergeCommit(
+      { dataset },
+      { retryOnConflict: true, signal: controller.signal },
+      async () => {
+        attempts += 1
+        controller.abort(cancelled)
+        throw new LakeConcurrencyError("stale")
+      }
+    )
+  ).rejects.toBe(cancelled)
+  expect(attempts).toBe(1)
+})

--- a/packages/pipeline-worker/src/execute-run-step.ts
+++ b/packages/pipeline-worker/src/execute-run-step.ts
@@ -19,6 +19,7 @@ export async function executeRunStep(input: {
   readonly signal: AbortSignal
   readonly logSession: PipelineLogSession
   readonly outputDataset: DatasetDefinition
+  readonly expectedLatestVersionId: string | null
   readonly resolvedInputs: readonly ResolvedStepInput[]
 }): Promise<{
   readonly version: DatasetVersion
@@ -80,6 +81,7 @@ export async function executeRunStep(input: {
     throwIfAborted(signal)
 
     const commit = await write.commit({
+      expectedLatestVersionId: input.expectedLatestVersionId,
       commitMessage: `pipeline ${pipeline.id} step ${step.id} run ${job.id}`,
     })
     const { outcome, ...version } = commit

--- a/packages/pipeline-worker/src/execute-sql-step.ts
+++ b/packages/pipeline-worker/src/execute-sql-step.ts
@@ -60,6 +60,7 @@ export async function executeSqlStep(input: {
   readonly job: PipelineJob
   readonly signal: AbortSignal
   readonly outputDataset: DatasetDefinition
+  readonly expectedLatestVersionId: string | null
   readonly resolvedInputs: readonly ResolvedStepInput[]
 }): Promise<{
   readonly version: DatasetVersion
@@ -126,6 +127,7 @@ export async function executeSqlStep(input: {
     ),
     sql: step.executor.sql,
     target: outputDataset,
+    expectedLatestVersionId: input.expectedLatestVersionId,
     mode: step.mode,
     producer: {
       kind: "pipeline",

--- a/packages/pipeline-worker/src/run-step.ts
+++ b/packages/pipeline-worker/src/run-step.ts
@@ -47,13 +47,8 @@ export async function runStep(input: {
   throwIfAborted(signal)
   let resolvedInputs: readonly ResolvedStepInput[]
   let outputDataset: DatasetDefinition
+  let expectedLatestVersionId: string | null
   try {
-    resolvedInputs = await resolveStepInputs({
-      runtime,
-      pipeline,
-      step,
-      pipelineRunId: job.id,
-    })
     outputDataset = requireRegisteredDataset({
       dataset: runtime.datasets.getById(step.output.id),
       pipelineId: pipeline.id,
@@ -64,6 +59,16 @@ export async function runStep(input: {
     })
 
     await runtime.lakeStorage.createDataset(outputDataset)
+    // Capture the output guard before any input is pinned. A later capture could legitimize
+    // overwriting a concurrent run with results computed from older inputs.
+    expectedLatestVersionId =
+      (await runtime.lakeStorage.getLatestVersion(outputDataset.id))?.versionId ?? null
+    resolvedInputs = await resolveStepInputs({
+      runtime,
+      pipeline,
+      step,
+      pipelineRunId: job.id,
+    })
   } catch (error) {
     if (statusForFailure(signal, error) === "failed") {
       throw createPipelineStepFailure({
@@ -102,6 +107,7 @@ export async function runStep(input: {
       signal,
       logSession: input.logSession,
       outputDataset,
+      expectedLatestVersionId,
       resolvedInputs,
     })
     committedVersion = execution.version
@@ -187,6 +193,7 @@ async function executeStep(input: {
   readonly signal: AbortSignal
   readonly logSession: PipelineLogSession
   readonly outputDataset: DatasetDefinition
+  readonly expectedLatestVersionId: string | null
   readonly resolvedInputs: readonly ResolvedStepInput[]
 }): Promise<StepExecutionResult> {
   switch (input.step.executor.kind) {

--- a/packages/pipeline-worker/tests/run-pipeline-job.test.ts
+++ b/packages/pipeline-worker/tests/run-pipeline-job.test.ts
@@ -710,6 +710,7 @@ describe("runPipelineJob", () => {
 
     expect(lakeStorage.executeCalls).toHaveLength(1)
     expect(lakeStorage.executeCalls[0]).toMatchObject({
+      expectedLatestVersionId: null,
       target: customerStatsDataset,
       mode: "append",
       producer: {
@@ -753,6 +754,9 @@ describe("runPipelineJob", () => {
         versionId: result.version?.versionId,
       },
     })
+    // Removing the worker's output guard must fail these assertions.
+    await runPipelineJob({ runtime, job: { id: "run_sql_second", pipelineId: "customers" } })
+    expect(lakeStorage.executeCalls[1]?.expectedLatestVersionId).toBe(result.version?.versionId)
   })
 
   test("fails SQL steps clearly when lake storage has no SQL transform support", async () => {
@@ -830,3 +834,71 @@ describe("runPipelineJob", () => {
     expect(stepRuns.steps[0]?.error?.message).toBe("Pipeline step execution failed.")
   })
 })
+
+for (const baseline of ["missing", "existing", "same-as-newer"] as const) {
+  test(`fences a stale pipeline with ${baseline} output`, async () => {
+    // Regression proof: omit the output guard in executeRunStep, or capture it after reading
+    // inputs; the slow run publishes stale data. Ignoring changed input lineage also breaks
+    // same-as-newer: the fast run must fence old work even when its rows equal the prior output.
+    const lakeStorage = new InMemoryLakeStorage()
+    const source = rawCustomersDataset
+    const target = customersDataset
+    await seedDatasetVersion(lakeStorage, source, [{ id: "42", name: "Sam" }])
+    if (baseline !== "missing") {
+      await seedDatasetVersion(lakeStorage, target, [
+        { id: "42", name: baseline === "same-as-newer" ? "Samuel" : "Before" },
+      ])
+    }
+    let release!: () => void
+    let started!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const ready = new Promise<void>((resolve) => {
+      started = resolve
+    })
+    const readLatest = lakeStorage.getLatestVersion.bind(lakeStorage)
+    let holdSourceRead = true
+    lakeStorage.getLatestVersion = async (datasetId) => {
+      const version = await readLatest(datasetId)
+      if (datasetId === source.id && holdSourceRead) {
+        holdSourceRead = false
+        started()
+        await gate
+      }
+      return version
+    }
+    const step = definePipelineStep("copy")
+      .inputs({ source })
+      .output(target)
+      .run(async ({ inputs, output }) => {
+        const rows = await collectRows(inputs.source!.readRows())
+        await output.writeRows(rows)
+      })
+    const pipeline = definePipeline("copy").then(step)
+    const runtime = createRuntime({
+      pipelines: [pipeline],
+      datasets: [source, target],
+      lakeStorage,
+    })
+    const slow = runPipelineJob({ runtime, job: { id: "slow", pipelineId: pipeline.id } })
+    await ready
+    try {
+      await seedDatasetVersion(lakeStorage, source, [{ id: "42", name: "Samuel" }])
+      await runPipelineJob({ runtime, job: { id: "fast", pipelineId: pipeline.id } })
+    } finally {
+      release()
+    }
+    await expect(slow).rejects.toThrow("Optimistic")
+    expect(await collectRows(lakeStorage.readRows({ datasetId: target.id }))).toEqual([
+      { id: "42", name: "Samuel" },
+    ])
+    expect(
+      await runtime.pipelineRunsStorage.getById({ projectId: runtime.id, id: "slow" })
+    ).toMatchObject({ status: "failed", error: { code: "pipeline.step_failed", retryable: false } })
+    // An explicit new run reads current inputs. Repeating the same inputs is still a no-op.
+    const latest = await lakeStorage.getLatestVersion(target.id)
+    await runPipelineJob({ runtime, job: { id: "fresh", pipelineId: pipeline.id } })
+    expect(await lakeStorage.getLatestVersion(target.id)).toEqual(latest)
+  })
+}

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -21,6 +21,7 @@ import {
   InMemoryLakeStorage,
   InMemoryStorage,
 } from "@sixb/core"
+import { writeDataset } from "@sixb/core/internal/datasets"
 import type { SyncConnectorSourceResolver } from "@sixb/core/internal/syncs"
 import type { LakeWriteSession } from "@sixb/core/lake-storage"
 import type { ExecutionStorage, SyncRunRecord, SyncRunStorage } from "@sixb/core/storage"
@@ -246,6 +247,119 @@ async function collectRows(rows: AsyncIterable<DatasetRow>): Promise<DatasetRow[
 }
 
 describe("runSyncJob", () => {
+  test("fails a source tie after rebasing a snapshot without advancing its checkpoint", async () => {
+    const dataset = defineDataset("source.conflict", {
+      schema: [col("id", "string"), col("revision", "int64"), col("name", "string")],
+      primaryKey: "id",
+      sequenceBy: "revision",
+    })
+    const lakeStorage = new InMemoryLakeStorage()
+    const signal = new AbortController().signal
+    let reads = 0
+    const sync = defineSync("source.conflict-sync", { mode: "snapshot" })
+      .checkpoint<{ page: number }>()
+      .from(erpDb)
+      .read(async (_client, context) => {
+        reads += 1
+        context.setCheckpoint({ page: 2 })
+        await writeDataset({
+          lakeStorage,
+          blobStorage: new InMemoryBlobStorage(),
+          dataset,
+          signal,
+          mode: "merge",
+          readValues: async () => [
+            { value: change.upsert({ id: "42", revision: 8, name: "webhook" }) },
+          ],
+        })
+        return [
+          { id: "other", revision: 1, name: "partial" },
+          { id: "42", revision: 8, name: "snapshot" },
+        ]
+      })
+      .intoDataset(dataset)
+    const runtime = createRuntime({ sync, lakeStorage })
+    await expect(
+      runSyncJob({ runtime, job: { id: "conflict-run", syncId: sync.id }, signal })
+    ).rejects.toThrow("conflicting content")
+    expect(reads).toBe(1)
+    expect(
+      (await collectRows(lakeStorage.readRows({ datasetId: dataset.id }))).map((row) => row.name)
+    ).toEqual(["webhook"])
+    const run = await runtime.syncRunsStorage.getById({ projectId: runtime.id, id: "conflict-run" })
+    expect(run?.status).toBe("failed")
+    expect(run?.checkpoint).toBeUndefined()
+  })
+  for (const provider of ["memory", "local"] as const)
+    test(`${provider}: reconciles a one-shot snapshot with concurrent source writes`, async () => {
+      // Regression proof: disable snapshot reconciliation or provider retries; the stale snapshot fails/overwrites.
+      const path = await mkdtemp(join(tmpdir(), "sixb-ordered-snapshot-"))
+      tempDirs.push(path)
+      const lakeStorage =
+        provider === "memory" ? new InMemoryLakeStorage() : new LocalLakeStorage({ path })
+      const dataset = defineDataset("source.people", {
+        schema: [col("id", "string"), col("revision", "int64"), col("name", "string")],
+        primaryKey: "id",
+        sequenceBy: "revision",
+      })
+      const signal = new AbortController().signal
+      const ingest = (changes: DatasetRow[]) =>
+        writeDataset({
+          lakeStorage,
+          blobStorage: new InMemoryBlobStorage(),
+          dataset,
+          signal,
+          mode: "merge",
+          readValues: async () => changes.map((row) => ({ value: change.upsert(row) })),
+        })
+      let reads = 0
+      const sync = defineSync("source.snapshot", { mode: "snapshot" })
+        .checkpoint<{ page: string }>()
+        .from(erpDb)
+        .read(async function* (_client, { setCheckpoint }) {
+          reads += 1
+          setCheckpoint({ page: "done" })
+          const reused = { id: "42", revision: 7, name: "snapshot" }
+          yield reused
+          await ingest([
+            { id: "42", revision: 8, name: "webhook" },
+            { id: "new", revision: 1, name: "created" },
+          ])
+          reused.id = "snapshot-only"
+          reused.name = "snapshot-only"
+          yield reused
+        })
+        .intoDataset(dataset)
+      const runtime = createRuntime({ sync, lakeStorage })
+      const result = await runSyncJob({
+        runtime,
+        job: { id: "ordered-run", syncId: sync.id },
+        signal,
+      })
+      expect(reads).toBe(1)
+      expect(result.rowsRead).toBe(2)
+      expect(result.version?.mode).toBe("merge")
+      expect(
+        (await collectRows(lakeStorage.readRows({ datasetId: dataset.id })))
+          .map((row) => row.name)
+          .sort()
+      ).toEqual(["created", "snapshot-only", "webhook"])
+      expect(
+        (await runtime.syncRunsStorage.getById({ projectId: runtime.id, id: "ordered-run" }))
+          ?.checkpoint
+      ).toEqual(storedErpCheckpoint({ page: "done" }))
+      const empty = defineSync("source.empty", { mode: "snapshot" })
+        .from(erpDb)
+        .read(() => [])
+        .intoDataset(dataset)
+      const emptyResult = await runSyncJob({
+        runtime: createRuntime({ sync: empty, lakeStorage }),
+        job: { id: "empty-run", syncId: empty.id },
+        signal,
+      })
+      expect(emptyResult.versionCreated).toBe(false)
+      expect(emptyResult.version?.versionId).toBe(result.version?.versionId)
+    })
   test("commits a snapshot sync, defines the dataset first, and stores a succeeded run", async () => {
     const calls: string[] = []
     const lakeStorage = new InMemoryLakeStorage()

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -360,6 +360,36 @@ describe("runSyncJob", () => {
       expect(emptyResult.versionCreated).toBe(false)
       expect(emptyResult.version?.versionId).toBe(result.version?.versionId)
     })
+  test("initializes an empty sequenced snapshot and stores its version and checkpoint", async () => {
+    // Regression proof: remove createInitialVersion in writeDataset; the first sync succeeds
+    // without an output version and cannot feed dataset-updated consumers.
+    const dataset = defineDataset("source.empty-initial", {
+      schema: [col("id", "string"), col("revision", "int64")],
+      primaryKey: "id",
+      sequenceBy: "revision",
+    })
+    const sync = defineSync("source.empty-initial", { mode: "snapshot" })
+      .checkpoint<{ page: string }>()
+      .from(erpDb)
+      .read((_client, { setCheckpoint }) => {
+        setCheckpoint({ page: "done" })
+        return []
+      })
+      .intoDataset(dataset)
+    const runtime = createRuntime({ sync })
+    const first = await runSyncJob({ runtime, job: { id: "empty-first", syncId: sync.id } })
+    expect(first).toMatchObject({ rowsRead: 0, versionCreated: true, version: { rowCount: 0 } })
+    expect(
+      await runtime.syncRunsStorage.getById({ projectId: runtime.id, id: first.id })
+    ).toMatchObject({
+      status: "succeeded",
+      output: { datasetId: dataset.id, versionId: first.version?.versionId },
+      checkpoint: storedErpCheckpoint({ page: "done" }),
+    })
+    const second = await runSyncJob({ runtime, job: { id: "empty-second", syncId: sync.id } })
+    expect(second).toMatchObject({ versionCreated: false, version: first.version })
+  })
+
   test("commits a snapshot sync, defines the dataset first, and stores a succeeded run", async () => {
     const calls: string[] = []
     const lakeStorage = new InMemoryLakeStorage()

--- a/storage/ducklake/README.md
+++ b/storage/ducklake/README.md
@@ -192,6 +192,8 @@ identical ties are unchanged, and conflicting ties abort the merge. Deletes requ
 companion DuckLake table in the same transaction as visible rows, surviving snapshot expiration.
 New tombstone state creates a version even when the visible row count stays zero. Sequenced
 provider writes use merge sessions; snapshot syncs convert rows to ordered upserts.
+Snapshot syncs use `commit({ createInitialVersion: true })` to make a first empty result
+addressable. Later no-op commits reuse the current version, including after a concurrent write.
 Use `commit({ retryOnConflict: true })` to rebase retained changes, with at most 3 attempts.
 Explicit `expectedLatestVersionId` guards are never relaxed.
 See [source ordering](../../docs/data/datasets.md#source-ordering).

--- a/storage/ducklake/README.md
+++ b/storage/ducklake/README.md
@@ -191,7 +191,14 @@ identical ties are unchanged, and conflicting ties abort the merge. Deletes requ
 `change.delete(key, { sequence })`. Source revisions and deletion tombstones are stored in a
 companion DuckLake table in the same transaction as visible rows, surviving snapshot expiration.
 New tombstone state creates a version even when the visible row count stays zero. Sequenced
-datasets currently require merge writes. See [source ordering](../../docs/data/datasets.md#source-ordering).
+provider writes use merge sessions; snapshot syncs convert rows to ordered upserts.
+Use `commit({ retryOnConflict: true })` to rebase retained changes, with at most 3 attempts.
+Explicit `expectedLatestVersionId` guards are never relaxed.
+See [source ordering](../../docs/data/datasets.md#source-ordering).
+
+Local catalogs serialize commits within one process. PostgreSQL catalogs support concurrent
+writer processes; known snapshot-ID conflicts are retried from the retained staging table.
+Other provider/connection failures propagate without an automatic retry.
 
 Snapshot, append, and SQL-transform writes to keyed datasets also enforce unique keys so a later
 merge never starts from an ambiguous baseline. Application authors normally use

--- a/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
+++ b/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
@@ -59,6 +59,7 @@ interface VisibleSnapshotRowsInput {
 export interface DuckLakeVersionSummary {
   readonly datasetId: string
   readonly versionId: string
+  readonly inputs?: readonly DatasetVersionRef[]
   readonly rowCount?: number
   readonly validatedPrimaryKeyColumns?: readonly string[]
 }
@@ -444,6 +445,7 @@ export class DuckLakeSnapshotReader {
     return {
       datasetId: tableRef.datasetId,
       versionId: toVersionId(row.snapshotId),
+      inputs: row.metadata?.inputs,
       ...(row.metadata?.rowCount !== undefined ? { rowCount: row.metadata.rowCount } : {}),
       ...(row.metadata?.validatedPrimaryKeyColumns !== undefined
         ? { validatedPrimaryKeyColumns: row.metadata.validatedPrimaryKeyColumns }

--- a/storage/ducklake/src/internal/ducklake-write-coordinator.ts
+++ b/storage/ducklake/src/internal/ducklake-write-coordinator.ts
@@ -13,7 +13,9 @@ import type {
 import {
   assertUnsequencedDatasetWrite,
   getDatasetPrimaryKeyColumns,
+  LakeConcurrencyError,
   LakeStorageError,
+  retryDatasetMergeCommit,
 } from "@sixb/core/lake-storage"
 import type { DuckLakeStorageOptions } from "../types"
 import { localCatalogCoordinationKey } from "./catalog-key"
@@ -59,6 +61,7 @@ interface DuckLakeCommitVersionOutcomeInput
   readonly mode: DatasetWriteMode | "merge"
   readonly expectedLatestVersionId?: string | null
   readonly allowInitialNoOp?: boolean
+  readonly signal?: AbortSignal
   readonly disableRetries?: boolean
   readonly optimisticOperation?: "commit" | "merge commit"
 }
@@ -138,7 +141,7 @@ export class DuckLakeWriteCoordinator {
       input.expectedLatestVersionId !== undefined &&
       latestVersion?.versionId !== input.expectedLatestVersionId
     ) {
-      throw new LakeStorageError(
+      throw new LakeConcurrencyError(
         `[SixbDuckLake] Optimistic merge start failed for dataset '${definition.id}': expected latest version '${input.expectedLatestVersionId}', found '${latestVersion?.versionId ?? "none"}'.`
       )
     }
@@ -187,35 +190,43 @@ export class DuckLakeWriteCoordinator {
       )
     }
 
-    return this.withCommitRuntime((runtime) =>
-      this.commitVersionOutcomeOnExclusiveRuntime(runtime, {
-        dataset: definition,
-        mode: "merge",
-        expectedLatestVersionId: input.baseVersionId,
-        allowInitialNoOp: true,
-        disableRetries: true,
-        optimisticOperation: "merge commit",
-        commitMessage: input.commit?.commitMessage ?? `merge dataset ${definition.id}`,
-        producer: input.merge.producer,
-        inputs: input.merge.inputs,
-        applyChanges: async (commitRuntime, context) => {
-          const result = await applyDatasetMergeFromRelation({
-            options: this.options,
-            runtime: commitRuntime,
-            dataset: definition,
-            stagingTableName: input.stagingTableName,
-            sequenceColumnName: input.sequenceColumnName,
-            kindColumnName: input.kindColumnName,
-            previousRowCount: context.previousRowCount,
-            validatedPrimaryKeyColumns: context.validatedPrimaryKeyColumns,
-          })
-          if (result.sourceRowCount !== input.changesWritten) {
-            throw new LakeStorageError(
-              `[SixbDuckLake] Staged merge for dataset '${definition.id}' accepted ${input.changesWritten} change(s), but DuckLake saw ${result.sourceRowCount} source change(s) at commit time.`
-            )
-          }
-          return result
-        },
+    return retryDatasetMergeCommit(input.merge, input.commit, (rebase) =>
+      this.withCommitRuntime(async (runtime) => {
+        input.commit?.signal?.throwIfAborted()
+        const baseVersionId = rebase
+          ? ((await this.snapshots.getLatestVersionForDefinition(runtime, definition))?.versionId ??
+            null)
+          : input.baseVersionId
+        return this.commitVersionOutcomeOnExclusiveRuntime(runtime, {
+          dataset: definition,
+          mode: "merge",
+          expectedLatestVersionId: baseVersionId,
+          allowInitialNoOp: true,
+          signal: input.commit?.signal,
+          disableRetries: true,
+          optimisticOperation: "merge commit",
+          commitMessage: input.commit?.commitMessage ?? `merge dataset ${definition.id}`,
+          producer: input.merge.producer,
+          inputs: input.merge.inputs,
+          applyChanges: async (commitRuntime, context) => {
+            const result = await applyDatasetMergeFromRelation({
+              options: this.options,
+              runtime: commitRuntime,
+              dataset: definition,
+              stagingTableName: input.stagingTableName,
+              sequenceColumnName: input.sequenceColumnName,
+              kindColumnName: input.kindColumnName,
+              previousRowCount: context.previousRowCount,
+              validatedPrimaryKeyColumns: context.validatedPrimaryKeyColumns,
+            })
+            if (result.sourceRowCount !== input.changesWritten) {
+              throw new LakeStorageError(
+                `[SixbDuckLake] Staged merge for dataset '${definition.id}' accepted ${input.changesWritten} change(s), but DuckLake saw ${result.sourceRowCount} source change(s) at commit time.`
+              )
+            }
+            return result
+          },
+        })
       })
     )
   }
@@ -338,6 +349,7 @@ export class DuckLakeWriteCoordinator {
         previousRowCount: latestVersion?.rowCount,
         validatedPrimaryKeyColumns: latestVersion?.validatedPrimaryKeyColumns,
       })
+      input.signal?.throwIfAborted()
       await this.ensureInitialNoOpHasSnapshot(input, changeResult, latestVersion)
       const commitId = randomUUID()
       await this.setCommitMetadata(
@@ -364,6 +376,24 @@ export class DuckLakeWriteCoordinator {
     } catch (error) {
       if (!committed) {
         await this.rollbackTransaction(input.runtime)
+        // DuckLake's snapshot-id uniqueness constraint is its catalog commit CAS. With native
+        // retries disabled, this error proves the transaction lost to another writer. Do not
+        // classify generic connection/COMMIT errors: their durable outcome may be ambiguous.
+        if (
+          error instanceof Error &&
+          error.message.startsWith(
+            "TransactionContext Error: Failed to commit: Failed to commit DuckLake transaction."
+          ) &&
+          error.message.includes("Exceeded the maximum retry count of 0") &&
+          error.message.includes(
+            'duplicate key value violates unique constraint "ducklake_snapshot_pkey"'
+          )
+        ) {
+          throw new LakeConcurrencyError(
+            `[SixbDuckLake] Concurrent catalog commit for dataset '${input.dataset.id}'.`,
+            { cause: error }
+          )
+        }
       }
       throw error
     }
@@ -639,7 +669,7 @@ export class DuckLakeWriteCoordinator {
     }
 
     if (input.actualLatestVersionId !== input.expectedLatestVersionId) {
-      throw new LakeStorageError(
+      throw new LakeConcurrencyError(
         `[SixbDuckLake] Optimistic ${input.operation} failed for dataset '${input.datasetId}': expected latest version '${input.expectedLatestVersionId ?? "none"}', found '${input.actualLatestVersionId ?? "none"}'.`
       )
     }

--- a/storage/ducklake/src/internal/ducklake-write-coordinator.ts
+++ b/storage/ducklake/src/internal/ducklake-write-coordinator.ts
@@ -13,6 +13,7 @@ import type {
 import {
   assertUnsequencedDatasetWrite,
   getDatasetPrimaryKeyColumns,
+  hasDatasetInputChanges,
   LakeConcurrencyError,
   LakeStorageError,
   retryDatasetMergeCommit,
@@ -46,7 +47,7 @@ import { parseCommitMetadata, type SixbCommitMetadata } from "./versions"
 export interface DuckLakeCommitDatasetVersionInput {
   readonly dataset: DatasetDefinition
   readonly mode: DatasetWriteMode
-  readonly expectedLatestVersionId?: string
+  readonly expectedLatestVersionId?: string | null
   readonly commitMessage: string
   readonly producer?: BeginDatasetWriteInput["producer"]
   readonly inputs?: BeginDatasetWriteInput["inputs"]
@@ -201,7 +202,7 @@ export class DuckLakeWriteCoordinator {
           dataset: definition,
           mode: "merge",
           expectedLatestVersionId: baseVersionId,
-          allowInitialNoOp: true,
+          allowInitialNoOp: !input.commit?.createInitialVersion,
           signal: input.commit?.signal,
           disableRetries: true,
           optimisticOperation: "merge commit",
@@ -350,7 +351,7 @@ export class DuckLakeWriteCoordinator {
         validatedPrimaryKeyColumns: latestVersion?.validatedPrimaryKeyColumns,
       })
       input.signal?.throwIfAborted()
-      await this.ensureInitialNoOpHasSnapshot(input, changeResult, latestVersion)
+      await this.ensureNoOpHasSnapshot(input, changeResult, latestVersion)
       const commitId = randomUUID()
       await this.setCommitMetadata(
         input,
@@ -523,26 +524,30 @@ export class DuckLakeWriteCoordinator {
     )
   }
 
-  private async ensureInitialNoOpHasSnapshot(
+  private async ensureNoOpHasSnapshot(
     input: DuckLakeCommitVersionOutcomeRuntimeInput,
     changeResult: ApplyDatasetRowsResult,
     knownLatestVersion: DuckLakeVersionSummary | null
   ): Promise<void> {
-    if (changeResult.dataChangeExpected || input.allowInitialNoOp) {
+    if (changeResult.dataChangeExpected) {
       return
     }
 
     const latestVersion =
       knownLatestVersion ??
       (await this.snapshots.getLatestVersionSummaryForDefinition(input.runtime, input.dataset))
-    if (latestVersion) {
+    if (
+      latestVersion
+        ? input.mode === "merge" || !hasDatasetInputChanges(latestVersion.inputs, input.inputs)
+        : input.allowInitialNoOp
+    ) {
       return
     }
 
     // DuckLake 1.5.2 does not create a snapshot for a transaction whose data and metadata are
     // unchanged, and set_commit_message alone cannot force one. Reapplying the current table
     // comment is an idempotent metadata write: it leaves the visible DatasetDefinition unchanged
-    // while giving the first empty write a real DuckLake snapshot for time travel and lineage.
+    // while giving initial empty writes and changed input lineage a real DuckLake snapshot.
     const table = qualifiedTableName(this.options, encodeDatasetTableName(input.dataset.id))
     const descriptionSql =
       input.dataset.description === undefined ? "NULL" : quoteSqlString(input.dataset.description)

--- a/storage/ducklake/tests/ducklake-remote.e2e.ts
+++ b/storage/ducklake/tests/ducklake-remote.e2e.ts
@@ -9,6 +9,89 @@ import { type DuckDbSecretOptions, DuckLakeStorage, type DuckLakeStorageOptions 
 import { collectRows } from "./test-utils"
 
 describe("DuckLakeStorage remote catalogs", () => {
+  // Regression proof: remove the DuckLake snapshot-CAS error classification; one child fails COMMIT.
+  for (const scenario of ["different keys", "same key", "existing key", "deletion"] as const)
+    test(`rebases source changes across processes: ${scenario}`, async () => {
+      const rootDir = await mkdtemp(join(tmpdir(), "sixb-source-processes-"))
+      const dataset = defineDataset(`source.processes.${randomId()}`, {
+        schema: [col("id", "string"), col("revision", "int64")],
+        primaryKey: "id",
+        sequenceBy: "revision",
+      })
+      const options: DuckLakeStorageOptions = {
+        catalog: postgresCatalog(),
+        dataPath: join(rootDir, "data"),
+      }
+      const storage = new DuckLakeStorage(options)
+      await storage.createDataset(dataset)
+      if (scenario === "existing key" || scenario === "deletion") {
+        const seed = await storage.beginMerge({ dataset })
+        await seed.writeChanges([change.upsert({ id: "42", revision: 7 })])
+        await seed.commit()
+      }
+      const children = [
+        [change.upsert({ id: "42", revision: 8 })],
+        scenario === "deletion"
+          ? [change.delete({ id: "42" }, { sequence: 9 })]
+          : [change.upsert({ id: scenario === "different keys" ? "other" : "42", revision: 9 })],
+      ].map((changes) => {
+        let resolveReady!: () => void
+        let rejectReady!: (error: Error) => void
+        const ready = new Promise<void>((resolve, reject) => {
+          resolveReady = resolve
+          rejectReady = reject
+        })
+        const process = Bun.spawn(
+          [
+            Bun.argv[0],
+            join(import.meta.dir, "fixtures/concurrent-source-merge.ts"),
+            JSON.stringify(options),
+            JSON.stringify(dataset),
+            JSON.stringify(changes),
+          ],
+          {
+            stdout: "ignore",
+            stderr: "pipe",
+            timeout: 30_000,
+            ipc(message) {
+              if (
+                typeof message === "object" &&
+                message !== null &&
+                "type" in message &&
+                message.type === "ready"
+              )
+                resolveReady()
+            },
+          }
+        )
+        const stderrText = new Response(process.stderr).text()
+        const finished = process.exited.then(async (code) => {
+          const stderr = await stderrText
+          // Rejecting an already-resolved readiness promise has no effect.
+          rejectReady(new Error(stderr || `child exited ${code} before reaching COMMIT`))
+          return { code, stderr }
+        })
+        return { process, ready, finished }
+      })
+      try {
+        // Both transactions reach COMMIT from the same base in independent Bun processes.
+        await Promise.all(children.map((child) => child.ready))
+        for (const child of children) child.process.send("commit")
+        for (const child of children) {
+          const { code, stderr } = await child.finished
+          if (code !== 0) throw new Error(stderr)
+        }
+        const rows = await collectRows(storage.readRows({ datasetId: dataset.id }))
+        if (scenario === "different keys")
+          expect(rows.map((row) => row.id).sort()).toEqual(["42", "other"])
+        else expect(rows).toEqual(scenario === "deletion" ? [] : [{ id: "42", revision: "9" }])
+      } finally {
+        for (const child of children) child.process.kill()
+        await Promise.all(children.map((child) => child.finished))
+        await storage.close()
+        await rm(rootDir, { recursive: true, force: true })
+      }
+    }, 40_000)
   test("uses a PostgreSQL catalog with a local data path", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "sixb-ducklake-pg-local-"))
     const dataset = defineDataset(`raw.pg.local.${randomId()}`, {

--- a/storage/ducklake/tests/ducklake-sql-transforms.e2e.ts
+++ b/storage/ducklake/tests/ducklake-sql-transforms.e2e.ts
@@ -575,6 +575,42 @@ describe("DuckLake SQL transforms", () => {
     ])
   })
 
+  // Regression: remove the null guard or lineage-only snapshot creation; this test must fail.
+  test("guards initial SQL output and advances lineage even when rows stay identical", async () => {
+    const target = defineDataset("guarded.sql-output", { schema: customersDataset.schema.columns })
+    await storage.createDataset(target)
+    const firstSource = await commitRows(storage, customersDataset, [
+      { customerId: "one", name: "Ada" },
+    ])
+    const execute = (versionId: string, expectedLatestVersionId: string | null) =>
+      storage.sql.execute({
+        sources: { customers: { dataset: customersDataset, versionId } },
+        target,
+        mode: "snapshot",
+        expectedLatestVersionId,
+        sql: ({ customers }) => `SELECT customerId, 'Constant' AS name FROM ${customers}`,
+      })
+    const first = await execute(firstSource.versionId, null)
+    expect(first.outcome).toBe("created")
+    const nextSource = await commitRows(storage, customersDataset, [
+      { customerId: "one", name: "Grace" },
+    ])
+    const next = await execute(nextSource.versionId, first.versionId)
+    expect(next.outcome).toBe("created")
+    expect(next.versionId).not.toBe(first.versionId)
+    expect(next.inputs).toEqual([
+      { datasetId: customersDataset.id, versionId: nextSource.versionId },
+    ])
+    await expect(execute(firstSource.versionId, first.versionId)).rejects.toThrow("Optimistic")
+    await expect(execute(nextSource.versionId, null)).rejects.toThrow("Optimistic")
+    const repeated = await execute(nextSource.versionId, next.versionId)
+    expect(repeated.outcome).toBe("unchanged")
+    expect(repeated.versionId).toBe(next.versionId)
+    expect(await collectRows(storage.readRows({ datasetId: target.id }))).toEqual([
+      { customerId: "one", name: "Constant" },
+    ])
+  })
+
   test("rejects stale expected latest versions for SQL execute commits", async () => {
     const firstVersion = await storage.sql.execute({
       sources: {},

--- a/storage/ducklake/tests/fixtures/concurrent-source-merge.ts
+++ b/storage/ducklake/tests/fixtures/concurrent-source-merge.ts
@@ -1,0 +1,43 @@
+import type { DatasetDefinition, DatasetRow, MergeChange } from "@sixb/core"
+import { DuckLakeStorage, type DuckLakeStorageOptions } from "../../src"
+import type { DuckDbRuntime } from "../../src/internal/duckdb-runtime"
+
+const options = JSON.parse(process.argv[2] ?? "") as DuckLakeStorageOptions
+const dataset = JSON.parse(process.argv[3] ?? "") as DatasetDefinition
+const changes = JSON.parse(process.argv[4] ?? "") as MergeChange<DatasetRow, DatasetRow>[]
+const storage = new DuckLakeStorage(options)
+try {
+  const session = await storage.beginMerge({ dataset })
+  await session.writeChanges(changes)
+  const runtime = await (
+    storage as unknown as { connections: { runtime(): Promise<DuckDbRuntime> } }
+  ).connections.runtime()
+  const exclusive = runtime.withExclusive.bind(runtime)
+  let firstCommit = true
+  runtime.withExclusive = (run) =>
+    exclusive((transaction) =>
+      run({
+        query: (sql, values) => transaction.query(sql, values),
+        runStatements: (statements) => transaction.runStatements(statements),
+        withAppender: (table, use) => transaction.withAppender(table, use),
+        async run(sql, values) {
+          if (sql === "COMMIT" && firstCommit) {
+            firstCommit = false
+            const released = new Promise<void>((resolve) =>
+              process.once("message", () => resolve())
+            )
+            process.send?.({ type: "ready" })
+            await released
+          }
+          await transaction.run(sql, values)
+        },
+      })
+    )
+  await session.commit({ retryOnConflict: true })
+} catch (error) {
+  console.error(error)
+  process.exitCode = 1
+} finally {
+  await storage.close()
+  process.disconnect?.()
+}

--- a/storage/lake-local/README.md
+++ b/storage/lake-local/README.md
@@ -106,6 +106,8 @@ conflicting ties abort the merge. Deletes require `change.delete(key, { sequence
 manifest retains source revisions and deletion tombstones, published atomically with the version's
 rows through the dataset head pointer. New tombstones create a version even for absent keys.
 Sequenced provider writes use merge sessions; snapshot syncs convert rows to ordered upserts.
+Snapshot syncs use `commit({ createInitialVersion: true })` to make a first empty result
+addressable. Later no-op commits reuse the current version, including after a concurrent write.
 Use `commit({ retryOnConflict: true })` to rebase retained changes, with at most 3 attempts.
 Explicit `expectedLatestVersionId` guards are never relaxed.
 See [source ordering](../../docs/data/datasets.md#source-ordering).

--- a/storage/lake-local/README.md
+++ b/storage/lake-local/README.md
@@ -105,7 +105,14 @@ For datasets declaring `sequenceBy`, newer source revisions win; older changes a
 conflicting ties abort the merge. Deletes require `change.delete(key, { sequence })`. Each version
 manifest retains source revisions and deletion tombstones, published atomically with the version's
 rows through the dataset head pointer. New tombstones create a version even for absent keys.
-Sequenced datasets currently require merge writes. See [source ordering](../../docs/data/datasets.md#source-ordering).
+Sequenced provider writes use merge sessions; snapshot syncs convert rows to ordered upserts.
+Use `commit({ retryOnConflict: true })` to rebase retained changes, with at most 3 attempts.
+Explicit `expectedLatestVersionId` guards are never relaxed.
+See [source ordering](../../docs/data/datasets.md#source-ordering).
+
+Concurrent commits are serialized across instances in **one process**, including symlinked paths.
+Multiple writer processes sharing a LocalLake directory are not supported; use a DuckLake
+PostgreSQL catalog for cross-process writers.
 
 Application authors normally use `defineSync(..., { mode: "merge" })`; the sync worker executes the
 same provider contract and advances its source checkpoint only after commit succeeds.

--- a/storage/lake-local/src/local-lake-storage.ts
+++ b/storage/lake-local/src/local-lake-storage.ts
@@ -5,6 +5,7 @@ import {
   mkdir,
   readdir,
   readFile,
+  realpath,
   rename,
   rm,
   stat,
@@ -33,6 +34,7 @@ import {
   encodeDatasetPrimaryKey,
   getDatasetMergeChangeValidationError,
   getDatasetPrimaryKeyColumns,
+  LakeConcurrencyError,
   type LakeMergeSession,
   type LakeStorage,
   LakeStorageError,
@@ -40,6 +42,7 @@ import {
   mergeStrictDatasetDefinition,
   type ReadDatasetRowsInput,
   reconcileDatasetSequences,
+  retryDatasetMergeCommit,
 } from "@sixb/core/lake-storage"
 import type {
   CommitMergeInput,
@@ -181,13 +184,17 @@ class LocalLakeMergeSession implements LakeMergeSession {
     this.closed = true
 
     try {
-      return await this.storage.commitMerge({
-        merge: this.input,
-        commit: input,
-        baseVersionId: this.baseVersionId,
-        sessionDir: this.sessionDir,
-        tempRowsPath: this.tempRowsPath,
-      })
+      return await retryDatasetMergeCommit(this.input, input, async (rebase) =>
+        this.storage.commitMerge({
+          merge: this.input,
+          commit: input,
+          baseVersionId: rebase
+            ? ((await this.storage.getLatestVersion(this.input.dataset.id))?.versionId ?? null)
+            : this.baseVersionId,
+          sessionDir: this.sessionDir,
+          tempRowsPath: this.tempRowsPath,
+        })
+      )
     } catch (error) {
       await this.cleanup()
       throw error
@@ -377,7 +384,7 @@ export class LocalLakeStorage implements LakeStorage {
       input.expectedLatestVersionId !== undefined &&
       latestVersion?.versionId !== input.expectedLatestVersionId
     ) {
-      throw new LakeStorageError(
+      throw new LakeConcurrencyError(
         `[LakeLocal] Optimistic merge start failed for dataset '${definition.id}': expected latest version '${input.expectedLatestVersionId}', found '${latestVersion?.versionId ?? "none"}'`
       )
     }
@@ -467,6 +474,7 @@ export class LocalLakeStorage implements LakeStorage {
 
   async commitMerge(options: CommitMergeInput): Promise<DatasetMergeCommitResult> {
     return this.withDatasetCommitLock(options.merge.dataset.id, async () => {
+      options.commit?.signal?.throwIfAborted()
       const definition = await this.getDataset(options.merge.dataset.id)
       if (!definition) {
         throw new LakeStorageError(`[LakeLocal] Unknown dataset '${options.merge.dataset.id}'`)
@@ -476,7 +484,7 @@ export class LocalLakeStorage implements LakeStorage {
       const latestVersion = await this.getLatestVersion(options.merge.dataset.id)
       const actualVersionId = latestVersion?.versionId ?? null
       if (actualVersionId !== options.baseVersionId) {
-        throw new LakeStorageError(
+        throw new LakeConcurrencyError(
           `[LakeLocal] Optimistic merge commit failed for dataset '${options.merge.dataset.id}': expected latest version '${options.baseVersionId ?? "none"}', found '${actualVersionId ?? "none"}'`
         )
       }
@@ -562,6 +570,7 @@ export class LocalLakeStorage implements LakeStorage {
           }),
           ...(ordered ? { sequences: [...ordered.states] } : {}),
         })
+        options.commit?.signal?.throwIfAborted()
         await writeJsonAtomic(this.statePath(options.merge.dataset.id), {
           latestVersionId: versionId,
         })
@@ -773,7 +782,8 @@ export class LocalLakeStorage implements LakeStorage {
   }
 
   private async withDatasetCommitLock<T>(datasetId: string, run: () => Promise<T>): Promise<T> {
-    return withLocalDatasetCommitLock(`${this.rootPath}\u0000${datasetId}`, run)
+    const root = await realpath(this.rootPath)
+    return withLocalDatasetCommitLock(`${root}\u0000${datasetId}`, run)
   }
 
   private async ensureBaseDirs(): Promise<void> {

--- a/storage/lake-local/src/local-lake-storage.ts
+++ b/storage/lake-local/src/local-lake-storage.ts
@@ -34,6 +34,7 @@ import {
   encodeDatasetPrimaryKey,
   getDatasetMergeChangeValidationError,
   getDatasetPrimaryKeyColumns,
+  hasDatasetInputChanges,
   LakeConcurrencyError,
   type LakeMergeSession,
   type LakeStorage,
@@ -527,10 +528,12 @@ export class LocalLakeStorage implements LakeStorage {
         }
       }
 
+      const createInitialVersion = options.commit?.createInitialVersion && latestVersion === null
       if (
-        ordered
+        !createInitialVersion &&
+        (ordered
           ? ordered.accepted.size === 0
-          : this.sameKeyedRowContent(previousByKey, nextByKey, definition.schema)
+          : this.sameKeyedRowContent(previousByKey, nextByKey, definition.schema))
       ) {
         await rm(options.sessionDir, { recursive: true, force: true })
         return { outcome: "unchanged", version: latestVersion }
@@ -599,10 +602,10 @@ export class LocalLakeStorage implements LakeStorage {
 
     const latestVersion = await this.getLatestVersion(options.write.dataset.id)
     if (options.commit?.expectedLatestVersionId !== undefined) {
-      const actual = latestVersion?.versionId
+      const actual = latestVersion?.versionId ?? null
       if (actual !== options.commit.expectedLatestVersionId) {
-        throw new LakeStorageError(
-          `[LakeLocal] Optimistic commit failed for dataset '${options.write.dataset.id}': expected latest version '${options.commit.expectedLatestVersionId}', found '${actual ?? "none"}'`
+        throw new LakeConcurrencyError(
+          `[LakeLocal] Optimistic commit failed for dataset '${options.write.dataset.id}': expected latest version '${options.commit.expectedLatestVersionId ?? "none"}', found '${actual ?? "none"}'`
         )
       }
     }
@@ -625,8 +628,12 @@ export class LocalLakeStorage implements LakeStorage {
     }
 
     // Content-identical snapshots and empty appends reuse the latest version
-    // instead of creating a new one.
-    if (latestVersion && (await this.isUnchangedWrite(mode, options, latestVersion, definition))) {
+    // unless explicitly supplied input lineage has changed.
+    if (
+      latestVersion &&
+      !hasDatasetInputChanges(latestVersion.inputs, options.write.inputs) &&
+      (await this.isUnchangedWrite(mode, options, latestVersion, definition))
+    ) {
       await rm(options.sessionDir, { recursive: true, force: true })
       return { ...latestVersion, outcome: "unchanged" }
     }

--- a/storage/lake-local/tests/local-lake-storage.test.ts
+++ b/storage/lake-local/tests/local-lake-storage.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test"
-import { appendFile, mkdtemp, readdir, rm } from "node:fs/promises"
+import { appendFile, mkdtemp, readdir, rm, symlink } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { col, type DatasetRow, defineDataset } from "@sixb/core"
+import { change, col, type DatasetRow, defineDataset } from "@sixb/core"
 import { runLakeMergeStorageContractSuite, runLakeStorageContractSuite } from "@sixb/core/testing"
 import { LocalLakeStorage } from "../src"
 
@@ -46,6 +46,32 @@ runLakeMergeStorageContractSuite("LocalLakeStorage merge contract", {
 })
 
 describe("LocalLakeStorage definition persistence", () => {
+  test("serializes source commits through symlinked paths in one process", async () => {
+    // Regression proof: use this.rootPath rather than realpath for the lock identity.
+    const root = await mkdtemp(join(tmpdir(), "sixb-lake-alias-"))
+    try {
+      const dataset = defineDataset("source.alias", {
+        schema: [col("id", "string"), col("revision", "int64")],
+        primaryKey: "id",
+        sequenceBy: "revision",
+      })
+      const storage = new LocalLakeStorage({ path: join(root, "lake") })
+      await storage.createDataset(dataset)
+      await symlink(join(root, "lake"), join(root, "alias"))
+      const peer = new LocalLakeStorage({ path: join(root, "alias") })
+      const first = await storage.beginMerge({ dataset })
+      const second = await peer.beginMerge({ dataset })
+      await first.writeChanges([change.upsert({ id: "first", revision: 1 })])
+      await second.writeChanges([change.upsert({ id: "second", revision: 1 })])
+      await Promise.all([
+        first.commit({ retryOnConflict: true }),
+        second.commit({ retryOnConflict: true }),
+      ])
+      expect((await storage.getLatestVersion(dataset.id))?.rowCount).toBe(2)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
   test("round-trips a keyed definition after reopening", async () => {
     // Regression guard: stripping primaryKey from definition.json makes the reopened reads fail.
     const rootDir = await mkdtemp(join(tmpdir(), "sixb-lake-local-reopen-definition-"))


### PR DESCRIPTION
## Reconcile snapshots with concurrent source writes

A sequenced snapshot must not overwrite a newer webhook update or remove a key created during its fetch. Part of #548.

```text
Snapshot starts fetching: person 42 at v7
    │
    ├─ another writer commits person 42 at v8
    ├─ another writer creates person 99
    │
Snapshot commits: person 42 at v7; person 99 omitted
    │
    └─ result: person 42 stays at v8; person 99 stays
```

### Snapshot behavior

| Dataset | Snapshot sync |
| --- | --- |
| Without `sequenceBy` | Replace the visible rows |
| With `sequenceBy` | Convert returned rows into ordered, complete-row upserts |
| Sequenced snapshot omits a key | Keep it; deletion requires an explicit sequenced delete |
| Empty sequenced snapshot | No-op; no initial version is invented |

```text
sync mode: snapshot
    ↓
shared writer: rows → change.upsert(row)
    ↓
dataset version mode: merge
```

### Commit retries

```ts
const session = await lakeStorage.beginMerge({ dataset: people })
await session.writeChanges(changes)
await session.commit({ retryOnConflict: true })
```

Sequenced writes through the shared writer enable this automatically.

| Failure | Behavior |
| --- | --- |
| Known concurrency conflict | Re-read the head and replay staged changes; at most 3 total attempts |
| Explicit `expectedLatestVersionId` fails | Fail; never relax the caller's guard |
| Validation or source-content conflict | Fail without retry |
| Ambiguous provider/COMMIT error | Propagate without retry |
| Cancellation | Stop before another attempt |

**Retries reuse provider staging.** They do not re-fetch connector data or consume a one-shot iterable again.

### Provider boundaries

| Provider | Coordination |
| --- | --- |
| InMemory | Serialized commits within the instance |
| LocalLake | Same-process instances share locks by canonical filesystem path |
| DuckLake local catalog | Same-process commit serialization |
| DuckLake PostgreSQL | Cross-process snapshot-ID commit conflicts trigger a fresh attempt |

### Review pointers

| File | What to review |
| --- | --- |
| `packages/core/src/datasets/write.ts` | Snapshot-to-merge conversion |
| `packages/core/src/lake-storage/merge.ts` | Shared bounded retry policy |
| `packages/sync-worker/tests/run-sync-job.test.ts` | Actual sync path, one-shot reads, and checkpoints |
| `storage/ducklake/tests/ducklake-remote.e2e.ts` | Independent processes racing at COMMIT |

**Verified:** sync/provider tests and DuckLake local/remote E2E; full build, typecheck, client generation, Biome, and publish checks. Retry bounds, lock identity, and native conflict classification were checked with safeguards disabled, then restored.

---
**Stack:** #552 Shared writer → #551 Source ordering → **#550 Concurrent snapshots** → #549 Webhook ingestion

Base: `datasets/source-ordering`. Durable commit recovery remains deferred.
