### PR TITLE
datasets: extract shared writer from sync execution

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -179,6 +179,12 @@
       "import": "./dist/storage/connector-connections/provider.js",
       "default": "./dist/storage/connector-connections/provider.js"
     },
+    "./internal/datasets": {
+      "types": "./dist/datasets/write.d.ts",
+      "bun": "./src/datasets/write.ts",
+      "import": "./dist/datasets/write.js",
+      "default": "./dist/datasets/write.js"
+    },
     "./internal/edits": {
       "types": "./dist/edits/index.d.ts",
       "bun": "./src/edits/index.ts",

--- a/packages/core/src/datasets/write.ts
+++ b/packages/core/src/datasets/write.ts
@@ -1,0 +1,231 @@
+import type { BlobStorage, FileRef } from "../blob-storage"
+import { isFileRef } from "../blob-storage"
+import { isPlainRecord } from "../json"
+import type { DatasetMergeCommitResult } from "../lake-storage/merge"
+import { getDatasetMergeChangeValidationError } from "../lake-storage/merge-validation"
+import type {
+  DatasetProducer,
+  DatasetRow,
+  DatasetWriteMode,
+  LakeStorage,
+} from "../lake-storage/types"
+import type { MergeChange } from "./changes"
+import type { DatasetDefinition } from "./types"
+import { getDatasetRowValidationError } from "./validation"
+
+export interface DatasetWriteValue {
+  readonly value: unknown
+}
+
+export interface WriteDatasetInput<TValue extends DatasetWriteValue = DatasetWriteValue> {
+  readonly lakeStorage: LakeStorage
+  readonly blobStorage: Pick<BlobStorage, "stat">
+  readonly dataset: DatasetDefinition
+  readonly mode: DatasetWriteMode | "merge"
+  readonly signal: AbortSignal
+  /** Lazy so a merge's latest-version guard is checked before fetching source data. */
+  readValues(): Promise<Iterable<TValue> | AsyncIterable<TValue>>
+  readonly producer?: DatasetProducer
+  readonly expectedLatestVersionId?: string
+  readonly commitMessage?: string
+  /** Diagnostic label for the caller, including its component prefix. */
+  readonly sourceLabel?: string
+  /** Progress includes validated values even if the operation subsequently fails. */
+  onRead?(rowsRead: number): void
+  /** Attach caller-owned source provenance to a validation failure. */
+  mapValidationError?(error: unknown, value: TValue, itemIndex: number): unknown
+}
+
+export type WriteDatasetResult = DatasetMergeCommitResult & { readonly rowsRead: number }
+
+/**
+ * Validate, stage, and commit one dataset write using existing lake sessions.
+ *
+ * The caller owns fetching/cancelling its source, execution bookkeeping, and publishing the
+ * dataset-update notification for a `created` result. This operation returns immediately after
+ * the lake commit; it does not wait for downstream pipelines or projections.
+ */
+export async function writeDataset<TValue extends DatasetWriteValue>(
+  input: WriteDatasetInput<TValue>
+): Promise<WriteDatasetResult> {
+  const { lakeStorage, dataset, signal } = input
+  let abortWrite: (() => Promise<void>) | undefined
+  let rowsRead = 0
+  const onRead = () => {
+    rowsRead += 1
+    input.onRead?.(rowsRead)
+  }
+
+  throwIfAborted(signal)
+  await lakeStorage.createDataset(dataset)
+  try {
+    throwIfAborted(signal)
+    if (input.mode === "merge") {
+      const session = await lakeStorage.beginMerge({
+        dataset,
+        expectedLatestVersionId: input.expectedLatestVersionId,
+        producer: input.producer,
+      })
+      abortWrite = () => session.abort()
+      throwIfAborted(signal)
+      const values = await input.readValues()
+      throwIfAborted(signal)
+      await session.writeChanges(
+        validatedValues(
+          input,
+          values,
+          (value, itemIndex) => validateMergeChange(value, input, itemIndex),
+          onRead
+        )
+      )
+      throwIfAborted(signal)
+      const result = await session.commit({ commitMessage: input.commitMessage })
+      return { ...result, rowsRead }
+    }
+
+    const values = await input.readValues()
+    throwIfAborted(signal)
+    const session = await lakeStorage.beginWrite({
+      dataset,
+      mode: input.mode,
+      producer: input.producer,
+    })
+    abortWrite = () => session.abort()
+    await session.writeRows(
+      validatedValues(
+        input,
+        values,
+        (value, itemIndex) => validateRow(value, input, itemIndex),
+        onRead
+      )
+    )
+    throwIfAborted(signal)
+
+    // Preserve sync semantics: an empty append must not invent an initial dataset version.
+    if (rowsRead === 0 && input.mode === "append") {
+      const version = await lakeStorage.getLatestVersion(dataset.id)
+      await session.abort()
+      return { outcome: "unchanged", version, rowsRead }
+    }
+
+    const { outcome, ...version } = await session.commit({
+      expectedLatestVersionId: input.expectedLatestVersionId,
+      commitMessage: input.commitMessage,
+    })
+    return { outcome, version, rowsRead }
+  } catch (error) {
+    // Cleanup must not replace the source, validation, cancellation, or commit failure.
+    await abortWrite?.().catch(() => {})
+    throw error
+  }
+}
+
+async function* validatedValues<TValue extends DatasetWriteValue, TResult>(
+  input: WriteDatasetInput<TValue>,
+  values: Iterable<TValue> | AsyncIterable<TValue>,
+  validate: (value: unknown, itemIndex: number) => Promise<TResult>,
+  onRead: () => void
+): AsyncIterable<TResult> {
+  let itemIndex = 0
+  for await (const sourceValue of values) {
+    throwIfAborted(input.signal)
+    itemIndex += 1
+    let value: TResult
+    try {
+      value = await validate(sourceValue.value, itemIndex)
+    } catch (error) {
+      throw input.mapValidationError
+        ? input.mapValidationError(error, sourceValue, itemIndex)
+        : error
+    }
+    onRead()
+    yield value
+  }
+}
+
+function sourceLabel(input: Pick<WriteDatasetInput, "dataset" | "sourceLabel">): string {
+  return input.sourceLabel ?? `[Sixb] Dataset '${input.dataset.id}' writer`
+}
+
+async function validateRow(
+  value: unknown,
+  input: WriteDatasetInput,
+  itemIndex: number
+): Promise<DatasetRow> {
+  if (!isPlainRecord(value)) {
+    throw new Error(
+      `${sourceLabel(input)} returned an invalid row at item ${itemIndex}. Dataset rows must be plain objects.`
+    )
+  }
+  const validationError = getDatasetRowValidationError(value, input.dataset)
+  if (validationError) {
+    throw new Error(
+      `${sourceLabel(input)} returned an invalid row at item ${itemIndex}. ${validationError}`
+    )
+  }
+  await verifyRowFileRefs(value, input, itemIndex)
+  return value
+}
+
+async function validateMergeChange(
+  value: unknown,
+  input: WriteDatasetInput,
+  itemIndex: number
+): Promise<MergeChange<DatasetRow, DatasetRow>> {
+  const validationError = getDatasetMergeChangeValidationError(value, input.dataset)
+  if (validationError) {
+    throw new Error(
+      `${sourceLabel(input)} returned an invalid merge change at item ${itemIndex}. ${validationError}`
+    )
+  }
+  const change = value as MergeChange<DatasetRow, DatasetRow>
+  if (change.kind === "upsert") await verifyRowFileRefs(change.row, input, itemIndex)
+  return change
+}
+
+async function verifyRowFileRefs(
+  row: DatasetRow,
+  input: WriteDatasetInput,
+  itemIndex: number
+): Promise<void> {
+  for (const column of input.dataset.schema.columns) {
+    if (column.type !== "fileRef") continue
+    const value = row[column.name]
+    if (isFileRef(value)) await verifyFileRef(value, input, column.name, itemIndex)
+  }
+}
+
+async function verifyFileRef(
+  fileRef: FileRef,
+  input: WriteDatasetInput,
+  columnName: string,
+  itemIndex: number
+): Promise<void> {
+  const blobInfo = await input.blobStorage.stat(fileRef.blobId)
+  const context = `${sourceLabel(input)} returned row ${itemIndex} with dataset '${input.dataset.id}' column '${columnName}'`
+  if (!blobInfo) {
+    throw new Error(`${context} referencing unknown blob '${fileRef.blobId}'.`)
+  }
+  if (blobInfo.digest !== fileRef.digest) {
+    throw new Error(
+      `${context} referencing blob '${fileRef.blobId}' with digest '${fileRef.digest}', but blob storage has '${blobInfo.digest}'.`
+    )
+  }
+  if (blobInfo.sizeBytes !== fileRef.sizeBytes) {
+    throw new Error(
+      `${context} referencing blob '${fileRef.blobId}' with size ${fileRef.sizeBytes}, but blob storage has ${blobInfo.sizeBytes}.`
+    )
+  }
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (!signal.aborted) return
+  if (signal.reason instanceof Error) throw signal.reason
+  const error = new Error(
+    typeof signal.reason === "string" && signal.reason.length > 0
+      ? signal.reason
+      : "[Sixb] Dataset write was cancelled."
+  )
+  error.name = "AbortError"
+  throw error
+}

--- a/packages/core/tests/dataset-write.test.ts
+++ b/packages/core/tests/dataset-write.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from "bun:test"
+import { InMemoryBlobStorage } from "../src/blob-storage"
+import { change, col, defineDataset } from "../src/datasets"
+import { writeDataset } from "../src/datasets/write"
+import {
+  type BeginDatasetMergeInput,
+  type BeginDatasetWriteInput,
+  type DatasetRow,
+  InMemoryLakeStorage,
+} from "../src/lake-storage"
+
+const people = defineDataset("people", {
+  schema: [col("id", "string"), col("name", "string")],
+  primaryKey: "id",
+})
+
+class ObservedLake extends InMemoryLakeStorage {
+  aborts = 0
+  failAbort = false
+
+  override async beginWrite(input: BeginDatasetWriteInput) {
+    return this.observe(await super.beginWrite(input))
+  }
+
+  override async beginMerge(input: BeginDatasetMergeInput) {
+    return this.observe(await super.beginMerge(input))
+  }
+
+  private observe<T extends { abort(): Promise<void> }>(session: T): T {
+    const abort = session.abort.bind(session)
+    session.abort = async () => {
+      this.aborts += 1
+      await abort()
+      if (this.failAbort) throw new Error("cleanup failed")
+    }
+    return session
+  }
+}
+
+async function rows(lake: InMemoryLakeStorage): Promise<DatasetRow[]> {
+  const result: DatasetRow[] = []
+  for await (const row of lake.readRows({ datasetId: people.id })) result.push(row)
+  return result
+}
+
+describe("shared dataset writer", () => {
+  test("writes snapshots, appends, and merges without a sync execution", async () => {
+    const lakeStorage = new InMemoryLakeStorage()
+    const common = {
+      lakeStorage,
+      blobStorage: new InMemoryBlobStorage(),
+      dataset: people,
+      signal: new AbortController().signal,
+    }
+    const first = await writeDataset({
+      ...common,
+      mode: "snapshot",
+      readValues: async () => [{ value: { id: "1", name: "Sam" } }],
+    })
+    expect(first).toMatchObject({ outcome: "created", rowsRead: 1, version: { rowCount: 1 } })
+    await writeDataset({
+      ...common,
+      mode: "append",
+      readValues: async () => [{ value: { id: "2", name: "Alex" } }],
+    })
+    const merged = await writeDataset({
+      ...common,
+      mode: "merge",
+      readValues: async () => [
+        { value: change.upsert({ id: "1", name: "Samuel" }) },
+        { value: change.delete({ id: "2" }) },
+      ],
+    })
+    expect(merged).toMatchObject({ outcome: "created", rowsRead: 2, version: { rowCount: 1 } })
+    expect(await rows(lakeStorage)).toEqual([{ id: "1", name: "Samuel" }])
+    const identical = await writeDataset({
+      ...common,
+      mode: "snapshot",
+      readValues: async () => [{ value: { id: "1", name: "Samuel" } }],
+    })
+    expect(identical).toMatchObject({
+      outcome: "unchanged",
+      version: { versionId: merged.version?.versionId },
+    })
+  })
+
+  test("empty append and merge reuse no version; an empty snapshot is addressable", async () => {
+    // Regression proof: remove the empty-append branch in writeDataset; the first assertion fails.
+    const lakeStorage = new InMemoryLakeStorage()
+    const common = {
+      lakeStorage,
+      blobStorage: new InMemoryBlobStorage(),
+      dataset: people,
+      signal: new AbortController().signal,
+      readValues: async () => [],
+    }
+    for (const mode of ["append", "merge"] as const) {
+      expect(await writeDataset({ ...common, mode })).toEqual({
+        outcome: "unchanged",
+        rowsRead: 0,
+        version: null,
+      })
+    }
+    const snapshot = await writeDataset({ ...common, mode: "snapshot" })
+    expect(snapshot).toMatchObject({ outcome: "created", rowsRead: 0, version: { rowCount: 0 } })
+    const append = await writeDataset({ ...common, mode: "append" })
+    expect(append).toMatchObject({
+      outcome: "unchanged",
+      version: { versionId: snapshot.version?.versionId },
+    })
+  })
+
+  for (const mode of ["snapshot", "merge"] as const) {
+    test(`${mode} validation preserves caller provenance and closes failed streams/sessions`, async () => {
+      // Regression proof: remove abortWrite from the catch path; the abort-count assertion fails.
+      const lakeStorage = new ObservedLake()
+      lakeStorage.failAbort = true
+      let read = 0
+      let closed = false
+      const failure = new Error("invalid record from account A")
+      const value = (row: object) => (mode === "merge" ? change.upsert(row) : row)
+      await expect(
+        writeDataset({
+          lakeStorage,
+          blobStorage: new InMemoryBlobStorage(),
+          dataset: people,
+          mode,
+          signal: new AbortController().signal,
+          readValues: async () =>
+            (async function* () {
+              try {
+                yield { value: value({ id: "1", name: "Sam" }), account: "A" }
+                yield { value: value({ id: "2" }), account: "A" }
+                throw new Error("must stop before requesting another value")
+              } finally {
+                closed = true
+              }
+            })(),
+          onRead(count) {
+            read = count
+          },
+          mapValidationError(error, item, index) {
+            expect(error).toBeInstanceOf(Error)
+            expect(item.account).toBe("A")
+            expect(index).toBe(2)
+            return failure
+          },
+        })
+      ).rejects.toBe(failure)
+      expect(read).toBe(1)
+      expect(closed).toBe(true)
+      expect(lakeStorage.aborts).toBe(1)
+      expect(await lakeStorage.getLatestVersion(people.id)).toBeNull()
+    })
+
+    test(`${mode} cancellation aborts staged rows and preserves the prior version`, async () => {
+      const lakeStorage = new ObservedLake()
+      const common = { lakeStorage, blobStorage: new InMemoryBlobStorage(), dataset: people }
+      const seed = await writeDataset({
+        ...common,
+        mode: "snapshot",
+        signal: new AbortController().signal,
+        readValues: async () => [{ value: { id: "1", name: "Sam" } }],
+      })
+      const controller = new AbortController()
+      const reason = new Error("delivery cancelled")
+      await expect(
+        writeDataset({
+          ...common,
+          mode,
+          signal: controller.signal,
+          readValues: async () =>
+            (async function* () {
+              const row = { id: "1", name: "Changed" }
+              yield { value: mode === "merge" ? change.upsert(row) : row }
+              controller.abort(reason)
+            })(),
+        })
+      ).rejects.toBe(reason)
+      expect(lakeStorage.aborts).toBe(1)
+      expect((await lakeStorage.getLatestVersion(people.id))?.versionId).toBe(
+        seed.version?.versionId
+      )
+      expect(await rows(lakeStorage)).toEqual([{ id: "1", name: "Sam" }])
+    })
+  }
+
+  test("verifies blob existence, digest, and size for rows/upserts; deletes need only keys", async () => {
+    // Regression proof: bypass verifyRowFileRefs in either validation path; invalid blobs commit.
+    const blobStorage = new InMemoryBlobStorage()
+    const ref = await blobStorage.put({ body: new TextEncoder().encode("source document") })
+    const dataset = defineDataset("documents", {
+      schema: [col("id", "string"), col("file", "fileRef")],
+      primaryKey: "id",
+    })
+    for (const mode of ["snapshot", "merge"] as const) {
+      for (const [stored, diagnostic] of [
+        [null, `referencing unknown blob '${ref.blobId}'`],
+        [
+          { ...ref, digest: "sha256:wrong" },
+          `with digest '${ref.digest}', but blob storage has 'sha256:wrong'`,
+        ],
+        [
+          { ...ref, sizeBytes: ref.sizeBytes + 1 },
+          `with size ${ref.sizeBytes}, but blob storage has ${ref.sizeBytes + 1}`,
+        ],
+      ] as const) {
+        const lakeStorage = new ObservedLake()
+        const row = { id: "1", file: ref }
+        await expect(
+          writeDataset({
+            lakeStorage,
+            blobStorage: { stat: async () => stored },
+            dataset,
+            mode,
+            signal: new AbortController().signal,
+            readValues: async () => [{ value: mode === "merge" ? change.upsert(row) : row }],
+          })
+        ).rejects.toThrow(diagnostic)
+        expect(lakeStorage.aborts).toBe(1)
+        expect(await lakeStorage.getLatestVersion(dataset.id)).toBeNull()
+      }
+    }
+    const result = await writeDataset({
+      lakeStorage: new InMemoryLakeStorage(),
+      blobStorage: {
+        stat: async () => {
+          throw new Error("deletes must not read blobs")
+        },
+      },
+      dataset,
+      mode: "merge",
+      signal: new AbortController().signal,
+      readValues: async () => [{ value: change.delete({ id: "1" }) }],
+    })
+    expect(result).toEqual({ outcome: "unchanged", rowsRead: 1, version: null })
+  })
+})

--- a/packages/sync-worker/src/normalize.ts
+++ b/packages/sync-worker/src/normalize.ts
@@ -68,16 +68,6 @@ export async function runAbortable<T>(
   }
 }
 
