### PR TITLE
accounting: attribute model calls to requests, actions, and workflows

### DIFF
--- a/packages/atlas/src/components/AiModelCallsTable.tsx
+++ b/packages/atlas/src/components/AiModelCallsTable.tsx
@@ -20,7 +20,7 @@ import {
   TableRow,
 } from "@sixb/ui/components"
 import { useQuery } from "@tanstack/react-query"
-import { ArrowUpRight, Bot, ChevronRight, GitBranch, Layers } from "lucide-react"
+import { ArrowUpRight, Bot, ChevronRight, GitBranch, Layers, Workflow, Zap } from "lucide-react"
 import { type ReactNode, useState } from "react"
 import { Link } from "react-router-dom"
 import { formatMoney } from "../lib/aiAccounting"
@@ -59,7 +59,7 @@ export function AiModelCallsTable({
         <div>
           <CardTitle>Model calls</CardTitle>
           <CardDescription>
-            Grouped by initiating run, including sub-agents. Totals follow your filters.
+            Calls by execution, including agent delegations. Totals follow your filters.
           </CardDescription>
         </div>
         {filterControl}
@@ -95,8 +95,8 @@ export function AiModelCallsTable({
         <div className="flex items-center justify-between gap-3 border-t px-6 py-3">
           <p className="text-xs text-muted-foreground">
             {data?.total
-              ? `${offset + 1}–${Math.min(offset + groups.length, data.total)} of ${data.total.toLocaleString()} runs`
-              : "0 runs"}
+              ? `${offset + 1}–${Math.min(offset + groups.length, data.total)} of ${data.total.toLocaleString()} executions`
+              : "0 executions"}
           </p>
           <div className="flex gap-2">
             <Button
@@ -139,16 +139,29 @@ function GroupRows({ group, filters }: { group: Group; filters: Filters }) {
     group.label ||
     (group.attribution?.kind === "agent"
       ? "Agent"
-      : group.attribution?.kind === "workflowAgent"
+      : group.attribution?.kind === "workflowAgent" || group.attribution?.kind === "workflow"
         ? `Workflow · ${group.attribution.workflowId}`
-        : "Execution")
-  const Icon = group.attribution?.kind === "agent" ? Bot : Layers
+        : group.attribution?.kind === "action"
+          ? `Action · ${group.attribution.actionId}`
+          : group.attribution?.kind === "request"
+            ? `Request · ${group.attribution.requestId}`
+            : "Execution")
+  const Icon =
+    group.attribution?.kind === "agent"
+      ? Bot
+      : group.attribution?.kind === "action"
+        ? Zap
+        : group.attribution?.kind === "workflow" || group.attribution?.kind === "workflowAgent"
+          ? Workflow
+          : Layers
   const href =
     group.attribution?.kind === "agent" && group.canOpenThread
       ? `/agents/${encodeURIComponent(group.attribution.threadId)}`
-      : group.attribution?.kind === "workflowAgent"
+      : group.attribution?.kind === "workflowAgent" || group.attribution?.kind === "workflow"
         ? `/workflows/${encodeURIComponent(group.attribution.workflowId)}?run=${encodeURIComponent(group.attribution.workflowRunId)}`
-        : undefined
+        : group.attribution?.kind === "action"
+          ? `/actions/runs/${encodeURIComponent(group.attribution.actionRunId)}`
+          : undefined
   return (
     <>
       <TableRow className={open ? "bg-muted/35 hover:bg-muted/35" : undefined}>

--- a/packages/atlas/src/pages/AiUsagePage.tsx
+++ b/packages/atlas/src/pages/AiUsagePage.tsx
@@ -467,7 +467,7 @@ export function AiUsagePage() {
               {workflowCosts.length > 1 ? (
                 <ChartCard
                   title="Cost by workflow"
-                  description="Highest recorded workflow Agent node cost in this range"
+                  description="Highest recorded workflow model cost in this range"
                 >
                   <AiUsageBreakdown
                     data={workflowCosts}

--- a/packages/atlas/tests/ai-model-calls-table.test.ts
+++ b/packages/atlas/tests/ai-model-calls-table.test.ts
@@ -81,7 +81,7 @@ function render(overrides: Partial<Parameters<typeof AiModelCallsTable>[0]> = {}
   }
 }
 
-test("starts collapsed with aggregate totals, source navigation and run pagination", () => {
+test("starts collapsed with aggregate totals, source navigation and execution pagination", () => {
   // Rendering flat calls, using only direct costs, or opening child rows by default fails this.
   const html = render()
   expect(html).toContain("Workplace forecast")
@@ -90,7 +90,7 @@ test("starts collapsed with aggregate totals, source navigation and run paginati
   expect(html).toContain("2 models")
   expect(html).toContain("USD 0.048007392")
   expect(html).toContain("81,668")
-  expect(html).toContain("1–1 of 30 runs")
+  expect(html).toContain("1–1 of 30 executions")
   expect(html).toContain('href="/agents/thread"')
   expect(html).not.toContain("research-task")
   expect(html).not.toContain("Loading calls")

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -6005,6 +6005,54 @@
                                 "properties": {
                                   "kind": {
                                     "type": "string",
+                                    "enum": ["request"]
+                                  },
+                                  "requestId": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["kind", "requestId"],
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "enum": ["action"]
+                                  },
+                                  "actionId": {
+                                    "type": "string"
+                                  },
+                                  "actionRunId": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["kind", "actionId", "actionRunId"],
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "enum": ["workflow"]
+                                  },
+                                  "workflowId": {
+                                    "type": "string"
+                                  },
+                                  "workflowRunId": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["kind", "workflowId", "workflowRunId"],
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
                                     "enum": ["agent"]
                                   },
                                   "agentRunId": {
@@ -8725,6 +8773,54 @@
                                 "properties": {
                                   "kind": {
                                     "type": "string",
+                                    "enum": ["request"]
+                                  },
+                                  "requestId": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["kind", "requestId"],
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "enum": ["action"]
+                                  },
+                                  "actionId": {
+                                    "type": "string"
+                                  },
+                                  "actionRunId": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["kind", "actionId", "actionRunId"],
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "enum": ["workflow"]
+                                  },
+                                  "workflowId": {
+                                    "type": "string"
+                                  },
+                                  "workflowRunId": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["kind", "workflowId", "workflowRunId"],
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
                                     "enum": ["agent"]
                                   },
                                   "agentRunId": {
@@ -8856,6 +8952,54 @@
                                 },
                                 "attribution": {
                                   "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["request"]
+                                        },
+                                        "requestId": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["kind", "requestId"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["action"]
+                                        },
+                                        "actionId": {
+                                          "type": "string"
+                                        },
+                                        "actionRunId": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["kind", "actionId", "actionRunId"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["workflow"]
+                                        },
+                                        "workflowId": {
+                                          "type": "string"
+                                        },
+                                        "workflowRunId": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["kind", "workflowId", "workflowRunId"],
+                                      "additionalProperties": false
+                                    },
                                     {
                                       "type": "object",
                                       "properties": {

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -2001,6 +2001,20 @@ export type ListAiModelCallsResponses = {
       }
       attribution?:
         | {
+            kind: "request"
+            requestId: string
+          }
+        | {
+            kind: "action"
+            actionId: string
+            actionRunId: string
+          }
+        | {
+            kind: "workflow"
+            workflowId: string
+            workflowRunId: string
+          }
+        | {
             kind: "agent"
             agentRunId: string
             threadId: string
@@ -2784,6 +2798,20 @@ export type ListAiModelCallGroupsResponses = {
       executionId: string
       attribution?:
         | {
+            kind: "request"
+            requestId: string
+          }
+        | {
+            kind: "action"
+            actionId: string
+            actionRunId: string
+          }
+        | {
+            kind: "workflow"
+            workflowId: string
+            workflowRunId: string
+          }
+        | {
             kind: "agent"
             agentRunId: string
             threadId: string
@@ -2817,6 +2845,20 @@ export type ListAiModelCallGroupsResponses = {
       executions: Array<{
         executionId: string
         attribution?:
+          | {
+              kind: "request"
+              requestId: string
+            }
+          | {
+              kind: "action"
+              actionId: string
+              actionRunId: string
+            }
+          | {
+              kind: "workflow"
+              workflowId: string
+              workflowRunId: string
+            }
           | {
               kind: "agent"
               agentRunId: string

--- a/packages/core/src/storage/ai-cost/analytics.ts
+++ b/packages/core/src/storage/ai-cost/analytics.ts
@@ -168,7 +168,7 @@ export function buildAiAccountingOverview(
         item
       )
     }
-    if (item.attribution?.kind === "workflowAgent") {
+    if (item.attribution?.kind === "workflowAgent" || item.attribution?.kind === "workflow") {
       appendGrouped(workflowItems, item.attribution.workflowId, item)
     }
   }

--- a/packages/core/src/storage/ai-cost/attribution.ts
+++ b/packages/core/src/storage/ai-cost/attribution.ts
@@ -1,0 +1,15 @@
+import type { AiAccountingAttribution } from "./types"
+
+/** Direct calls are identified by durable provenance, even when their run has been removed. */
+export function directModelCallAttribution(
+  kind: string | null,
+  id: string | null,
+  primitiveId: string | null
+): AiAccountingAttribution | undefined {
+  if (!id) return undefined
+  if (kind === "request") return { kind, requestId: id }
+  if (kind === "action" && primitiveId) return { kind, actionId: primitiveId, actionRunId: id }
+  if (kind === "workflow" && primitiveId)
+    return { kind, workflowId: primitiveId, workflowRunId: id }
+  return undefined
+}

--- a/packages/core/src/storage/ai-cost/groups.ts
+++ b/packages/core/src/storage/ai-cost/groups.ts
@@ -1,5 +1,6 @@
 import type { AiAccountingRecordSetItem } from "./analytics"
 import { aiAccountingItemMatchesQuery, normalizeAiModelCallAccountingQuery } from "./analytics"
+import { directModelCallAttribution } from "./attribution"
 import type {
   AiAccountingAttribution,
   AiBillingIdentity,
@@ -56,12 +57,15 @@ export interface AiModelCallGroupRow {
   readonly workflow_node_run_id: string | null
   readonly workflow_id: string | null
   readonly workflow_run_id: string | null
+  readonly executor_kind: string | null
+  readonly executor_id: string | null
+  readonly primitive_id: string | null
 }
 
 export function aiModelCallGroupFragmentFromRow(
   row: AiModelCallGroupRow
 ): AiModelCallGroupFragment {
-  let attribution: AiAccountingAttribution | undefined
+  let attribution = directModelCallAttribution(row.executor_kind, row.executor_id, row.primitive_id)
   if (row.root_agent_run_id && row.root_thread_id) {
     attribution = {
       kind: "agent",

--- a/packages/core/src/storage/ai-cost/provider.ts
+++ b/packages/core/src/storage/ai-cost/provider.ts
@@ -12,6 +12,7 @@ export {
   normalizeAiModelCallAccountingQuery,
   toAccountingItem,
 } from "./analytics"
+export { directModelCallAttribution } from "./attribution"
 export type { AiModelCallCostDetails } from "./codec"
 export { aiModelCallCostDetails, parseAiModelCallCostDetails } from "./codec"
 export type {

--- a/packages/core/src/storage/ai-cost/types.ts
+++ b/packages/core/src/storage/ai-cost/types.ts
@@ -181,7 +181,14 @@ export interface AiAccountingOverview {
   readonly workflows: readonly AiAccountingWorkflowBreakdown[]
 }
 
+/**
+ * The execution that made the model call, rather than the request that triggered its work.
+ * `request` identifies a direct call from a request-bound SDK, outside an action or workflow.
+ */
 export type AiAccountingAttribution =
+  | { readonly kind: "request"; readonly requestId: string }
+  | { readonly kind: "action"; readonly actionId: string; readonly actionRunId: string }
+  | { readonly kind: "workflow"; readonly workflowId: string; readonly workflowRunId: string }
   | {
       readonly kind: "agent"
       readonly agentRunId: string

--- a/packages/core/src/storage/in-memory/index.ts
+++ b/packages/core/src/storage/in-memory/index.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks"
 import { InMemoryActionRunStorage } from "../action-runs"
 import { type AgentStorage, InMemoryAgentStorage } from "../agents"
 import { type AiAccountingAttribution, type AiCostStorage, InMemoryAiCostStorage } from "../ai-cost"
+import { directModelCallAttribution } from "../ai-cost/attribution"
 import { type AiLimitStorage, InMemoryAiLimitStorage } from "../ai-limits"
 import { type AiUsageStorage, InMemoryAiUsageStorage } from "../ai-usage"
 import { type AuthStorage, InMemoryAuthStorage } from "../auth"
@@ -177,7 +178,21 @@ export class InMemoryStorage implements Storage {
       projectId: input.projectId,
       id: input.executionId,
     })
-    if (!execution || execution.executor.type !== "agent") return undefined
+    if (!execution) return undefined
+    if (execution.executor.type !== "agent") {
+      const executor = execution.executor
+      return directModelCallAttribution(
+        executor.type === "primitive" ? executor.kind : executor.type,
+        executor.type === "request"
+          ? executor.requestId
+          : executor.type === "primitive"
+            ? executor.runId
+            : null,
+        execution.authorizationRef.type === "trustedPrimitive"
+          ? execution.authorizationRef.primitive.id
+          : null
+      )
+    }
     const directRun = await this.agentStorage.runs.getById({
       projectId: input.projectId,
       id: execution.executor.runId,

--- a/packages/core/src/testing/ai-model-call-groups-contract.ts
+++ b/packages/core/src/testing/ai-model-call-groups-contract.ts
@@ -22,6 +22,80 @@ export function runAiModelCallGroupsContractSuite<T extends AiModelCallGroupsCon
   options: AiStorageContractSuiteOptions<T>
 ): void {
   describe(name, () => {
+    test("attributes direct calls and retries to requests, actions, and workflows", async () => {
+      // Removal proof: return undefined from directModelCallAttribution and run this suite.
+      const storage = await options.createStorage()
+      try {
+        await options.setup?.(storage)
+        const expected = [
+          { kind: "request", requestId: "request" },
+          { kind: "action", actionId: "summarize", actionRunId: "action" },
+          { kind: "workflow", workflowId: "summarize", workflowRunId: "workflow" },
+        ] as const
+        for (const attribution of expected) {
+          const kind = attribution.kind
+          const primitive = {
+            kind: kind === "action" ? ("action" as const) : ("workflow" as const),
+            id: "summarize",
+            runId: kind,
+          }
+          const execution = await storage.executions.create({
+            projectId,
+            id: kind,
+            executor:
+              kind === "request"
+                ? { type: "request", requestId: kind }
+                : { type: "primitive", kind, runId: kind },
+            source:
+              kind === "request"
+                ? { type: "http", requestId: kind }
+                : { type: "event", eventId: kind },
+            correlationId: kind,
+            authorizationRef:
+              kind === "request" ? { type: "disabled" } : { type: "trustedPrimitive", primitive },
+          })
+          for (const attempt of [1, 2]) {
+            await storage.aiUsage.recordModelCall({
+              projectId,
+              id: `${kind}:${attempt}`,
+              executionId: execution.id,
+              attempt,
+              callId: `${kind}:${attempt}`,
+              requesterGroupIds: execution.requesterGroupIds,
+              providerId: "test",
+              requestedModelId: "small",
+              responseId: `${kind}:${attempt}`,
+              usage: { inputTokens: 2, outputTokens: 3 },
+              occurredAt: new Date("2026-09-01T12:00:00Z"),
+            })
+          }
+          const calls = await storage.aiCosts.listModelCalls({
+            ...range,
+            executionId: execution.id,
+          })
+          expect(calls.total).toBe(2)
+          expect(calls.items.map((call) => call.attribution)).toEqual([attribution, attribution])
+        }
+        const groups = await storage.aiCosts.listModelCallGroups(range)
+        expect(groups.total).toBe(3)
+        for (const attribution of expected) {
+          const group = groups.items.find((item) => item.executionId === attribution.kind)
+          expect(group).toMatchObject({
+            attribution,
+            modelCallCount: 2,
+            totalTokens: 10,
+            executions: [{ attribution, modelCallCount: 2 }],
+          })
+        }
+        const overview = await storage.aiCosts.queryProjectOverview({ ...range, bucket: "day" })
+        expect(overview.totals.modelCallCount).toBe(6)
+        expect(overview.agents).toEqual([])
+        expect(overview.workflows).toMatchObject([{ workflowId: "summarize", modelCallCount: 2 }])
+      } finally {
+        await options.cleanup?.(storage)
+      }
+    })
+
     test("attributes workflow usage to step references and keeps same-named steps separate", async () => {
       const storage = await options.createStorage()
       try {

--- a/packages/server/src/schemas/ai-accounting.ts
+++ b/packages/server/src/schemas/ai-accounting.ts
@@ -193,6 +193,9 @@ export const AiModelCallAccountingItemSchema = z.object({
   usage: AiModelCallUsageRecordSchema,
   attribution: z
     .discriminatedUnion("kind", [
+      z.object({ kind: z.literal("request"), requestId: z.string() }),
+      z.object({ kind: z.literal("action"), actionId: z.string(), actionRunId: z.string() }),
+      z.object({ kind: z.literal("workflow"), workflowId: z.string(), workflowRunId: z.string() }),
       z.object({
         kind: z.literal("agent"),
         agentRunId: z.string(),

--- a/storage/pg/src/ai-cost-groups.ts
+++ b/storage/pg/src/ai-cost-groups.ts
@@ -39,6 +39,7 @@ WITH filtered AS (
   SELECT COALESCE(root_agent.execution_id, usage.execution_id) AS root_execution_id,
     usage.execution_id, usage.provider_id, usage.requested_model_id, usage.occurred_at,
     usage.total_tokens,
+    execution.executor_kind, execution.executor_id, execution.authority_primitive_id AS primitive_id,
     COALESCE(cost.status, 'unvalued') AS valuation_status,
     cost.currency AS amount_currency, cost.amount_nanos,
     root_agent.id AS root_agent_run_id,
@@ -51,6 +52,7 @@ WITH filtered AS (
     workflow_node.workflow_id AS workflow_id,
     workflow_node.workflow_run_id AS workflow_run_id
   FROM ai_model_call_usage AS usage
+  JOIN executions AS execution ON execution.project_id = usage.project_id AND execution.id = usage.execution_id
   LEFT JOIN agent_runs AS direct_agent
     ON direct_agent.project_id = usage.project_id AND direct_agent.execution_id = usage.execution_id
   LEFT JOIN agent_runs AS root_agent
@@ -88,6 +90,7 @@ SELECT filtered.root_execution_id, execution_id, provider_id, requested_model_id
   CAST(SUM((amount_nanos / 1000000) % 1000000) AS TEXT) AS amount_middle,
   CAST(SUM(amount_nanos % 1000000) AS TEXT) AS amount_low,
   MAX(root_agent_run_id) AS root_agent_run_id,
+  MAX(executor_kind) AS executor_kind, MAX(executor_id) AS executor_id, MAX(primitive_id) AS primitive_id,
   MAX(root_thread_id) AS root_thread_id,
   MAX(direct_kind) AS direct_kind,
   MAX(direct_run_id) AS direct_run_id,

--- a/storage/pg/src/pg-ai-cost-storage.ts
+++ b/storage/pg/src/pg-ai-cost-storage.ts
@@ -4,6 +4,7 @@ import {
   aiModelCallCostDetails,
   aiModelCallCostMatchesUsage,
   buildAiAccountingOverviewFromFragments,
+  directModelCallAttribution,
   normalizeAiAccountingQuery,
   normalizeAiModelCallAccountingQuery,
   normalizeAiModelCallCostRecord,
@@ -117,11 +118,14 @@ export class PgAiCostStorage implements AiCostStorage {
             ELSE NULL
           END AS attribution_agent_kind,
           workflow_node.node_id AS attribution_agent_step_id,
-          workflow_node.workflow_id AS attribution_workflow_id,
+          COALESCE(workflow_node.workflow_id,
+            CASE WHEN execution.executor_kind = 'workflow' THEN execution.authority_primitive_id END
+          ) AS attribution_workflow_id,
           cost.status AS cost_status,
           cost.currency AS cost_currency,
           cost.amount_nanos AS cost_amount_nanos
         FROM ai_model_call_usage AS usage
+        JOIN executions AS execution ON execution.project_id = usage.project_id AND execution.id = usage.execution_id
         LEFT JOIN agent_runs AS direct_agent
           ON direct_agent.project_id = usage.project_id
           AND direct_agent.execution_id = usage.execution_id
@@ -251,6 +255,7 @@ export class PgAiCostStorage implements AiCostStorage {
         workflow_agent.node_run_id AS attribution_node_run_id,
         workflow_node.workflow_id AS attribution_workflow_id,
         workflow_node.workflow_run_id AS attribution_workflow_run_id,
+        execution.executor_kind, execution.executor_id, execution.authority_primitive_id AS primitive_id,
         COALESCE((
           SELECT jsonb_agg(groups.group_id ORDER BY groups.group_id)
           FROM ai_model_call_usage_groups AS groups
@@ -265,6 +270,7 @@ export class PgAiCostStorage implements AiCostStorage {
         cost.details AS cost_details,
         cost.rated_at AS cost_rated_at
       FROM ai_model_call_usage AS usage
+      JOIN executions AS execution ON execution.project_id = usage.project_id AND execution.id = usage.execution_id
       LEFT JOIN agent_runs AS direct_agent
         ON direct_agent.project_id = usage.project_id
         AND direct_agent.execution_id = usage.execution_id
@@ -342,6 +348,9 @@ interface UsageRow {
 }
 
 interface JoinedRow extends UsageRow {
+  readonly executor_kind: string | null
+  readonly executor_id: string | null
+  readonly primitive_id: string | null
   readonly attribution_kind: "agent" | "subagent" | "workflowAgent" | null
   readonly attribution_agent_step_id: string | null
   readonly attribution_agent_run_id: string | null
@@ -491,7 +500,7 @@ function accountingItemFromRow(row: JoinedRow): AiAccountingRecordSetItem {
   const cost = row.cost_status === null ? undefined : costFromJoinedRow(row)
   const attribution =
     row.attribution_kind === null
-      ? undefined
+      ? directModelCallAttribution(row.executor_kind, row.executor_id, row.primitive_id)
       : row.attribution_kind === "agent"
         ? {
             kind: "agent" as const,

--- a/storage/sqlite/src/ai-cost-groups.ts
+++ b/storage/sqlite/src/ai-cost-groups.ts
@@ -37,6 +37,7 @@ WITH filtered AS (
   SELECT COALESCE(root_agent.execution_id, usage.execution_id) AS root_execution_id,
     usage.execution_id, usage.provider_id, usage.requested_model_id, usage.occurred_at,
     usage.total_tokens,
+    execution.executor_kind, execution.executor_id, execution.authority_primitive_id AS primitive_id,
     COALESCE(cost.status, 'unvalued') AS valuation_status,
     cost.currency AS amount_currency, cost.amount_nanos,
     root_agent.id AS root_agent_run_id,
@@ -49,6 +50,7 @@ WITH filtered AS (
     workflow_node.workflow_id AS workflow_id,
     workflow_node.workflow_run_id AS workflow_run_id
   FROM ai_model_call_usage AS usage
+  JOIN executions AS execution ON execution.project_id = usage.project_id AND execution.id = usage.execution_id
   LEFT JOIN agent_runs AS direct_agent
     ON direct_agent.project_id = usage.project_id AND direct_agent.execution_id = usage.execution_id
   LEFT JOIN agent_runs AS root_agent
@@ -86,6 +88,7 @@ SELECT filtered.root_execution_id, execution_id, provider_id, requested_model_id
   CAST(SUM((amount_nanos / 1000000) % 1000000) AS TEXT) AS amount_middle,
   CAST(SUM(amount_nanos % 1000000) AS TEXT) AS amount_low,
   MAX(root_agent_run_id) AS root_agent_run_id,
+  MAX(executor_kind) AS executor_kind, MAX(executor_id) AS executor_id, MAX(primitive_id) AS primitive_id,
   MAX(root_thread_id) AS root_thread_id,
   MAX(direct_kind) AS direct_kind,
   MAX(direct_run_id) AS direct_run_id,

--- a/storage/sqlite/src/ai-cost-storage.ts
+++ b/storage/sqlite/src/ai-cost-storage.ts
@@ -4,6 +4,7 @@ import {
   aiModelCallCostDetails,
   aiModelCallCostMatchesUsage,
   buildAiAccountingOverviewFromFragments,
+  directModelCallAttribution,
   normalizeAiAccountingQuery,
   normalizeAiModelCallAccountingQuery,
   normalizeAiModelCallCostRecord,
@@ -199,6 +200,7 @@ const SQLITE_ACCOUNTING_LIST_PAGE_SQL = `
     workflow_agent.node_run_id AS attribution_node_run_id,
     workflow_node.workflow_id AS attribution_workflow_id,
     workflow_node.workflow_run_id AS attribution_workflow_run_id,
+    execution.executor_kind, execution.executor_id, execution.authority_primitive_id AS primitive_id,
     COALESCE((
       SELECT json_group_array(group_id) FROM (
         SELECT group_id FROM ai_model_call_usage_groups
@@ -215,6 +217,7 @@ const SQLITE_ACCOUNTING_LIST_PAGE_SQL = `
     cost.details AS cost_details,
     cost.rated_at AS cost_rated_at
   FROM ai_model_call_usage AS usage
+  JOIN executions AS execution ON execution.project_id = usage.project_id AND execution.id = usage.execution_id
   LEFT JOIN agent_runs AS direct_agent
     ON direct_agent.project_id = usage.project_id
     AND direct_agent.execution_id = usage.execution_id
@@ -250,7 +253,9 @@ const SQLITE_ACCOUNTING_OVERVIEW_SQL = `
         ELSE NULL
       END AS attribution_agent_kind,
       workflow_node.node_id AS attribution_agent_step_id,
-      workflow_node.workflow_id AS attribution_workflow_id,
+      COALESCE(workflow_node.workflow_id,
+        CASE WHEN execution.executor_kind = 'workflow' THEN execution.authority_primitive_id END
+      ) AS attribution_workflow_id,
       CASE
         WHEN cost.status = 'rated' THEN 'rated'
         WHEN cost.status = 'unpriceable' THEN 'unpriceable'
@@ -259,6 +264,7 @@ const SQLITE_ACCOUNTING_OVERVIEW_SQL = `
       CASE WHEN cost.status = 'rated' THEN cost.currency ELSE NULL END AS amount_currency,
       CASE WHEN cost.status = 'rated' THEN cost.amount_nanos ELSE NULL END AS amount_nanos
     FROM ai_model_call_usage AS usage
+    JOIN executions AS execution ON execution.project_id = usage.project_id AND execution.id = usage.execution_id
     LEFT JOIN agent_runs AS direct_agent
       ON direct_agent.project_id = usage.project_id
       AND direct_agent.execution_id = usage.execution_id
@@ -393,6 +399,9 @@ interface UsageRow {
 }
 
 interface JoinedRow extends UsageRow {
+  readonly executor_kind: string | null
+  readonly executor_id: string | null
+  readonly primitive_id: string | null
   readonly attribution_kind: "agent" | "subagent" | "workflowAgent" | null
   readonly attribution_agent_step_id: string | null
   readonly attribution_agent_run_id: string | null
@@ -534,7 +543,7 @@ function accountingItemFromRow(row: JoinedRow): AiAccountingRecordSetItem {
   const cost = row.cost_status === null ? undefined : costFromJoinedRow(row)
   const attribution =
     row.attribution_kind === null
-      ? undefined
+      ? directModelCallAttribution(row.executor_kind, row.executor_id, row.primitive_id)
       : row.attribution_kind === "agent"
         ? {
             kind: "agent" as const,


### PR DESCRIPTION
## Attribute every model call

Extend accounting reads and Atlas to identify the execution that made a call.

```ts
// New AiAccountingAttribution variants
{ kind: "request", requestId }
{ kind: "action", actionId, actionRunId }
{ kind: "workflow", workflowId, workflowRunId }

// Existing variants remain distinct
{ kind: "agent", agentRunId, threadId }
{ kind: "workflowAgent", agentStepId, nodeRunId, workflowId, workflowRunId }
{ kind: "subagent", subagentRunId, parentRunId }
```

### Ownership

```text
HTTP request ── direct call                  → request
HTTP request ── action ── direct call        → action
HTTP request ── workflow ── direct call      → workflow
HTTP request ── workflow ── Agent task       → workflowAgent
```

| Read surface | Change |
| --- | --- |
| Model-call pages | Resolve request/action/workflow identity from durable provenance |
| Grouped calls | Preserve execution ownership and delivery totals |
| Workflow overview | Include direct calls alongside workflow-Agent calls |
| Atlas | Execution labels, action/workflow run links, existing delegation grouping |
| Server/client | Expanded attribution union in OpenAPI and generated types |

### Review map

```text
durable execution
  → shared directModelCallAttribution()
  → in-memory / SQLite / PostgreSQL accounting reads
  → HTTP schemas + generated client
  → Atlas model-call table
```

| Files | Review focus |
| --- | --- |
| `packages/core/src/storage/ai-cost/` | Attribution types, shared mapping, workflow totals |
| `storage/{sqlite,pg}/src/*ai-cost*` | Join durable execution identity into reads |
| `packages/core/src/testing/ai-model-call-groups-contract.ts` | Cross-provider ownership and retry totals |
| `packages/server/src/schemas/ai-accounting.ts` | Wire contract |
| `packages/atlas/src/components/AiModelCallsTable.tsx` | Labels and navigation |

### Verification

| Check | Result |
| --- | --- |
| Core/server/Atlas/SQLite accounting tests | 148 passed |
| PostgreSQL accounting E2E tests | 12 passed |
| Build, full typecheck, Biome | Passed |
| Publish boundaries | 55 packages passed |
| OpenAPI + typed client | Regenerated |

> **Stack 3/5** · Base: #564
>
> Merge order: #563 → #564 → **#565** → #566 → #567
