### PR TITLE
agent-ui: export chat components for custom layouts

### DIFF
--- a/packages/agent-ui/README.md
+++ b/packages/agent-ui/README.md
@@ -91,6 +91,135 @@ to the rest of their app with `sidebarHeader`, `sidebarFooter`, and `sidebarWidt
 footer accept React nodes; the width accepts any React CSS width value and applies on desktop while
 mobile keeps its responsive sheet width.
 
+## Compose a custom UI
+
+All chat building blocks are available as named imports from `@sixb/agent-ui`:
+
+| Exports | Purpose |
+| --- | --- |
+| `AgentChat` | Complete route-independent workspace with navigation callbacks. |
+| `ConversationPanel` | Conversation header, welcome state, transcript, and composer. |
+| `Composer` | Chat input, uploads, context mentions, model controls, and send/stop buttons. |
+| `Transcript` | Durable and streaming messages, optimistic user messages, scroll anchoring, and run status. |
+| `MessageView`, `LiveAssistant`, `AssistantBody` | Individual messages, a live assistant row, or normalized assistant parts. |
+| `ThreadSidebar` | Thread navigation with search and pagination callbacks. |
+| `ContextPicker`, `ContextChips` | Context selection and selected context display. |
+| `ModelControls`, `ModelPickerRow`, `ReasoningEffortSlider`, `ProviderLogo` | Model and reasoning selection. |
+| `FileAttachmentCard`, `UserFileAttachment` | File attachments. |
+| `ActivityStatusText`, `ThinkingMarker`, `CompactionMarker`, `ReconnectingMarker` | Live activity indicators. |
+| `RunCancelledMarker`, `RunErrorMarker`, `RunFailureMarker`, `RunTimeoutMarker` | Run outcomes and recovery actions. |
+| `DocumentPreviewRoot`, `useDocumentPreview` | Shared document viewer and programmatic preview controls. |
+
+Use `useAgentConversation` once per conversation surface to share thread data, streaming state,
+model selection, send/stop/retry actions, and failed-send draft restoration. The host owns `threadId`;
+update it when `onThreadCreated` fires. Use `embedded: true` for a compact surface that does not need
+the workspace-wide activity subscription.
+
+The example below requires a configured Sixb client and a `QueryClientProvider` from
+`@tanstack/react-query` above it. Load `@sixb/ui/globals.css` for the shared theme/Tailwind styles and
+`@sixb/agent-ui/globals.css` for the agent component classes and animations.
+
+```tsx
+import { useState } from "react"
+import {
+  Composer,
+  DocumentPreviewRoot,
+  Transcript,
+  useAgentConversation,
+  useRegisteredAgentContext,
+} from "@sixb/agent-ui"
+import "@sixb/ui/globals.css"
+import "@sixb/agent-ui/globals.css"
+
+export function CustomChat() {
+  const [threadId, setThreadId] = useState<string | null>(null)
+  const ambientContext = useRegisteredAgentContext()
+  const chat = useAgentConversation({
+    threadId,
+    embedded: true,
+    onThreadCreated: setThreadId,
+  })
+  const turn = chat.presentation
+  const canRetry = turn.kind === "failed" || (turn.kind === "timeout" && !turn.hasProgress)
+
+  if (chat.agentLoading) return <p role="status">Loading agent…</p>
+  if (chat.agentError || !chat.currentAgent) return <p role="alert">Agent unavailable.</p>
+  if (chat.threadUnavailable) return <p role="alert">Conversation unavailable.</p>
+
+  return (
+    <DocumentPreviewRoot compact scopeKey={threadId ?? "draft"} persistenceKey={threadId}>
+      <section data-agent-panel="" className="flex h-full min-h-0 flex-col">
+        <header>
+          <h2>Project assistant</h2>
+          <button type="button" onClick={() => setThreadId(null)}>New chat</button>
+        </header>
+        <div className="flex min-h-0 flex-1 flex-col">
+          {chat.messagesLoading && <p role="status">Loading conversation…</p>}
+          {chat.messagesError && <p role="alert">{chat.messagesError}</p>}
+          <Transcript
+            threadId={threadId}
+            messages={chat.messages}
+            live={chat.live}
+            pendingUserText={chat.pendingUser?.text}
+            pendingUserAttachments={chat.pendingUser?.attachments}
+            pendingUserContext={chat.pendingUser?.context}
+            anchorCurrentTurn={chat.anchorCurrentTurn}
+            awaitingResponse={chat.isRunning}
+            waitingLonger={chat.waitingLonger}
+            reconnecting={chat.reconnecting}
+            failedBeforeResponse={turn.kind === "failed"}
+            cancelledBeforeResponse={turn.kind === "cancelled"}
+            timeout={turn.kind === "timeout" ? turn : undefined}
+            onRetry={canRetry ? () => chat.retry(turn.run) : undefined}
+            onContinue={
+              turn.kind === "timeout" && turn.hasProgress ? chat.continueAfterTimeout : undefined
+            }
+            retrying={chat.retrying}
+            continuing={chat.composerPending}
+          />
+        </div>
+        <Composer
+          key={threadId ?? "draft"}
+          compact
+          onSend={chat.send}
+          onStop={chat.stop}
+          disabled={chat.isRunning}
+          pending={chat.composerPending}
+          running={chat.isRunning}
+          stopping={chat.stopping}
+          error={chat.sendError ?? undefined}
+          draft={chat.draftReseed.text}
+          draftAttachments={chat.draftReseed.attachments}
+          draftContext={chat.draftReseed.context}
+          draftNonce={chat.draftReseed.nonce}
+          ambientContext={ambientContext}
+          models={chat.models}
+          modelsLoading={chat.modelsLoading}
+          modelsError={chat.modelsError}
+          selectedModel={chat.selectedModel}
+          selectedReasoning={chat.selectedReasoning}
+          onSelectModel={chat.selectModel}
+          onSelectReasoning={chat.selectReasoning}
+        />
+      </section>
+    </DocumentPreviewRoot>
+  )
+}
+```
+
+`useRegisteredAgentContext` reads entries contributed through `AgentContextProvider`; without a
+provider it returns an empty list. Pass your own `ambientContext` to `Composer` when the host owns it.
+`DocumentPreviewRoot` enables in-app attachment previews; without it, durable attachments use links.
+
+You can also supply your own data/controller. `Transcript` accepts `AgentMessage[]` and `LiveRunState`;
+`createLiveRunState()` supplies idle state for a non-streaming transcript. For custom message layouts,
+use `MessageView` or pass `normalizeDurableParts(message.parts)` to `AssistantBody`.
+
+Named types include `ComposerProps`, `TranscriptProps`, `ConversationPanelProps`, `ThreadSidebarProps`,
+`ContextPickerProps`, `ContextPickerResult`, `ModelControlsProps`, `AgentConversation`,
+`UseAgentConversationInput`, and the message, context, model, and normalized-part types. For components
+with inline props, use React's `ComponentProps<typeof Component>`.
+
 ## Document previews
 
 Durable files attached by a user or produced by an agent open directly from the conversation when

--- a/packages/agent-ui/src/components/ContextPicker.tsx
+++ b/packages/agent-ui/src/components/ContextPicker.tsx
@@ -3,12 +3,12 @@ import { Spinner } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
 import { Search } from "lucide-react"
 
-interface ContextPickerResult {
+export interface ContextPickerResult {
   readonly context: AgentContextInput
   readonly label: string
 }
 
-interface ContextPickerProps {
+export interface ContextPickerProps {
   readonly open: boolean
   readonly query: string
   readonly loading: boolean

--- a/packages/agent-ui/src/document-preview/DocumentPreviewRoot.tsx
+++ b/packages/agent-ui/src/document-preview/DocumentPreviewRoot.tsx
@@ -55,7 +55,7 @@ import {
 } from "./state"
 import type { AgentDocumentPreviewRenderer, AgentDocumentSource } from "./types"
 
-interface DocumentPreviewContextValue {
+export interface DocumentPreviewContextValue {
   readonly canPreview: (document: AgentDocumentSource) => boolean
   readonly openDocument: (document: AgentDocumentSource) => void
 }

--- a/packages/agent-ui/src/hooks/useAgentConversation.ts
+++ b/packages/agent-ui/src/hooks/useAgentConversation.ts
@@ -61,6 +61,8 @@ export interface UseAgentConversationInput {
   readonly onThreadCreated: (threadId: string) => void
 }
 
+export type AgentConversation = ReturnType<typeof useAgentConversation>
+
 /** Shared route-independent controller for full-page and embedded agent conversations. */
 export function useAgentConversation({
   threadId,

--- a/packages/agent-ui/src/index.ts
+++ b/packages/agent-ui/src/index.ts
@@ -1,6 +1,10 @@
+export type { AgentRunFailure } from "@sixb/client"
+export type { ModelReasoningLevel } from "@sixb/core/models"
+export { AgentChat, type AgentChatProps } from "./AgentChat"
 export {
   AgentContextProvider,
   useAgentContext,
+  useRegisteredAgentContext,
 } from "./AgentContextProvider"
 export {
   AgentExecutionTrace,
@@ -8,8 +12,68 @@ export {
   type AgentExecutionTraceVariant,
 } from "./AgentExecutionTrace"
 export { AgentPanel, type AgentPanelProps } from "./AgentPanel"
+export { ActivityStatusText } from "./components/ActivityStatus"
+export { Composer, type ComposerProps } from "./components/Composer"
+export { ContextChips } from "./components/ContextChips"
+export {
+  ContextPicker,
+  type ContextPickerProps,
+  type ContextPickerResult,
+} from "./components/ContextPicker"
+export {
+  ConversationPanel,
+  type ConversationPanelProps,
+} from "./components/ConversationPanel"
+export { FileAttachmentCard } from "./components/FileAttachmentCard"
+export { AssistantBody } from "./components/MessageParts"
+export {
+  CompactionMarker,
+  LiveAssistant,
+  MessageView,
+  ReconnectingMarker,
+  RunCancelledMarker,
+  RunErrorMarker,
+  RunFailureMarker,
+  RunTimeoutMarker,
+  ThinkingMarker,
+  UserFileAttachment,
+} from "./components/MessageView"
+export { ModelControls, type ModelControlsProps } from "./components/ModelControls"
+export { ModelPickerRow } from "./components/ModelPickerRow"
+export { ProviderLogo } from "./components/ProviderLogo"
+export { ReasoningEffortSlider } from "./components/ReasoningEffortSlider"
+export { ThreadSidebar, type ThreadSidebarProps } from "./components/ThreadSidebar"
+export { Transcript, type TranscriptProps } from "./components/Transcript"
+export {
+  type DocumentPreviewContextValue,
+  DocumentPreviewRoot,
+  useDocumentPreview,
+} from "./document-preview/DocumentPreviewRoot"
 export type {
+  AgentDocumentKind,
   AgentDocumentPreviewRenderer,
   AgentDocumentPreviewRendererProps,
+  AgentDocumentSource,
 } from "./document-preview/types"
-export type { AgentFileRef } from "./types"
+export {
+  type AgentConversation,
+  type UseAgentConversationInput,
+  useAgentConversation,
+} from "./hooks/useAgentConversation"
+export { createLiveRunState, type LiveRunState } from "./liveRun"
+export { type NormalizedPart, type NormalizedTool, normalizeDurableParts } from "./parts"
+export type { ActiveTurnPresentation } from "./runPresentation"
+export type {
+  Agent,
+  AgentContextEntryInput,
+  AgentContextInput,
+  AgentContextPart,
+  AgentFileRef,
+  AgentMessage,
+  AgentMessagePart,
+  AgentModelSelection,
+  AgentRun,
+  AgentRunStatus,
+  AgentThread,
+  LanguageModel,
+} from "./types"


### PR DESCRIPTION
Apps can now compose their own agent UI using the shared components and conversation hook. Includes supporting types and a full README example.

```tsx
import {
  Composer,
  Transcript,
  MessageView,
  ThreadSidebar,
  ContextPicker,
  ModelControls,
  DocumentPreviewRoot,
  useAgentConversation,
} from "@sixb/agent-ui"
```

### Verified

```text
Agent UI tests:          143 passed
Agent UI typecheck:      passed
Agent UI build:          passed
Repo declaration build: passed
README example:         typechecked
Client generation:      passed
Biome check/fix:         passed
```