-export function assertDatasetRow(value: unknown, syncId: string, itemIndex: number): DatasetRow {
-  if (isPlainObject(value)) {
-    return value
-  }
-
-  throw new Error(
-    `[SixbSyncWorker] Sync '${syncId}' returned an invalid row at item ${itemIndex}. Dataset rows must be plain objects.`
-  )
-}
-
 export async function* normalizeReadResult(
   readResult: SyncReadResult,
   syncId: string,

--- a/packages/sync-worker/src/run-sync-job.ts
+++ b/packages/sync-worker/src/run-sync-job.ts
@@ -1,14 +1,5 @@
-import {
-  type BlobStorage,
-  cloneJsonValue,
-  type DatasetDefinition,
-  type DatasetRow,
-  type FileRef,
-  getDatasetRowValidationError,
-  isFileRef,
-  type JsonValue,
-  type MergeChange,
-} from "@sixb/core"
+import { cloneJsonValue, type DatasetDefinition, type JsonValue } from "@sixb/core"
+import { writeDataset } from "@sixb/core/internal/datasets"
 import {
   captureSixbFailure,
   createSixbError,
@@ -16,9 +7,9 @@ import {
   summarizeErrorMessage,
 } from "@sixb/core/internal/errors"
 import { resolveLoggingService } from "@sixb/core/internal/logging"
-import { type DatasetVersion, getDatasetMergeChangeValidationError } from "@sixb/core/lake-storage"
+import type { DatasetVersion } from "@sixb/core/lake-storage"
 import { SYNC_RUN_FAILURE_CODES, type SyncRunRecord } from "@sixb/core/storage"
-import { assertDatasetRow, throwIfAborted } from "./normalize"
+import { throwIfAborted } from "./normalize"
 import { readSyncValues, type SyncSourceValue } from "./source-read"
 import type { RunSyncJobInput, SyncRunFinishedHandler, SyncRunResult } from "./types"
 
@@ -97,151 +88,6 @@ function translateSyncExecutionError(
   )
 }
 
-async function verifyFileRef(options: {
-  blobStorage: BlobStorage
-  syncId: string
-  datasetId: string
-  columnName: string
-  itemIndex: number
-  fileRef: FileRef
-}): Promise<void> {
-  const blobInfo = await options.blobStorage.stat(options.fileRef.blobId)
-  if (!blobInfo) {
-    throw new Error(
-      `[SixbSyncWorker] Sync '${options.syncId}' returned row ${options.itemIndex} with dataset '${options.datasetId}' column '${options.columnName}' referencing unknown blob '${options.fileRef.blobId}'.`
-    )
-  }
-
-  if (blobInfo.digest !== options.fileRef.digest) {
-    throw new Error(
-      `[SixbSyncWorker] Sync '${options.syncId}' returned row ${options.itemIndex} with dataset '${options.datasetId}' column '${options.columnName}' referencing blob '${options.fileRef.blobId}' with digest '${options.fileRef.digest}', but blob storage has '${blobInfo.digest}'.`
-    )
-  }
-
-  if (blobInfo.sizeBytes !== options.fileRef.sizeBytes) {
-    throw new Error(
-      `[SixbSyncWorker] Sync '${options.syncId}' returned row ${options.itemIndex} with dataset '${options.datasetId}' column '${options.columnName}' referencing blob '${options.fileRef.blobId}' with size ${options.fileRef.sizeBytes}, but blob storage has ${blobInfo.sizeBytes}.`
-    )
-  }
-}
-
-async function verifyRowFileRefs(options: {
-  blobStorage: BlobStorage
-  syncId: string
-  dataset: { id: string; schema: { columns: readonly { name: string; type: string }[] } }
-  row: Record<string, unknown>
-  itemIndex: number
-}): Promise<void> {
-  const fileRefColumns = options.dataset.schema.columns.filter(
-    (column) => column.type === "fileRef"
-  )
-  for (const column of fileRefColumns) {
-    const value = options.row[column.name]
-    if (!isFileRef(value)) {
-      continue
-    }
-
-    await verifyFileRef({
-      blobStorage: options.blobStorage,
-      syncId: options.syncId,
-      datasetId: options.dataset.id,
-      columnName: column.name,
-      itemIndex: options.itemIndex,
-      fileRef: value,
-    })
-  }
-}
-
-function assertMergeChange(
-  value: unknown,
-  syncId: string,
-  dataset: DatasetDefinition,
-  itemIndex: number
-): MergeChange<DatasetRow, DatasetRow> {
-  const validationError = getDatasetMergeChangeValidationError(value, dataset)
-  if (validationError) {
-    throw new Error(
-      `[SixbSyncWorker] Sync '${syncId}' returned an invalid merge change at item ${itemIndex}. ${validationError}`
-    )
-  }
-  return value as MergeChange<DatasetRow, DatasetRow>
-}
-
-async function* validatedDatasetRows(options: {
-  values: AsyncIterable<SyncSourceValue>
-  signal: AbortSignal
-  blobStorage: BlobStorage
-  syncId: string
-  runId: string
-  dataset: DatasetDefinition
-  onRead(): void
-}): AsyncIterable<DatasetRow> {
-  let itemIndex = 0
-  for await (const sourceValue of options.values) {
-    throwIfAborted(options.signal)
-    itemIndex += 1
-
-    let row: DatasetRow
-    try {
-      row = assertDatasetRow(sourceValue.value, options.syncId, itemIndex)
-      // Validate before handing rows to lake storage so sync failures include
-      // the source item index; lake storage still re-validates as the final boundary.
-      const validationError = getDatasetRowValidationError(row, options.dataset)
-      if (validationError) {
-        throw new Error(
-          `[SixbSyncWorker] Sync '${options.syncId}' returned an invalid row at item ${itemIndex}. ${validationError}`
-        )
-      }
-
-      // Lake storage validates fileRef shape; the worker owns existence checks against blob storage.
-      await verifyRowFileRefs({
-        blobStorage: options.blobStorage,
-        syncId: options.syncId,
-        dataset: options.dataset,
-        row,
-        itemIndex,
-      })
-      options.onRead()
-    } catch (error) {
-      throw sourceValidationError(error, sourceValue, options, itemIndex)
-    }
-    yield row
-  }
-}
-
-async function* validatedMergeChanges(options: {
-  values: AsyncIterable<SyncSourceValue>
-  signal: AbortSignal
-  blobStorage: BlobStorage
-  syncId: string
-  runId: string
-  dataset: DatasetDefinition
-  onRead(): void
-}): AsyncIterable<MergeChange<DatasetRow, DatasetRow>> {
-  let itemIndex = 0
-  for await (const sourceValue of options.values) {
-    throwIfAborted(options.signal)
-    itemIndex += 1
-    let mergeChange: MergeChange<DatasetRow, DatasetRow>
-    try {
-      mergeChange = assertMergeChange(sourceValue.value, options.syncId, options.dataset, itemIndex)
-      if (mergeChange.kind === "upsert") {
-        await verifyRowFileRefs({
-          blobStorage: options.blobStorage,
-          syncId: options.syncId,
-          dataset: options.dataset,
-          row: mergeChange.row,
-          itemIndex,
-        })
-      }
-      options.onRead()
-    } catch (error) {
-      throw sourceValidationError(error, sourceValue, options, itemIndex)
-    }
-    yield mergeChange
-  }
-}
-
 function sourceValidationError(
   error: unknown,
   sourceValue: SyncSourceValue,
@@ -265,11 +111,6 @@ function sourceValidationError(
       accountId: connection.account.id,
     },
   })
