### PR TITLE
datasets: order source changes and retain deletion sequences

### DIFF
--- a/docs/data/datasets.md
+++ b/docs/data/datasets.md
@@ -38,6 +38,7 @@ The id `erp.invoices` is the name every other part of the project references.
 | --- | --- | --- |
 | `schema` | `col(...)[]` | Required. The ordered list of column definitions. |
 | `primaryKey` | `string \| string[]` | Optional. One key column or an ordered composite key. |
+| `sequenceBy` | `string` | Optional. Non-nullable `timestamp` or `int64` column used to order source changes; requires a primary key. |
 | `partitionBy` | `string[]` | Optional. Logical partition columns; each name must exist in `schema`. |
 | `description` | `string` | Optional. Human-readable description. |
 
@@ -71,6 +72,56 @@ V1 primary keys have these constraints:
 
 Use a keyed dataset with a [merge sync](./syncs.md#sync-modes) when the source exposes ordered row
 changes and the dataset should stay current without replacing every row on each run.
+
+### Source ordering
+
+Use `sequenceBy` to keep the newest source record when changes arrive out of order:
+
+```ts
+export const people = defineDataset("crm.people", {
+  schema: [col("id", "string"), col("name", "string"), col("updatedAt", "timestamp")],
+  primaryKey: "id",
+  sequenceBy: "updatedAt",
+})
+```
+
+Use the **source's** revision or timestamp, not fetch/receipt time. Submit complete rows or sequenced deletes:
+
+```ts
+import { change } from "@sixb/core"
+
+change.upsert({ id: "42", name: "Sam", updatedAt: "2026-09-09T10:00:00.123Z" })
+change.delete({ id: "42" }, { sequence: "2026-09-09T10:01:00.000Z" })
+```
+
+#### Merge behavior
+
+| Incoming change | Result |
+| --- | --- |
+| Newer sequence | Applies |
+| Older sequence | Ignored |
+| Equal sequence, identical content | Unchanged |
+| Equal sequence, different content or upsert/delete tie | Entire merge fails |
+| Delete v9 → upsert v8 → upsert v10 | Stays deleted at v8; restored at v10 |
+
+Repeated keys are processed in submission order. Deletions retain durable ordering state, even for
+absent keys; new deletion state creates a version without requiring a visible row change.
+
+#### Sequence values
+
+| Column type | Accepted values |
+| --- | --- |
+| `int64` | Signed 64-bit integers. Use decimal strings outside JavaScript's safe integer range. |
+| `timestamp` | Valid `Date` or ISO timestamp with `Z`/`±HH:MM` and at most 3 fractional digits. Equivalent instants compare equally. |
+
+#### V1 constraints
+
+- **Merge writes only.** Snapshot, append, and SQL-transform writes to sequenced datasets are rejected.
+- **Immutable configuration.** Create a new dataset and backfill to adopt or change `sequenceBy`.
+- **Explicit derivation.** Derived datasets must declare their own `sequenceBy` and primary key.
+
+For content equality, object-key order is ignored; array order matters. Nullable columns treat
+omitted, `undefined`, and `null` equally. Integer, decimal, date, and timestamp columns use canonical values.
 
 ### `col` options
 
@@ -198,6 +249,7 @@ export const invoicesSummary = defineDataset("invoices.summary").derive(rawInvoi
 | `pick` | `string[]` | Keep only these parent columns. Each name must exist on the parent. |
 | `add` | `col(...)[]` | Append these columns after the kept ones. |
 | `primaryKey` | `string \| string[]` | Optional key over the resulting columns. |
+| `sequenceBy` | `string` | Optional ordering column over the resulting columns; requires an explicit primary key. |
 | `partitionBy` | `string[]` | Optional partition columns for the derived dataset. |
 | `description` | `string` | Optional description for the derived dataset. |
 

--- a/docs/data/datasets.md
+++ b/docs/data/datasets.md
@@ -122,6 +122,9 @@ absent keys; new deletion state creates a version without requiring a visible ro
 
 For content equality, object-key order is ignored; array order matters. Nullable columns treat
 omitted, `undefined`, and `null` equally. Integer, decimal, date, and timestamp columns use canonical values.
+On a sequenced dataset, **every timestamp column** must use a valid `Date` or timezone-explicit
+ISO string with at most 3 fractional digits, including columns other than `sequenceBy`. Higher
+precision is rejected before staging so content comparison never silently discards it.
 
 ### `col` options
 

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -12734,6 +12734,9 @@
                           }
                         ]
                       },
+                      "sequenceBy": {
+                        "type": "string"
+                      },
                       "partitionBy": {
                         "type": "array",
                         "items": {
@@ -12913,6 +12916,9 @@
                           "minItems": 2
                         }
                       ]
+                    },
+                    "sequenceBy": {
+                      "type": "string"
                     },
                     "partitionBy": {
                       "type": "array",
@@ -13744,6 +13750,9 @@
                                   }
                                 ]
                               },
+                              "sequenceBy": {
+                                "type": "string"
+                              },
                               "partitionBy": {
                                 "type": "array",
                                 "items": {
@@ -14017,6 +14026,9 @@
                                   "minItems": 2
                                 }
                               ]
+                            },
+                            "sequenceBy": {
+                              "type": "string"
                             },
                             "partitionBy": {
                               "type": "array",
@@ -14759,6 +14771,9 @@
                                                   }
                                                 ]
                                               },
+                                              "sequenceBy": {
+                                                "type": "string"
+                                              },
                                               "partitionBy": {
                                                 "type": "array",
                                                 "items": {
@@ -14833,6 +14848,9 @@
                                               "minItems": 2
                                             }
                                           ]
+                                        },
+                                        "sequenceBy": {
+                                          "type": "string"
                                         },
                                         "partitionBy": {
                                           "type": "array",
@@ -15133,6 +15151,9 @@
                                                 }
                                               ]
                                             },
+                                            "sequenceBy": {
+                                              "type": "string"
+                                            },
                                             "partitionBy": {
                                               "type": "array",
                                               "items": {
@@ -15207,6 +15228,9 @@
                                             "minItems": 2
                                           }
                                         ]
