### PR TITLE
ci: use pinned official MinIO images from Quay

### DIFF
--- a/storage/blob-s3/docker-compose.yml
+++ b/storage/blob-s3/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z
     command: ["server", "/data", "--address", ":9000", "--console-address", ":9001"]
     environment:
       MINIO_ROOT_USER: minioadmin
@@ -14,7 +14,7 @@ services:
       retries: 20
 
   minio-mc:
-    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    image: quay.io/minio/mc:RELEASE.2025-04-16T18-13-26Z
     depends_on:
       minio:
         condition: service_healthy

--- a/storage/ducklake/docker-compose.yml
+++ b/storage/ducklake/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       retries: 15
 
   minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z
     command: ["server", "/data", "--console-address", ":9001"]
     environment:
       MINIO_ROOT_USER: sixb
@@ -28,7 +28,7 @@ services:
       retries: 20
 
   createbuckets:
-    image: minio/mc:latest
+    image: quay.io/minio/mc:RELEASE.2025-04-16T18-13-26Z
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
## Changes

- Use official MinIO images from Quay for S3 and remote DuckLake tests: Docker Hub pulls fail before the tests start.
- Pin both server and client versions to keep fixtures reproducible.

## Validation

- 11 S3 and 5 remote DuckLake tests passed locally.
- Both CI jobs passed with these image references in #561.

Extracted from #561 so this fix can be merged independently and used by all PRs after updating from `main`.