-}
-
-interface SyncCommitResult {
-  readonly outcome: "created" | "unchanged"
-  readonly version?: DatasetVersion
 }
 
 /**
@@ -317,7 +158,6 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
     id: job.id,
   })
   const logger = logSession.logger
-  let abortWrite: (() => Promise<void>) | undefined
   let rowsRead = 0
   let committedVersion: DatasetVersion | undefined
 
@@ -338,9 +178,6 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
         `[SixbSyncWorker] Sync '${sync.id}' targets unknown dataset '${run.datasetId}'.`
       )
     }
-
-    throwIfAborted(signal)
-    await lakeStorage.createDataset(dataset)
 
     const latestSuccessfulRuns = await syncRunsStorage.list({
       projectId: runtime.id,
@@ -372,115 +209,24 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
           nextCheckpoint = next === undefined ? undefined : cloneJsonValue(next)
         },
       })
-    const onRead = () => {
-      rowsRead += 1
-    }
-    const commitMessage = job.commitMessage ?? `sync ${sync.id} run ${job.id}`
-    let commitResult: SyncCommitResult
-
-    if (sync.config.mode === "merge") {
-      const mergeWrite = await lakeStorage.beginMerge({
-        dataset,
-        expectedLatestVersionId: job.expectedLatestVersionId,
-        producer,
-      })
-      abortWrite = () => mergeWrite.abort()
-
-      const values = await readValues()
-      throwIfAborted(signal)
-      await mergeWrite.writeChanges(
-        validatedMergeChanges({
-          values,
-          signal,
-          blobStorage,
-          syncId: sync.id,
-          runId: job.id,
-          dataset,
-          onRead,
-        })
-      )
-      throwIfAborted(signal)
-
-      const commit = await mergeWrite.commit({ commitMessage })
-      abortWrite = undefined
-      commitResult = {
-        outcome: commit.outcome,
-        ...(commit.version ? { version: commit.version } : {}),
-      }
-    } else {
-      const values = await readValues()
-      throwIfAborted(signal)
-
-      const rowWrite = await lakeStorage.beginWrite({
-        dataset,
-        mode: sync.config.mode,
-        producer,
-      })
-      abortWrite = () => rowWrite.abort()
-      await rowWrite.writeRows(
-        validatedDatasetRows({
-          values,
-          signal,
-          blobStorage,
-          syncId: sync.id,
-          runId: job.id,
-          dataset,
-          onRead,
-        })
-      )
-      throwIfAborted(signal)
-
-      if (rowsRead === 0 && sync.config.mode === "append") {
-        const version = await lakeStorage.getLatestVersion(dataset.id)
-        await rowWrite.abort()
-        abortWrite = undefined
-        const finishedRun = await syncRunsStorage.finish({
-          projectId: runtime.id,
-          id: job.id,
-          status: "succeeded",
-          rowsRead,
-          ...(version
-            ? { output: { datasetId: version.datasetId, versionId: version.versionId } }
-            : {}),
-          checkpoint: nextCheckpoint,
-        })
-        const finishedAt = requireFinishedAt({
-          syncId: sync.id,
-          runId: job.id,
-          finishedAt: finishedRun.finishedAt,
-        })
-        await notifyRunFinished(input.onRunFinished, finishedRun)
-
-        return {
-          id: job.id,
-          syncId: sync.id,
-          datasetId: dataset.id,
-          mode: sync.config.mode,
-          startedAt: requireStartedAt(job.id, startedRun.startedAt),
-          finishedAt,
-          rowsRead,
-          ...(version ? { version } : {}),
-          versionCreated: false,
-        }
-      }
-
-      const { outcome, ...version } = await rowWrite.commit({
-        expectedLatestVersionId: job.expectedLatestVersionId,
-        commitMessage,
-      })
-      abortWrite = undefined
-      commitResult = { outcome, version }
-    }
-
-    const { outcome, version } = commitResult
+    const { outcome, version } = await writeDataset({
+      lakeStorage,
+      blobStorage,
+      dataset,
+      mode: sync.config.mode,
+      signal,
+      producer,
+      readValues,
+      expectedLatestVersionId: job.expectedLatestVersionId,
+      commitMessage: job.commitMessage ?? `sync ${sync.id} run ${job.id}`,
+      sourceLabel: `[SixbSyncWorker] Sync '${sync.id}'`,
+      onRead(count) {
+        rowsRead = count
+      },
+      mapValidationError: (error, value, itemIndex) =>
+        sourceValidationError(error, value, { syncId: sync.id, runId: job.id, dataset }, itemIndex),
+    })
     if (outcome === "created") {
-      if (!version) {
-        throw createSixbError(
-          "internal.unexpected",
-          `[SixbSyncWorker] Sync '${sync.id}' created no dataset version.`,
-          { details: { syncId: sync.id, runId: job.id, datasetId: dataset.id } }
-        )
-      }
       committedVersion = version
     }
     let finishedRun: SyncRunRecord
@@ -528,9 +274,7 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
       : { ...result, versionCreated: false }
   } catch (error) {
     if (!committedVersion) {
-      // Without a created commit, best-effort clean up any open session and the run record.
-      await abortWrite?.().catch(() => {})
-
+      // The shared writer has already cleaned up its session. Finalize the failed sync run.
       const status = signal.aborted ? "cancelled" : "failed"
       try {
         const failureError =

--- a/packages/sync-worker/src/worker.ts
+++ b/packages/sync-worker/src/worker.ts
@@ -162,6 +162,8 @@ async function emitSyncRunFinishedEvents(
   correlationId: string,
   createdVersion?: DatasetVersion
 ): Promise<void> {
+  // Sync owns notification after its run is finalized; the shared dataset writer returns the
+  // created version but does not publish events. Durable delivery is a separate follow-up.
   await host.events?.emit(
     {
       events: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -82,6 +82,7 @@
         "./packages/core/src/storage/connector-connections/provider.ts"
       ],
       "@sixb/core/internal/edits": ["./packages/core/src/edits/index.ts"],
+      "@sixb/core/internal/datasets": ["./packages/core/src/datasets/write.ts"],
       "@sixb/core/internal/error-reporting": ["./packages/core/src/error-reporting/internal.ts"],
       "@sixb/core/internal/errors": ["./packages/core/src/errors/internal.ts"],
       "@sixb/core/internal/events": ["./packages/core/src/events/index.ts"],


### PR DESCRIPTION
## Shared dataset writer

Extract the dataset-write operation from sync execution so other callers can reuse it. First PR in the #548 stack.

```text
Before
runSyncJob
  ├─ fetch connector data
  ├─ validate → stage → commit / abort
  └─ finalize run + checkpoint

After
runSyncJob
  ├─ fetch connector data
  ├─ writeDataset() → validate → stage → commit / abort
  └─ finalize run + checkpoint
```

### Internal API

```ts
const result = await writeDataset({
  lakeStorage,
  blobStorage,
  dataset,
  mode: "snapshot", // also "append" or "merge"
  signal,
  readValues: async () => rows.map((value) => ({ value })),
})

result.outcome  // "created" | "unchanged"
result.version  // committed/reused version, or null for an initial merge no-op
result.rowsRead // validated input count
```

### Ownership

| Shared writer | Sync worker |
| --- | --- |
| Row/change and blob-reference validation | Connector reads and source provenance |
| Streaming into existing lake sessions | Checkpoints and run history |
| Commit, cancellation, and failed-session cleanup | Dataset-update and run lifecycle events |

### Behavior preserved

| Write | Result |
| --- | --- |
| Snapshot | Replace rows; reuse an identical version |
| Append | Add rows; empty sync append creates no initial version |
| Merge | Apply keyed upserts/deletes; reuse unchanged state |
| Invalid input or cancellation | Abort staged data |

### Review pointers

| File | What to review |
| --- | --- |
| `packages/core/src/datasets/write.ts` | Extracted write lifecycle |
| `packages/sync-worker/src/run-sync-job.ts` | Delegation and retained sync bookkeeping |
| `packages/core/tests/dataset-write.test.ts` | Direct writer coverage |

**Verified:** writer/sync-worker/CLI tests; full build, typecheck, Biome, and publish checks.

---
**Stack:** **#552 Shared writer** → #551 Source ordering → #550 Concurrent snapshots → #549 Webhook ingestion

Base: `main`. The public ingestion method arrives in #549.