+                                      },
+                                      "sequenceBy": {
+                                        "type": "string"
                                       },
                                       "partitionBy": {
                                         "type": "array",

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4134,6 +4134,7 @@ export type ListDatasetsResponses = {
     id: string
     description?: string
     primaryKey?: string | Array<string>
+    sequenceBy?: string
     partitionBy?: Array<string>
     schema: {
       columns: Array<{
@@ -4207,6 +4208,7 @@ export type GetDatasetResponses = {
     id: string
     description?: string
     primaryKey?: string | Array<string>
+    sequenceBy?: string
     partitionBy?: Array<string>
     schema: {
       columns: Array<{
@@ -4507,6 +4509,7 @@ export type ListSyncsResponses = {
         id: string
         description?: string
         primaryKey?: string | Array<string>
+        sequenceBy?: string
         partitionBy?: Array<string>
         schema: {
           columns: Array<{
@@ -4613,6 +4616,7 @@ export type GetSyncResponses = {
         id: string
         description?: string
         primaryKey?: string | Array<string>
+        sequenceBy?: string
         partitionBy?: Array<string>
         schema: {
           columns: Array<{
@@ -4855,6 +4859,7 @@ export type ListPipelinesResponses = {
               id: string
               description?: string
               primaryKey?: string | Array<string>
+              sequenceBy?: string
               partitionBy?: Array<string>
               schema: {
                 columns: Array<{
@@ -4878,6 +4883,7 @@ export type ListPipelinesResponses = {
             id: string
             description?: string
             primaryKey?: string | Array<string>
+            sequenceBy?: string
             partitionBy?: Array<string>
             schema: {
               columns: Array<{
@@ -4991,6 +4997,7 @@ export type GetPipelineResponses = {
               id: string
               description?: string
               primaryKey?: string | Array<string>
+              sequenceBy?: string
               partitionBy?: Array<string>
               schema: {
                 columns: Array<{
@@ -5014,6 +5021,7 @@ export type GetPipelineResponses = {
             id: string
             description?: string
             primaryKey?: string | Array<string>
+            sequenceBy?: string
             partitionBy?: Array<string>
             schema: {
               columns: Array<{

--- a/packages/core/src/datasets/builders.ts
+++ b/packages/core/src/datasets/builders.ts
@@ -15,6 +15,7 @@ type DatasetColumnOptions = {
 type DefineDatasetOptions = {
   readonly schema: readonly DatasetColumnDefinition[]
   readonly primaryKey?: DatasetPrimaryKey
+  readonly sequenceBy?: string
   readonly partitionBy?: readonly string[]
   readonly description?: string
 }
@@ -23,6 +24,7 @@ type DeriveDatasetOptions<TParent extends DatasetDefinition> = {
   readonly pick?: readonly DatasetColumnNameOf<TParent>[]
   readonly add?: readonly DatasetColumnDefinition[]
   readonly primaryKey?: DatasetPrimaryKey
+  readonly sequenceBy?: string
   readonly partitionBy?: readonly string[]
   readonly description?: string
 }
@@ -58,7 +60,21 @@ type PrimaryKeyColumnNameOf<TColumns extends readonly DatasetColumnDefinition[]>
 
 type CheckedDefineDatasetOptions<TOptions extends DefineDatasetOptions> = TOptions & {
   readonly primaryKey?: DatasetPrimaryKey<PrimaryKeyColumnNameOf<TOptions["schema"]>>
+  readonly sequenceBy?: SequenceColumnNameOf<TOptions["schema"]>
 }
+
+type SequenceColumnNameOf<TColumns extends readonly DatasetColumnDefinition[]> =
+  string extends ColumnNameOf<TColumns>
+    ? string
+    : {
+        [TName in ColumnNameOf<TColumns>]: ColumnDefinitionOf<TColumns, TName>["type"] extends
+          | "timestamp"
+          | "int64"
+          ? ColumnDefinitionOf<TColumns, TName> extends { readonly nullable: true }
+            ? never
+            : TName
+          : never
+      }[ColumnNameOf<TColumns>]
 
 type PickColumns<
   TColumns extends readonly DatasetColumnDefinition[],
@@ -107,8 +123,9 @@ type DatasetColumnResult<
 
 type DatasetDefinitionResult<TId extends string, TOptions extends DefineDatasetOptions> = Omit<
   DatasetDefinition<TId, TOptions["schema"]>,
-  "primaryKey" | "partitionBy" | "description"
+  "primaryKey" | "sequenceBy" | "partitionBy" | "description"
 > &
+  FieldFromOptions<TOptions, "sequenceBy", string> &
   FieldFromOptions<TOptions, "primaryKey", DatasetPrimaryKey> &
   FieldFromOptions<TOptions, "partitionBy", readonly string[]> &
   FieldFromOptions<TOptions, "description", string>
@@ -119,8 +136,9 @@ type DerivedDatasetDefinitionResult<
   TOptions extends DeriveDatasetOptions<TParent> | undefined,
 > = Omit<
   DatasetDefinition<TId, DerivedColumns<TParent, TOptions>>,
-  "primaryKey" | "partitionBy" | "description"
+  "primaryKey" | "sequenceBy" | "partitionBy" | "description"
 > &
+  FieldFromOptions<TOptions, "sequenceBy", string> &
   FieldFromOptions<TOptions, "primaryKey", DatasetPrimaryKey> &
   FieldFromOptions<TOptions, "partitionBy", readonly string[]> &
   FieldFromOptions<TOptions, "description", string>
@@ -130,6 +148,7 @@ type CheckedDeriveDatasetOptions<
   TOptions extends DeriveDatasetOptions<TParent>,
 > = TOptions & {
   readonly primaryKey?: DatasetPrimaryKey<PrimaryKeyColumnNameOf<DerivedColumns<TParent, TOptions>>>
+  readonly sequenceBy?: SequenceColumnNameOf<DerivedColumns<TParent, TOptions>>
 }
 
 export function col<const TName extends string, const TType extends DatasetColumnType>(
@@ -177,6 +196,7 @@ function createDatasetDefinition(id: string, options: DefineDatasetOptions): Dat
         }
       : {}),
     ...(options.partitionBy !== undefined ? { partitionBy: [...options.partitionBy] } : {}),
+    ...(options.sequenceBy !== undefined ? { sequenceBy: options.sequenceBy } : {}),
     ...(options.description !== undefined ? { description: options.description } : {}),
   }
 
@@ -230,6 +250,7 @@ function deriveDatasetDefinition(
   return createDatasetDefinition(id, {
     schema: [...pickedColumns, ...(options.add ?? [])],
     ...(options.primaryKey !== undefined ? { primaryKey: options.primaryKey } : {}),
+    ...(options.sequenceBy !== undefined ? { sequenceBy: options.sequenceBy } : {}),
     ...(options.partitionBy !== undefined ? { partitionBy: options.partitionBy } : {}),
     ...(options.description !== undefined ? { description: options.description } : {}),
   })

--- a/packages/core/src/datasets/changes.ts
+++ b/packages/core/src/datasets/changes.ts
@@ -1,13 +1,25 @@
 export type MergeChange<Row, Key> =
   | { readonly kind: "upsert"; readonly row: Row }
-  | { readonly kind: "delete"; readonly key: Key }
+  | { readonly kind: "delete"; readonly key: Key; readonly sequence?: string | number | Date }
 
 export const change = {
   upsert<const Row extends object>(row: Row): { readonly kind: "upsert"; readonly row: Row } {
     return { kind: "upsert", row }
   },
 
-  delete<const Key extends object>(key: Key): { readonly kind: "delete"; readonly key: Key } {
-    return { kind: "delete", key }
-  },
+  delete: deleteChange,
+}
+
+function deleteChange<const Key extends object>(
+  key: Key
+): { readonly kind: "delete"; readonly key: Key }
+function deleteChange<const Key extends object, const Sequence extends string | number | Date>(
+  key: Key,
+  options: { readonly sequence: Sequence }
+): { readonly kind: "delete"; readonly key: Key; readonly sequence: Sequence }
+function deleteChange<Key extends object>(
+  key: Key,
+  options?: { readonly sequence: string | number | Date }
+): { readonly kind: "delete"; readonly key: Key; readonly sequence?: string | number | Date } {
+  return { kind: "delete", key, ...(options ? { sequence: options.sequence } : {}) }
 }

--- a/packages/core/src/datasets/sequence.ts
+++ b/packages/core/src/datasets/sequence.ts
@@ -19,7 +19,7 @@ export function datasetSequenceValue(dataset: DatasetDefinition, value: unknown)
     )
   }
   if (column?.type === "timestamp") {
-    const millis = parseSequenceTimestamp(value)
+    const millis = parseDatasetTimestamp(value)
     if (millis !== null) return BigInt(millis)
     throw new Error(
       `Dataset '${dataset.id}' sequence must be a valid Date or ISO timestamp with an explicit timezone and at most millisecond precision.`
@@ -31,7 +31,7 @@ export function datasetSequenceValue(dataset: DatasetDefinition, value: unknown)
 }
 
 /** Date.parse alone normalizes impossible calendar dates instead of rejecting them. */
-function parseSequenceTimestamp(value: unknown): number | null {
+export function parseDatasetTimestamp(value: unknown): number | null {
   if (value instanceof Date && Number.isFinite(value.getTime())) return value.getTime()
   if (typeof value === "string") {
     const match =

--- a/packages/core/src/datasets/sequence.ts
+++ b/packages/core/src/datasets/sequence.ts
@@ -1,0 +1,77 @@
+import type { DatasetDefinition } from "./types"
+
+const MIN_INT64 = -(1n << 63n)
+const MAX_INT64 = (1n << 63n) - 1n
+
+/** Normalize source ordering to an exact integer (timestamp milliseconds or signed int64). */
+export function datasetSequenceValue(dataset: DatasetDefinition, value: unknown): bigint {
+  const column = dataset.schema.columns.find((column) => column.name === dataset.sequenceBy)
+  if (column?.type === "int64") {
+    if (
+      (typeof value === "number" && Number.isSafeInteger(value)) ||
+      (typeof value === "string" && /^-?\d+$/.test(value))
+    ) {
+      const integer = BigInt(value)
+      if (integer >= MIN_INT64 && integer <= MAX_INT64) return integer
+    }
+    throw new Error(
+      `Dataset '${dataset.id}' sequence must be a signed int64; use a string outside the safe integer range.`
+    )
+  }
+  if (column?.type === "timestamp") {
+    const millis = parseSequenceTimestamp(value)
+    if (millis !== null) return BigInt(millis)
+    throw new Error(
+      `Dataset '${dataset.id}' sequence must be a valid Date or ISO timestamp with an explicit timezone and at most millisecond precision.`
+    )
+  }
+  throw new Error(
+    `Dataset '${dataset.id}' sequenceBy must reference a non-nullable timestamp or int64 column.`
+  )
+}
+
+/** Date.parse alone normalizes impossible calendar dates instead of rejecting them. */
+function parseSequenceTimestamp(value: unknown): number | null {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.getTime()
+  if (typeof value === "string") {
+    const match =
+      /^([+-]\d{6}|\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?(Z|[+-]\d{2}:\d{2})$/.exec(
+        value
+      )
+    if (match) {
+      const [, year, month, day, hour, minute, second, , zone] = match
+      const numericYear = Number(year)
+      const leapYear = numericYear % 4 === 0 && (numericYear % 100 !== 0 || numericYear % 400 === 0)
+      const days =
+        Number(month) === 2 ? (leapYear ? 29 : 28) : [4, 6, 9, 11].includes(Number(month)) ? 30 : 31
+      const validZone =
+        zone === "Z" || (Number(zone?.slice(1, 3)) <= 23 && Number(zone?.slice(4)) <= 59)
+      const millis = Date.parse(value)
+      if (
+        Number(month) >= 1 &&
+        Number(month) <= 12 &&
+        Number(day) >= 1 &&
+        Number(day) <= days &&
+        Number(hour) < 24 &&
+        Number(minute) < 60 &&
+        Number(second) < 60 &&
+        validZone &&
+        Number.isFinite(millis)
+      )
+        return millis
+    }
+  }
+  return null
+}
+
+export function getDatasetSequenceValidationError(
+  dataset: DatasetDefinition,
+  value: unknown
+): string | null {
+  try {
+    datasetSequenceValue(dataset, value)
+    return null
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error)
+  }
+}

--- a/packages/core/src/datasets/types.ts
+++ b/packages/core/src/datasets/types.ts
@@ -36,6 +36,7 @@ export interface DatasetDefinition<
   readonly id: TId
   readonly schema: DatasetSchema<TColumns>
   readonly primaryKey?: DatasetPrimaryKey
+  readonly sequenceBy?: string
   readonly partitionBy?: readonly string[]
   readonly description?: string
 }

--- a/packages/core/src/datasets/validation.ts
+++ b/packages/core/src/datasets/validation.ts
@@ -2,6 +2,7 @@ import { isFileRef } from "../blob-storage"
 import { isJsonValue, isPlainRecord } from "../json"
 import { isDecimalString } from "../ontology/decimal"
 import { DatasetValidationError } from "./errors"
+import { getDatasetSequenceValidationError } from "./sequence"
 import type {
   DatasetColumnDefinition,
   DatasetColumnType,
@@ -185,6 +186,20 @@ export function assertDatasetDefinition(
     assertDatasetPrimaryKey(definition.primaryKey, definition.schema, createError)
   }
 
+  if (definition.sequenceBy !== undefined) {
+    const column = definition.schema.columns.find((column) => column.name === definition.sequenceBy)
+    if (
+      definition.primaryKey === undefined ||
+      !column ||
+      column.nullable ||
+      !["timestamp", "int64"].includes(column.type)
+    ) {
+      throw createError(
+        "Dataset sequenceBy requires a primaryKey and a non-nullable timestamp or int64 column."
+      )
+    }
+  }
+
   if (definition.partitionBy !== undefined) {
     if (!Array.isArray(definition.partitionBy)) {
       throw createError("Dataset partitionBy must be an array of column names.")
@@ -268,6 +283,9 @@ function getColumnValidationError(
 ): string | null {
   const hasValue = Object.hasOwn(row, column.name)
   const value = row[column.name]
+  if (column.name === dataset.sequenceBy) {
+    return getDatasetSequenceValidationError(dataset, value)
+  }
 
   // Treat `undefined` the same as an omitted field so callers either send a real
   // value or use `null` explicitly on nullable columns.

--- a/packages/core/src/datasets/validation.ts
+++ b/packages/core/src/datasets/validation.ts
@@ -2,7 +2,7 @@ import { isFileRef } from "../blob-storage"
 import { isJsonValue, isPlainRecord } from "../json"
 import { isDecimalString } from "../ontology/decimal"
 import { DatasetValidationError } from "./errors"
-import { getDatasetSequenceValidationError } from "./sequence"
+import { getDatasetSequenceValidationError, parseDatasetTimestamp } from "./sequence"
 import type {
   DatasetColumnDefinition,
   DatasetColumnType,
@@ -301,6 +301,14 @@ function getColumnValidationError(
       return `Dataset '${dataset.id}' column '${column.name}' does not allow null values.`
     }
     return null
+  }
+
+  // Every timestamp contributes to a sequenced row's millisecond-precision content digest.
+  // Reject ambiguous or lossy values before staging, even when another column orders the row.
+  if (dataset.sequenceBy !== undefined && column.type === "timestamp") {
+    return parseDatasetTimestamp(value) === null
+      ? `Dataset '${dataset.id}' column '${column.name}' must be a valid Date or ISO timestamp with an explicit timezone and at most millisecond precision.`
+      : null
   }
 
   if (!matchesColumnType(value, column.type)) {

--- a/packages/core/src/lake-storage/definition-updates.ts
+++ b/packages/core/src/lake-storage/definition-updates.ts
@@ -1,4 +1,5 @@
 import type { DatasetColumnDefinition, DatasetDefinition } from "../datasets"
+import { assertDatasetDefinition } from "../datasets/validation"
 import { LakeStorageError } from "./errors"
 import type { LakeStorage } from "./types"
 
@@ -36,6 +37,12 @@ export function planDatasetDefinitionUpdate(
   requested: DatasetDefinition
 ): DatasetDefinitionUpdatePlan {
   assertSameDataset(existing, requested)
+  assertDatasetDefinition(requested, (message) => new LakeStorageError(`[SixbLake] ${message}`))
+  if (existing.sequenceBy !== requested.sequenceBy) {
+    throw new LakeStorageError(
+      `[SixbLake] Dataset '${requested.id}' sequenceBy is immutable. Create a new dataset and backfill to adopt or change source ordering.`
+    )
+  }
   assertPrimaryKeyUnchanged(existing, requested)
 
   const addedColumns = getAddedColumnsAfterValidatingExistingColumns(existing, requested)
@@ -66,6 +73,7 @@ export function mergeStrictDatasetDefinition(options: {
   readonly existing?: DatasetDefinition | null
   readonly next: DatasetDefinition
 }): DatasetDefinition {
+  assertDatasetDefinition(options.next, (message) => new LakeStorageError(`[SixbLake] ${message}`))
   if (!options.existing) {
     return structuredClone(options.next)
   }
@@ -221,6 +229,7 @@ function mergeDatasetDefinition(
     id: requested.id,
     schema: { columns },
     ...(primaryKey !== undefined ? { primaryKey: structuredClone(primaryKey) } : {}),
+    ...(existing.sequenceBy !== undefined ? { sequenceBy: existing.sequenceBy } : {}),
     ...(partitionBy !== undefined ? { partitionBy: [...partitionBy] } : {}),
     ...(description !== undefined ? { description } : {}),
   }

--- a/packages/core/src/lake-storage/in-memory.ts
+++ b/packages/core/src/lake-storage/in-memory.ts
@@ -15,6 +15,12 @@ import {
   getDatasetMergeChangeValidationError,
   getDatasetPrimaryKeyColumns,
 } from "./merge-validation"
+import {
+  assertUnsequencedDatasetWrite,
+  type DatasetSequenceState,
+  datasetSequenceChange,
+  reconcileDatasetSequences,
+} from "./source-ordering"
 import type {
   BeginDatasetWriteInput,
   CommitDatasetWriteInput,
@@ -201,6 +207,7 @@ export class InMemoryLakeStorage implements LakeStorage {
   private readonly datasets = new Map<string, DatasetDefinition>()
   private readonly versionsByDataset = new Map<string, DatasetVersion[]>()
   private readonly rowsByVersionId = new Map<string, readonly DatasetRow[]>()
+  private readonly sequencesByVersionId = new Map<string, Map<string, DatasetSequenceState>>()
   private readonly latestVersionIdByDataset = new Map<string, string>()
   private readonly commitLocks = new Map<string, Promise<void>>()
 
@@ -295,6 +302,7 @@ export class InMemoryLakeStorage implements LakeStorage {
       throw new LakeStorageError(`[LakeStorage] Unknown dataset '${input.dataset.id}'`)
     }
 
+    assertUnsequencedDatasetWrite(definition)
     return new InMemoryLakeWriteSession(this, {
       ...input,
       dataset: definition,
@@ -408,9 +416,21 @@ export class InMemoryLakeStorage implements LakeStorage {
       const previousRows = this.rowsByVersionId.get(latestVersion?.versionId ?? "") ?? []
       const previousByKey = this.rowsByPrimaryKey(previousRows, definition)
       const finalChanges = new Map<string, MergeChange<DatasetRow, DatasetRow>>()
-      for (const change of options.changes) {
-        const value = change.kind === "upsert" ? change.row : change.key
-        finalChanges.set(encodeDatasetPrimaryKey(definition, value), change)
+      const ordered =
+        definition.sequenceBy === undefined
+          ? undefined
+          : reconcileDatasetSequences(
+              definition,
+              this.sequencesByVersionId.get(actualVersionId ?? "") ?? new Map(),
+              options.changes.map((change) => datasetSequenceChange(definition, change))
+            )
+      if (ordered) {
+        for (const [key, index] of ordered.accepted) finalChanges.set(key, options.changes[index]!)
+      } else {
+        for (const change of options.changes) {
+          const value = change.kind === "upsert" ? change.row : change.key
+          finalChanges.set(encodeDatasetPrimaryKey(definition, value), change)
+        }
       }
 
       const nextByKey = new Map(previousByKey)
@@ -422,7 +442,11 @@ export class InMemoryLakeStorage implements LakeStorage {
         }
       }
 
-      if (this.sameKeyedRowContent(previousByKey, nextByKey, definition.schema)) {
+      if (
+        ordered
+          ? ordered.accepted.size === 0
+          : this.sameKeyedRowContent(previousByKey, nextByKey, definition.schema)
+      ) {
         return {
           outcome: "unchanged",
           version: latestVersion ? cloneDatasetVersion(latestVersion) : null,
@@ -454,6 +478,7 @@ export class InMemoryLakeStorage implements LakeStorage {
         visibleRows.map((row) => cloneRow(row))
       )
       this.latestVersionIdByDataset.set(options.merge.dataset.id, versionId)
+      if (ordered) this.sequencesByVersionId.set(versionId, ordered.states)
 
       return { outcome: "created", version: cloneDatasetVersion(version) }
     })
@@ -470,6 +495,7 @@ export class InMemoryLakeStorage implements LakeStorage {
     }
 
     const mode = options.write.mode ?? "snapshot"
+    assertUnsequencedDatasetWrite(definition)
     const latestVersion = await this.getLatestVersion(options.write.dataset.id)
 
     if (options.commit?.expectedLatestVersionId !== undefined) {

--- a/packages/core/src/lake-storage/index.ts
+++ b/packages/core/src/lake-storage/index.ts
@@ -6,6 +6,7 @@ export type {
   DatasetSchema,
   MergeChange,
 } from "../datasets"
+export { assertDatasetDefinition } from "../datasets/validation"
 export type { JsonValue } from "../json"
 export type {
   DatasetDefinitionUpdatePlan,
@@ -31,6 +32,12 @@ export {
   getDatasetMergeChangeValidationError,
   getDatasetPrimaryKeyColumns,
 } from "./merge-validation"
+export type { DatasetSequenceChange, DatasetSequenceState } from "./source-ordering"
+export {
+  assertUnsequencedDatasetWrite,
+  datasetSequenceChange,
+  reconcileDatasetSequences,
+} from "./source-ordering"
 export type {
   ExecuteSqlTransformInput,
   LakeSqlExecutor,

--- a/packages/core/src/lake-storage/merge-validation.ts
+++ b/packages/core/src/lake-storage/merge-validation.ts
@@ -1,5 +1,6 @@
 import type { DatasetDefinition, MergeChange } from "../datasets"
 import { getDatasetRowValidationError } from "../datasets"
+import { getDatasetSequenceValidationError } from "../datasets/sequence"
 import { isPlainRecord } from "../json"
 import { LakeStorageError } from "./errors"
 import type { DatasetRow } from "./types"
@@ -58,7 +59,11 @@ export function getDatasetMergeChangeValidationError(
     if (shapeError) {
       return shapeError
     }
-    return getDeleteKeyValidationError(change.key, dataset, primaryKeyColumns)
+    const keyError = getDeleteKeyValidationError(change.key, dataset, primaryKeyColumns)
+    if (keyError) return keyError
+    return dataset.sequenceBy === undefined
+      ? null
+      : getDatasetSequenceValidationError(dataset, change.sequence)
   }
 
   return `Dataset '${dataset.id}' merge change kind must be 'upsert' or 'delete'.`
@@ -70,7 +75,11 @@ export function cloneDatasetMergeChange(
 ): MergeChange<DatasetRow, DatasetRow> {
   return change.kind === "upsert"
     ? { kind: "upsert", row: structuredClone(change.row) }
-    : { kind: "delete", key: structuredClone(change.key) }
+    : {
+        kind: "delete",
+        key: structuredClone(change.key),
+        ...(change.sequence !== undefined ? { sequence: structuredClone(change.sequence) } : {}),
+      }
 }
 
 function getChangeShapeError(
@@ -79,6 +88,7 @@ function getChangeShapeError(
   payloadField: "row" | "key"
 ): string | null {
   const allowedFields = new Set(["kind", payloadField])
+  if (payloadField === "key" && dataset.sequenceBy !== undefined) allowedFields.add("sequence")
   for (const field of Object.keys(change)) {
     if (!allowedFields.has(field)) {
       return `Dataset '${dataset.id}' ${change.kind as string} change contains unknown field '${field}'.`

--- a/packages/core/src/lake-storage/merge.ts
+++ b/packages/core/src/lake-storage/merge.ts
@@ -23,7 +23,10 @@ export type DatasetMergeCommitResult =
   | { readonly outcome: "unchanged"; readonly version: DatasetVersion | null }
 
 export interface LakeMergeSession {
-  /** Stage ordered complete-row upserts and exact primary-key deletes. */
+  /**
+   * Stage ordered complete-row upserts and exact primary-key deletes. With sequenceBy, deletes
+   * require a sequence, stale changes are ignored, and conflicting ties abort the whole merge.
+   */
   writeChanges(
     changes:
       | Iterable<MergeChange<DatasetRow, DatasetRow>>

--- a/packages/core/src/lake-storage/source-ordering.ts
+++ b/packages/core/src/lake-storage/source-ordering.ts
@@ -1,0 +1,95 @@
+import { createHash } from "node:crypto"
+import type { DatasetDefinition, MergeChange } from "../datasets"
+import { datasetSequenceValue } from "../datasets/sequence"
+import { stableJsonStringify } from "../json"
+import { normalizeDecimalValue } from "../ontology/decimal"
+import { LakeStorageError } from "./errors"
+import { encodeDatasetPrimaryKey } from "./merge-validation"
+import type { DatasetRow } from "./types"
+
+/** Current source revision; a null content digest is a deletion tombstone. */
+export interface DatasetSequenceState {
+  readonly sequence: string
+  readonly content: string | null
+}
+
+export interface DatasetSequenceChange extends DatasetSequenceState {
+  readonly key: string
+}
+
+export function datasetSequenceChange(
+  dataset: DatasetDefinition,
+  change: MergeChange<DatasetRow, DatasetRow>
+): DatasetSequenceChange {
+  const value = change.kind === "upsert" ? change.row[dataset.sequenceBy ?? ""] : change.sequence
+  return {
+    key: encodeDatasetPrimaryKey(dataset, change.kind === "upsert" ? change.row : change.key),
+    sequence: datasetSequenceValue(dataset, value).toString(),
+    content: change.kind === "delete" ? null : rowDigest(dataset, change.row),
+  }
+}
+
+/** Process in submission order against a private copy; conflicts publish no partial state. */
+export function reconcileDatasetSequences(
+  dataset: DatasetDefinition,
+  previous: ReadonlyMap<string, DatasetSequenceState>,
+  changes: readonly DatasetSequenceChange[]
+): { states: Map<string, DatasetSequenceState>; accepted: Map<string, number> } {
+  const states = new Map(previous)
+  const accepted = new Map<string, number>()
+  for (const [index, change] of changes.entries()) {
+    const current = states.get(change.key)
+    if (current) {
+      const difference = BigInt(change.sequence) - BigInt(current.sequence)
+      if (difference < 0n) continue
+      if (difference === 0n) {
+        if (current.content !== change.content) {
+          throw new LakeStorageError(
+            `[SixbLake] Dataset '${dataset.id}' has conflicting content at source sequence '${change.sequence}' for key ${change.key}.`
+          )
+        }
+        continue
+      }
+    }
+    states.set(change.key, { sequence: change.sequence, content: change.content })
+    accepted.set(change.key, index)
+  }
+  return { states, accepted }
+}
+
+function rowDigest(dataset: DatasetDefinition, row: DatasetRow): string {
+  const content: Record<string, unknown> = Object.create(null)
+  for (const column of dataset.schema.columns) {
+    const value = row[column.name]
+    // Nullable additions and omitted/undefined/null values have identical content.
+    if (value == null) continue
+    switch (column.type) {
+      case "int64":
+        content[column.name] = BigInt(value as string | number).toString()
+        break
+      case "timestamp":
+        content[column.name] = new Date(value as string | Date).toISOString()
+        break
+      case "date":
+        content[column.name] = new Date(value as string | Date).toISOString().slice(0, 10)
+        break
+      case "decimal":
+        content[column.name] = normalizeDecimalValue(value as string)
+        break
+      default:
+        content[column.name] = value
+    }
+  }
+  return createHash("sha256")
+    .update(stableJsonStringify(JSON.parse(JSON.stringify(content))))
+    .digest("hex")
+}
+
+/** Until row reconciliation is supported, replacement writes must not erase source history. */
+export function assertUnsequencedDatasetWrite(dataset: DatasetDefinition): void {
+  if (dataset.sequenceBy !== undefined) {
+    throw new LakeStorageError(
+      `[SixbLake] Dataset '${dataset.id}' declares sequenceBy; use beginMerge with source-ordered changes.`
+    )
+  }
+}

--- a/packages/core/src/testing/dataset-sequence-contract.ts
+++ b/packages/core/src/testing/dataset-sequence-contract.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "bun:test"
+import { change, col, type DatasetDefinition, defineDataset, type MergeChange } from "../datasets"
+import type { DatasetRow, LakeStorage } from "../lake-storage"
+import type { LakeMergeStorageContractSuiteOptions } from "./lake-merge-storage-contract"
+
+const dataset = defineDataset("contract.source_order", {
+  schema: [
+    col("id", "string"),
+    col("revision", "int64"),
+    col("name", "string"),
+    col("details", "json", { nullable: true }),
+  ],
+  primaryKey: "id",
+  sequenceBy: "revision",
+})
+const upsert = (revision: string | number, name = "Sam", id = "42") =>
+  change.upsert({ id, revision, name })
+
+async function merge(
+  storage: LakeStorage,
+  changes: readonly MergeChange<DatasetRow, DatasetRow>[],
+  definition: DatasetDefinition = dataset
+) {
+  const session = await storage.beginMerge({ dataset: definition })
+  try {
+    await session.writeChanges(changes)
+    return await session.commit()
+  } catch (error) {
+    await session.abort()
+    throw error
+  }
+}
+
+async function rows(storage: LakeStorage, definition = dataset) {
+  const result: DatasetRow[] = []
+  for await (const row of storage.readRows({ datasetId: definition.id })) result.push(row)
+  return result
+}
+
+export function runDatasetSequenceContract<TStorage extends LakeStorage>(
+  options: LakeMergeStorageContractSuiteOptions<TStorage>
+): void {
+  const withStorage = async (run: (storage: TStorage) => Promise<void>) => {
+    const storage = await options.createStorage()
+    try {
+      await storage.createDataset(dataset)
+      await run(storage)
+    } finally {
+      await options.teardown?.(storage)
+    }
+  }
+
+  describe("source ordering", () => {
+    // Regression proof: bypass reconcileDatasetSequences at the provider commit boundary.
+    // The stale-write, conflict, and deletion assertions below must then fail.
+    test("orders repeated keys exactly and conflicts atomically", () =>
+      withStorage(async (storage) => {
+        const first = await merge(storage, [upsert("9007199254740993")])
+        expect((await merge(storage, [upsert("9007199254740992", "stale")])).outcome).toBe(
+          "unchanged"
+        )
+        expect((await merge(storage, [upsert("09007199254740993")])).outcome).toBe("unchanged")
+        await expect(
+          merge(storage, [upsert("1", "other", "other"), upsert("9007199254740993", "conflict")])
+        ).rejects.toThrow("conflicting content")
+        expect((await storage.getLatestVersion(dataset.id))?.versionId).toBe(
+          first.version?.versionId
+        )
+        expect(await rows(storage)).toHaveLength(1)
+        await merge(storage, [
+          upsert("9007199254740995", "newest"),
+          upsert("9007199254740994", "stale"),
+        ])
+        expect((await rows(storage))[0]?.name).toBe("newest")
+        await expect(
+          merge(storage, [upsert("9007199254740996", "a"), upsert("9007199254740996", "b")])
+        ).rejects.toThrow("conflicting content")
+        expect((await rows(storage))[0]?.name).toBe("newest")
+      }))
+
+    test("retains absent-key deletions and protects their version boundary", () =>
+      withStorage(async (storage) => {
+        const staleSession = await storage.beginMerge({ dataset })
+        await staleSession.writeChanges([upsert(8)])
+        const deleted = await merge(storage, [change.delete({ id: "42" }, { sequence: 9 })])
+        expect(deleted).toMatchObject({ outcome: "created", version: { rowCount: 0 } })
+        await expect(staleSession.commit()).rejects.toThrow("Optimistic")
+        await staleSession.abort()
+        expect((await merge(storage, [upsert(8)])).outcome).toBe("unchanged")
+        expect(
+          (await merge(storage, [change.delete({ id: "42" }, { sequence: "9" })])).outcome
+        ).toBe("unchanged")
+        await expect(merge(storage, [upsert(9)])).rejects.toThrow("conflicting content")
+        await merge(storage, [upsert(10)])
+        expect(await rows(storage)).toHaveLength(1)
+        expect((await merge(storage, [change.delete({ id: "42" }, { sequence: 9 })])).outcome).toBe(
+          "unchanged"
+        )
+        await merge(storage, [change.delete({ id: "42" }, { sequence: 11 })])
+        expect(await rows(storage)).toEqual([])
+      }))
+
+    test("compares canonical content across JSON order and nullable representations", () =>
+      withStorage(async (storage) => {
+        await merge(storage, [
+          change.upsert({ id: "42", revision: 1, name: "Sam", details: { a: 1, b: 2 } }),
+        ])
+        expect(
+          (
+            await merge(storage, [
+              change.upsert({ id: "42", revision: "01", name: "Sam", details: { b: 2, a: 1 } }),
+            ])
+          ).outcome
+        ).toBe("unchanged")
+        await merge(storage, [upsert(2)])
+        expect(
+          (
+            await merge(storage, [
+              change.upsert({ id: "42", revision: "2", name: "Sam", details: null }),
+            ])
+          ).outcome
+        ).toBe("unchanged")
+      }))
+
+    test("validates integer ranges and delete sequences at the provider boundary", () =>
+      withStorage(async (storage) => {
+        for (const revision of [
+          null,
+          undefined,
+          1.5,
+          Number.MAX_SAFE_INTEGER + 1,
+          "9223372036854775808",
+          "-9223372036854775809",
+          "1e3",
+        ]) {
+          await expect(
+            merge(storage, [change.upsert({ id: "42", revision, name: "Sam" })])
+          ).rejects.toThrow("sequence")
+        }
+        await expect(merge(storage, [change.delete({ id: "42" })])).rejects.toThrow("sequence")
+        await merge(storage, [upsert("-9223372036854775808"), upsert("9223372036854775807")])
+        expect((await rows(storage))[0]?.revision?.toString()).toBe("9223372036854775807")
+      }))
+
+    test("normalizes timezone-aware timestamps without discarding precision", () =>
+      withStorage(async (storage) => {
+        const timestamps = defineDataset("contract.source_timestamps", {
+          schema: [col("id", "string"), col("updated", "timestamp"), col("name", "string")],
+          primaryKey: "id",
+          sequenceBy: "updated",
+        })
+        await storage.createDataset(timestamps)
+        const row = (updated: unknown, name = "Sam") => change.upsert({ id: "42", updated, name })
+        await merge(storage, [row("2026-09-09T10:00:00.123Z")], timestamps)
+        for (const updated of [
+          "2026-09-09T12:00:00.123+02:00",
+          new Date("2026-09-09T10:00:00.123Z"),
+        ]) {
+          expect((await merge(storage, [row(updated)], timestamps)).outcome).toBe("unchanged")
+        }
+        for (const updated of [
+          "2026-09-09T10:00:00.1234Z",
+          "2026-09-09T10:00:00",
+          "2026-02-30T00:00:00Z",
+          new Date(Number.NaN),
+        ]) {
+          await expect(merge(storage, [row(updated)], timestamps)).rejects.toThrow("sequence")
+        }
+        await merge(
+          storage,
+          [change.delete({ id: "42" }, { sequence: "2026-09-09T10:00:00.124Z" })],
+          timestamps
+        )
+        expect((await merge(storage, [row("2026-09-09T10:00:00.123Z")], timestamps)).outcome).toBe(
+          "unchanged"
+        )
+      }))
+
+    test("round-trips immutable sequencing and rejects writes that bypass ordering", () =>
+      withStorage(async (storage) => {
+        expect((await storage.getDataset(dataset.id))?.sequenceBy).toBe("revision")
+        expect(
+          (await storage.listDatasets()).find((item) => item.id === dataset.id)?.sequenceBy
+        ).toBe("revision")
+        const { sequenceBy: _, ...unsequenced } = dataset
+        await expect(storage.createDataset(unsequenced)).rejects.toThrow("immutable")
+        await storage.createDataset({ ...unsequenced, id: "legacy" })
+        await expect(storage.createDataset({ ...dataset, id: "legacy" })).rejects.toThrow(
+          "immutable"
+        )
+        await expect(
+          storage.createDataset({ ...dataset, id: "invalid", primaryKey: undefined })
+        ).rejects.toThrow("sequenceBy")
+        await expect(
+          storage.createDataset({ ...dataset, id: "invalid", sequenceBy: "name" })
+        ).rejects.toThrow("sequenceBy")
+        await expect(storage.beginWrite({ dataset })).rejects.toThrow("beginMerge")
+      }))
+
+    const reopen = options.reopen
+    if (reopen)
+      test("preserves source state after reopen", async () => {
+        let storage = await options.createStorage()
+        try {
+          await storage.createDataset(dataset)
+          await merge(storage, [
+            upsert(8, "visible", "visible"),
+            change.delete({ id: "42" }, { sequence: 9 }),
+          ])
+          storage = await reopen(storage)
+          expect((await storage.getDataset(dataset.id))?.sequenceBy).toBe("revision")
+          expect((await merge(storage, [upsert(8), upsert(7, "stale", "visible")])).outcome).toBe(
+            "unchanged"
+          )
+          expect(await rows(storage)).toHaveLength(1)
+          await merge(storage, [upsert(10)])
+          expect(await rows(storage)).toHaveLength(2)
+        } finally {
+          await options.teardown?.(storage)
+        }
+      })
+  })
+}

--- a/packages/core/src/testing/dataset-sequence-contract.ts
+++ b/packages/core/src/testing/dataset-sequence-contract.ts
@@ -51,6 +51,39 @@ export function runDatasetSequenceContract<TStorage extends LakeStorage>(
   }
 
   describe("source ordering", () => {
+    test("rejects lossy timestamps outside the ordering column before changing source state", () =>
+      withStorage(async (storage) => {
+        // Regression proof: remove the sequenced timestamp check in getColumnValidationError;
+        // submillisecond content is accepted and its distinct values collapse to one digest.
+        const timestamps = defineDataset("contract.content_timestamps", {
+          schema: [...dataset.schema.columns, col("at", "timestamp", { nullable: true })],
+          primaryKey: "id",
+          sequenceBy: "revision",
+        })
+        await storage.createDataset(timestamps)
+        const row = (at: unknown, id = "42") => change.upsert({ id, revision: 1, name: "Sam", at })
+        const initial = await merge(storage, [row("2026-09-09T10:00:00.123Z")], timestamps)
+        for (const at of [
+          "2026-09-09T10:00:00.123001Z",
+          "2026-09-09T10:00:00.123999Z",
+          "2026-09-09T10:00:00",
+          "2026-02-30T00:00:00Z",
+        ]) {
+          await expect(merge(storage, [row(at, "new")], timestamps)).rejects.toThrow("column 'at'")
+          expect(await storage.getLatestVersion(timestamps.id)).toEqual(initial.version)
+        }
+        for (const at of ["2026-09-09T12:00:00.123+02:00", new Date("2026-09-09T10:00:00.123Z")]) {
+          expect((await merge(storage, [row(at)], timestamps)).outcome).toBe("unchanged")
+        }
+        await expect(merge(storage, [row("2026-09-09T10:00:00.124Z")], timestamps)).rejects.toThrow(
+          "conflicting content"
+        )
+        await merge(storage, [row(null, "nullable")], timestamps)
+        expect((await merge(storage, [row(undefined, "nullable")], timestamps)).outcome).toBe(
+          "unchanged"
+        )
+      }))
+
     // Regression proof: bypass reconcileDatasetSequences at the provider commit boundary.
     // The stale-write, conflict, and deletion assertions below must then fail.
     test("orders repeated keys exactly and conflicts atomically", () =>

--- a/packages/core/src/testing/lake-merge-storage-contract.ts
+++ b/packages/core/src/testing/lake-merge-storage-contract.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test"
 import { change, col, defineDataset } from "../datasets"
 import type { DatasetMergeCommitResult, DatasetRow, LakeStorage } from "../lake-storage"
+import { runDatasetSequenceContract } from "./dataset-sequence-contract"
 
 export interface LakeMergeStorageContractSuiteOptions<TStorage extends LakeStorage = LakeStorage> {
   readonly createStorage: () => TStorage | Promise<TStorage>
   readonly teardown?: (storage: TStorage) => void | Promise<void>
+  readonly reopen?: (storage: TStorage) => TStorage | Promise<TStorage>
 }
 
 const invoices = defineDataset("contract.merges.invoices", {
@@ -35,6 +37,7 @@ export function runLakeMergeStorageContractSuite<TStorage extends LakeStorage>(
   }
 
   describe(label, () => {
+    runDatasetSequenceContract(options)
     test("creates an initial merge version from async changes", async () => {
       await withStorage(async (storage) => {
         await storage.createDataset(invoices)

--- a/packages/core/tests/datasets.test.ts
+++ b/packages/core/tests/datasets.test.ts
@@ -50,6 +50,34 @@ describe("change", () => {
 })
 
 describe("defineDataset", () => {
+  test("validates source ordering and derives it only when explicitly configured", () => {
+    // Regression proof: remove the sequenceBy check in assertDatasetDefinition.
+    const schema = [
+      col("id", "string"),
+      col("revision", "int64"),
+      col("optional", "timestamp", { nullable: true }),
+    ]
+    for (const options of [
+      { schema, sequenceBy: "revision" },
+      { schema, primaryKey: "id", sequenceBy: "missing" },
+      { schema, primaryKey: "id", sequenceBy: "id" },
+      { schema, primaryKey: "id", sequenceBy: "optional" },
+    ]) {
+      expect(() => defineDataset("invalid", options as never)).toThrow("sequenceBy")
+    }
+    const source = defineDataset("ordered", { schema, primaryKey: "id", sequenceBy: "revision" })
+    expect(source.sequenceBy).toBe("revision")
+    expect(defineDataset("derived").derive(source).sequenceBy).toBeUndefined()
+    expect(
+      defineDataset("ordered-derived").derive(source, { primaryKey: "id", sequenceBy: "revision" })
+        .sequenceBy
+    ).toBe("revision")
+    expect(change.delete({ id: "42" }, { sequence: 9 })).toEqual({
+      kind: "delete",
+      key: { id: "42" },
+      sequence: 9,
+    })
+  })
   test("builds single and composite primary keys", () => {
     const customers = defineDataset("canonical.customers", {
       schema: [col("id", "string")],

--- a/packages/core/tests/datasets.types.ts
+++ b/packages/core/tests/datasets.types.ts
@@ -50,6 +50,28 @@ type _inferredUpsert = Expect<
 >
 
 const invoiceDelete = change.delete({ id: "inv_1" })
+const sequencedDelete = change.delete({ id: "inv_1" }, { sequence: "9223372036854775807" })
+type _deleteSequence = Expect<Equal<typeof sequencedDelete.sequence, "9223372036854775807">>
+const sequencedDataset = defineDataset("sequenced", {
+  schema: [
+    col("id", "string"),
+    col("revision", "int64"),
+    col("optional", "timestamp", { nullable: true }),
+  ],
+  primaryKey: "id",
+  sequenceBy: "revision",
+})
+type _sequenceBy = Expect<Equal<typeof sequencedDataset.sequenceBy, "revision">>
+const invalidSequenceOptions = {
+  schema: sequencedDataset.schema.columns,
+  primaryKey: "id",
+  sequenceBy: "id",
+} as const
+// @ts-expect-error sequence columns must be timestamps or int64
+defineDataset("invalid-sequence", invalidSequenceOptions)
+const nullableSequenceOptions = { ...invalidSequenceOptions, sequenceBy: "optional" } as const
+// @ts-expect-error sequence columns must be non-nullable
+defineDataset("invalid-nullable-sequence", nullableSequenceOptions)
 type _inferredDelete = Expect<
   Equal<typeof invoiceDelete, { readonly kind: "delete"; readonly key: { readonly id: "inv_1" } }>
 >

--- a/packages/server/src/schemas/datasets.ts
+++ b/packages/server/src/schemas/datasets.ts
@@ -43,6 +43,7 @@ export const DatasetDefinitionSchema = z.object({
   id: z.string(),
   description: z.string().optional(),
   primaryKey: z.union([z.string(), z.array(z.string()).min(2)]).optional(),
+  sequenceBy: z.string().optional(),
   partitionBy: z.array(z.string()).optional(),
   schema: DatasetSchema,
 })

--- a/packages/server/tests/datasets-routes.test.ts
+++ b/packages/server/tests/datasets-routes.test.ts
@@ -77,8 +77,9 @@ function createTestApp(lakeStorage: LakeStorage, definitions: readonly DatasetDe
 
 const definitions: DatasetDefinition[] = [
   defineDataset("raw.catalog.dataset_0", {
-    schema: [col("source", "string"), col("id", "string")],
+    schema: [col("source", "string"), col("id", "string"), col("revision", "int64")],
     primaryKey: ["source", "id"],
+    sequenceBy: "revision",
   }),
   ...Array.from({ length: 4 }, (_, index) =>
     defineDataset(`raw.catalog.dataset_${index + 1}`, { schema: [col("id", "string")] })
@@ -108,12 +109,14 @@ describe("dataset catalog routes", () => {
     const body = (await response.json()) as Array<{
       id: string
       primaryKey?: string | string[]
+      sequenceBy?: string
       materialized: boolean
       latestVersion: { versionId: string; mode: string; rowCount?: number } | null
     }>
 
     expect(body).toHaveLength(5)
     expect(body[0]?.primaryKey).toEqual(["source", "id"])
+    expect(body[0]?.sequenceBy).toBe("revision")
     for (const item of body) {
       expect(item.materialized).toBe(true)
       expect(item.latestVersion?.mode).toBe("snapshot")
@@ -135,11 +138,13 @@ describe("dataset catalog routes", () => {
 
     const item = (await response.json()) as {
       primaryKey?: string | string[]
+      sequenceBy?: string
       materialized: boolean
       latestVersion: { mode: string } | null
     }
     expect(item.materialized).toBe(true)
     expect(item.primaryKey).toEqual(["source", "id"])
+    expect(item.sequenceBy).toBe("revision")
     expect(item.latestVersion?.mode).toBe("snapshot")
 
     expect(calls()).toBe(1)

--- a/storage/ducklake/README.md
+++ b/storage/ducklake/README.md
@@ -180,11 +180,18 @@ await merge.writeChanges([
 const result = await merge.commit()
 ```
 
-Changes remain ordered across `writeChanges(...)` calls, and the final change for a repeated key
+For datasets without `sequenceBy`, changes remain ordered across `writeChanges(...)` calls, and the final change for a repeated key
 wins. Upserts are complete rows rather than patches. Commit checks the dataset version captured by
 `beginMerge`, applies effective changes atomically, and creates a version only when visible rows
 change. An initial no-op returns `{ outcome: "unchanged", version: null }`; a later no-op returns the
 existing latest version.
+
+Datasets declaring `sequenceBy` instead compare source revisions: older changes are ignored,
+identical ties are unchanged, and conflicting ties abort the merge. Deletes require
+`change.delete(key, { sequence })`. Source revisions and deletion tombstones are stored in a
+companion DuckLake table in the same transaction as visible rows, surviving snapshot expiration.
+New tombstone state creates a version even when the visible row count stays zero. Sequenced
+datasets currently require merge writes. See [source ordering](../../docs/data/datasets.md#source-ordering).
 
 Snapshot, append, and SQL-transform writes to keyed datasets also enforce unique keys so a later
 merge never starts from an ambiguous baseline. Application authors normally use

--- a/storage/ducklake/src/internal/dataset-row-merge.ts
+++ b/storage/ducklake/src/internal/dataset-row-merge.ts
@@ -1,10 +1,16 @@
 import type { DatasetDefinition } from "@sixb/core"
-import { getDatasetPrimaryKeyColumns, LakeStorageError } from "@sixb/core/lake-storage"
+import {
+  type DatasetSequenceChange,
+  type DatasetSequenceState,
+  getDatasetPrimaryKeyColumns,
+  LakeStorageError,
+  reconcileDatasetSequences,
+} from "@sixb/core/lake-storage"
 import type { DuckLakeStorageOptions } from "../types"
 import { type ApplyDatasetRowsResult, inspectUniqueKeyedRelation } from "./dataset-row-commit"
-import { getBigIntLike } from "./duckdb-row"
+import { getBigIntLike, getOptionalString, getString } from "./duckdb-row"
 import type { DuckDbQueryRuntime } from "./duckdb-runtime"
-import { encodeDatasetTableName } from "./names"
+import { encodeDatasetSequenceTableName, encodeDatasetTableName } from "./names"
 import { datasetSchemaColumnNamesSql } from "./schema"
 import { qualifiedTableName, quoteIdentifier, quoteSqlString } from "./sql"
 
@@ -40,23 +46,26 @@ export async function applyDatasetMergeFromRelation(
   const sourceRowCount = await countRows(input.runtime, stagingTable)
   const previousRowCount = await currentBaselineRowCount(input, targetTable, primaryKeyColumns)
 
-  return withMaterializedFinalChanges(input, primaryKeyColumns, async (finalChanges) => {
-    const effects = await countMergeEffects(input, targetTable, finalChanges, primaryKeyColumns)
-    const effectiveChangeCount = effects.inserts + effects.updates + effects.deletes
+  return withMaterializedFinalChanges(
+    input,
+    primaryKeyColumns,
+    async (finalChanges, orderingChanged) => {
+      const effects = await countMergeEffects(input, targetTable, finalChanges, primaryKeyColumns)
+      const effectiveChangeCount = effects.inserts + effects.updates + effects.deletes
 
-    if (effectiveChangeCount === 0) {
-      return {
-        dataChangeExpected: false,
-        sourceRowCount,
-        resultingRowCount: { kind: "exact", value: previousRowCount },
+      if (effectiveChangeCount === 0) {
+        return {
+          dataChangeExpected: orderingChanged,
+          sourceRowCount,
+          resultingRowCount: { kind: "exact", value: previousRowCount },
+        }
       }
-    }
 
-    const keyMatchSql = primaryKeyMatchSql(primaryKeyColumns, "target", "source")
-    const rowDifferenceSql = datasetRowDifferenceSql(input.dataset, "target", "source")
-    const kindColumn = `source.${quoteIdentifier(input.kindColumnName)}`
+      const keyMatchSql = primaryKeyMatchSql(primaryKeyColumns, "target", "source")
+      const rowDifferenceSql = datasetRowDifferenceSql(input.dataset, "target", "source")
+      const kindColumn = `source.${quoteIdentifier(input.kindColumnName)}`
 
-    await input.runtime.run(`
+      await input.runtime.run(`
       DELETE FROM ${targetTable} AS target
       USING ${finalChanges} AS source
       WHERE ${keyMatchSql}
@@ -69,12 +78,12 @@ export async function applyDatasetMergeFromRelation(
         )
     `)
 
-    const columnsSql = datasetSchemaColumnNamesSql(input.dataset.schema)
-    const selectedColumnsSql = input.dataset.schema.columns
-      .map((column) => `source.${quoteIdentifier(column.name)}`)
-      .join(", ")
-    const firstSequenceColumnName = firstSequenceName(input.sequenceColumnName)
-    await input.runtime.run(`
+      const columnsSql = datasetSchemaColumnNamesSql(input.dataset.schema)
+      const selectedColumnsSql = input.dataset.schema.columns
+        .map((column) => `source.${quoteIdentifier(column.name)}`)
+        .join(", ")
+      const firstSequenceColumnName = firstSequenceName(input.sequenceColumnName)
+      await input.runtime.run(`
       INSERT INTO ${targetTable} (${columnsSql})
       SELECT ${selectedColumnsSql}
       FROM ${finalChanges} AS source
@@ -87,15 +96,77 @@ export async function applyDatasetMergeFromRelation(
       ORDER BY source.${quoteIdentifier(firstSequenceColumnName)}
     `)
 
-    return {
-      dataChangeExpected: true,
-      sourceRowCount,
-      resultingRowCount: {
-        kind: "exact",
-        value: previousRowCount + effects.inserts - effects.deletes,
-      },
+      return {
+        dataChangeExpected: true,
+        sourceRowCount,
+        resultingRowCount: {
+          kind: "exact",
+          value: previousRowCount + effects.inserts - effects.deletes,
+        },
+      }
     }
-  })
+  )
+}
+
+/** The companion table is current state, committed in the same DuckLake transaction as rows.
+ * It is not recovered from expirable snapshot history. Only keys present in staging are read.
+ */
+async function applySourceOrdering(
+  input: ApplyDatasetMergeFromRelationInput,
+  acceptedTable: string
+): Promise<boolean> {
+  const source = quoteIdentifier(`${input.sequenceColumnName}_source`)
+  const ordinal = quoteIdentifier(input.sequenceColumnName)
+  const staging = quoteIdentifier(input.stagingTableName)
+  const stateTable = qualifiedTableName(
+    input.options,
+    encodeDatasetSequenceTableName(input.dataset.id)
+  )
+  await input.runtime.run(
+    `CREATE TEMP TABLE ${acceptedTable} (source_key VARCHAR, ordinal UBIGINT)`
+  )
+  let lastOrdinal = -1n
+  let changed = false
+  while (true) {
+    const staged = await input.runtime.query(
+      `SELECT ${ordinal} AS ordinal, ${source} AS source FROM ${staging}
+       WHERE ${ordinal} > ${lastOrdinal} ORDER BY ${ordinal} LIMIT 1000`
+    )
+    if (staged.length === 0) return changed
+    const changes = staged.map(
+      (row) => JSON.parse(getString(row, "source")) as DatasetSequenceChange
+    )
+    lastOrdinal = getBigIntLike(staged[staged.length - 1]!, "ordinal")
+    const batchKeys = changes.map((change) => quoteSqlString(change.key)).join(",")
+    const current = await input.runtime.query(
+      `SELECT * FROM ${stateTable} WHERE source_key IN (${batchKeys})`
+    )
+    const previous = new Map<string, DatasetSequenceState>()
+    for (const row of current) {
+      previous.set(getString(row, "source_key"), {
+        sequence: getString(row, "sequence"),
+        content: getOptionalString(row, "content") ?? null,
+      })
+    }
+    // Earlier batches are visible inside this transaction. A later conflict rolls them all back.
+    const { states, accepted } = reconcileDatasetSequences(input.dataset, previous, changes)
+    if (accepted.size === 0) continue
+    changed = true
+    const stateValues: string[] = []
+    const acceptedValues: string[] = []
+    for (const [key, index] of accepted) {
+      const state = states.get(key)!
+      stateValues.push(
+        `(${quoteSqlString(key)}, ${quoteSqlString(state.sequence)}, ${state.content === null ? "NULL" : quoteSqlString(state.content)})`
+      )
+      acceptedValues.push(`(${quoteSqlString(key)}, ${getBigIntLike(staged[index]!, "ordinal")})`)
+    }
+    const keys = [...accepted.keys()].map(quoteSqlString).join(",")
+    await input.runtime.run(`DELETE FROM ${stateTable} WHERE source_key IN (${keys})`)
+    await input.runtime.run(`INSERT INTO ${stateTable} VALUES ${stateValues.join(",")}`)
+    await input.runtime.run(`DELETE FROM ${acceptedTable} WHERE source_key IN (${keys})`)
+    await input.runtime.run(`INSERT INTO ${acceptedTable} VALUES ${acceptedValues.join(",")}`)
+  }
 }
 
 async function currentBaselineRowCount(
@@ -120,25 +191,32 @@ async function currentBaselineRowCount(
 async function withMaterializedFinalChanges<T>(
   input: ApplyDatasetMergeFromRelationInput,
   primaryKeyColumns: readonly string[],
-  run: (finalChangesTable: string) => Promise<T>
+  run: (finalChangesTable: string, orderingChanged: boolean) => Promise<T>
 ): Promise<T> {
   const table = quoteIdentifier(`${input.stagingTableName}_final`)
-  await input.runtime.run(`
-    CREATE TEMP TABLE ${table} AS
-    ${finalChangesSelectSql(input, primaryKeyColumns)}
-  `)
+  const acceptedTable = quoteIdentifier(`${input.stagingTableName}_accepted`)
 
   let outcome:
     | { readonly kind: "success"; readonly value: T }
     | { readonly kind: "error"; readonly error: unknown }
   try {
-    outcome = { kind: "success", value: await run(table) }
+    const sequenced = input.dataset.sequenceBy !== undefined
+    const orderingChanged = sequenced ? await applySourceOrdering(input, acceptedTable) : false
+    const ordinal = quoteIdentifier(input.sequenceColumnName)
+    const selectSql = sequenced
+      ? `SELECT source.*, source.${ordinal} AS ${quoteIdentifier(firstSequenceName(input.sequenceColumnName))}
+         FROM ${quoteIdentifier(input.stagingTableName)} AS source
+         JOIN ${acceptedTable} AS accepted ON source.${ordinal} = accepted.ordinal`
+      : finalChangesSelectSql(input, primaryKeyColumns)
+    await input.runtime.run(`CREATE TEMP TABLE ${table} AS ${selectSql}`)
+    outcome = { kind: "success", value: await run(table, orderingChanged) }
   } catch (error) {
     outcome = { kind: "error", error }
   }
 
   try {
     await input.runtime.run(`DROP TABLE IF EXISTS ${table}`)
+    await input.runtime.run(`DROP TABLE IF EXISTS ${acceptedTable}`)
   } catch (cleanupError) {
     if (outcome.kind === "success") {
       throw cleanupError

--- a/storage/ducklake/src/internal/ducklake-catalog-schema.ts
+++ b/storage/ducklake/src/internal/ducklake-catalog-schema.ts
@@ -14,6 +14,7 @@ export interface DuckLakeCatalogColumn {
 }
 
 const SIXB_PRIMARY_KEY_COMMENT_NAMESPACE = "sixb:primary-key:"
+export const DATASET_SEQUENCE_COLUMN_COMMENT = "sixb.sequenceBy.v1"
 const SIXB_PRIMARY_KEY_COMMENT_PREFIX = `${SIXB_PRIMARY_KEY_COMMENT_NAMESPACE}v1:`
 
 const FILE_REF_STRUCT_CHILDREN = [

--- a/storage/ducklake/src/internal/ducklake-current-dataset-definitions.ts
+++ b/storage/ducklake/src/internal/ducklake-current-dataset-definitions.ts
@@ -10,6 +10,7 @@ import {
 } from "./duckdb-row"
 import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import {
+  DATASET_SEQUENCE_COLUMN_COMMENT,
   type DuckLakeCatalogColumn,
   duckLakeCatalogColumnsToDatasetPrimaryKey,
   duckLakeCatalogColumnsToDatasetSchema,
@@ -59,12 +60,16 @@ export async function readCurrentDatasetDefinitions(
   for (const table of tables) {
     const columns = columnsByTableName.get(table.tableName) ?? []
     const primaryKey = duckLakeCatalogColumnsToDatasetPrimaryKey(table.tableName, columns)
+    const sequenceBy = columns.find(
+      (column) => column.comment === DATASET_SEQUENCE_COLUMN_COMMENT
+    )?.columnName
     const partitionBy = partitionByTableName.get(table.tableName) ?? []
     definitions.set(table.datasetId, {
       kind: "dataset",
       id: table.datasetId,
       schema: duckLakeCatalogColumnsToDatasetSchema(table.tableName, columns),
       ...(primaryKey !== undefined ? { primaryKey } : {}),
+      ...(sequenceBy !== undefined ? { sequenceBy } : {}),
       ...(partitionBy.length > 0 ? { partitionBy } : {}),
       ...(table.comment !== undefined ? { description: table.comment } : {}),
     })

--- a/storage/ducklake/src/internal/ducklake-dataset-catalog.ts
+++ b/storage/ducklake/src/internal/ducklake-dataset-catalog.ts
@@ -1,18 +1,23 @@
 import { randomUUID } from "node:crypto"
 import type { DatasetDefinition, DatasetSchema } from "@sixb/core"
 import type { DatasetDefinitionUpdatePlan, DatasetSchemaUpdatePlan } from "@sixb/core/lake-storage"
-import { LakeStorageError, planDatasetDefinitionUpdate } from "@sixb/core/lake-storage"
+import {
+  assertDatasetDefinition,
+  LakeStorageError,
+  planDatasetDefinitionUpdate,
+} from "@sixb/core/lake-storage"
 import type { DuckLakeStorageOptions } from "../types"
 import { getBigIntLike, getBoolean, getOptionalBigIntLike, getString } from "./duckdb-row"
 import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import {
+  DATASET_SEQUENCE_COLUMN_COMMENT,
   type DuckLakeCatalogColumn,
   duckLakeCatalogColumnsToDatasetSchema,
   duckLakePrimaryKeyColumnComment,
 } from "./ducklake-catalog-schema"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
 import { readCurrentDatasetDefinitions } from "./ducklake-current-dataset-definitions"
-import { encodeDatasetTableName } from "./names"
+import { encodeDatasetSequenceTableName, encodeDatasetTableName } from "./names"
 import { datasetColumnToDuckDbSql, datasetSchemaToDuckDbColumnsSql } from "./schema"
 import {
   duckLakeAlias,
@@ -76,6 +81,14 @@ export class DuckLakeDatasetCatalog {
         }
 
         await this.applyPrimaryKey(runtime, qualifiedName, definition)
+        if (definition.sequenceBy !== undefined) {
+          await runtime.run(
+            `COMMENT ON COLUMN ${qualifiedName}.${quoteIdentifier(definition.sequenceBy)} IS ${quoteSqlString(DATASET_SEQUENCE_COLUMN_COMMENT)}`
+          )
+          await runtime.run(
+            `CREATE TABLE ${qualifiedTableName(this.options, encodeDatasetSequenceTableName(definition.id))} (source_key VARCHAR NOT NULL, sequence VARCHAR NOT NULL, content VARCHAR)`
+          )
+        }
         await this.applyPartitionBy(runtime, qualifiedName, definition)
 
         await runtime.run("COMMIT")
@@ -208,6 +221,10 @@ export class DuckLakeDatasetCatalog {
   }
 
   assertSchema(definition: DatasetDefinition): void {
+    assertDatasetDefinition(
+      definition,
+      (message) => new LakeStorageError(`[SixbDuckLake] ${message}`)
+    )
     if (!definition.schema) {
       throw new LakeStorageError(
         `[SixbDuckLake] Dataset '${definition.id}' requires a schema for DuckLake storage.`

--- a/storage/ducklake/src/internal/ducklake-dataset-catalog.ts
+++ b/storage/ducklake/src/internal/ducklake-dataset-catalog.ts
@@ -225,11 +225,6 @@ export class DuckLakeDatasetCatalog {
       definition,
       (message) => new LakeStorageError(`[SixbDuckLake] ${message}`)
     )
-    if (!definition.schema) {
-      throw new LakeStorageError(
-        `[SixbDuckLake] Dataset '${definition.id}' requires a schema for DuckLake storage.`
-      )
-    }
   }
 
   private async applyExistingDatasetUpdate(plan: DatasetDefinitionUpdatePlan): Promise<void> {

--- a/storage/ducklake/src/internal/ducklake-merge-session.ts
+++ b/storage/ducklake/src/internal/ducklake-merge-session.ts
@@ -8,6 +8,7 @@ import type {
 } from "@sixb/core/lake-storage"
 import {
   cloneDatasetMergeChange,
+  datasetSequenceChange,
   getDatasetMergeChangeValidationError,
   LakeStorageError,
 } from "@sixb/core/lake-storage"
@@ -54,6 +55,7 @@ export async function createDuckLakeMergeSession(
     CREATE TEMP TABLE ${quoteIdentifier(stagingTableName)} (
       ${quoteIdentifier(sequenceColumnName)} UBIGINT NOT NULL,
       ${quoteIdentifier(kindColumnName)} VARCHAR NOT NULL,
+      ${input.merge.dataset.sequenceBy === undefined ? "" : `${quoteIdentifier(`${sequenceColumnName}_source`)} VARCHAR NOT NULL,`}
       ${datasetSchemaToDuckDbNullableColumnsSql(input.merge.dataset.schema)}
     )
   `)
@@ -122,6 +124,11 @@ class DuckLakeMergeSession implements LakeMergeSession {
       for (const staged of batch) {
         appender.appendBigInt(staged.sequence)
         appender.appendVarchar(staged.change.kind)
+        if (this.input.dataset.sequenceBy !== undefined) {
+          appender.appendVarchar(
+            JSON.stringify(datasetSequenceChange(this.input.dataset, staged.change))
+          )
+        }
         appendDatasetRow(
           appender,
           this.input.dataset.schema,

--- a/storage/ducklake/src/internal/ducklake-write-coordinator.ts
+++ b/storage/ducklake/src/internal/ducklake-write-coordinator.ts
@@ -10,7 +10,11 @@ import type {
   LakeMergeSession,
   LakeWriteSession,
 } from "@sixb/core/lake-storage"
-import { getDatasetPrimaryKeyColumns, LakeStorageError } from "@sixb/core/lake-storage"
+import {
+  assertUnsequencedDatasetWrite,
+  getDatasetPrimaryKeyColumns,
+  LakeStorageError,
+} from "@sixb/core/lake-storage"
 import type { DuckLakeStorageOptions } from "../types"
 import { localCatalogCoordinationKey } from "./catalog-key"
 import {
@@ -93,6 +97,7 @@ export class DuckLakeWriteCoordinator {
     }
 
     this.datasets.assertSchema(definition)
+    assertUnsequencedDatasetWrite(definition)
     const mode = input.mode ?? "snapshot"
     assertDatasetWriteMode(mode, "write")
 
@@ -235,6 +240,7 @@ export class DuckLakeWriteCoordinator {
     runtime: DuckDbQueryRuntime,
     input: DuckLakeCommitDatasetVersionInput
   ): Promise<DatasetWriteCommitResult> {
+    assertUnsequencedDatasetWrite(input.dataset)
     const result = await this.commitVersionOutcomeOnExclusiveRuntime(runtime, {
       ...input,
       // DuckLake has no primary-key constraint. Do not let its automatic retry replay a keyed

--- a/storage/ducklake/src/internal/names.ts
+++ b/storage/ducklake/src/internal/names.ts
@@ -99,6 +99,11 @@ export function encodeDatasetTableName(datasetId: string): string {
   return `${DATASET_TABLE_PREFIX}${encodeDatasetId(datasetId)}`
 }
 
+/** Current source-ordering state, deliberately outside the dataset table namespace. */
+export function encodeDatasetSequenceTableName(datasetId: string): string {
+  return `sixb__seq__${encodeDatasetTableName(datasetId)}`
+}
+
 /**
  * Decode a physical DuckLake table name back to a Sixb dataset id.
  */

--- a/storage/ducklake/tests/ducklake-contract.e2e.ts
+++ b/storage/ducklake/tests/ducklake-contract.e2e.ts
@@ -30,6 +30,14 @@ runLakeStorageContractSuite("DuckLakeStorage LakeStorage contract", {
 })
 
 runLakeMergeStorageContractSuite("DuckLakeStorage merge contract", {
+  async reopen(storage: DuckLakeStorage) {
+    const rootDir = roots.get(storage)
+    if (!rootDir) throw new Error("Missing test root")
+    await storage.close()
+    const reopened = createLocalDuckLakeStorage(rootDir)
+    roots.set(reopened, rootDir)
+    return reopened
+  },
   async createStorage() {
     const rootDir = await mkdtemp(join(tmpdir(), "sixb-ducklake-merge-contract-"))
     const storage = createLocalDuckLakeStorage(rootDir)

--- a/storage/ducklake/tests/ducklake-maintenance.e2e.ts
+++ b/storage/ducklake/tests/ducklake-maintenance.e2e.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { col, defineDataset } from "@sixb/core"
+import { change, col, defineDataset } from "@sixb/core"
 import { DuckLakeStorage, type DuckLakeStorageOptions } from "../src"
 import { duckLakeMetadataTableName } from "../src/internal/sql"
 import { collectRows, createLocalDuckLakeStorage, localDuckLakeOptions } from "./test-utils"
@@ -56,6 +56,33 @@ describe("DuckLakeStorage maintenance", () => {
     expect(await duckLakeSnapshotCount(storage, localDuckLakeOptions(rootDir))).toBe(
       snapshotsBefore
     )
+  })
+
+  test("retains deletion ordering after snapshot expiration and reopen", async () => {
+    // Tombstones live in current transactional state. They must not depend on expired versions.
+    const dataset = defineDataset("source.maintenance", {
+      schema: [col("id", "string"), col("revision", "int64")],
+      primaryKey: "id",
+      sequenceBy: "revision",
+    })
+    await storage.createDataset(dataset)
+    const deleted = await storage.beginMerge({ dataset })
+    await deleted.writeChanges([change.delete({ id: "42" }, { sequence: 9 })])
+    await deleted.commit()
+    // Advance another dataset, making the deletion snapshot eligible for expiration.
+    await writeSnapshot([{ orderId: "other", total: 1 }])
+    await storage.runMaintenance({ expireOlderThan: "0 seconds", deleteOlderThan: "0 seconds" })
+    await storage.close()
+    storage = createLocalDuckLakeStorage(rootDir)
+    const stale = await storage.beginMerge({ dataset })
+    await stale.writeChanges([change.upsert({ id: "42", revision: 8 })])
+    expect((await stale.commit()).outcome).toBe("unchanged")
+    const restore = await storage.beginMerge({ dataset })
+    await restore.writeChanges([change.upsert({ id: "42", revision: 10 })])
+    expect((await restore.commit()).outcome).toBe("created")
+    expect(await collectRows(storage.readRows({ datasetId: dataset.id }))).toEqual([
+      { id: "42", revision: "10" },
+    ])
   })
 
   test("non-dry-run maintenance expires eligible snapshots and preserves latest data", async () => {

--- a/storage/ducklake/tests/ducklake-merges.e2e.ts
+++ b/storage/ducklake/tests/ducklake-merges.e2e.ts
@@ -209,6 +209,83 @@ describe("DuckLakeStorage keyed merges", () => {
     expect(rows[0]).toEqual({ id: "inv_0", status: "paid", note: null })
     expect(rows.at(-1)).toEqual({ id: "inv_999", status: "open", note: null })
   })
+
+  test("rolls back source revisions and tombstones when row insertion fails", async () => {
+    // Regression proof: commit source state outside the row transaction; the later v2/v4
+    // upserts will be incorrectly ignored after the injected insert failure.
+    const dataset = defineDataset("source.atomic", {
+      schema: [col("id", "string"), col("revision", "int64")],
+      primaryKey: "id",
+      sequenceBy: "revision",
+    })
+    await storage.createDataset(dataset)
+    const seed = await storage.beginMerge({ dataset })
+    await seed.writeChanges([change.upsert({ id: "42", revision: 1 })])
+    await seed.commit()
+    const failed = await storage.beginMerge({ dataset })
+    await failed.writeChanges([
+      change.upsert({ id: "42", revision: 3 }),
+      change.delete({ id: "gone" }, { sequence: 5 }),
+    ])
+    const runtime = await internals(storage).connections.runtime()
+    const failure = new Error("source row insert failed")
+    const restore = failNextInsert(
+      runtime,
+      qualifiedTableName(options, encodeDatasetTableName(dataset.id)),
+      failure
+    )
+    try {
+      await expect(failed.commit()).rejects.toBe(failure)
+    } finally {
+      restore()
+    }
+    const next = await storage.beginMerge({ dataset })
+    await next.writeChanges([
+      change.upsert({ id: "42", revision: 2 }),
+      change.upsert({ id: "gone", revision: 4 }),
+    ])
+    await next.commit()
+    expect(await collectRows(storage.readRows({ datasetId: dataset.id }))).toEqual([
+      { id: "42", revision: "2" },
+      { id: "gone", revision: "4" },
+    ])
+  })
+
+  test("bounds source metadata batches and rolls back conflicts across batches", async () => {
+    // Regression proof: remove LIMIT 1000 from the staged metadata query. The result bound fails.
+    const dataset = defineDataset("source.batches", {
+      schema: [col("id", "string"), col("revision", "int64"), col("name", "string")],
+      primaryKey: "id",
+      sequenceBy: "revision",
+    })
+    await storage.createDataset(dataset)
+    const changes = Array.from({ length: 2001 }, (_, index) =>
+      change.upsert({ id: String(index), revision: 1, name: "original" })
+    )
+    const failed = await storage.beginMerge({ dataset })
+    await failed.writeChanges(changes)
+    await failed.writeChanges([change.upsert({ id: "0", revision: 1, name: "conflict" })])
+    await expect(failed.commit()).rejects.toThrow("conflicting content")
+    expect(await storage.getLatestVersion(dataset.id)).toBeNull()
+    expect(await temporaryMergeTableNames(storage)).toEqual([])
+
+    const merge = await storage.beginMerge({ dataset })
+    await merge.writeChanges(changes)
+    await merge.writeChanges([
+      change.upsert({ id: "0", revision: 2, name: "newer" }),
+      change.upsert({ id: "0", revision: 0, name: "stale" }),
+      change.delete({ id: "2000" }, { sequence: 2 }),
+    ])
+    const runtime = await internals(storage).connections.runtime()
+    const captured = await captureExclusiveSql(runtime, () => merge.commit())
+    expect(captured.maxQueryRows).toBeGreaterThan(0)
+    expect(captured.maxQueryRows).toBeLessThanOrEqual(1000)
+    expect(captured.result).toMatchObject({ outcome: "created", version: { rowCount: 2000 } })
+    const rows = await collectRows(storage.readRows({ datasetId: dataset.id }))
+    expect(rows.find((row) => row.id === "0")?.name).toBe("newer")
+    expect(rows.some((row) => row.id === "2000")).toBe(false)
+    expect(await temporaryMergeTableNames(storage)).toEqual([])
+  })
 })
 
 function internals(storage: DuckLakeStorage): DuckLakeStorageInternals {
@@ -290,9 +367,14 @@ function wrapExclusiveRuntime(
 async function captureExclusiveSql<T>(
   runtime: DuckDbRuntime,
   run: () => Promise<T>
-): Promise<{ readonly result: T; readonly statements: readonly string[] }> {
+): Promise<{
+  readonly result: T
+  readonly statements: readonly string[]
+  readonly maxQueryRows: number
+}> {
   const originalWithExclusive = runtime.withExclusive.bind(runtime)
   const statements: string[] = []
+  let maxQueryRows = 0
 
   runtime.withExclusive = (useRuntime) =>
     originalWithExclusive((exclusiveRuntime) =>
@@ -307,7 +389,9 @@ async function captureExclusiveSql<T>(
         },
         query: async (sql, values) => {
           statements.push(sql)
-          return exclusiveRuntime.query(sql, values)
+          const rows = await exclusiveRuntime.query(sql, values)
+          maxQueryRows = Math.max(maxQueryRows, rows.length)
+          return rows
         },
         withAppender: (tableName, useAppender) =>
           exclusiveRuntime.withAppender(tableName, useAppender),
@@ -315,7 +399,8 @@ async function captureExclusiveSql<T>(
     )
 
   try {
-    return { result: await run(), statements }
+    const result = await run()
+    return { result, statements, maxQueryRows }
   } finally {
     runtime.withExclusive = originalWithExclusive
   }

--- a/storage/ducklake/tests/ducklake-storage.test.ts
+++ b/storage/ducklake/tests/ducklake-storage.test.ts
@@ -20,7 +20,7 @@ describe("DuckLakeStorage", () => {
 
     await expect(rejected).rejects.toBeInstanceOf(LakeStorageError)
     await expect(rejected).rejects.toThrow(
-      "Dataset 'raw.erp.orders' requires a schema for DuckLake storage"
+      "[SixbDuckLake] Dataset definitions must declare a schema."
     )
   })
 

--- a/storage/lake-local/README.md
+++ b/storage/lake-local/README.md
@@ -97,9 +97,15 @@ const result = await merge.commit()
 ```
 
 The session captures the latest version when it begins and rejects its commit if another write wins
-first. The final change for a repeated key wins. Deletes of absent keys, identical upserts, and
+first. Without `sequenceBy`, the final change for a repeated key wins. Deletes of absent keys, identical upserts, and
 other changes that leave the visible rows unchanged do not create a version. An initial no-op
 returns `{ outcome: "unchanged", version: null }`.
+
+For datasets declaring `sequenceBy`, newer source revisions win; older changes are ignored and
+conflicting ties abort the merge. Deletes require `change.delete(key, { sequence })`. Each version
+manifest retains source revisions and deletion tombstones, published atomically with the version's
+rows through the dataset head pointer. New tombstones create a version even for absent keys.
+Sequenced datasets currently require merge writes. See [source ordering](../../docs/data/datasets.md#source-ordering).
 
 Application authors normally use `defineSync(..., { mode: "merge" })`; the sync worker executes the
 same provider contract and advances its source checkpoint only after commit succeeds.

--- a/storage/lake-local/src/local-lake-storage.ts
+++ b/storage/lake-local/src/local-lake-storage.ts
@@ -18,6 +18,7 @@ import {
   type MergeChange,
 } from "@sixb/core"
 import {
+  assertUnsequencedDatasetWrite,
   type BeginDatasetMergeInput,
   type BeginDatasetWriteInput,
   type CommitDatasetMergeInput,
@@ -28,6 +29,7 @@ import {
   type DatasetVersion,
   type DatasetWriteCommitResult,
   type DatasetWriteMode,
+  datasetSequenceChange,
   encodeDatasetPrimaryKey,
   getDatasetMergeChangeValidationError,
   getDatasetPrimaryKeyColumns,
@@ -37,6 +39,7 @@ import {
   type LakeWriteSession,
   mergeStrictDatasetDefinition,
   type ReadDatasetRowsInput,
+  reconcileDatasetSequences,
 } from "@sixb/core/lake-storage"
 import type {
   CommitMergeInput,
@@ -338,6 +341,7 @@ export class LocalLakeStorage implements LakeStorage {
       throw new LakeStorageError(`[LakeLocal] Unknown dataset '${input.dataset.id}'`)
     }
 
+    assertUnsequencedDatasetWrite(definition)
     await this.ensureBaseDirs()
 
     const sessionDir = join(this.tempRootPath(), `session-${randomUUID()}`)
@@ -482,10 +486,28 @@ export class LocalLakeStorage implements LakeStorage {
         : []
       const previousByKey = this.rowsByPrimaryKey(previousRows, definition)
       const stagedChanges = await this.readMergeChanges(options.tempRowsPath, definition)
+      const previousManifest =
+        definition.sequenceBy !== undefined && latestVersion
+          ? await readJsonFile<StoredDatasetVersionManifest>(
+              this.versionManifestPath(definition.id, latestVersion.versionId)
+            )
+          : null
+      const ordered =
+        definition.sequenceBy === undefined
+          ? undefined
+          : reconcileDatasetSequences(
+              definition,
+              new Map(previousManifest?.sequences ?? []),
+              stagedChanges.map((change) => datasetSequenceChange(definition, change))
+            )
       const finalChanges = new Map<string, MergeChange<DatasetRow, DatasetRow>>()
-      for (const change of stagedChanges) {
-        const value = change.kind === "upsert" ? change.row : change.key
-        finalChanges.set(encodeDatasetPrimaryKey(definition, value), change)
+      if (ordered) {
+        for (const [key, index] of ordered.accepted) finalChanges.set(key, stagedChanges[index]!)
+      } else {
+        for (const change of stagedChanges) {
+          const value = change.kind === "upsert" ? change.row : change.key
+          finalChanges.set(encodeDatasetPrimaryKey(definition, value), change)
+        }
       }
 
       const nextByKey = new Map(previousByKey)
@@ -497,7 +519,11 @@ export class LocalLakeStorage implements LakeStorage {
         }
       }
 
-      if (this.sameKeyedRowContent(previousByKey, nextByKey, definition.schema)) {
+      if (
+        ordered
+          ? ordered.accepted.size === 0
+          : this.sameKeyedRowContent(previousByKey, nextByKey, definition.schema)
+      ) {
         await rm(options.sessionDir, { recursive: true, force: true })
         return { outcome: "unchanged", version: latestVersion }
       }
@@ -528,14 +554,14 @@ export class LocalLakeStorage implements LakeStorage {
           sizeBytes: versionRowsStat.size,
         }
 
-        await writeJsonAtomic(
-          versionManifestPath,
-          toStoredManifest({
+        await writeJsonAtomic(versionManifestPath, {
+          ...toStoredManifest({
             version,
             rowFile: basename(versionRowsPath),
             commitMessage: options.commit?.commitMessage,
-          })
-        )
+          }),
+          ...(ordered ? { sequences: [...ordered.states] } : {}),
+        })
         await writeJsonAtomic(this.statePath(options.merge.dataset.id), {
           latestVersionId: versionId,
         })
@@ -573,6 +599,7 @@ export class LocalLakeStorage implements LakeStorage {
     }
 
     const mode = options.write.mode ?? "snapshot"
+    assertUnsequencedDatasetWrite(definition)
 
     if (getDatasetPrimaryKeyColumns(definition) !== null) {
       if (mode === "append" && latestVersion) {

--- a/storage/lake-local/src/types.ts
+++ b/storage/lake-local/src/types.ts
@@ -4,6 +4,7 @@ import type {
   BeginDatasetWriteInput,
   CommitDatasetMergeInput,
   CommitDatasetWriteInput,
+  DatasetSequenceState,
   DatasetVersion,
   DatasetVersionMode,
   DatasetVersionRef,
@@ -19,6 +20,7 @@ export interface DatasetState {
 }
 
 export interface StoredDatasetVersionManifest {
+  readonly sequences?: readonly (readonly [string, DatasetSequenceState])[]
   readonly datasetId: string
   readonly versionId: string
   readonly parentVersionId?: string

--- a/storage/lake-local/tests/local-lake-storage.test.ts
+++ b/storage/lake-local/tests/local-lake-storage.test.ts
@@ -24,6 +24,13 @@ runLakeStorageContractSuite("LocalLakeStorage", {
 })
 
 runLakeMergeStorageContractSuite("LocalLakeStorage merge contract", {
+  reopen(storage: LocalLakeStorage) {
+    const rootDir = roots.get(storage)
+    if (!rootDir) throw new Error("Missing test root")
+    const reopened = new LocalLakeStorage({ path: join(rootDir, "lake") })
+    roots.set(reopened, rootDir)
+    return reopened
+  },
   async createStorage() {
     const rootDir = await mkdtemp(join(tmpdir(), "sixb-lake-local-merge-contract-"))
     const storage = new LocalLakeStorage({ path: join(rootDir, "lake") })


### PR DESCRIPTION
## Order changes by source revision

Let a keyed dataset reject stale source changes, regardless of arrival order. Part of #548.

```ts
const people = defineDataset("crm.people", {
  schema: [
    col("id", "string"),
    col("name", "string"),
    col("revision", "int64"),
  ],
  primaryKey: "id",
  sequenceBy: "revision",
})

change.upsert({ id: "42", name: "Sam", revision: 8 })
change.delete({ id: "42" }, { sequence: 9 })
```

### Ordering rules

| Incoming change | Result |
| --- | --- |
| Newer revision | Apply |
| Older revision | Ignore |
| Equal revision + identical canonical content | Unchanged |
| Equal revision + different content | Fail the entire merge |
| Upsert/delete at the same revision | Fail the entire merge |

```text
delete v9 → upsert v8 → upsert v10
   │            │            │
 deleted     ignored      restored
```

Deletes retain ordering state even for absent keys. New deletion state creates a version, so concurrent writers can detect it.

### Definition contract

| Setting | Rule |
| --- | --- |
| `sequenceBy` | Non-nullable `int64` or `timestamp` column; requires a primary key |
| `int64` | Exact signed 64-bit comparison; unsafe JS integers use decimal strings |
| `timestamp` | Valid `Date` or timezone-explicit ISO string; at most millisecond precision |
| Adoption/change | New dataset + backfill; stored `sequenceBy` is immutable |
| Write mode in this PR | Merge only; snapshot reconciliation follows in #550 |

### Provider implementation

| Provider | Source-order state |
| --- | --- |
| InMemory | Stored per version |
| LocalLake | Version manifest, published with the row version |
| DuckLake | Companion current-state table, committed transactionally with rows |

DuckLake evaluates batches of at most **1,000** changes. Later batches see earlier transactional state; a later conflict rolls back the whole operation.

### Review pointers

| File | What to review |
| --- | --- |
| `packages/core/src/lake-storage/source-ordering.ts` | Shared reducer and canonical content digests |
| `packages/core/src/datasets/sequence.ts` | Exact sequence parsing |
| `storage/ducklake/src/internal/dataset-row-merge.ts` | Bounded transactional processing |
| `packages/core/src/testing/dataset-sequence-contract.ts` | Cross-provider ordering contract |

**Verified:** authoring, provider/reopen, rollback, maintenance, and batch-bound tests; full build, typecheck, client generation, Biome, and publish checks. Regression tests failed with safeguards disabled, then passed after restoration.

---
**Stack:** #552 Shared writer → **#551 Source ordering** → #550 Concurrent snapshots → #549 Webhook ingestion

Base: `datasets/shared-writer`.
