### PR TITLE
models: add direct language generation

### DIFF
--- a/packages/action-worker/src/action-execution/context.ts
+++ b/packages/action-worker/src/action-execution/context.ts
@@ -31,6 +31,7 @@ export function toActionRuntimeFacade(runtime: RunActionJobInput["runtime"]): Ac
       },
     },
     connector: runtime.sixb.connector,
+    models: runtime.sixb.models,
     objects(objectType) {
       return {
         appendTelemetryBatch(items) {

--- a/packages/action-worker/src/types.ts
+++ b/packages/action-worker/src/types.ts
@@ -4,6 +4,7 @@ import type {
   BlobsRuntime,
   ConnectorRuntime,
   DomainEventLog,
+  ModelsRuntime,
   ObjectsRuntime,
   OntologySource,
   SixbDefinitions,
@@ -20,6 +21,7 @@ import type {
 
 /** Execution-bound primitives exposed to Action phase handlers. */
 export interface ActionExecutionFacade {
+  readonly models: ModelsRuntime
   readonly objects: ObjectsRuntime<readonly OntologySource[]>
   readonly actions: ActionsRuntime
   readonly connector: ConnectorRuntime

--- a/packages/action-worker/src/worker.ts
+++ b/packages/action-worker/src/worker.ts
@@ -130,6 +130,7 @@ export class ActionWorker extends QueueWorker<
 
     const actionJob: ActionJob = { id: run.id, actionId: run.actionId }
     const execution = bindDurablePrimitiveExecution(this.host, {
+      modelExecution: { attempt: job.attempt, signal },
       execution: durableExecution,
       primitive: {
         kind: "action",
@@ -223,6 +224,7 @@ function buildActionContext(
     )
   }
   const sixb = {
+    models: execution.sixb.models,
     objects: execution.sixb.objects,
     actions: execution.sixb.actions,
     connector: execution.sixb.connector,

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -103,6 +103,7 @@ async function createContext(
     actionRunsStorage: host.storage.actionRuns!,
     ontologyMutations: execution.ontologyMutations,
     sixb: {
+      models: execution.sixb.models,
       objects: execution.sixb.objects,
       actions: execution.sixb.actions,
       connector: execution.sixb.connector,

--- a/packages/action-worker/tests/worker.test.ts
+++ b/packages/action-worker/tests/worker.test.ts
@@ -16,6 +16,11 @@ import {
 } from "@sixb/core"
 import { attachSixbErrorReporter } from "@sixb/core/internal/error-reporting"
 import { LOGS_STREAM } from "@sixb/core/internal/logging"
+import {
+  defineLanguageModel,
+  type LanguageModel,
+  type LanguageModelStreamEvent,
+} from "@sixb/core/models"
 import type { ActionRunRecord } from "@sixb/core/storage"
 import { createTestSixb } from "@sixb/core/testing"
 import { ActionWorker } from "../src"
@@ -77,6 +82,69 @@ function captureThrown(callback: () => unknown): unknown {
 }
 
 describe("ActionWorker", () => {
+  test("accounts for direct generation in action writeback before persisting the result", async () => {
+    // Removal proof: remove models from the Action facade or its worker attempt binding.
+    const model: LanguageModel = {
+      providerId: "test",
+      modelId: "extract",
+      definition: defineLanguageModel({
+        kind: "language",
+        providerId: "test",
+        modelId: "extract",
+        capabilities: { nativeStructuredOutput: true },
+      }),
+      async stream() {
+        return {
+          events: (async function* (): AsyncIterable<LanguageModelStreamEvent> {
+            yield { type: "stream-start" }
+            yield { type: "text-start", id: "text" }
+            yield { type: "text-delta", id: "text", delta: '{"status":"ready"}' }
+            yield { type: "text-end", id: "text" }
+            yield {
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 5, outputTokens: 3 },
+            }
+          })(),
+        }
+      },
+    }
+    const action = defineAction("extract-status")
+      .on(Device)
+      .params({})
+      .writeback(async ({ sixb }) => {
+        const result = await sixb.models.language.generate({
+          model,
+          prompt: "Extract status",
+          output: { status: "string" },
+        })
+        return result.output
+      })
+      .edits(({ objects, subject, writeback }) => {
+        objects(Device).byId(subject.primaryId).update({ status: writeback.status })
+      })
+    const { host, sixb } = createSixb([action])
+    const worker = new ActionWorker(host)
+    await sixb.objects.upsert("Device", { id: "device-1", name: "Device" })
+    await worker.start()
+    try {
+      const run = await deviceObjects(sixb).requestActionAndWait({
+        id: "device-1",
+        actionId: action.id,
+      })
+      expect(run.status).toBe("succeeded")
+      expect(run.writeback).toMatchObject({ status: "succeeded", result: { status: "ready" } })
+      expect(
+        await host.storage.aiUsage!.getLatestForExecution({
+          projectId: host.id,
+          executionId: run.executionId,
+        })
+      ).toMatchObject({ attempt: 1, requesterGroupIds: [], usage: { totalTokens: 8 } })
+    } finally {
+      await worker.stop()
+    }
+  })
+
   test("idles without action definitions or action-run storage", async () => {
     const storage = createStorageWithoutActionRuns()
     const worker = new ActionWorker(createSixb([], storage).host)

--- a/packages/agent-worker/src/context-budget.ts
+++ b/packages/agent-worker/src/context-budget.ts
@@ -1,9 +1,9 @@
 import { AgentDefinitionError } from "@sixb/core"
+import { resolveLanguageModel } from "@sixb/core/internal/model-execution"
 import {
   defineLanguageModel,
   type LanguageModel,
   type LanguageModelDefinition,
-  ModelCatalogUnavailableError,
   type ModelReasoning,
 } from "@sixb/core/models"
 
@@ -27,24 +27,8 @@ export async function prepareAgentModel(selection: AgentModelSelection): Promise
   readonly model: LanguageModel
   readonly budget: AgentContextBudget
 }> {
-  const binding = selection.model
-  const offline = hasContextLimit(binding.definition)
-  let model: LanguageModel
-  try {
-    model = (await binding.resolve?.({ offline })) ?? binding
-  } catch (cause) {
-    if (offline || !(cause instanceof ModelCatalogUnavailableError)) throw cause
-    model = (await binding.resolve?.({ offline: true })) ?? binding
-  }
+  const model = await resolveLanguageModel(selection.model)
   const definition = defineLanguageModel(model.definition)
-  if (
-    definition.providerId !== binding.providerId ||
-    definition.modelId !== binding.modelId ||
-    model.providerId !== binding.providerId ||
-    model.modelId !== binding.modelId
-  ) {
-    throw invalidBudget("resolved model identity does not match the selected model.")
-  }
   const budget = resolveAgentContextBudget({ model, reasoning: selection.reasoning }, definition)
   if (budget.source === "fallback") {
     console.warn(
@@ -75,10 +59,6 @@ export async function prepareAgentModel(selection: AgentModelSelection): Promise
         }),
     }),
   }
-}
-
-function hasContextLimit(definition: LanguageModelDefinition): boolean {
-  return definition.contextWindow !== undefined || definition.maxInputTokens !== undefined
 }
 
 /** Input-only limits are a conservative window: leave the same reserve without inventing a total. */

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -6199,6 +6199,53 @@ describe("AgentWorker", () => {
     }
   })
 
+  test("recovers direct generation accounting through the configured agent worker", async () => {
+    // Removal proof: omit recordRecoveredAiModelCall in AgentWorker.execute; recovery never drains.
+    const storage = new InMemoryStorage()
+    let available = false
+    const host = new SixbHost({
+      id: PROJECT_ID,
+      ontology: [],
+      models: { language: [answerModel()] },
+      sandboxes: new RecordingSandboxFactory(),
+      storage: withAiUsageRecordInterceptor(storage, async (_input, record) => {
+        if (!available) throw new Error("accounting temporarily unavailable")
+        return record()
+      }),
+      broker: new InMemoryBroker(),
+      queues: new InMemoryQueues(),
+      lakeStorage: new InMemoryLakeStorage(),
+      blobStorage: new InMemoryBlobStorage(),
+    })
+    const sixb = bindRequestExecution(host, {
+      request: new Request("http://localhost/generate"),
+      authorization: { type: "disabled" },
+    })
+    await expect(
+      sixb.models.language.generate({ model: answerModel(), prompt: "Hi" })
+    ).rejects.toMatchObject({ name: "ModelUsageRecordingError", recoveryScheduled: true })
+    const identity = { projectId: host.id, executionId: sixb.execution.id }
+    expect((await storage.aiUsage.summarizeExecution(identity)).modelCallCount).toBe(0)
+    available = true
+    const worker = new AgentWorker(host, workerOptions())
+    await worker.start()
+    try {
+      const summary = await waitFor(
+        async () => {
+          const result = await storage.aiUsage.summarizeExecution(identity)
+          return result.modelCallCount === 1 ? result : null
+        },
+        { label: "direct request accounting recovery" }
+      )
+      expect(summary.modelCallCount).toBe(1)
+      await expect(
+        sixb.models.language.generate({ model: answerModel(), prompt: "Again" })
+      ).rejects.toMatchObject({ name: "ModelUsageRecordingError" })
+    } finally {
+      await worker.stop()
+    }
+  })
+
   test("fails the run before another provider call when storage and recovery queue fail", async () => {
     let modelCalls = 0
     const model = new WorkerTestModel({

--- a/packages/core/src/actions/types/context.ts
+++ b/packages/core/src/actions/types/context.ts
@@ -7,6 +7,7 @@ import type {
   EffectiveObjectChange,
   OntologyOperationOutcome,
 } from "../../materializer"
+import type { ModelsRuntime } from "../../models/generation-types"
 import type { ObjectType, Property, ValueType } from "../../ontology"
 import type { InferPropertyUnit, InferPropertyValue } from "../../ontology/inference"
 import type { LinkToken, ObjectTypeWithPropertyTokens, PropertyToken } from "../../ontology/tokens"
@@ -196,6 +197,7 @@ export interface ActionRuntimeFacade<
   TValueTypes extends readonly ValueType[] = readonly ValueType[],
 > {
   readonly blobs: ActionBlobContext
+  readonly models: ModelsRuntime
   readonly connector: ConnectorRuntime
   objects<const TObjectType extends ObjectTypeWithPropertyTokens>(
     objectType: TObjectType

--- a/packages/core/src/agents/model-loop.ts
+++ b/packages/core/src/agents/model-loop.ts
@@ -42,6 +42,8 @@ interface ModelLoopOptions {
   readonly maxOutputTokens?: number
   readonly caching?: "auto" | "off"
   readonly maxSteps: number
+  /** Direct generation cannot execute or synthesize local tool results. */
+  readonly rejectLocalToolCalls?: boolean
   readonly signal: AbortSignal
   /** Reserve the final provider call for a tool-free synthesis response. */
   readonly finalStepInstruction?: string
@@ -245,6 +247,12 @@ export async function runModelLoop(
     }
 
     const localCalls = response.toolCalls.filter((call) => call.part.providerExecuted !== true)
+    if (
+      input.rejectLocalToolCalls &&
+      (localCalls.length > 0 || response.finishReason === "tool-calls")
+    ) {
+      throw new ModelStreamError("[SixbModels] Direct generation cannot continue local tool calls.")
+    }
     if (response.finishReason === "pause" && localCalls.length === 0) {
       const step = modelStep(response, responseId, response.content, cost)
       steps.push(step)

--- a/packages/core/src/execution/primitive.ts
+++ b/packages/core/src/execution/primitive.ts
@@ -1,3 +1,4 @@
+import { bindModelExecutionAttempt, type ModelExecutionAttempt } from "../models/execution/binding"
 import type { OntologySource } from "../ontology"
 import type { OntologyMutationRuntime } from "../runtime/ontology-mutations"
 import { getOntologyMutationRuntime } from "../runtime/ontology-mutations"
@@ -24,9 +25,12 @@ export function bindDurablePrimitiveExecution(
   input: {
     readonly execution: ExecutionRecord
     readonly primitive: TrustedPrimitiveRef
+    readonly modelExecution?: ModelExecutionAttempt
   }
 ): BoundPrimitiveExecution {
-  return bindPrimitiveScope(host, restoreTrustedPrimitiveExecutionScope(input))
+  const bound = bindPrimitiveScope(host, restoreTrustedPrimitiveExecutionScope(input))
+  if (input.modelExecution) bindModelExecutionAttempt(bound.sixb.models, input.modelExecution)
+  return bound
 }
 
 function bindPrimitiveScope(

--- a/packages/core/src/execution/request.ts
+++ b/packages/core/src/execution/request.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto"
 import type { AuthorizationContext } from "../authorization"
+import { bindModelExecutionAttempt } from "../models/execution/binding"
 import type { OntologySource } from "../ontology"
 import { isBoundSixb, type Sixb } from "../runtime/sixb"
 import { createDisabledRequestScope, createPrincipalRequestScope } from "./scopes"
@@ -22,6 +23,7 @@ export type { AuthorizationContext } from "../authorization"
 export type { DatasetsRuntime } from "../datasets/execution"
 export type { EventsRuntime } from "../events/execution"
 export type { LogsRuntime } from "../logging/execution"
+export type { LanguageModelsRuntime, ModelsRuntime } from "../models/generation-types"
 export type {
   ExecutionObjectByIdHandle,
   ExecutionObjectSet,
@@ -95,6 +97,7 @@ export function bindRequestExecution(
   if (!isBoundSixb(sixb)) {
     throw new Error("[Sixb] Request host did not return an execution-bound Sixb SDK.")
   }
+  bindModelExecutionAttempt(sixb.models, { attempt: 1, signal: input.request.signal })
   return sixb
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1059,6 +1059,14 @@ export type {
   ModelCatalog,
   ModelCatalogInput,
 } from "./models"
+export type {
+  InferLanguageModelOutput,
+  LanguageModelGenerateInput,
+  LanguageModelGenerateResult,
+  LanguageModelOutputShape,
+  LanguageModelsRuntime,
+  ModelsRuntime,
+} from "./models/generation-types"
 
 // ── Scheduling ──────────────────────────────────────────────
 

--- a/packages/core/src/models/execution.ts
+++ b/packages/core/src/models/execution.ts
@@ -1,0 +1,207 @@
+import { runModelLoop } from "../agents/model-loop"
+import { assertProviderAccess } from "../authorization"
+import type { ExecutionContext } from "../execution"
+import { ensureExecutionRecord, executionRecordInputFromRuntime } from "../execution/durable"
+import type { SixbRuntimeContext } from "../runtime/types"
+import type { ModelCatalog } from "./catalog"
+import { ModelProviderError, ModelStreamError, UnsupportedModelFeatureError } from "./errors"
+import type { ModelCallEndEvent } from "./events"
+import { type ModelExecutionAttempt, registerModelExecutionBinding } from "./execution/binding"
+import { requireAccountingCapabilities } from "./execution/model-call-accounting"
+import { aiModelCallOutputTokenAllowance } from "./execution/model-call-admission"
+import { createAiModelCallLimitController } from "./execution/model-call-limits"
+import { AiModelCallRecorder } from "./execution/model-call-recorder"
+import { enqueueAiModelCallRecovery } from "./execution/recovery-queue"
+import type {
+  InferLanguageModelOutput,
+  LanguageModelGenerateInput,
+  LanguageModelGenerateResult,
+  LanguageModelOutputShape,
+  ModelsRuntime,
+} from "./generation-types"
+import { modelReasoningSupportIssue } from "./language-model"
+import type { ModelMessage } from "./messages"
+import { languageModelOutput } from "./output"
+import { resolveLanguageModel } from "./resolve"
+
+export function createModelsRuntime(
+  runtime: SixbRuntimeContext,
+  execution: ExecutionContext,
+  catalog: ModelCatalog | undefined
+): ModelsRuntime {
+  let binding: ModelExecutionAttempt | undefined
+  let recorder: Promise<AiModelCallRecorder> | undefined
+
+  async function createRecorder(): Promise<AiModelCallRecorder> {
+    const storage = {
+      ...requireAccountingCapabilities(runtime.storage),
+      transaction: runtime.storage.transaction.bind(runtime.storage),
+    }
+    if (!binding) {
+      throw new Error(
+        "[SixbModels] Generation requires a bound request or worker execution attempt."
+      )
+    }
+    const { requesterGroupIds } = await ensureExecutionRecord(
+      runtime.storage.executions,
+      executionRecordInputFromRuntime({
+        execution,
+        runtimeAuthorization: runtime.runtimeAuthorization,
+      })
+    )
+    return new AiModelCallRecorder({
+      storage,
+      projectId: runtime.projectId,
+      executionId: execution.id,
+      attempt: binding.attempt,
+      requesterGroupIds,
+      limits: createAiModelCallLimitController({
+        storage,
+        projectId: runtime.projectId,
+        requestedBy: execution.requestedBy,
+        requesterGroupIds,
+      }),
+      recoverAiModelCall: (input) => enqueueAiModelCallRecovery(runtime.queues.agents, input),
+    })
+  }
+
+  function generate<const TShape extends LanguageModelOutputShape | undefined = undefined>(
+    input: LanguageModelGenerateInput<TShape>
+  ): Promise<
+    LanguageModelGenerateResult<
+      TShape extends LanguageModelOutputShape ? InferLanguageModelOutput<TShape> : string
+    >
+  >
+  async function generate(
+    input: LanguageModelGenerateInput<LanguageModelOutputShape | undefined>
+  ): Promise<LanguageModelGenerateResult<unknown>> {
+    assertProviderAccess(runtime, execution, "models.language.generate")
+    const messages = generationMessages(input)
+    if (!binding) {
+      throw new Error(
+        "[SixbModels] Generation requires a bound request or worker execution attempt."
+      )
+    }
+    const signal = input.signal ? AbortSignal.any([binding.signal, input.signal]) : binding.signal
+    signal.throwIfAborted()
+    const selected = input.model
+      ? catalog
+        ? catalog.language.getByRef({
+            provider: input.model.providerId,
+            modelId: input.model.modelId,
+          })?.model
+        : input.model
+      : catalog?.language.default.model
+    if (!selected) {
+      throw new Error(
+        input.model
+          ? `[SixbModels] Model '${input.model.providerId}/${input.model.modelId}' is not configured in models.language.`
+          : "[SixbModels] Configure models.language in createSixb() or supply a model to generate()."
+      )
+    }
+    const output =
+      input.output === undefined
+        ? undefined
+        : languageModelOutput(input.output, runtime.ontology.getValueTypesById())
+    const model = await resolveLanguageModel(selected)
+    const reasoningIssue = modelReasoningSupportIssue(
+      model.definition.capabilities.reasoning,
+      input.reasoning
+    )
+    if (reasoningIssue) throw new UnsupportedModelFeatureError(`[SixbModels] ${reasoningIssue}.`)
+    if (output && model.definition.capabilities.nativeStructuredOutput === false) {
+      throw new UnsupportedModelFeatureError(
+        "[SixbModels] Model does not support native structured output."
+      )
+    }
+    const maxOutputTokens = Math.min(
+      aiModelCallOutputTokenAllowance(input.maxOutputTokens ?? model.definition.maxOutputTokens),
+      model.definition.maxOutputTokens ?? Infinity
+    )
+    if (typeof input.reasoning === "object" && input.reasoning.budgetTokens >= maxOutputTokens) {
+      throw new TypeError("[SixbModels] Output allowance must exceed the reasoning token budget.")
+    }
+    recorder ??= createRecorder()
+    const accounting = await recorder
+    accounting.assertHealthy()
+    signal.throwIfAborted()
+    let event: ModelCallEndEvent | undefined
+    const options = {
+      model: accounting.wrapModel(model),
+      messages,
+      maxSteps: 1,
+      rejectLocalToolCalls: true,
+      maxOutputTokens,
+      reasoning: input.reasoning,
+      caching: input.caching,
+      signal,
+      onModelCallEnd: async (completed: ModelCallEndEvent) => {
+        await accounting.onModelCallEnd(completed)
+        event = completed
+      },
+    }
+    const result = output ? await runModelLoop({ ...options, output }) : await runModelLoop(options)
+    if (result.status === "aborted") {
+      signal.throwIfAborted()
+      throw new DOMException("Model generation aborted", "AbortError")
+    }
+    if (result.finishReason === "error" || result.finishReason === "content-filter") {
+      throw new ModelProviderError(
+        `[SixbModels] Generation ended with '${result.finishReason}'.`,
+        model.providerId,
+        model.modelId
+      )
+    }
+    if (!event)
+      throw new ModelStreamError("[SixbModels] Generation completed without accounting metadata.")
+    return {
+      output: result.output,
+      usage: event.usage,
+      cost: event.cost,
+      callId: event.callId,
+      finishReason: result.finishReason,
+    }
+  }
+
+  const models: ModelsRuntime = {
+    language: { generate },
+  }
+  registerModelExecutionBinding(models, (input) => {
+    binding = { attempt: input.attempt, signal: input.signal }
+  })
+  return models
+}
+
+function generationMessages(
+  input: LanguageModelGenerateInput<LanguageModelOutputShape | undefined>
+): readonly ModelMessage[] {
+  if ((input.prompt === undefined) === (input.messages === undefined)) {
+    throw new TypeError("[SixbModels] Supply exactly one of prompt or messages.")
+  }
+  if (input.prompt !== undefined && typeof input.prompt !== "string") {
+    throw new TypeError("[SixbModels] prompt must be a string.")
+  }
+  if (input.messages !== undefined && !Array.isArray(input.messages)) {
+    throw new TypeError("[SixbModels] messages must be an array.")
+  }
+  if (input.instructions !== undefined && typeof input.instructions !== "string") {
+    throw new TypeError("[SixbModels] instructions must be a string.")
+  }
+  if (
+    input.maxOutputTokens !== undefined &&
+    (!Number.isSafeInteger(input.maxOutputTokens) || input.maxOutputTokens <= 0)
+  ) {
+    throw new TypeError("[SixbModels] maxOutputTokens must be a positive safe integer.")
+  }
+  if (input.caching !== undefined && input.caching !== "auto" && input.caching !== "off") {
+    throw new TypeError("[SixbModels] caching must be 'auto' or 'off'.")
+  }
+  return [
+    ...(input.instructions === undefined
+      ? []
+      : [{ role: "system" as const, content: input.instructions }]),
+    ...(input.prompt !== undefined
+      ? [{ role: "user" as const, content: [{ type: "text" as const, text: input.prompt }] }]
+      : (input.messages ?? [])),
+  ]
+}

--- a/packages/core/src/models/execution/binding.ts
+++ b/packages/core/src/models/execution/binding.ts
@@ -1,0 +1,29 @@
+import type { ModelsRuntime } from "../generation-types"
+
+export interface ModelExecutionAttempt {
+  readonly attempt: number
+  readonly signal: AbortSignal
+}
+
+const bindings = new WeakMap<ModelsRuntime, (input: ModelExecutionAttempt) => void>()
+
+export function registerModelExecutionBinding(
+  models: ModelsRuntime,
+  bind: (input: ModelExecutionAttempt) => void
+): void {
+  bindings.set(models, bind)
+}
+
+/** Called once on a fresh facade at the request or worker delivery boundary. */
+export function bindModelExecutionAttempt(
+  models: ModelsRuntime,
+  input: ModelExecutionAttempt
+): void {
+  const bind = bindings.get(models)
+  if (!bind) throw new Error("[SixbModels] Model runtime has no execution binding.")
+  if (!Number.isSafeInteger(input.attempt) || input.attempt < 1) {
+    throw new TypeError("[SixbModels] Execution attempt must be a positive safe integer.")
+  }
+  bind(input)
+  bindings.delete(models)
+}

--- a/packages/core/src/models/execution/index.ts
+++ b/packages/core/src/models/execution/index.ts
@@ -1,3 +1,4 @@
+export { resolveLanguageModel } from "../resolve"
 export { ModelUsageRecordingError } from "./errors"
 export type {
   AiModelCallAdmissionDecision,

--- a/packages/core/src/models/execution/model-call-admission.ts
+++ b/packages/core/src/models/execution/model-call-admission.ts
@@ -1,7 +1,7 @@
 import type { AiModelCallReservationIdentity } from "../../storage"
 import type { ModelCostEstimator } from "../pricing"
 
-/** Fixed internal allowance used only to estimate aggregate-budget reservations. */
+/** Default output ceiling when a call and its resolved model supply no limit. */
 export const AI_MODEL_CALL_OUTPUT_TOKEN_ALLOWANCE = 4_096
 
 export type AiModelCallInputTokenEstimate =

--- a/packages/core/src/models/generation-types.ts
+++ b/packages/core/src/models/generation-types.ts
@@ -1,0 +1,50 @@
+import type { InferSchemaOrRef, SchemaOrRef } from "../ontology"
+import type { ModelFinishReason, ModelUsage } from "./events"
+import type { LanguageModel, ModelReasoning } from "./language-model"
+import type { ModelMessage } from "./messages"
+import type { ModelCallCost } from "./pricing"
+
+export type LanguageModelOutputShape = Readonly<Record<string, SchemaOrRef>>
+
+export type InferLanguageModelOutput<TShape extends LanguageModelOutputShape> =
+  string extends keyof TShape
+    ? Record<string, unknown>
+    : { -readonly [K in keyof TShape]: InferSchemaOrRef<TShape[K]> }
+
+export type LanguageModelGenerateInput<
+  TShape extends LanguageModelOutputShape | undefined = undefined,
+> = {
+  readonly instructions?: string
+  readonly model?: LanguageModel
+  readonly output?: TShape
+  readonly maxOutputTokens?: number
+  readonly reasoning?: ModelReasoning
+  readonly caching?: "auto" | "off"
+  readonly signal?: AbortSignal
+} & (undefined extends TShape ? unknown : { readonly output: TShape }) &
+  (
+    | { readonly prompt: string; readonly messages?: never }
+    | { readonly messages: readonly ModelMessage[]; readonly prompt?: never }
+  )
+
+export interface LanguageModelGenerateResult<TOutput = string> {
+  readonly output: TOutput
+  readonly usage: ModelUsage
+  readonly cost: ModelCallCost
+  readonly finishReason: ModelFinishReason
+  readonly callId: string
+}
+
+export interface LanguageModelsRuntime {
+  generate<const TShape extends LanguageModelOutputShape | undefined = undefined>(
+    input: LanguageModelGenerateInput<TShape>
+  ): Promise<
+    LanguageModelGenerateResult<
+      TShape extends LanguageModelOutputShape ? InferLanguageModelOutput<TShape> : string
+    >
+  >
+}
+
+export interface ModelsRuntime {
+  readonly language: LanguageModelsRuntime
+}

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -36,6 +36,14 @@ export type {
 } from "./events"
 export { normalizeModelProviderIds } from "./events"
 export type {
+  InferLanguageModelOutput,
+  LanguageModelGenerateInput,
+  LanguageModelGenerateResult,
+  LanguageModelOutputShape,
+  LanguageModelsRuntime,
+  ModelsRuntime,
+} from "./generation-types"
+export type {
   LanguageModel,
   LanguageModelProvider,
   LanguageModelRequest,

--- a/packages/core/src/models/output.ts
+++ b/packages/core/src/models/output.ts
@@ -1,0 +1,45 @@
+import { assertJsonObject } from "../json"
+import { schemaRecordToJsonSchema } from "../ontology/json-schema"
+import { isObjectRefSchema, validateSchemaOrRefValue } from "../ontology/refs"
+import type { ValueType } from "../ontology/types"
+import { isRecord } from "../ontology/validation"
+import { coerceSchemaValueToTyped, normalizeSchemaValue } from "../ontology/validation/normalize"
+import type { LanguageModelOutputShape } from "./generation-types"
+import type { ModelOutput } from "./tools"
+
+export function languageModelOutput(
+  shape: LanguageModelOutputShape,
+  valueTypesById: ReadonlyMap<string, ValueType>
+): ModelOutput<Record<string, unknown>> {
+  if (!isRecord(shape)) throw new TypeError("[SixbModels] output must be a Sixb schema record.")
+  const schema = schemaRecordToJsonSchema({ shape, valueTypesById })
+  assertJsonObject(schema, "model output schema")
+  return {
+    name: "sixb_output",
+    schema,
+    validate(value) {
+      if (!isRecord(value)) throw new TypeError("[SixbModels] Output must be an object.")
+      for (const key of Object.keys(value)) {
+        if (!Object.hasOwn(shape, key)) {
+          throw new TypeError(`[SixbModels] Unknown output field '${key}'.`)
+        }
+      }
+      return Object.fromEntries(
+        Object.entries(shape).map(([key, field]) => {
+          if (!Object.hasOwn(value, key)) {
+            throw new TypeError(`[SixbModels] Missing output field '${key}'.`)
+          }
+          validateSchemaOrRefValue(field, value[key], `output.${key}`, valueTypesById)
+          const output = isObjectRefSchema(field)
+            ? value[key]
+            : coerceSchemaValueToTyped(
+                field,
+                normalizeSchemaValue(field, value[key], `output.${key}`, valueTypesById),
+                valueTypesById
+              )
+          return [key, output]
+        })
+      )
+    },
+  }
+}

--- a/packages/core/src/models/resolve.ts
+++ b/packages/core/src/models/resolve.ts
@@ -1,0 +1,27 @@
+import { defineLanguageModel } from "./definitions"
+import { ModelCatalogUnavailableError } from "./errors"
+import type { LanguageModel } from "./language-model"
+
+/** Pin operational metadata once, falling back offline only when the catalog is unavailable. */
+export async function resolveLanguageModel(binding: LanguageModel): Promise<LanguageModel> {
+  const offline =
+    binding.definition.contextWindow !== undefined ||
+    binding.definition.maxInputTokens !== undefined
+  let model: LanguageModel
+  try {
+    model = (await binding.resolve?.({ offline })) ?? binding
+  } catch (cause) {
+    if (offline || !(cause instanceof ModelCatalogUnavailableError)) throw cause
+    model = (await binding.resolve?.({ offline: true })) ?? binding
+  }
+  const definition = defineLanguageModel(model.definition)
+  if (
+    definition.providerId !== binding.providerId ||
+    definition.modelId !== binding.modelId ||
+    model.providerId !== binding.providerId ||
+    model.modelId !== binding.modelId
+  ) {
+    throw new TypeError("[SixbModels] Resolved model identity does not match the selected model.")
+  }
+  return model
+}

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -13,6 +13,8 @@ import { createEventsRuntime, type EventsRuntime } from "../events/execution"
 import type { ExecutionContext } from "../execution"
 import { createLogsRuntime, type LogsRuntime } from "../logging/execution"
 import type { LoggingService } from "../logging/service"
+import { createModelsRuntime } from "../models/execution"
+import type { ModelsRuntime } from "../models/generation-types"
 import { createObjectsRuntime, type ObjectsRuntime } from "../objects/execution"
 import { createPipelinesRuntime, type PipelinesRuntime } from "../pipelines/execution"
 import { createProjectionsRuntime, type ProjectionsRuntime } from "../projections/execution"
@@ -38,6 +40,7 @@ export interface Sixb<
   readonly projections: ProjectionsRuntime
   readonly rules: RulesRuntime
   readonly agent: AgentRuntime
+  readonly models: ModelsRuntime
   readonly aiUsage: AiUsageRuntime
   readonly events: EventsRuntime
   readonly logs: LogsRuntime
@@ -98,6 +101,7 @@ function createExecutionFacades<TOntologySources extends readonly OntologySource
     projections: createProjectionsRuntime(runtime, dependencies.definitions.projections),
     rules: createRulesRuntime(runtime, dependencies.definitions.rules),
     agent: createAgentRuntime(runtime, execution, dependencies.definitions.models),
+    models: createModelsRuntime(runtime, execution, dependencies.definitions.models),
     aiUsage: createAiUsageRuntime(runtime, dependencies.definitions.security),
     events: createEventsRuntime(runtime),
     logs: createLogsRuntime(runtime, dependencies.logging),

--- a/packages/core/src/testing/execution.ts
+++ b/packages/core/src/testing/execution.ts
@@ -1,6 +1,7 @@
 import type { AuthorizationContext } from "../authorization"
 import { createTestingScope } from "../execution/scopes"
 import type { ExecutionScope } from "../execution/types"
+import { bindModelExecutionAttempt } from "../models/execution/binding"
 import type { OntologySource } from "../ontology"
 import { SixbHost, type SixbHostOptions } from "../runtime/host"
 import { isBoundSixb, type Sixb } from "../runtime/sixb"
@@ -8,6 +9,7 @@ import { isBoundSixb, type Sixb } from "../runtime/sixb"
 export type { AuthorizationContext } from "../authorization"
 
 export interface TestExecutionOptions {
+  readonly signal?: AbortSignal
   readonly authorization?: AuthorizationContext
   readonly executionId?: string
   readonly requestId?: string
@@ -44,5 +46,9 @@ export function createTestSixb<
   if (!isBoundSixb<TOntologySources>(sixb)) {
     throw new Error("[Sixb] Test host did not return an execution-bound Sixb SDK.")
   }
+  bindModelExecutionAttempt(sixb.models, {
+    attempt: 1,
+    signal: options.signal ?? new AbortController().signal,
+  })
   return sixb
 }

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -15,6 +15,7 @@ import type { EventsRuntime } from "../events/execution"
 import type { JsonValue } from "../json"
 import type { Logger } from "../logging"
 import type { LogsRuntime } from "../logging/execution"
+import type { ModelsRuntime } from "../models/generation-types"
 import type { LanguageModel } from "../models/language-model"
 import type { ObjectsRuntime } from "../objects/execution"
 import type { InferSchemaOrRef, ObjectRef, OntologySource, SchemaOrRef } from "../ontology"
@@ -60,6 +61,7 @@ export interface StepRunContext<TInput extends Record<string, unknown>> {
  * It is a type-level cycle break, not a separate runtime or compatibility surface.
  */
 export interface WorkflowRuntimeFacade {
+  readonly models: ModelsRuntime
   readonly objects: ObjectsRuntime<readonly OntologySource[]>
   readonly actions: ActionsRuntime
   readonly agent: AgentRuntime

--- a/packages/core/tests/language-generation.test.ts
+++ b/packages/core/tests/language-generation.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, test } from "bun:test"
+import { decimal, SixbHost } from "../src"
+import { bindDurablePrimitiveExecution } from "../src/execution/primitive"
+import { bindRequestExecution } from "../src/execution/request"
+import {
+  defineLanguageModel,
+  type LanguageModel,
+  type LanguageModelRequest,
+  type LanguageModelStreamEvent,
+  ModelCatalogUnavailableError,
+  ModelStreamError,
+  rateModelCall,
+  StructuredOutputError,
+} from "../src/models"
+import { createTestActionExecution } from "../src/testing"
+import { createTestRuntimeDeps } from "./test-runtime-deps"
+
+function fakeModel(
+  options: {
+    modelId?: string
+    text?: string
+    finishReason?: "stop" | "length" | "pause" | "error" | "content-filter"
+    events?: (request: LanguageModelRequest) => AsyncIterable<LanguageModelStreamEvent>
+  } = {}
+) {
+  const requests: LanguageModelRequest[] = []
+  const modelId = options.modelId ?? "model"
+  const model: LanguageModel = {
+    providerId: "test",
+    modelId,
+    definition: defineLanguageModel({
+      kind: "language",
+      providerId: "test",
+      modelId,
+      maxOutputTokens: 1000,
+      capabilities: { nativeStructuredOutput: true },
+    }),
+    costEstimator: {
+      estimate: ({ usage }) =>
+        rateModelCall({
+          usage,
+          rateCard: { currency: "USD", unit: "million-tokens", input: "1", output: "2" },
+        }),
+    },
+    async stream(request) {
+      requests.push(request)
+      return {
+        events: options.events
+          ? options.events(request)
+          : (async function* (): AsyncIterable<LanguageModelStreamEvent> {
+              yield { type: "stream-start" }
+              yield { type: "text-start", id: "text" }
+              yield { type: "text-delta", id: "text", delta: options.text ?? "Hello" }
+              yield { type: "text-end", id: "text" }
+              yield {
+                type: "finish",
+                finishReason: options.finishReason ?? "stop",
+                usage: { inputTokens: 10, outputTokens: 4 },
+              }
+            })(),
+      }
+    },
+  }
+  return { model, requests }
+}
+
+function setup(models?: readonly LanguageModel[], controller = new AbortController()) {
+  const deps = createTestRuntimeDeps()
+  const host = new SixbHost({
+    id: "generation",
+    ontology: [],
+    ...deps,
+    models: models ? { language: models } : undefined,
+  })
+  const sixb = bindRequestExecution(host, {
+    request: new Request("http://localhost/generate", { signal: controller.signal }),
+    authorization: { type: "disabled" },
+  })
+  const identity = { projectId: host.id, executionId: sixb.execution.id }
+  return { ...deps, host, sixb, identity, controller }
+}
+
+describe("language generation", () => {
+  test("pins requester groups across deliveries and uses real attempts and worker cancellation", async () => {
+    // Removal proof: omit the execution signal from generate()'s combined signal.
+    const { model, requests } = fakeModel()
+    const { host, storage } = setup([model])
+    const requesterGroupIds = ["admitted-group"]
+    const executionId = await createTestActionExecution(storage.executions, {
+      projectId: host.id,
+      actionId: "extract",
+      runId: "action",
+      requesterGroupIds,
+    })
+    const execution = await storage.executions.getById({ projectId: host.id, id: executionId })
+    if (!execution) throw new Error("Missing test execution")
+    const controller = new AbortController()
+    const first = bindDurablePrimitiveExecution(host, {
+      execution,
+      primitive: { kind: "action", id: "extract", runId: "action" },
+      modelExecution: { attempt: 3, signal: controller.signal },
+    }).sixb
+    requesterGroupIds.push("later-group")
+    const result = await first.models.language.generate({ prompt: "Hi" })
+    const identity = { projectId: host.id, executionId }
+    expect(await storage.aiUsage.getLatestForExecution(identity)).toMatchObject({
+      attempt: 3,
+      requesterGroupIds: ["admitted-group"],
+    })
+    controller.abort(new Error("worker stopped"))
+    await expect(
+      first.models.language.generate({ prompt: "Hi", signal: new AbortController().signal })
+    ).rejects.toThrow("worker stopped")
+    expect(requests).toHaveLength(1)
+    const second = bindDurablePrimitiveExecution(host, {
+      execution,
+      primitive: { kind: "action", id: "extract", runId: "action" },
+      modelExecution: {
+        attempt: 4,
+        signal: new AbortController().signal,
+      },
+    }).sixb
+    const next = await second.models.language.generate({ prompt: "Retry" })
+    expect(next.callId).not.toBe(result.callId)
+    const calls = await storage.aiCosts.listModelCalls({
+      projectId: host.id,
+      from: new Date("2000-01-01"),
+      to: new Date("2100-01-01"),
+    })
+    expect(calls.items.find((call) => call.usage.callId === next.callId)?.usage.attempt).toBe(4)
+  })
+
+  // Removal proof: bypass the recorder's onModelCallEnd in createModelsRuntime and run this file.
+  test("returns text only after usage, valuation, and actuals are stored", async () => {
+    const { model, requests } = fakeModel()
+    const { sixb, storage, identity } = setup([model])
+    const result = await sixb.models.language.generate({ instructions: "Be brief", prompt: "Hi" })
+    expect(result).toMatchObject({
+      output: "Hello",
+      finishReason: "stop",
+      usage: { inputTokens: 10, outputTokens: 4 },
+      cost: { status: "rated" },
+    })
+    expect(requests).toHaveLength(1)
+    expect(requests[0]).toMatchObject({
+      maxOutputTokens: 1000,
+      messages: [
+        { role: "system", content: "Be brief" },
+        { role: "user", content: [{ type: "text", text: "Hi" }] },
+      ],
+    })
+    expect(await storage.aiUsage.getLatestForExecution(identity)).toMatchObject({
+      callId: result.callId,
+      attempt: 1,
+      executionId: sixb.execution.id,
+      usage: { totalTokens: 14 },
+    })
+    expect(await storage.aiUsage.summarizeExecution(identity)).toMatchObject({ modelCallCount: 1 })
+    const calls = await storage.aiCosts.listModelCalls({
+      projectId: identity.projectId,
+      from: new Date("2000-01-01"),
+      to: new Date("2100-01-01"),
+    })
+    expect(calls.total).toBe(1)
+    expect(calls.items[0]?.cost).toMatchObject({ status: "rated", money: { amountNanos: "18000" } })
+  })
+
+  test("uses the configured binding for overrides and permits explicit models without a catalog", async () => {
+    const first = fakeModel()
+    const second = fakeModel({ modelId: "second", text: "Second" })
+    const impostor = fakeModel({ modelId: "second", text: "Wrong binding" })
+    const { sixb } = setup([first.model, second.model])
+    expect(
+      (await sixb.models.language.generate({ model: impostor.model, prompt: "Hi" })).output
+    ).toBe("Second")
+    expect(impostor.requests).toHaveLength(0)
+    expect(first.requests).toHaveLength(0)
+    expect(
+      (await setup().sixb.models.language.generate({ model: first.model, prompt: "Hi" })).output
+    ).toBe("Hello")
+  })
+
+  test("rejects missing models, unknown overrides, and conflicting inputs before inference", async () => {
+    const known = fakeModel()
+    const unknown = fakeModel({ modelId: "unknown" })
+    await expect(setup().sixb.models.language.generate({ prompt: "Hi" })).rejects.toThrow(
+      "Configure models.language"
+    )
+    const { sixb } = setup([known.model])
+    await expect(
+      sixb.models.language.generate({ model: unknown.model, prompt: "Hi" })
+    ).rejects.toThrow("not configured")
+    // @ts-expect-error runtime validation also protects JavaScript callers
+    await expect(sixb.models.language.generate({ prompt: "Hi", messages: [] })).rejects.toThrow(
+      "exactly one"
+    )
+    await expect(
+      sixb.models.language.generate({ prompt: "Hi", maxOutputTokens: 0 })
+    ).rejects.toThrow("positive safe integer")
+    expect(known.requests).toHaveLength(0)
+    expect(unknown.requests).toHaveLength(0)
+  })
+
+  test("preserves existing message order and applies the caller's stricter ceiling", async () => {
+    const { model, requests } = fakeModel()
+    const messages = [
+      { role: "system" as const, content: "Original" },
+      { role: "user" as const, content: [{ type: "text" as const, text: "Task" }] },
+    ]
+    await setup([model]).sixb.models.language.generate({
+      messages,
+      instructions: "First",
+      maxOutputTokens: 17,
+      caching: "off",
+    })
+    expect(requests[0]?.messages).toEqual([{ role: "system", content: "First" }, ...messages])
+    expect(requests[0]).toMatchObject({ maxOutputTokens: 17, caching: "off" })
+    expect(messages).toHaveLength(2)
+  })
+
+  test("validates and hydrates Sixb output shapes", async () => {
+    const { model, requests } = fakeModel({
+      text: JSON.stringify({ date: "2026-09-11", amount: "12.50", count: 2 }),
+    })
+    const { sixb } = setup([model])
+    const { output } = await sixb.models.language.generate({
+      prompt: "Extract",
+      output: { date: "date", amount: "decimal", count: "integer" },
+    })
+    expect(output).toEqual({ date: new Date("2026-09-11"), amount: decimal("12.50"), count: 2 })
+    expect(requests[0]?.responseFormat).toMatchObject({
+      name: "sixb_output",
+      schema: { type: "object", additionalProperties: false },
+    })
+  })
+
+  test.each([
+    "not JSON",
+    '{"count":"wrong"}',
+    "{}",
+    '{"count":2,"extra":true}',
+  ])("accounts for invalid structured output: %s", async (text) => {
+    const { model, requests } = fakeModel({ text })
+    const { sixb, storage, identity } = setup([model])
+    await expect(
+      sixb.models.language.generate({ prompt: "Extract", output: { count: "integer" } })
+    ).rejects.toBeInstanceOf(StructuredOutputError)
+    expect(requests).toHaveLength(1)
+    expect(await storage.aiUsage.summarizeExecution(identity)).toMatchObject({ modelCallCount: 1 })
+  })
+
+  test("preserves output fields whose names also exist on Object.prototype", async () => {
+    // Removal proof: build output with output[key] = value on {}; __proto__ disappears.
+    const { model } = fakeModel({
+      text: '{"__proto__":"value","constructor":"label"}',
+    })
+    const { output } = await setup([model]).sixb.models.language.generate({
+      prompt: "Extract",
+      output: { ["__proto__"]: "string", constructor: "string" },
+    })
+    expect(Object.hasOwn(output, "__proto__")).toBe(true)
+    expect(output).toEqual(JSON.parse('{"__proto__":"value","constructor":"label"}'))
+    expect(Object.getPrototypeOf(output)).toBe(Object.prototype)
+  })
+
+  test("returns text truncation but rejects incomplete structured output", async () => {
+    const { model } = fakeModel({ text: '{"count":2}', finishReason: "length" })
+    const { sixb } = setup([model])
+    expect((await sixb.models.language.generate({ prompt: "Hi" })).finishReason).toBe("length")
+    await expect(
+      sixb.models.language.generate({ prompt: "Hi", output: { count: "integer" } })
+    ).rejects.toBeInstanceOf(StructuredOutputError)
+  })
+
+  test.each([
+    "error",
+    "content-filter",
+    "pause",
+  ] as const)("rejects %s without a continuation", async (finishReason) => {
+    const { model, requests } = fakeModel({ finishReason })
+    const { sixb, storage, identity } = setup([model])
+    await expect(sixb.models.language.generate({ prompt: "Hi" })).rejects.toThrow()
+    expect(requests).toHaveLength(1)
+    expect(await storage.aiUsage.summarizeExecution(identity)).toMatchObject({ modelCallCount: 1 })
+  })
+
+  test("rejects local tool calls after accounting", async () => {
+    // Removal proof: remove rejectLocalToolCalls from direct generation's loop options.
+    const { model } = fakeModel({
+      events: async function* () {
+        yield { type: "stream-start" }
+        yield { type: "tool-call", toolCallId: "tool", toolName: "unexpected", input: "{}" }
+        yield { type: "finish", finishReason: "tool-calls", usage: {} }
+      },
+    })
+    const { sixb, storage, identity } = setup([model])
+    await expect(sixb.models.language.generate({ prompt: "Hi" })).rejects.toBeInstanceOf(
+      ModelStreamError
+    )
+    expect(await storage.aiUsage.summarizeExecution(identity)).toMatchObject({ modelCallCount: 1 })
+  })
+
+  test("combines request and caller cancellation, recording an interrupted stream as unknown", async () => {
+    const controller = new AbortController()
+    const reason = new Error("request closed")
+    const { model } = fakeModel({
+      events: async function* (request) {
+        yield { type: "stream-start" }
+        controller.abort(reason)
+        request.signal.throwIfAborted()
+      },
+    })
+    const { sixb, storage, identity } = setup([model], controller)
+    await expect(
+      sixb.models.language.generate({ prompt: "Hi", signal: new AbortController().signal })
+    ).rejects.toBe(reason)
+    expect(await storage.aiUsage.getLatestForExecution(identity)).toMatchObject({
+      usage: { reportingStatus: "unavailable" },
+    })
+  })
+
+  test("reserves using the effective ceiling and denies a later call before inference", async () => {
+    const { model, requests } = fakeModel()
+    const { sixb, storage, host } = setup([model])
+    await storage.aiLimits.createPolicy({
+      id: "tokens",
+      projectId: host.id,
+      subject: { type: "project" },
+      limit: { meter: "tokens.total", amount: 1100 },
+    })
+    await sixb.models.language.generate({ prompt: "Hi", maxOutputTokens: 9000 })
+    expect(requests[0]?.maxOutputTokens).toBe(1000)
+    const statuses = await storage.aiLimits.listPolicyStatuses({ projectId: host.id })
+    expect(statuses[0]).toMatchObject({
+      consumption: { actual: { amount: 14 }, reserved: { amount: 0 } },
+    })
+    await storage.aiLimits.updatePolicy({
+      id: "tokens",
+      projectId: host.id,
+      limit: { meter: "tokens.total", amount: 1 },
+    })
+    await expect(sixb.models.language.generate({ prompt: "Hi" })).rejects.toMatchObject({
+      code: "ai.usage_limit_exceeded",
+    })
+    expect(requests).toHaveLength(1)
+  })
+
+  test("concurrent generations have distinct call IDs in the same execution", async () => {
+    const { model } = fakeModel()
+    const { sixb, storage, identity } = setup([model])
+    const results = await Promise.all([
+      sixb.models.language.generate({ prompt: "One" }),
+      sixb.models.language.generate({ prompt: "Two" }),
+    ])
+    expect(new Set(results.map((result) => result.callId)).size).toBe(2)
+    expect(await storage.aiUsage.summarizeExecution(identity)).toMatchObject({ modelCallCount: 2 })
+  })
+
+  test("pins resolution once per generation with an offline catalog fallback", async () => {
+    const pinned = fakeModel()
+    const resolutions: boolean[] = []
+    const selected: LanguageModel = {
+      ...pinned.model,
+      resolve: async (options) => {
+        resolutions.push(options?.offline ?? false)
+        if (!options?.offline) throw new ModelCatalogUnavailableError("offline")
+        return pinned.model
+      },
+    }
+    await setup([selected]).sixb.models.language.generate({ prompt: "Hi" })
+    expect(resolutions).toEqual([false, true])
+    expect(pinned.requests).toHaveLength(1)
+  })
+})

--- a/packages/core/tests/models.types.ts
+++ b/packages/core/tests/models.types.ts
@@ -3,6 +3,7 @@ import type {
   LanguageModelEntry,
   LanguageModelRef,
   ModelCatalogInput,
+  ModelsRuntime,
 } from "../src"
 
 declare const input: ModelCatalogInput
@@ -22,3 +23,26 @@ catalog.getByRef("gateway/openai/gpt-5.4")
 void entry
 void listed
 void defaultEntry
+
+declare const models: ModelsRuntime
+const text = await models.language.generate({ prompt: "Summarize" })
+const textOutput: string = text.output
+const structured = await models.language.generate({
+  prompt: "Extract",
+  output: { title: "string", count: "integer", date: "date", amount: "decimal" },
+})
+const structuredOutput: { title: string; count: number; date: Date | string; amount: string } =
+  structured.output
+// @ts-expect-error text output is not a record
+const incorrectText: { title: string } = text.output
+// @ts-expect-error structured output is not text
+const incorrectStructured: string = structured.output
+// @ts-expect-error prompt and messages are mutually exclusive
+models.language.generate({ prompt: "Task", messages: [] })
+// @ts-expect-error prompt or messages is required
+models.language.generate({})
+// @ts-expect-error output uses Sixb schemas
+models.language.generate({ prompt: "Task", output: { count: "number" } })
+// @ts-expect-error a declared structured result requires its runtime output shape
+models.language.generate<{ title: "string" }>({ prompt: "Task" })
+void [textOutput, structuredOutput, incorrectText, incorrectStructured]

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -1182,6 +1182,7 @@ describe("bound Sixb surface", () => {
         "events",
         "execution",
         "logs",
+        "models",
         "objects",
         "pipelines",
         "projections",

--- a/packages/workflow-worker/src/worker.ts
+++ b/packages/workflow-worker/src/worker.ts
@@ -95,6 +95,10 @@ export class WorkflowWorker extends QueueWorker<
     const executionScope = bindDurablePrimitiveExecution(this.host, {
       execution: durableExecution,
       primitive: { kind: "workflow", id: run.workflowId, runId: run.id },
+      modelExecution: {
+        attempt: claimed.job.attempt,
+        signal,
+      },
     })
     const context = buildWorkflowContext(this.host, this.workflowRuns, executionScope.sixb)
     const stopOwnershipProjection = delivery.onLeaseRenewed((renewed) => {

--- a/packages/workflow-worker/tests/worker.test.ts
+++ b/packages/workflow-worker/tests/worker.test.ts
@@ -19,6 +19,11 @@ import {
 } from "@sixb/core"
 import { createSixbError } from "@sixb/core/internal/errors"
 import { LOGS_STREAM } from "@sixb/core/internal/logging"
+import {
+  defineLanguageModel,
+  type LanguageModel,
+  type LanguageModelStreamEvent,
+} from "@sixb/core/models"
 import type { ClaimedQueueJob, WorkflowQueueJob } from "@sixb/core/queues"
 import {
   createTestSixb,
@@ -152,6 +157,61 @@ async function waitFor<T>(
 }
 
 describe("WorkflowWorker", () => {
+  test("ordinary workflow steps generate inline under the workflow execution", async () => {
+    // Removal proof: remove modelExecution from the Workflow worker's primitive binding.
+    const model: LanguageModel = {
+      providerId: "test",
+      modelId: "summarize",
+      definition: defineLanguageModel({
+        kind: "language",
+        providerId: "test",
+        modelId: "summarize",
+        capabilities: {},
+      }),
+      async stream() {
+        return {
+          events: (async function* (): AsyncIterable<LanguageModelStreamEvent> {
+            yield { type: "stream-start" }
+            yield { type: "text-start", id: "text" }
+            yield { type: "text-delta", id: "text", delta: "Summary" }
+            yield { type: "text-end", id: "text" }
+            yield {
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 7, outputTokens: 2 },
+            }
+          })(),
+        }
+      },
+    }
+    const step = defineWorkflowStep("summarize")
+      .input({})
+      .output({ summary: "string" })
+      .run(async ({ sixb }) => ({
+        summary: (await sixb.models.language.generate({ model, prompt: "Summarize" })).output,
+      }))
+    const workflow = defineWorkflow("inline-model").input({}).then(step)
+    const host = createSixb({ workflows: [workflow] })
+    const worker = new WorkflowWorker(host)
+    await worker.start()
+    try {
+      await requestWorkflowRun(host, workflow, "model-run", {})
+      const run = await waitFor(
+        () => host.storage.workflowRuns!.getById({ projectId: host.id, id: "model-run" }),
+        (value) => value?.status === "succeeded" || value?.status === "failed"
+      )
+      expect(run?.status).toBe("succeeded")
+      expect(
+        await host.storage.aiUsage!.getLatestForExecution({
+          projectId: host.id,
+          executionId: run!.executionId,
+        })
+      ).toMatchObject({ attempt: 1, requesterGroupIds: [], usage: { totalTokens: 9 } })
+    } finally {
+      await worker.stop()
+    }
+  })
+
   test("defaults to one concurrent job and accepts an explicit limit", () => {
     const workflow = defineWorkflow("concurrency-options")
       .input({ transaction: ref(Transaction) })


### PR DESCRIPTION
## Direct language generation

One text or structured response through the execution-bound Sixb SDK, with automatic accounting.

```ts
const { output, usage, cost, finishReason, callId } =
  await sixb.models.language.generate({
    instructions: "Use only facts in the document.",
    prompt: document,
  })

// output: string
```

```ts
const { output } = await sixb.models.language.generate({
  prompt: document,
  output: {
    invoiceNumber: "string",
    amount: "decimal",
    overdue: "boolean",
  },
})

output.invoiceNumber // string
output.amount        // exact decimal string
output.overdue       // boolean
```

### Ordinary workflow steps

```ts
export const summarize = defineWorkflowStep("summarize")
  .input({ document: "string" })
  .output({ summary: "string" })
  .run(async ({ input, sixb }) => {
    const { output } = await sixb.models.language.generate({
      prompt: input.document,
    })
    return { summary: output }
  })
```

### Call contract

| Input / outcome | Behavior |
| --- | --- |
| `prompt` / `messages` | Exactly one; optional `instructions` prepends a system message |
| Omitted `model` | First configured language binding |
| Explicit model | Configured provider/model identity, or supplied binding without a catalog |
| `output` | Sixb schema record; infer, validate, normalize, hydrate dates |
| Output allowance | Resolved ceiling or 4,096; caller can lower it |
| Text truncation | Return text with `finishReason: "length"` |
| Invalid/incomplete structured output | Reject after accounting |
| Tools / pending continuation | Reject; one inference invocation |
| Cancellation | Combine caller and request/worker signals |
| Accounting failure | Reject and attempt durable accounting recovery |

```text
request / action / ordinary workflow step
  → resolve model
  → shared admission + one provider call
  → shared accounting
  → validated output + usage + cost + finishReason + callId
```

### Review map

| Files | Review focus |
| --- | --- |
| `packages/core/src/models/generation-types.ts` | Public input/result inference |
| `packages/core/src/models/execution.ts` | Selection, cancellation, accounting, return contract |
| `packages/core/src/models/output.ts` | Sixb structured-output adapter |
| `packages/core/src/models/resolve.ts` | Resolution shared with AgentWorker |
| Request/action/workflow binding | Durable execution identity and delivery attempt |
| `packages/core/tests/language-generation.test.ts` | One-call behavior, accounting, output, limits, cancellation |

### Verification

| Check | Result |
| --- | --- |
| Generation/accounting/worker integration tests | 181 passed |
| `bun run test:ci` | 5,036 passed, 2 skipped |
| Build, full typecheck, Biome | Passed |
| Publish boundaries | 55 packages passed |
| `__proto__` output regression | Failed before the fix; passed after it |

> **Stack 4/5** · Base: #565
>
> Merge order: #563 → #564 → #565 → **#566** → #567
